### PR TITLE
feat(ontology): 2.4.0 — lifecycle DSL sugar + fluent similarity search

### DIFF
--- a/docs/designs/2026-03-01-ontology-unstructured-data.md
+++ b/docs/designs/2026-03-01-ontology-unstructured-data.md
@@ -400,9 +400,10 @@ var result = await IngestionPipeline<KnowledgeChunk>.Create()
     .Build()
     .ExecuteAsync(documents, ct);
 
-// Querying (existing ObjectSet API, unchanged):
+// Querying (fluent ObjectSet API — 2.4.0+):
 var results = await objectSet.Of<KnowledgeChunk>()
-    .SimilarTo("how does authentication work?", topK: 5)
+    .SimilarTo("how does authentication work?")
+    .Take(5)
     .ExecuteAsync(ct);
 ```
 
@@ -411,7 +412,7 @@ var results = await objectSet.Of<KnowledgeChunk>()
 | Before (Obsolete) | After |
 |---|---|
 | `services.AddRagCollection<T, TAdapter>()` | `services.AddOntology(o => o.UsePgVector(...))` |
-| `IVectorSearchAdapter.SearchAsync(query, topK, min)` | `ObjectSet<T>.SimilarTo(query, topK, min).ExecuteAsync()` |
+| `IVectorSearchAdapter.SearchAsync(query, topK, min)` | `ObjectSet<T>.SimilarTo(query).Take(topK).WithMinRelevance(min).ExecuteAsync()` |
 | `VectorSearchResult` (string content + score) | `ScoredObjectSetResult<T>` (typed items + scores) |
 | Manual embedding in adapter | `IEmbeddingProvider` injected into provider |
 | Manual chunking | `IngestionPipeline<T>` with built-in chunkers |

--- a/docs/reference/platform-architecture.md
+++ b/docs/reference/platform-architecture.md
@@ -3452,10 +3452,12 @@ public class AnalyzeDocumentStep : IWorkflowStep<ClaimState>
     public async Task<StepResult<ClaimState>> ExecuteAsync(
         ClaimState state, StepContext context, CancellationToken ct)
     {
-        // Similarity search via the ontology object set API
+        // Similarity search via the ontology object set API (fluent chain — 2.4.0+)
         var docSet = new ObjectSet<DocumentChunk>(_provider, _dispatcher, _events);
         var searchResult = await docSet
-            .SimilarTo(state.SearchQuery, topK: 10, minRelevance: 0.7)
+            .SimilarTo(state.SearchQuery)
+            .WithMinRelevance(0.7)
+            .Take(10)
             .ExecuteAsync(ct);
 
         var assembledContext = $"""
@@ -3512,7 +3514,9 @@ public class ResearchStep(IObjectSetProvider provider, IActionDispatcher dispatc
     {
         var docSet = new ObjectSet<DocumentChunk>(provider, dispatcher, events);
         var results = await docSet
-            .SimilarTo(state.Query, topK: 10, minRelevance: 0.7)
+            .SimilarTo(state.Query)
+            .WithMinRelevance(0.7)
+            .Take(10)
             .ExecuteAsync(ct);
 
         return StepResult<ResearchState>.Success(

--- a/src/Strategos.Ontology.Tests/Builder/ActionBuilderOfTTests.cs
+++ b/src/Strategos.Ontology.Tests/Builder/ActionBuilderOfTTests.cs
@@ -25,6 +25,19 @@ public record TestPositionWithStatus(
 
 public record TestTradeExecutedEvent(Guid OrderId);
 
+public enum TrackATestState
+{
+    Open,
+    Closed,
+    Pending,
+    Active,
+}
+
+public sealed class TrackATestType
+{
+    public TrackATestState Status { get; set; }
+}
+
 public class ActionBuilderOfTTests
 {
     [Test]
@@ -253,5 +266,15 @@ public class ActionBuilderOfTTests
         var descriptor = builder.Build();
 
         await Assert.That(descriptor.BindingType).IsEqualTo(ActionBindingType.Tool);
+    }
+
+    [Test]
+    public async Task ValidFromState_RecordsStateNameOnBuilder()
+    {
+        var builder = new ActionBuilder<TrackATestType>("ClosePosition");
+
+        builder.ValidFromState(TrackATestState.Open);
+
+        await Assert.That(builder.ValidFromStates).Contains("Open");
     }
 }

--- a/src/Strategos.Ontology.Tests/Builder/LifecycleBuilderTests.cs
+++ b/src/Strategos.Ontology.Tests/Builder/LifecycleBuilderTests.cs
@@ -117,6 +117,46 @@ public class LifecycleBuilderTests
     }
 
     [Test]
+    public async Task InitialState_Shorthand_CallsStateThenInitial()
+    {
+        var builder = new LifecycleBuilder<TestPositionStatus>();
+
+        builder.InitialState(TestPositionStatus.Pending);
+        var descriptor = builder.Build();
+
+        await Assert.That(descriptor.States.Count).IsEqualTo(1);
+        await Assert.That(descriptor.States[0].Name).IsEqualTo("Pending");
+        await Assert.That(descriptor.States[0].IsInitial).IsTrue();
+    }
+
+    [Test]
+    public async Task TerminalState_Shorthand_CallsStateThenTerminal()
+    {
+        var builder = new LifecycleBuilder<TestPositionStatus>();
+
+        builder.TerminalState(TestPositionStatus.Closed);
+        var descriptor = builder.Build();
+
+        await Assert.That(descriptor.States.Count).IsEqualTo(1);
+        await Assert.That(descriptor.States[0].Name).IsEqualTo("Closed");
+        await Assert.That(descriptor.States[0].IsTerminal).IsTrue();
+    }
+
+    [Test]
+    public async Task Transition_WithTriggerOverload_ChainsTriggeredByAction()
+    {
+        var builder = new LifecycleBuilder<TestPositionStatus>();
+
+        builder.Transition(TestPositionStatus.Pending, TestPositionStatus.Active, trigger: "ActivatePosition");
+        var descriptor = builder.Build();
+
+        await Assert.That(descriptor.Transitions.Count).IsEqualTo(1);
+        await Assert.That(descriptor.Transitions[0].FromState).IsEqualTo("Pending");
+        await Assert.That(descriptor.Transitions[0].ToState).IsEqualTo("Active");
+        await Assert.That(descriptor.Transitions[0].TriggerActionName).IsEqualTo("ActivatePosition");
+    }
+
+    [Test]
     public async Task FullLifecycle_ComplexStateMachine()
     {
         var builder = new LifecycleBuilder<TestOrderStatus>();

--- a/src/Strategos.Ontology.Tests/Builder/ObjectTypeBuilderTests.cs
+++ b/src/Strategos.Ontology.Tests/Builder/ObjectTypeBuilderTests.cs
@@ -132,4 +132,65 @@ public class ObjectTypeBuilderTests
         await Assert.That(descriptor.ImplementedInterfaces.Count).IsEqualTo(1);
         await Assert.That(descriptor.ImplementedInterfaces[0].InterfaceType).IsEqualTo(typeof(ITestSearchable));
     }
+
+    [Test]
+    public async Task Build_WithValidFromStateOnAction_EmitsSelfLoopTransitionIntoLifecycle()
+    {
+        var builder = new ObjectTypeBuilder<TrackATestType>("test-domain");
+        builder.Lifecycle<TrackATestState>(t => t.Status, lc =>
+        {
+            lc.State(TrackATestState.Open).Initial();
+            lc.State(TrackATestState.Closed).Terminal();
+        });
+        builder.Action("ViewPosition").ValidFromState(TrackATestState.Open);
+
+        var descriptor = builder.Build();
+
+        var selfLoop = descriptor.Lifecycle!.Transitions
+            .FirstOrDefault(t => t.FromState == "Open" && t.ToState == "Open" && t.TriggerActionName == "ViewPosition");
+        await Assert.That(selfLoop).IsNotNull();
+    }
+
+    [Test]
+    public async Task Build_WithValidFromStateForUndeclaredState_Throws()
+    {
+        var builder = new ObjectTypeBuilder<TrackATestType>("test-domain");
+        builder.Lifecycle<TrackATestState>(t => t.Status, lc =>
+        {
+            lc.State(TrackATestState.Open).Initial();
+            // Closed is intentionally NOT declared
+        });
+        builder.Action("Inspect").ValidFromState(TrackATestState.Closed);
+
+        await Assert.That(() => builder.Build())
+            .ThrowsException()
+            .WithExceptionType(typeof(InvalidOperationException));
+
+        await Assert.That(() => builder.Build())
+            .ThrowsException()
+            .WithMessageContaining("Closed");
+    }
+
+    [Test]
+    public async Task Build_WithMultipleValidFromStates_EmitsOneSelfLoopPerState()
+    {
+        var builder = new ObjectTypeBuilder<TrackATestType>("test-domain");
+        builder.Lifecycle<TrackATestState>(t => t.Status, lc =>
+        {
+            lc.State(TrackATestState.Pending).Initial();
+            lc.State(TrackATestState.Active).Terminal();
+        });
+        builder.Action("ExecuteTrade")
+            .ValidFromState(TrackATestState.Pending)
+            .ValidFromState(TrackATestState.Active);
+
+        var descriptor = builder.Build();
+
+        var pending = descriptor.Lifecycle!.Transitions
+            .Any(t => t.FromState == "Pending" && t.ToState == "Pending" && t.TriggerActionName == "ExecuteTrade");
+        var active = descriptor.Lifecycle!.Transitions
+            .Any(t => t.FromState == "Active" && t.ToState == "Active" && t.TriggerActionName == "ExecuteTrade");
+        await Assert.That(pending).IsTrue();
+        await Assert.That(active).IsTrue();
+    }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTests.cs
@@ -94,18 +94,17 @@ public class ObjectSetTests
     }
 
     [Test]
-    public async Task ObjectSet_SimilarTo_ExpressionHasCorrectProperties()
+    public async Task ObjectSet_SimilarTo_FluentChain_ProducesCorrectExpression()
     {
         // Arrange
         var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
 
-        // Act
-        var similar = set.SimilarTo(
-            "find related items",
-            topK: 10,
-            minRelevance: 0.8,
-            metric: DistanceMetric.L2,
-            embeddingPropertyName: "ContentEmbedding");
+        // Act — fluent chain replaces the legacy positional/optional-arg API
+        var similar = set
+            .SimilarTo("find related items")
+            .Take(10)
+            .WithMinRelevance(0.8)
+            .WithMetric(DistanceMetric.L2);
 
         // Assert
         var expr = similar.Expression;
@@ -113,41 +112,7 @@ public class ObjectSetTests
         await Assert.That(expr.TopK).IsEqualTo(10);
         await Assert.That(expr.MinRelevance).IsEqualTo(0.8);
         await Assert.That(expr.Metric).IsEqualTo(DistanceMetric.L2);
-        await Assert.That(expr.EmbeddingPropertyName).IsEqualTo("ContentEmbedding");
         await Assert.That(expr.Source).IsTypeOf<RootExpression>();
-    }
-
-    [Test]
-    public async Task ObjectSet_SimilarTo_DefaultParameters()
-    {
-        // Arrange
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
-
-        // Act
-        var similar = set.SimilarTo("query");
-
-        // Assert
-        var expr = similar.Expression;
-        await Assert.That(expr.TopK).IsEqualTo(5);
-        await Assert.That(expr.MinRelevance).IsEqualTo(0.7);
-        await Assert.That(expr.Metric).IsEqualTo(DistanceMetric.Cosine);
-        await Assert.That(expr.EmbeddingPropertyName).IsNull();
-        await Assert.That(expr.QueryVector).IsNull();
-    }
-
-    [Test]
-    public async Task ObjectSet_SimilarTo_WithQueryVector()
-    {
-        // Arrange
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
-        var vector = new float[] { 0.1f, 0.2f, 0.3f };
-
-        // Act
-        var similar = set.SimilarTo("query", queryVector: vector);
-
-        // Assert
-        await Assert.That(similar.Expression.QueryVector).IsNotNull();
-        await Assert.That(similar.Expression.QueryVector!.Length).IsEqualTo(3);
     }
 
     [Test]
@@ -162,5 +127,33 @@ public class ObjectSetTests
         // Assert
         var expr = similar.Expression;
         await Assert.That(expr.Source).IsTypeOf<FilterExpression>();
+    }
+
+    [Test]
+    public async Task SimilarTo_WithOnlyQueryText_ReturnsSimilarObjectSetWithDefaults()
+    {
+        // Arrange
+        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
+
+        // Act
+        var similar = set.SimilarTo("query text");
+
+        // Assert
+        await Assert.That(similar.Expression.QueryText).IsEqualTo("query text");
+        await Assert.That(similar.Expression.TopK).IsEqualTo(5);
+        await Assert.That(similar.Expression.MinRelevance).IsEqualTo(0.7);
+        await Assert.That(similar.Expression.Metric).IsEqualTo(DistanceMetric.Cosine);
+        await Assert.That(similar.Expression.EmbeddingPropertyName).IsNull();
+        await Assert.That(similar.Expression.QueryVector).IsNull();
+    }
+
+    [Test]
+    public async Task SimilarTo_HasOnlyOneParameter()
+    {
+        var method = typeof(ObjectSet<string>).GetMethod("SimilarTo");
+        await Assert.That(method).IsNotNull();
+        var parameters = method!.GetParameters();
+        await Assert.That(parameters.Length).IsEqualTo(1);
+        await Assert.That(parameters[0].ParameterType).IsEqualTo(typeof(string));
     }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/SimilarObjectSetTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/SimilarObjectSetTests.cs
@@ -64,4 +64,85 @@ public class SimilarObjectSetTests
         await provider.Received(1).ExecuteSimilarityAsync<string>(
             similarity, cts.Token);
     }
+
+    [Test]
+    public async Task WithMinRelevance_ReturnsNewInstanceWithUpdatedMinRelevance()
+    {
+        // Arrange
+        var root = new RootExpression(typeof(string));
+        var original = new SimilarityExpression(root, "query", topK: 5, minRelevance: 0.7);
+        var provider = Substitute.For<IObjectSetProvider>();
+        var originalSet = new SimilarObjectSet<string>(original, provider);
+
+        // Act
+        var updated = originalSet.WithMinRelevance(0.9);
+
+        // Assert
+        await Assert.That(updated).IsNotSameReferenceAs(originalSet);
+        await Assert.That(updated.Expression.MinRelevance).IsEqualTo(0.9);
+        await Assert.That(originalSet.Expression.MinRelevance).IsEqualTo(0.7);
+    }
+
+    [Test]
+    public async Task Take_ReturnsNewInstanceWithUpdatedTopK()
+    {
+        // Arrange
+        var root = new RootExpression(typeof(string));
+        var original = new SimilarityExpression(root, "query", topK: 5, minRelevance: 0.7);
+        var provider = Substitute.For<IObjectSetProvider>();
+        var originalSet = new SimilarObjectSet<string>(original, provider);
+
+        // Act
+        var updated = originalSet.Take(20);
+
+        // Assert
+        await Assert.That(updated).IsNotSameReferenceAs(originalSet);
+        await Assert.That(updated.Expression.TopK).IsEqualTo(20);
+        await Assert.That(originalSet.Expression.TopK).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task WithMetric_ReturnsNewInstanceWithUpdatedMetric()
+    {
+        // Arrange
+        var root = new RootExpression(typeof(string));
+        var original = new SimilarityExpression(
+            root, "query", topK: 5, minRelevance: 0.7, metric: DistanceMetric.Cosine);
+        var provider = Substitute.For<IObjectSetProvider>();
+        var originalSet = new SimilarObjectSet<string>(original, provider);
+
+        // Act
+        var updated = originalSet.WithMetric(DistanceMetric.L2);
+
+        // Assert
+        await Assert.That(updated).IsNotSameReferenceAs(originalSet);
+        await Assert.That(updated.Expression.Metric).IsEqualTo(DistanceMetric.L2);
+        await Assert.That(originalSet.Expression.Metric).IsEqualTo(DistanceMetric.Cosine);
+    }
+
+    [Test]
+    public async Task FluentChain_PreservesQueryTextAndIsImmutable()
+    {
+        // Arrange
+        var root = new RootExpression(typeof(string));
+        var original = new SimilarityExpression(root, "find docs", topK: 5, minRelevance: 0.7);
+        var provider = Substitute.For<IObjectSetProvider>();
+        var originalSet = new SimilarObjectSet<string>(original, provider);
+
+        // Act
+        var final = originalSet
+            .WithMinRelevance(0.8)
+            .Take(15)
+            .WithMetric(DistanceMetric.Cosine);
+
+        // Assert — final has updated values
+        await Assert.That(final.Expression.QueryText).IsEqualTo("find docs");
+        await Assert.That(final.Expression.MinRelevance).IsEqualTo(0.8);
+        await Assert.That(final.Expression.TopK).IsEqualTo(15);
+        await Assert.That(final.Expression.Metric).IsEqualTo(DistanceMetric.Cosine);
+
+        // Assert — original is unchanged
+        await Assert.That(originalSet.Expression.MinRelevance).IsEqualTo(0.7);
+        await Assert.That(originalSet.Expression.TopK).IsEqualTo(5);
+    }
 }

--- a/src/Strategos.Ontology.Tests/Query/OntologyQueryFluentSimilarityTests.cs
+++ b/src/Strategos.Ontology.Tests/Query/OntologyQueryFluentSimilarityTests.cs
@@ -1,0 +1,87 @@
+using Strategos.Ontology.Actions;
+using Strategos.Ontology.Builder;
+using Strategos.Ontology.Embeddings;
+using Strategos.Ontology.Events;
+using Strategos.Ontology.ObjectSets;
+using Strategos.Ontology.Query;
+
+namespace Strategos.Ontology.Tests.Query;
+
+/// <summary>
+/// End-to-end coverage for the fluent similarity chain — from
+/// <see cref="IOntologyQuery.GetObjectSet{T}"/> through
+/// <see cref="ObjectSet{T}.SimilarTo"/> and the
+/// <see cref="SimilarObjectSet{T}"/> immutable setters to materialization
+/// against an <see cref="InMemoryObjectSetProvider"/>.
+/// </summary>
+public class OntologyQueryFluentSimilarityTests
+{
+    public sealed record TestDoc : ISearchable
+    {
+        public string Id { get; init; } = string.Empty;
+        public string Content { get; init; } = string.Empty;
+        public float[] Embedding { get; init; } = [];
+    }
+
+    public sealed class TestDocOntology : DomainOntology
+    {
+        public override string DomainName => "test-docs";
+
+        protected override void Define(IOntologyBuilder builder)
+        {
+            builder.Object<TestDoc>(obj =>
+            {
+                obj.Key(d => d.Id);
+                obj.Property(d => d.Content);
+            });
+        }
+    }
+
+    [Test]
+    public async Task OntologyQuery_ExecutesFluentSimilarityChainViaInMemoryProvider()
+    {
+        // Arrange — fake embedding provider returning a deterministic query vector
+        var embedder = Substitute.For<IEmbeddingProvider>();
+        embedder.Dimensions.Returns(3);
+        embedder.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new float[] { 1f, 0f, 0f }));
+
+        var provider = new InMemoryObjectSetProvider(embedder);
+
+        // Seed 5 docs with distinct embeddings — closest to query [1,0,0] is doc-1.
+        provider.Seed(new TestDoc { Id = "doc-1", Content = "exact match", Embedding = [1f, 0f, 0f] }, "exact match");
+        provider.Seed(new TestDoc { Id = "doc-2", Content = "near match", Embedding = [0.9f, 0.1f, 0f] }, "near match");
+        provider.Seed(new TestDoc { Id = "doc-3", Content = "distant", Embedding = [0f, 1f, 0f] }, "distant");
+        provider.Seed(new TestDoc { Id = "doc-4", Content = "very distant", Embedding = [0f, 0f, 1f] }, "very distant");
+        provider.Seed(new TestDoc { Id = "doc-5", Content = "negated", Embedding = [-1f, 0f, 0f] }, "negated");
+
+        // Build a minimal ontology so OntologyQueryService can resolve TestDoc by name.
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain(new TestDocOntology());
+        var ontology = graphBuilder.Build();
+
+        var dispatcher = Substitute.For<IActionDispatcher>();
+        var eventStream = Substitute.For<IEventStreamProvider>();
+        var query = new OntologyQueryService(ontology, provider, dispatcher, eventStream);
+
+        // Act — execute the full fluent chain end-to-end
+        var hits = await query
+            .GetObjectSet<TestDoc>("TestDoc")
+            .SimilarTo("test query")
+            .WithMinRelevance(0.5)
+            .Take(3)
+            .ExecuteAsync(CancellationToken.None);
+
+        // Assert — wiring is correct: top-K honored, min-relevance honored, scores descending.
+        await Assert.That(hits.Items.Count).IsLessThanOrEqualTo(3);
+        await Assert.That(hits.Scores.All(s => s >= 0.5)).IsTrue();
+        for (var i = 1; i < hits.Scores.Count; i++)
+        {
+            await Assert.That(hits.Scores[i]).IsLessThanOrEqualTo(hits.Scores[i - 1]);
+        }
+
+        // The closest match (doc-1, exact embedding) must be the top hit.
+        await Assert.That(hits.Items.Count).IsGreaterThan(0);
+        await Assert.That(hits.Items[0].Id).IsEqualTo("doc-1");
+    }
+}

--- a/src/Strategos.Ontology.Tests/Query/OntologyQueryTests.cs
+++ b/src/Strategos.Ontology.Tests/Query/OntologyQueryTests.cs
@@ -858,3 +858,59 @@ public class OntologyQueryServiceDiTests
         await Assert.That(types.Count).IsEqualTo(3);
     }
 }
+
+public class OntologyQueryServiceGetObjectSetTests
+{
+    [Test]
+    public async Task IOntologyQuery_HasGetObjectSetMethod()
+    {
+        // Arrange
+        var mock = Substitute.For<IOntologyQuery>();
+        var provider = Substitute.For<Strategos.Ontology.ObjectSets.IObjectSetProvider>();
+        var dispatcher = Substitute.For<Strategos.Ontology.Actions.IActionDispatcher>();
+        var eventStream = Substitute.For<Strategos.Ontology.Events.IEventStreamProvider>();
+        mock.GetObjectSet<QueryPosition>("QueryPosition")
+            .Returns(new Strategos.Ontology.ObjectSets.ObjectSet<QueryPosition>(provider, dispatcher, eventStream));
+
+        // Act
+        var result = mock.GetObjectSet<QueryPosition>("QueryPosition");
+
+        // Assert
+        await Assert.That(result).IsNotNull();
+    }
+
+    [Test]
+    public async Task OntologyQueryService_GetObjectSet_ReturnsObjectSetForRegisteredType()
+    {
+        // Arrange
+        var graph = QueryTestGraphFactory.Build();
+        var provider = Substitute.For<Strategos.Ontology.ObjectSets.IObjectSetProvider>();
+        var dispatcher = Substitute.For<Strategos.Ontology.Actions.IActionDispatcher>();
+        var eventStream = Substitute.For<Strategos.Ontology.Events.IEventStreamProvider>();
+        var query = new OntologyQueryService(graph, provider, dispatcher, eventStream);
+
+        // Act
+        var set = query.GetObjectSet<QueryPosition>("QueryPosition");
+
+        // Assert
+        await Assert.That(set).IsNotNull();
+        await Assert.That(set.Expression).IsTypeOf<Strategos.Ontology.ObjectSets.RootExpression>();
+        await Assert.That(set.Expression.ObjectType).IsEqualTo(typeof(QueryPosition));
+    }
+
+    [Test]
+    public async Task OntologyQueryService_GetObjectSet_ForUnregisteredType_ThrowsKeyNotFoundException()
+    {
+        // Arrange
+        var graph = QueryTestGraphFactory.Build();
+        var provider = Substitute.For<Strategos.Ontology.ObjectSets.IObjectSetProvider>();
+        var dispatcher = Substitute.For<Strategos.Ontology.Actions.IActionDispatcher>();
+        var eventStream = Substitute.For<Strategos.Ontology.Events.IEventStreamProvider>();
+        var query = new OntologyQueryService(graph, provider, dispatcher, eventStream);
+
+        // Act + Assert
+        await Assert.That(() => query.GetObjectSet<QueryPosition>("BogusType"))
+            .Throws<KeyNotFoundException>()
+            .WithMessageContaining("BogusType");
+    }
+}

--- a/src/Strategos.Ontology.Tests/Query/OntologyQueryTests.cs
+++ b/src/Strategos.Ontology.Tests/Query/OntologyQueryTests.cs
@@ -819,6 +819,86 @@ public class OntologyQueryServiceExtensionPointTests
     }
 }
 
+// --- Track A (2.4.0) ValidFromState end-to-end tests ---
+
+public enum TrackAQueryState
+{
+    Open,
+    Closed,
+}
+
+public sealed class TrackAQueryItem
+{
+    public Guid Id { get; set; }
+    public TrackAQueryState Status { get; set; }
+}
+
+public sealed class TrackAQueryDomainOntology : DomainOntology
+{
+    public override string DomainName => "track-a";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TrackAQueryItem>(obj =>
+        {
+            obj.Key(i => i.Id);
+            obj.Property(i => i.Status);
+
+            obj.Lifecycle<TrackAQueryState>(i => i.Status, lc =>
+            {
+                lc.InitialState(TrackAQueryState.Open);
+                lc.TerminalState(TrackAQueryState.Closed);
+                lc.Transition(TrackAQueryState.Open, TrackAQueryState.Closed, trigger: "CloseItem");
+            });
+
+            obj.Action("ViewItem").ValidFromState(TrackAQueryState.Open);
+            obj.Action("CloseItem");
+            obj.Action("Inspect");
+        });
+    }
+}
+
+public class OntologyQueryServiceValidFromStateTests
+{
+    private static IOntologyQuery CreateQueryService()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain(new TrackAQueryDomainOntology());
+        return new OntologyQueryService(graphBuilder.Build());
+    }
+
+    [Test]
+    public async Task GetActionsForState_ReturnsActionDeclaredViaValidFromState()
+    {
+        var query = CreateQueryService();
+
+        var openActions = query.GetActionsForState("TrackAQueryItem", "Open");
+        var closedActions = query.GetActionsForState("TrackAQueryItem", "Closed");
+
+        // ViewItem must be returned for the declared state...
+        await Assert.That(openActions.Select(a => a.Name)).Contains("ViewItem");
+
+        // ...and must NOT be returned for any other state. This is the discriminating
+        // assertion: without the A5 projection, ViewItem would be unconstrained
+        // (appears in no transition) and would leak into every state.
+        await Assert.That(closedActions.Select(a => a.Name)).DoesNotContain("ViewItem");
+    }
+
+    [Test]
+    public async Task GetActionsForState_UnconstrainedAction_RemainsUnconstrained()
+    {
+        var query = CreateQueryService();
+
+        // "Inspect" has no ValidFromState calls and is not referenced by any transition.
+        // It should appear in every lifecycle state.
+        var openActions = query.GetActionsForState("TrackAQueryItem", "Open");
+        var closedActions = query.GetActionsForState("TrackAQueryItem", "Closed");
+
+        await Assert.That(openActions.Select(a => a.Name)).Contains("Inspect");
+        await Assert.That(closedActions.Select(a => a.Name)).Contains("Inspect");
+    }
+}
+
 public class OntologyQueryServiceDiTests
 {
     [Test]

--- a/src/Strategos.Ontology.Tests/Query/OntologyQueryTests.cs
+++ b/src/Strategos.Ontology.Tests/Query/OntologyQueryTests.cs
@@ -993,4 +993,21 @@ public class OntologyQueryServiceGetObjectSetTests
             .Throws<KeyNotFoundException>()
             .WithMessageContaining("BogusType");
     }
+
+    [Test]
+    public async Task OntologyQueryService_GetObjectSet_WithReadOnlyCtor_ThrowsInvalidOperationException()
+    {
+        // Arrange — construct via the read-only single-arg ctor (no provider/dispatcher/eventStream).
+        // This path is reachable in production via the DI factory in OntologyServiceCollectionExtensions
+        // when only the OntologyGraph is registered.
+        var graph = QueryTestGraphFactory.Build();
+        var query = new OntologyQueryService(graph);
+
+        // Act + Assert — query a REGISTERED type so KeyNotFoundException does not fire first.
+        // The defensive throw should produce an InvalidOperationException naming the missing
+        // dependency (IObjectSetProvider) so the user knows what to register.
+        await Assert.That(() => query.GetObjectSet<QueryPosition>("QueryPosition"))
+            .Throws<InvalidOperationException>()
+            .WithMessageContaining(nameof(Strategos.Ontology.ObjectSets.IObjectSetProvider));
+    }
 }

--- a/src/Strategos.Ontology/Builder/ActionBuilderOfT.cs
+++ b/src/Strategos.Ontology/Builder/ActionBuilderOfT.cs
@@ -15,6 +15,11 @@ internal sealed class ActionBuilder<T>(string name) : IActionBuilder<T>
     private string? _boundToolMethod;
     private readonly List<ActionPrecondition> _preconditions = [];
     private readonly List<ActionPostcondition> _postconditions = [];
+    private readonly List<string> _validFromStates = [];
+
+    internal string Name => name;
+
+    internal IReadOnlyList<string> ValidFromStates => _validFromStates;
 
     IActionBuilder IActionBuilder.Description(string description) => Description(description);
     IActionBuilder IActionBuilder.Accepts<TAccepts>() => Accepts<TAccepts>();
@@ -145,6 +150,12 @@ internal sealed class ActionBuilder<T>(string name) : IActionBuilder<T>
             Kind = PostconditionKind.EmitsEvent,
             EventTypeName = typeof(TEvent).Name,
         });
+        return this;
+    }
+
+    public IActionBuilder<T> ValidFromState<TEnum>(TEnum state) where TEnum : struct, Enum
+    {
+        _validFromStates.Add(state.ToString());
         return this;
     }
 

--- a/src/Strategos.Ontology/Builder/IActionBuilderOfT.cs
+++ b/src/Strategos.Ontology/Builder/IActionBuilderOfT.cs
@@ -30,4 +30,6 @@ public interface IActionBuilder<T> : IActionBuilder
     IActionBuilder<T> CreatesLinked<TTarget>(string linkName);
 
     IActionBuilder<T> EmitsEvent<TEvent>();
+
+    IActionBuilder<T> ValidFromState<TEnum>(TEnum state) where TEnum : struct, Enum;
 }

--- a/src/Strategos.Ontology/Builder/ILifecycleBuilder.cs
+++ b/src/Strategos.Ontology/Builder/ILifecycleBuilder.cs
@@ -5,5 +5,11 @@ public interface ILifecycleBuilder<TEnum>
 {
     ILifecycleStateBuilder State(TEnum state);
 
+    ILifecycleStateBuilder InitialState(TEnum state);
+
+    ILifecycleStateBuilder TerminalState(TEnum state);
+
     ILifecycleTransitionBuilder Transition(TEnum from, TEnum to);
+
+    ILifecycleTransitionBuilder Transition(TEnum from, TEnum to, string trigger);
 }

--- a/src/Strategos.Ontology/Builder/LifecycleBuilder.cs
+++ b/src/Strategos.Ontology/Builder/LifecycleBuilder.cs
@@ -15,12 +15,19 @@ internal sealed class LifecycleBuilder<TEnum> : ILifecycleBuilder<TEnum>
         return builder;
     }
 
+    public ILifecycleStateBuilder InitialState(TEnum state) => State(state).Initial();
+
+    public ILifecycleStateBuilder TerminalState(TEnum state) => State(state).Terminal();
+
     public ILifecycleTransitionBuilder Transition(TEnum from, TEnum to)
     {
         var builder = new LifecycleTransitionBuilder(from.ToString(), to.ToString());
         _transitionBuilders.Add(builder);
         return builder;
     }
+
+    public ILifecycleTransitionBuilder Transition(TEnum from, TEnum to, string trigger) =>
+        Transition(from, to).TriggeredByAction(trigger);
 
     public LifecycleDescriptor Build() =>
         new()

--- a/src/Strategos.Ontology/Builder/ObjectTypeBuilder.cs
+++ b/src/Strategos.Ontology/Builder/ObjectTypeBuilder.cs
@@ -131,6 +131,44 @@ internal sealed class ObjectTypeBuilder<T>(string domainName) : IObjectTypeBuild
         var actions = _actionBuilders.ConvertAll(b => b.Build());
         actions.AddRange(_defaultActionDescriptors);
 
+        // Project ValidFromState declarations into self-loop transitions (Track A — 2.4.0).
+        // Each (action, state) pair recorded via ActionBuilder<T>.ValidFromState becomes a
+        // self-loop LifecycleTransitionDescriptor { FromState = state, ToState = state, TriggerActionName = action.Name }.
+        // The OntologyQueryService.GetActionsForState read path then naturally returns those
+        // actions for the declared state(s) — no read-side changes are required.
+        //
+        // Validation note: AONT017 (LifecycleTransitionBadState) is a Roslyn analyzer that
+        // walks source-level transitions only and cannot see ValidFromState desugaring.
+        // We therefore add a runtime guard here so users get a clear error pointing back
+        // to ValidFromState rather than a downstream OntologyGraphBuilder failure.
+        if (_lifecycle is not null && _actionBuilders.Any(ab => ab.ValidFromStates.Count > 0))
+        {
+            var declaredStateNames = _lifecycle.States.Select(s => s.Name).ToHashSet();
+            var augmentedTransitions = new List<LifecycleTransitionDescriptor>(_lifecycle.Transitions);
+            foreach (var actionBuilder in _actionBuilders)
+            {
+                foreach (var stateName in actionBuilder.ValidFromStates)
+                {
+                    if (!declaredStateNames.Contains(stateName))
+                    {
+                        throw new InvalidOperationException(
+                            $"Action '{actionBuilder.Name}' on '{typeof(T).Name}' declares ValidFromState '{stateName}', " +
+                            $"but that state is not declared in the lifecycle. " +
+                            $"Declared states: {string.Join(", ", declaredStateNames)}.");
+                    }
+
+                    augmentedTransitions.Add(new LifecycleTransitionDescriptor
+                    {
+                        FromState = stateName,
+                        ToState = stateName,
+                        TriggerActionName = actionBuilder.Name,
+                    });
+                }
+            }
+
+            _lifecycle = _lifecycle with { Transitions = augmentedTransitions.AsReadOnly() };
+        }
+
         return new(typeof(T).Name, typeof(T), domainName)
         {
             Kind = _objectKind,

--- a/src/Strategos.Ontology/Builder/ObjectTypeBuilder.cs
+++ b/src/Strategos.Ontology/Builder/ObjectTypeBuilder.cs
@@ -131,43 +131,7 @@ internal sealed class ObjectTypeBuilder<T>(string domainName) : IObjectTypeBuild
         var actions = _actionBuilders.ConvertAll(b => b.Build());
         actions.AddRange(_defaultActionDescriptors);
 
-        // Project ValidFromState declarations into self-loop transitions (Track A — 2.4.0).
-        // Each (action, state) pair recorded via ActionBuilder<T>.ValidFromState becomes a
-        // self-loop LifecycleTransitionDescriptor { FromState = state, ToState = state, TriggerActionName = action.Name }.
-        // The OntologyQueryService.GetActionsForState read path then naturally returns those
-        // actions for the declared state(s) — no read-side changes are required.
-        //
-        // Validation note: AONT017 (LifecycleTransitionBadState) is a Roslyn analyzer that
-        // walks source-level transitions only and cannot see ValidFromState desugaring.
-        // We therefore add a runtime guard here so users get a clear error pointing back
-        // to ValidFromState rather than a downstream OntologyGraphBuilder failure.
-        if (_lifecycle is not null && _actionBuilders.Any(ab => ab.ValidFromStates.Count > 0))
-        {
-            var declaredStateNames = _lifecycle.States.Select(s => s.Name).ToHashSet();
-            var augmentedTransitions = new List<LifecycleTransitionDescriptor>(_lifecycle.Transitions);
-            foreach (var actionBuilder in _actionBuilders)
-            {
-                foreach (var stateName in actionBuilder.ValidFromStates)
-                {
-                    if (!declaredStateNames.Contains(stateName))
-                    {
-                        throw new InvalidOperationException(
-                            $"Action '{actionBuilder.Name}' on '{typeof(T).Name}' declares ValidFromState '{stateName}', " +
-                            $"but that state is not declared in the lifecycle. " +
-                            $"Declared states: {string.Join(", ", declaredStateNames)}.");
-                    }
-
-                    augmentedTransitions.Add(new LifecycleTransitionDescriptor
-                    {
-                        FromState = stateName,
-                        ToState = stateName,
-                        TriggerActionName = actionBuilder.Name,
-                    });
-                }
-            }
-
-            _lifecycle = _lifecycle with { Transitions = augmentedTransitions.AsReadOnly() };
-        }
+        ProjectValidFromStatesIntoLifecycle();
 
         return new(typeof(T).Name, typeof(T), domainName)
         {
@@ -185,5 +149,52 @@ internal sealed class ObjectTypeBuilder<T>(string domainName) : IObjectTypeBuild
             ParentTypeName = _parentType?.Name,
             ExternalLinkExtensionPoints = _extensionPointBuilders.ConvertAll(b => b.Build()).AsReadOnly(),
         };
+    }
+
+    /// <summary>
+    /// Projects every <see cref="ActionBuilder{T}.ValidFromStates"/> declaration into a
+    /// self-loop <see cref="LifecycleTransitionDescriptor"/> on the current lifecycle.
+    /// Each (action, state) pair becomes
+    /// <c>{ FromState = state, ToState = state, TriggerActionName = action.Name }</c>,
+    /// which is what <see cref="Strategos.Ontology.Query.OntologyQueryService.GetActionsForState"/>
+    /// reads — no read-side changes are required (Track A — 2.4.0).
+    /// </summary>
+    /// <remarks>
+    /// AONT017 (LifecycleTransitionBadState) is a Roslyn analyzer that walks source-level
+    /// transitions only and cannot see ValidFromState desugaring. A runtime guard is therefore
+    /// added here so users get a clear error pointing back to ValidFromState rather than a
+    /// downstream OntologyGraphBuilder failure.
+    /// </remarks>
+    private void ProjectValidFromStatesIntoLifecycle()
+    {
+        if (_lifecycle is null || !_actionBuilders.Any(ab => ab.ValidFromStates.Count > 0))
+        {
+            return;
+        }
+
+        var declaredStateNames = _lifecycle.States.Select(s => s.Name).ToHashSet();
+        var augmentedTransitions = new List<LifecycleTransitionDescriptor>(_lifecycle.Transitions);
+        foreach (var actionBuilder in _actionBuilders)
+        {
+            foreach (var stateName in actionBuilder.ValidFromStates)
+            {
+                if (!declaredStateNames.Contains(stateName))
+                {
+                    throw new InvalidOperationException(
+                        $"Action '{actionBuilder.Name}' on '{typeof(T).Name}' declares ValidFromState '{stateName}', " +
+                        $"but that state is not declared in the lifecycle. " +
+                        $"Declared states: {string.Join(", ", declaredStateNames)}.");
+                }
+
+                augmentedTransitions.Add(new LifecycleTransitionDescriptor
+                {
+                    FromState = stateName,
+                    ToState = stateName,
+                    TriggerActionName = actionBuilder.Name,
+                });
+            }
+        }
+
+        _lifecycle = _lifecycle with { Transitions = augmentedTransitions.AsReadOnly() };
     }
 }

--- a/src/Strategos.Ontology/Configuration/OntologyServiceCollectionExtensions.cs
+++ b/src/Strategos.Ontology/Configuration/OntologyServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
+using Strategos.Ontology.Actions;
+using Strategos.Ontology.Events;
 using Strategos.Ontology.ObjectSets;
 using Strategos.Ontology.Query;
 
@@ -33,7 +35,25 @@ public static class OntologyServiceCollectionExtensions
 
         var graph = graphBuilder.Build();
         services.AddSingleton(graph);
-        services.AddSingleton<IOntologyQuery>(new OntologyQueryService(graph));
+
+        // Register IOntologyQuery as a factory so that IObjectSetProvider/IActionDispatcher/
+        // IEventStreamProvider — registered later via OntologyOptions service registrations —
+        // can be resolved at activation time. When backing services are not registered,
+        // falls back to the read-only constructor; GetObjectSet<T> will then throw with a
+        // clear diagnostic if invoked without those dependencies.
+        services.AddSingleton<IOntologyQuery>(sp =>
+        {
+            var graphInstance = sp.GetRequiredService<OntologyGraph>();
+            var objectSetProvider = sp.GetService<IObjectSetProvider>();
+            var actionDispatcher = sp.GetService<IActionDispatcher>();
+            var eventStreamProvider = sp.GetService<IEventStreamProvider>();
+
+            return objectSetProvider is not null
+                && actionDispatcher is not null
+                && eventStreamProvider is not null
+                    ? new OntologyQueryService(graphInstance, objectSetProvider, actionDispatcher, eventStreamProvider)
+                    : new OntologyQueryService(graphInstance);
+        });
 
         foreach (var registration in options.ServiceRegistrations)
         {

--- a/src/Strategos.Ontology/ObjectSets/ObjectSet.cs
+++ b/src/Strategos.Ontology/ObjectSets/ObjectSet.cs
@@ -74,24 +74,15 @@ public sealed class ObjectSet<T> where T : class
     }
 
     /// <summary>
-    /// Returns a similarity search over this object set.
+    /// Returns a similarity search over this object set. Configure additional knobs
+    /// (TopK, MinRelevance, DistanceMetric) via the fluent setters on
+    /// <see cref="SimilarObjectSet{T}"/>.
     /// </summary>
-    public SimilarObjectSet<T> SimilarTo(
-        string queryText,
-        int topK = 5,
-        double minRelevance = 0.7,
-        DistanceMetric metric = DistanceMetric.Cosine,
-        string? embeddingPropertyName = null,
-        float[]? queryVector = null)
+    public SimilarObjectSet<T> SimilarTo(string queryText)
     {
         ArgumentNullException.ThrowIfNull(queryText);
-
-        // Defensive copy of mutable float[] to preserve immutability
-        var vectorCopy = queryVector is not null ? (float[])queryVector.Clone() : null;
-
         var expression = new SimilarityExpression(
-            Expression, queryText, topK, minRelevance, metric,
-            embeddingPropertyName, vectorCopy);
+            Expression, queryText, topK: 5, minRelevance: 0.7);
         return new SimilarObjectSet<T>(expression, _provider);
     }
 

--- a/src/Strategos.Ontology/ObjectSets/ObjectSetExpression.cs
+++ b/src/Strategos.Ontology/ObjectSets/ObjectSetExpression.cs
@@ -140,6 +140,28 @@ public sealed class SimilarityExpression : ObjectSetExpression
         Filters = filters;
     }
 
+    /// <summary>
+    /// Internal copy constructor for fluent builder mutations.
+    /// Chains to the primary constructor so validation always re-runs.
+    /// Used by <see cref="SimilarObjectSet{T}"/> fluent setters; not exposed publicly.
+    /// </summary>
+    internal SimilarityExpression(
+        SimilarityExpression source,
+        int? topK = null,
+        double? minRelevance = null,
+        DistanceMetric? metric = null)
+        : this(
+            source.Source,
+            source.QueryText,
+            topK ?? source.TopK,
+            minRelevance ?? source.MinRelevance,
+            metric ?? source.Metric,
+            source.EmbeddingPropertyName,
+            source.QueryVector,
+            source.Filters)
+    {
+    }
+
     public ObjectSetExpression Source { get; }
     public string QueryText { get; }
     public int TopK { get; }

--- a/src/Strategos.Ontology/ObjectSets/SimilarObjectSet.cs
+++ b/src/Strategos.Ontology/ObjectSets/SimilarObjectSet.cs
@@ -34,4 +34,25 @@ public sealed class SimilarObjectSet<T> where T : class
     {
         return _provider.ExecuteSimilarityAsync<T>(Expression, ct);
     }
+
+    /// <summary>
+    /// Returns a new <see cref="SimilarObjectSet{T}"/> with the minimum relevance score updated.
+    /// The original instance is unchanged.
+    /// </summary>
+    public SimilarObjectSet<T> WithMinRelevance(double minRelevance)
+        => new(new SimilarityExpression(Expression, minRelevance: minRelevance), _provider);
+
+    /// <summary>
+    /// Returns a new <see cref="SimilarObjectSet{T}"/> that limits results to the top <paramref name="topK"/> matches.
+    /// The original instance is unchanged.
+    /// </summary>
+    public SimilarObjectSet<T> Take(int topK)
+        => new(new SimilarityExpression(Expression, topK: topK), _provider);
+
+    /// <summary>
+    /// Returns a new <see cref="SimilarObjectSet{T}"/> using the specified distance metric.
+    /// The original instance is unchanged.
+    /// </summary>
+    public SimilarObjectSet<T> WithMetric(DistanceMetric metric)
+        => new(new SimilarityExpression(Expression, metric: metric), _provider);
 }

--- a/src/Strategos.Ontology/Query/IOntologyQuery.cs
+++ b/src/Strategos.Ontology/Query/IOntologyQuery.cs
@@ -1,4 +1,5 @@
 using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.ObjectSets;
 
 namespace Strategos.Ontology.Query;
 
@@ -58,4 +59,7 @@ public interface IOntologyQuery
 
     IReadOnlyList<ResolvedCrossDomainLink> GetIncomingCrossDomainLinks(
         string objectType);
+
+    // Object set queries
+    ObjectSet<T> GetObjectSet<T>(string objectType) where T : class;
 }

--- a/src/Strategos.Ontology/Query/OntologyQueryService.cs
+++ b/src/Strategos.Ontology/Query/OntologyQueryService.cs
@@ -1,10 +1,72 @@
 using System.Text.RegularExpressions;
+using Strategos.Ontology.Actions;
 using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Events;
+using Strategos.Ontology.ObjectSets;
 
 namespace Strategos.Ontology.Query;
 
-internal sealed class OntologyQueryService(OntologyGraph graph) : IOntologyQuery
+internal sealed class OntologyQueryService : IOntologyQuery
 {
+    private readonly OntologyGraph graph;
+    private readonly IObjectSetProvider? _objectSetProvider;
+    private readonly IActionDispatcher? _actionDispatcher;
+    private readonly IEventStreamProvider? _eventStreamProvider;
+
+    /// <summary>
+    /// Creates an <see cref="OntologyQueryService"/> for read-only graph queries.
+    /// <see cref="GetObjectSet{T}"/> will throw <see cref="InvalidOperationException"/>
+    /// because no provider/dispatcher/event stream were supplied.
+    /// </summary>
+    public OntologyQueryService(OntologyGraph graph)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+        this.graph = graph;
+    }
+
+    /// <summary>
+    /// Creates an <see cref="OntologyQueryService"/> with full object-set materialization
+    /// support. <see cref="GetObjectSet{T}"/> requires the provider/dispatcher/event stream
+    /// dependencies, which are forwarded into <see cref="ObjectSet{T}"/>.
+    /// </summary>
+    public OntologyQueryService(
+        OntologyGraph graph,
+        IObjectSetProvider objectSetProvider,
+        IActionDispatcher actionDispatcher,
+        IEventStreamProvider eventStreamProvider)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+        ArgumentNullException.ThrowIfNull(objectSetProvider);
+        ArgumentNullException.ThrowIfNull(actionDispatcher);
+        ArgumentNullException.ThrowIfNull(eventStreamProvider);
+
+        this.graph = graph;
+        _objectSetProvider = objectSetProvider;
+        _actionDispatcher = actionDispatcher;
+        _eventStreamProvider = eventStreamProvider;
+    }
+
+    public ObjectSet<T> GetObjectSet<T>(string objectType) where T : class
+    {
+        ArgumentNullException.ThrowIfNull(objectType);
+        var ot = FindObjectType(objectType);
+        if (ot is null)
+        {
+            throw new KeyNotFoundException(
+                $"Object type '{objectType}' is not registered in the ontology.");
+        }
+
+        if (_objectSetProvider is null || _actionDispatcher is null || _eventStreamProvider is null)
+        {
+            throw new InvalidOperationException(
+                $"GetObjectSet<{typeof(T).Name}> requires {nameof(IObjectSetProvider)}, " +
+                $"{nameof(IActionDispatcher)}, and {nameof(IEventStreamProvider)} to be supplied " +
+                "when constructing the OntologyQueryService.");
+        }
+
+        return new ObjectSet<T>(_objectSetProvider, _actionDispatcher, _eventStreamProvider);
+    }
+
     public IReadOnlyList<ObjectTypeDescriptor> GetObjectTypes(
         string? domain = null,
         string? implementsInterface = null,


### PR DESCRIPTION
## Summary

Ships Strategos.Ontology 2.4.0 — two ergonomic refinements that unblock Basileus integration without touching the descriptor schema or read-side query paths. Both tracks add builder-layer sugar over existing capabilities (no behavioral changes to the runtime), so the descriptor model and `OntologyQueryService.GetActionsForState` remain spec-faithful per platform-architecture §4.14.6.

## Changes

- **Lifecycle DSL sugar (Issue #29)** — `ILifecycleBuilder.InitialState`/`TerminalState`/`Transition(from,to,trigger)` shorthand methods, plus `IActionBuilder<T>.ValidFromState<TEnum>(state)` that records states on the builder and projects them into self-loop `LifecycleTransitionDescriptor`s at `ObjectTypeBuilder.Build()` time. Includes a runtime guard for undeclared states (AONT017's source-only analyzer can't see synthesized transitions).
- **Fluent similarity search (Issue #28)** — `SimilarObjectSet<T>.WithMinRelevance`/`Take`/`WithMetric` immutable setters, simplified `ObjectSet<T>.SimilarTo(string queryText)`, and a new `IOntologyQuery.GetObjectSet<T>(string)` typed entry point. `SimilarityExpression` gains an `internal` copy constructor that chains the primary ctor so validation invariants cannot be bypassed.
- **Backward-compatible service constructor** — `OntologyQueryService` keeps its original single-arg ctor as a read-only overload alongside the new 4-arg form; the DI factory in `OntologyServiceCollectionExtensions` selects the right one based on what's registered.

## Test Plan

19 TDD tasks (A1–A9, B1–B9, C1) implemented across 2 parallel worktrees and merged onto an integration branch. 21 new tests cover every new public surface, the projection block, the runtime guard, fluent chain immutability, and the new `IOntologyQuery.GetObjectSet<T>` throw branches (both `KeyNotFoundException` for unregistered types and `InvalidOperationException` for the read-only ctor path). Ground-truth: 493/493 in `Strategos.Ontology.Tests`, 68/68 in `Strategos.Ontology.Npgsql.Tests`, full solution build clean.

---

**Results:** Tests 561 ✓ · Build 0 errors · 0 warnings
**Design:** [2026-04-06-ontology-2-4-0.md](docs/designs/2026-04-06-ontology-2-4-0.md)
**Plan:** [2026-04-06-ontology-2-4-0.md](docs/plans/2026-04-06-ontology-2-4-0.md)
**Closes:** #28, #29