### PR TITLE
feat(ontology): 2.4.1 — descriptor-name dispatch fix (closes #31)

### DIFF
--- a/docs/designs/2026-04-08-ontology-descriptor-name-dispatch.md
+++ b/docs/designs/2026-04-08-ontology-descriptor-name-dispatch.md
@@ -1,0 +1,364 @@
+# Strategos 2.4.1 — Ontology Descriptor-Name Dispatch
+
+**Date:** 2026-04-08
+**Issues:** #31 (descriptor name discarded in `GetObjectSet<T>`), #32 (future Option Y follow-up)
+**Closes:** #28 and #29 (delivered in 2.4.0 via #30 — housekeeping)
+**Target package version:** LevelUp.Strategos.Ontology 2.4.1, LevelUp.Strategos.Ontology.Npgsql 2.4.1
+**Downstream consumer:** Basileus `OntologyContextAssembler` (per-collection `SemanticDocument` isolation)
+**Status:** Proposed (Approach 1 + Option X — name threads through expression tree, multi-registration is leaf-only)
+
+---
+
+## 1. Problem Statement
+
+Strategos 2.4.0 shipped `IOntologyQuery.GetObjectSet<T>(string objectType)` as the typed entry point to the fluent similarity chain. The canonical Basileus call site in the 2.4.0 design (`docs/designs/2026-04-06-ontology-2-4-0.md` §3.2) iterates over a list of `RagCollection` entries with distinct `ObjectType` strings, expecting each to dispatch to its own physical pgvector table:
+
+```csharp
+foreach (var collection in profile.RagCollections)
+{
+    var hits = await _ontologyQuery
+        .GetObjectSet<SemanticDocument>(collection.ObjectType)  // "trading_documents" | "knowledge_documents"
+        .SimilarTo(query)
+        .ExecuteAsync(cancellationToken);
+    // ...
+}
+```
+
+**The implementation silently discards the descriptor name.** `OntologyQueryService.GetObjectSet<T>` uses the `objectType` parameter to throw `KeyNotFoundException` on unknown names, then constructs `new ObjectSet<T>(...)` without threading the name into the expression tree (`OntologyQueryService.cs:49-68`). `ObjectSet<T>`'s root is `new RootExpression(typeof(T))` — the descriptor name never reaches the provider. `PgVectorObjectSetProvider` dispatches purely by `TypeMapper.GetTableName<T>()`, which is `ToSnakeCase(typeof(T).Name)`. Two calls with different `objectType` strings but the same `T` execute against the same physical table.
+
+**Downstream consequence.** Basileus cannot physically isolate per-collection semantic documents as the 2.4.0 design intended. It currently works around this by registering `SemanticDocument` exactly once via a domain-agnostic `BasileusDataFabricOntology`, accepting that all collections share one table and using `SourceDomain` as the only discriminator. This defeats the per-collection storage isolation that 2.4.0 was designed to enable, and the fallback is tracked on the Basileus side in commit `8a4a9490`.
+
+**Scope of the fix.** The 2.4.0 design intent is correct — descriptor name is meant to be the dispatch key. The implementation just failed to thread it through. This fix makes the implementation match the design, with **no new architectural concepts introduced**. Multi-registration of a CLR type under multiple descriptor names becomes the mechanism that makes the parameter meaningful; the fix is a refinement of 2.4.0, not a new feature.
+
+---
+
+## 2. Design Intent — What the Spec and 2.4.0 Design Already Say
+
+**The descriptor name is already a first-class field on `ObjectTypeDescriptor`.** `ObjectTypeBuilder.Build()` constructs `new(typeof(T).Name, typeof(T), domainName)` (`ObjectTypeBuilder.cs:136`) — the name is stored, but it cannot be overridden and does not flow through to dispatch. The schema already supports what we need; only the wiring is missing.
+
+**The 2.4.0 "single source of truth" principle applies directly.** 2.4.0 §2 articulates this as the reason for rejecting `ActionDescriptor.ValidFromStates`: the spec recognizes exactly one set of identifiers and refuses to introduce a parallel one. The same principle applies here — descriptor name and CLR type are currently two parallel dispatch keys (builder uses name, provider uses type), and the two have silently drifted. The fix consolidates dispatch through descriptor name end-to-end, making CLR type a compile-time constraint and descriptor name the runtime routing key.
+
+**The 2.4.0 "spec-aligned sugar over schema change" discipline applies.** 2.4.0's Track A used build-time projection to satisfy a new user-facing API without modifying descriptor schema. This fix uses the same pattern: the `Object<T>(string? name, config)` overload is pure builder sugar; the descriptor already has a `Name` field; the expression tree gains one additive field (`RootExpression.ObjectTypeName`) and a walk-to-root helper for derived nodes. No schema migrations, no interface-shape changes to `IObjectSetProvider`, no parallel generic `IObjectSetProvider<T>`.
+
+**The 2.4.0 "What Is Not Changing" table needs honest revision.** Three entries are affected, all minimally:
+
+| Surface | 2.4.0 status | 2.4.1 delta |
+|---|---|---|
+| `IObjectSetProvider` interface shape | Unchanged | **Still unchanged** — dispatch key travels in the expression, not as a parameter |
+| `SimilarityExpression` shape | Unchanged | **Still unchanged** — `RootObjectTypeName` is a computed property that walks to root |
+| `RootExpression` shape | (not listed) | **Additive:** one required constructor parameter `ObjectTypeName: string` |
+| pgvector schema | Unchanged | **Keying convention clarified:** tables are per descriptor name. For single-registration (the default), `typeof(T).Name` is the descriptor name, so physical tables are unchanged. No migration |
+| `ObjectTypeBuilder` / `IOntologyBuilder.Object<T>` | (not listed) | **Additive overload:** `Object<T>(string? name, config)` |
+| Graph key | (implicit `(domain, CLR type)`) | **Changed to `(domain, name)`.** For single-registration, equivalent to old behavior. Promotes today's implicit `ToDictionary` failure on duplicate names into an explicit `AONT040` diagnostic |
+
+---
+
+## 3. Approach 1 — Name Threads Through the Expression Tree
+
+The fix splits into six concrete changes, each scoped to a small set of files. All changes are additive except where noted.
+
+### 3.1 Builder: `Object<T>(string? name, config)` overload
+
+`IOntologyBuilder` and `OntologyBuilder` gain a second `Object<T>` overload accepting an explicit descriptor name. The existing `Object<T>(config)` overload remains and is equivalent to `Object<T>(name: null, config)`. `ObjectTypeBuilder<T>` takes an optional `explicitName` in its constructor and uses it in `Build()` instead of `typeof(T).Name` when non-null:
+
+```csharp
+public void Object<T>(string? name, Action<IObjectTypeBuilder<T>> configure) where T : class
+{
+    var builder = new ObjectTypeBuilder<T>(domainName, explicitName: name);
+    configure(builder);
+    _objectTypes.Add(builder.Build());
+}
+
+// Build() change:
+var descriptorName = _explicitName ?? typeof(T).Name;
+return new(descriptorName, typeof(T), domainName) { /* ... */ };
+```
+
+**Name validation.** Explicit names are validated at construction time against the regex `^[a-zA-Z_][a-zA-Z0-9_]*$` (same rule as C# identifiers, which ensures the name is safe for snake-case table conversion and safe as a dictionary key). Invalid names throw `ArgumentException` with a clear message. The default-name case is unchanged and validation is skipped (since `typeof(T).Name` is by definition a valid C# identifier).
+
+**Back-compat.** Existing `Object<T>(config)` callers are unaffected — same default name, same table, same dispatch.
+
+### 3.2 Graph freeze: rekey by `(domain, name)` and add reverse index
+
+`OntologyGraphBuilder.Build()` already keys its lookup by descriptor name within domain (`g.ToDictionary(ot => ot.Name)` at line 61), but this lookup fails with a cryptic `ArgumentException` if two descriptors in the same domain share a name. The fix promotes this failure into an explicit diagnostic:
+
+**`AONT040 DuplicateObjectTypeName`** — fires when two `ObjectTypeDescriptor` entries in the same domain have the same `Name`. The error message names both CLR types (so users can tell whether they accidentally registered the same name twice, or registered the same type twice without explicit names):
+
+> Object type name 'trading_documents' is registered twice in domain 'Basileus'. First registration: CLR type `SemanticDocument`. Second registration: CLR type `SemanticDocument`. Either remove one registration, or specify distinct names via `Object<T>("name", ...)`.
+
+**`AONT041 MultiRegisteredTypeInLink`** — fires when a CLR type has multiple registrations in any domain *and* is referenced as a link source or target in any domain. The check walks every link descriptor's `TargetType` and `SourceType` against the reverse index. Error message:
+
+> CLR type `SemanticDocument` has multiple registrations (`trading_documents`, `knowledge_documents`) but is also referenced as a link target in 'Portfolio.Documents'. Multi-registered types cannot participate in structural links. See #32 for a future relaxation path.
+
+**Reverse index.** Graph freeze builds a `Dictionary<Type, IReadOnlyList<string>>` mapping each CLR type to its list of descriptor names across all domains. This is a free byproduct of the existing object type iteration and is stored on `OntologyGraph` as a new public property `ObjectTypeNamesByType`. It powers the `AONT041` check and the public `IOntologyQuery.GetObjectTypeNames<T>()` method (§3.5).
+
+### 3.3 Expression tree: `RootExpression.ObjectTypeName` + walk-to-root helper
+
+`RootExpression` gains a required `ObjectTypeName: string` constructor parameter. Its constructor stores the name alongside the existing `ObjectType: Type`. `ObjectSetExpression` (the base class) gains a protected helper method `GetRootObjectTypeName()` that walks `Source` references until it reaches a `RootExpression` and returns its `ObjectTypeName`:
+
+```csharp
+public abstract class ObjectSetExpression
+{
+    // existing: ObjectType: Type
+
+    /// <summary>
+    /// Walks to the root of this expression tree and returns the descriptor
+    /// name of the RootExpression. Used by providers to resolve dispatch.
+    /// </summary>
+    public string RootObjectTypeName => WalkToRoot(this).ObjectTypeName;
+
+    private static RootExpression WalkToRoot(ObjectSetExpression expr) => expr switch
+    {
+        RootExpression root => root,
+        FilterExpression f => WalkToRoot(f.Source),
+        TraverseLinkExpression t => WalkToRoot(t.Source),  // constrained: target is single-registration under Option X
+        InterfaceNarrowExpression i => WalkToRoot(i.Source),
+        RawFilterExpression r => WalkToRoot(r.Source),
+        IncludeExpression i => WalkToRoot(i.Source),
+        SimilarityExpression s => WalkToRoot(s.Source),
+        _ => throw new InvalidOperationException($"Unknown expression type: {expr.GetType().Name}")
+    };
+}
+```
+
+**Why a tree-walk instead of a copy-propagated field.** Copy-propagation forces every expression constructor to accept, validate, and store the name — a ~5x larger refactor surface with no semantic benefit for the single-root case we're targeting. The walk is O(depth), and expression depth is small and bounded in practice (typically 1-3 nodes). If profiling ever shows this as a hotspot, caching the root reference on each derived expression is a trivial follow-up.
+
+**`TraverseLinkExpression` and link traversal.** Under Option X (§1), multi-registered types cannot be link targets (enforced by `AONT041`). Therefore every link target has exactly one descriptor registration, and `WalkToRoot` on a traverse expression correctly returns the **source** descriptor's name — but after traversal, the expression produces objects of the target type. This is the one subtlety: `TraverseLinkExpression.ObjectType` is the linked type, but `RootObjectTypeName` returns the source's root name, which is wrong after traversal.
+
+**Resolution.** `TraverseLinkExpression` overrides the walk: its `RootObjectTypeName` returns `typeof(TLinked).Name` directly, which is unambiguous under Option X because link targets are always single-registration. `WalkToRoot` terminates at `TraverseLinkExpression` rather than recursing into its source. This preserves the dispatch guarantee: after a traverse, the expression carries the target's (only) descriptor name.
+
+### 3.4 Query service + ObjectSet: thread the name through
+
+`OntologyQueryService.GetObjectSet<T>` reads the resolved `ObjectTypeDescriptor`'s `Name` field and passes it into a new `ObjectSet<T>` constructor parameter. `ObjectSet<T>` passes the name into `new RootExpression(typeof(T), descriptorName)`:
+
+```csharp
+public ObjectSet<T> GetObjectSet<T>(string objectType) where T : class
+{
+    var ot = FindObjectType(objectType)
+        ?? throw new KeyNotFoundException($"Object type '{objectType}' is not registered in the ontology.");
+
+    return new ObjectSet<T>(
+        descriptorName: ot.Name,   // NEW
+        _objectSetProvider!,
+        _actionDispatcher!,
+        _eventStreamProvider!);
+}
+```
+
+The read-only `OntologyQueryService(OntologyGraph)` constructor continues to work for callers that never invoke `GetObjectSet<T>`; its existing `InvalidOperationException` branch remains unchanged.
+
+### 3.5 Provider dispatch: read from expression, remove `GetTableName<T>()`
+
+`PgVectorObjectSetProvider.ExecuteSimilarityAsync<T>`, `ExecuteAsync<T>`, and `StreamAsync<T>` read `expression.RootObjectTypeName` and call a new pure-function helper `TypeMapper.ToSnakeCase(string name)` to produce the table name. The old `TypeMapper.GetTableName<T>()` method is **removed** entirely — there is no valid caller after this change, and leaving it in place would preserve the silent-wrong-dispatch footgun the fix is eliminating. Removal is a source-level break, but only to internal code (the method is `internal`).
+
+`InMemoryObjectSetProvider` switches its storage partition key from `ConcurrentDictionary<Type, List<object>>` to `ConcurrentDictionary<string, List<object>>`, keyed by descriptor name. The `Seed<T>` method gains an optional `descriptorName` parameter that defaults to `typeof(T).Name` (so existing tests continue to pass without modification). All query methods read the partition key from `expression.RootObjectTypeName`. This ensures test fixtures observe the same multi-registration semantics as production.
+
+### 3.6 Public reverse-index API on `IOntologyQuery`
+
+`IOntologyQuery` gains one new method:
+
+```csharp
+/// <summary>
+/// Returns all descriptor names registered for the given CLR type across the composed ontology.
+/// Empty list if <typeparamref name="T"/> is not registered. Used by consumers (e.g. Basileus)
+/// that need to enumerate per-collection partitions of a shared content-carrier type without
+/// hardcoding descriptor names at call sites.
+/// </summary>
+IReadOnlyList<string> GetObjectTypeNames<T>() where T : class;
+```
+
+Implementation reads directly from `OntologyGraph.ObjectTypeNamesByType`. Returns an empty list (not a throw) for unregistered types, consistent with `GetObjectTypes(domain, interface, includeSubtypes)` semantics. Basileus will use this to iterate over configured collections without a hardcoded name list in its `RagCollections` configuration code.
+
+### 3.7 Write-path dispatch: `IObjectSetWriter` descriptor-name overloads
+
+The read path carries the descriptor name in the expression tree, but `IObjectSetWriter.StoreAsync<T>(T item, ...)` and `StoreBatchAsync<T>(IReadOnlyList<T> items, ...)` take no expression — they receive an item and a CLR type only. `PgVectorObjectSetProvider`'s write-path call sites (`StoreAsync`, `StoreBatchAsync`, `EnsureSchemaAsync`) currently all use `TypeMapper.GetTableName<T>()`. If multi-registration is to work symmetrically across reads and writes, the writer must know which descriptor the caller is targeting.
+
+**Design choice: explicit-name overloads on `IObjectSetWriter` with a single-registration default.** The interface gains descriptor-name overloads alongside the existing signatures:
+
+```csharp
+public interface IObjectSetWriter
+{
+    // Existing — resolves descriptor name from the graph: if T has exactly one registration,
+    // uses that name; if T has multiple registrations, throws InvalidOperationException
+    // with a message instructing the caller to use the explicit-name overload.
+    Task StoreAsync<T>(T item, CancellationToken ct = default) where T : class;
+    Task StoreBatchAsync<T>(IReadOnlyList<T> items, CancellationToken ct = default) where T : class;
+
+    // NEW — explicit descriptor name. Always unambiguous.
+    Task StoreAsync<T>(string descriptorName, T item, CancellationToken ct = default) where T : class;
+    Task StoreBatchAsync<T>(string descriptorName, IReadOnlyList<T> items, CancellationToken ct = default) where T : class;
+}
+```
+
+**Why two overloads instead of one.** The single-registration case is the overwhelming majority of calls in existing and future code; requiring every call site to thread an explicit name would be ergonomic regression for 99% of usage. The default overload resolves via the new `OntologyGraph.ObjectTypeNamesByType` reverse index: exactly-one-name → use it; zero or multiple → throw with a clear diagnostic pointing at the explicit-name overload. This makes the default overload safe (it cannot silently dispatch to the wrong table) and keeps single-registration callers untouched.
+
+**How the resolver reaches the graph.** `PgVectorObjectSetProvider`'s constructor is updated to take an optional `OntologyGraph?` parameter (registered by the DI pipeline at the same time as the graph itself). When the graph is present, the default `StoreAsync<T>(T)` overload calls `graph.ObjectTypeNamesByType.GetValueOrDefault(typeof(T))` and applies the exactly-one rule. When the graph is absent (e.g., direct instantiation in a unit test), the default overload falls back to `typeof(T).Name` for backwards compatibility with existing tests — the fallback is documented but not recommended for production.
+
+**`InMemoryObjectSetProvider`** implements the same pattern: the default `StoreAsync<T>(T)` overload uses `typeof(T).Name` as the descriptor name (preserving all existing test code), while the new explicit-name overload partitions by the supplied name. Tests that exercise multi-registration use the explicit overload.
+
+**`EnsureSchemaAsync<T>` gets the same treatment.** `EnsureSchemaAsync<T>()` becomes `EnsureSchemaAsync<T>(string? descriptorName = null)` — name parameter optional, resolved via the same graph path. Schema creation for multi-registered types requires calling `EnsureSchemaAsync<T>("trading_documents")` once per descriptor.
+
+**`IngestionPipeline<T>.WriteTo()` plumbing.** The ingestion pipeline builder's `WriteTo(IObjectSetWriter writer)` method gains a sibling `WriteTo(IObjectSetWriter writer, string descriptorName)`. When the descriptor name is supplied, `IngestionPipeline<T>.ExecuteCoreAsync` calls `_writer.StoreBatchAsync<T>(descriptorName, mappedItems, ct)`; otherwise it calls the existing default overload. This is the path Basileus will use to ingest per-collection `SemanticDocument` batches once multi-registration lands.
+
+---
+
+## 4. What Is *Not* Changing
+
+Normative list — reviewers should reject any task that touches an item below.
+
+| Surface | Status | Reason |
+|---|---|---|
+| `ActionDescriptor` schema | Unchanged | Unrelated to dispatch |
+| `LifecycleDescriptor` schema | Unchanged | Unrelated to dispatch |
+| `ObjectTypeDescriptor` schema | Unchanged | `Name` field already exists; only its provenance changes (explicit vs default) |
+| `IObjectSetProvider` interface shape | Unchanged | Dispatch key travels inside the expression tree, not as a parameter |
+| `IObjectSetWriter` interface shape | **Additive** | Two new descriptor-name overloads (`StoreAsync`, `StoreBatchAsync`); existing signatures unchanged and default to single-registration resolution |
+| `SimilarityExpression` shape | Unchanged | `RootObjectTypeName` is a computed walk, not a stored field |
+| `FilterExpression` / `TraverseLinkExpression` / `InterfaceNarrowExpression` / `RawFilterExpression` / `IncludeExpression` shapes | Unchanged (except `TraverseLinkExpression` override) | Walk-to-root handles all of them uniformly |
+| pgvector physical schema | Unchanged | Per-descriptor-name tables; for single-registration (the default), identical to 2.4.0 |
+| Link DSL (`HasMany`/`HasOne`/`ManyToMany`/`RequiresLink`/`CreatesLinked`) | Unchanged | Multi-registration is leaf-only under Option X (#32) |
+| `ObjectSet<T>.Where` / `.TraverseLink` / `.OfInterface` / `.Include` / `.SimilarTo` | Unchanged | Expression tree walks handle the name propagation |
+| `SimilarObjectSet<T>` fluent setters (`WithMinRelevance`/`Take`/`WithMetric`) | Unchanged | Added in 2.4.0 Track B; untouched here |
+| `.ValidFromState` lifecycle sugar (2.4.0 Track A) | Unchanged | Orthogonal to dispatch |
+| Existing Basileus workaround (`BasileusDataFabricOntology` single-registration) | Migrated post-release | Basileus will split `SemanticDocument` into per-collection registrations after 2.4.1 ships; tracked separately |
+| Generator-emitted code (source generators) | Unchanged | Generator emits builder calls using `Object<T>(config)`; users opt into the explicit-name overload manually |
+
+---
+
+## 5. Test Plan
+
+All tests use TUnit with NSubstitute (existing convention). Descriptor-name dispatch is tested at the builder, graph, expression, query, and provider layers. TUnit invocation: `dotnet test -- --treenode-filter "/*/*/*/TestName"` per the established convention.
+
+### 5.1 Builder-layer tests (`Strategos.Ontology.Tests/Builder/`)
+
+- `ObjectTypeBuilder_with_explicit_name_uses_explicit_name` — `Object<T>("custom_name", ...)` produces a descriptor with `Name == "custom_name"`
+- `ObjectTypeBuilder_without_explicit_name_uses_typeof_T_name` — regression guard for default behavior
+- `ObjectTypeBuilder_with_explicit_name_validates_identifier_regex` — `Object<T>("has spaces", ...)` throws `ArgumentException`
+- `ObjectTypeBuilder_with_null_explicit_name_falls_back_to_default` — `Object<T>(null, ...)` is equivalent to `Object<T>(...)`
+
+### 5.2 Graph-freeze tests (`Strategos.Ontology.Tests/OntologyGraphBuilderTests.cs`)
+
+- `GraphBuilder_allows_same_clr_type_under_distinct_names_in_same_domain` — multi-registration succeeds when names differ
+- `GraphBuilder_raises_AONT040_when_same_descriptor_name_registered_twice` — explicit diagnostic replaces today's implicit `ArgumentException`
+- `GraphBuilder_allows_same_descriptor_name_across_different_domains` — `(domain, name)` is the key, not just `name`
+- `GraphBuilder_raises_AONT041_when_multi_registered_type_is_link_target` — Option X enforcement (source side)
+- `GraphBuilder_raises_AONT041_when_multi_registered_type_is_link_source` — Option X enforcement (target side)
+- `GraphBuilder_allows_multi_registered_leaf_type_without_links` — positive case: `SemanticDocument` registered twice with no structural link references succeeds
+- `GraphBuilder_exposes_ObjectTypeNamesByType_reverse_index` — single-registration and multi-registration both populate correctly
+
+### 5.3 Expression-tree tests (`Strategos.Ontology.Tests/ObjectSets/ObjectSetExpressionTests.cs`)
+
+- `RootExpression_requires_ObjectTypeName_in_constructor` — cannot construct without descriptor name
+- `FilterExpression_RootObjectTypeName_walks_to_source_root` — walk-to-root correctness
+- `SimilarityExpression_RootObjectTypeName_walks_to_source_root` — similarity case specifically (this is the one Basileus exercises)
+- `InterfaceNarrowExpression_RootObjectTypeName_walks_to_source_root`
+- `IncludeExpression_RootObjectTypeName_walks_to_source_root`
+- `RawFilterExpression_RootObjectTypeName_walks_to_source_root`
+- `TraverseLinkExpression_RootObjectTypeName_returns_linked_type_name` — override behavior; guarded by Option X single-registration invariant
+- `ComposedExpression_Root_Filter_Similarity_returns_correct_name` — end-to-end: `GetObjectSet("trading").Where(...).SimilarTo("q")` walks to `"trading"`
+
+### 5.4 Query-service tests (`Strategos.Ontology.Tests/Query/OntologyQueryServiceTests.cs`)
+
+- `GetObjectSet_threads_descriptor_name_into_RootExpression` — the core dispatch-correctness test; the regression guard against #31 reappearing
+- `GetObjectSet_unknown_name_throws_KeyNotFoundException` — existing behavior preserved
+- `GetObjectSet_multi_registration_returns_distinct_root_expressions_for_each_name` — the multi-registration happy path
+- `GetObjectTypeNames_returns_all_registrations_for_multi_registered_type`
+- `GetObjectTypeNames_returns_single_entry_for_single_registered_type`
+- `GetObjectTypeNames_returns_empty_list_for_unregistered_type`
+
+### 5.5 InMemory provider tests (`Strategos.Ontology.Tests/ObjectSets/InMemoryObjectSetProviderTests.cs`)
+
+- `InMemoryProvider_partitions_by_descriptor_name_not_clr_type` — seed `SemanticDocument` under name "trading_documents"; query under name "knowledge_documents"; assert empty result
+- `InMemoryProvider_default_seed_uses_typeof_T_name` — regression guard for existing test code
+- `InMemoryProvider_similarity_search_dispatches_by_descriptor_name` — end-to-end: seed under two distinct names, run `SimilarTo` on each, verify distinct result sets
+
+### 5.6 PgVector provider tests — reads (`Strategos.Ontology.Npgsql.Tests/`)
+
+- `PgVectorProvider_ExecuteSimilarityAsync_uses_descriptor_name_from_expression` — SQL generation asserts the `FROM` clause is `trading_documents`, not `semantic_document`
+- `PgVectorProvider_ExecuteAsync_uses_descriptor_name_from_expression` — non-similarity path
+- `PgVectorProvider_StreamAsync_uses_descriptor_name_from_expression`
+- `PgVectorProvider_default_name_unchanged` — single-registration regression guard: `Object<SemanticDocument>(...)` still hits table `semantic_document`
+- `PgVectorProvider_TypeMapper_GetTableName_of_T_is_removed` — compile-time guard that the footgun is gone (a simple reflection test asserting the method no longer exists)
+
+### 5.7 Write-path tests — `IObjectSetWriter` descriptor-name overloads
+
+**`Strategos.Ontology.Tests/ObjectSets/IObjectSetWriterTests.cs` (new file):**
+
+- `InMemoryWriter_StoreAsync_default_overload_uses_typeof_T_name` — backwards-compat regression guard
+- `InMemoryWriter_StoreAsync_explicit_name_overload_uses_supplied_name` — new overload threads through correctly
+- `InMemoryWriter_StoreBatchAsync_explicit_name_overload_partitions_by_name` — batch variant
+- `InMemoryWriter_StoreAsync_default_overload_throws_when_type_has_multiple_registrations` — safety check: default overload refuses to silently guess for multi-registered types (when graph is present)
+- `InMemoryWriter_StoreAsync_default_overload_falls_back_to_typeof_T_name_when_graph_absent` — unit-test-mode fallback
+
+**`Strategos.Ontology.Npgsql.Tests/PgVectorWriteTests.cs`:**
+
+- `PgVectorProvider_StoreAsync_explicit_name_writes_to_named_table` — SQL generation asserts `INSERT INTO trading_documents`
+- `PgVectorProvider_StoreBatchAsync_explicit_name_uses_COPY_to_named_table` — COPY target table assertion
+- `PgVectorProvider_EnsureSchemaAsync_with_explicit_name_creates_named_table` — DDL target table assertion
+- `PgVectorProvider_StoreAsync_default_overload_resolves_via_graph_reverse_index` — graph-backed single-registration resolution
+- `PgVectorProvider_StoreAsync_default_overload_throws_with_diagnostic_when_type_has_multiple_registrations` — safety check with clear error message
+
+**`Strategos.Ontology.Tests/Ingestion/IngestionPipelineTests.cs`:**
+
+- `IngestionPipeline_WriteTo_with_descriptor_name_threads_name_into_StoreBatchAsync` — pipeline builder overload plumbs the name through
+- `IngestionPipeline_WriteTo_without_descriptor_name_calls_default_StoreBatchAsync` — backwards-compat for existing pipeline tests
+
+### 5.8 Housekeeping
+
+- Close issues #28 and #29 with a comment pointing to commit `9e47550` (delivered in 2.4.0 via #30). Both issues were resolved by the 2.4.0 ship; this design doc closes them as part of 2.4.1 scope cleanup.
+
+---
+
+## 6. Migration & Compatibility
+
+**Strategos internal.** The `ObjectSet<T>(IObjectSetProvider, IActionDispatcher, IEventStreamProvider)` constructor signature changes — it gains a required `descriptorName: string` parameter. Only `OntologyQueryService.GetObjectSet<T>` constructs `ObjectSet<T>` directly today, so the surface is contained. Internal tests that construct `ObjectSet<T>` directly (there are a few in `ObjectSetTests.cs`) will be updated to pass an explicit name — the diff is small and mechanical. `TypeMapper.GetTableName<T>()` is removed; one internal provider call site is updated.
+
+**Strategos published consumers.** None other than Basileus (unshipped). No NuGet migration required.
+
+**Basileus integration (separate PR, post-2.4.1 NuGet bump).** Basileus will:
+1. Split `SemanticDocument` out of `BasileusDataFabricOntology` and register it per-collection via `Object<SemanticDocument>("trading_documents", ...)` and `Object<SemanticDocument>("knowledge_documents", ...)` in the respective domain ontologies.
+2. Remove the `SourceDomain` discriminator filter in `OntologyContextAssembler.SearchViaObjectSetsAsync` — per-collection isolation is now physical, not logical.
+3. Optionally use the new `_ontologyQuery.GetObjectTypeNames<SemanticDocument>()` API to drive the `RagCollections` configuration loop without hardcoded name lists.
+
+**No breaking changes for single-registration consumers.** Every existing `Object<T>(config)` call site continues to work with identical dispatch semantics. The 2.4.0 ObjectSet tests continue to pass with an explicit `descriptorName: typeof(T).Name` argument added in one place.
+
+---
+
+## 7. Open Questions
+
+1. **Should `Object<T>(string? name, ...)` validate the name as snake_case specifically, or any C# identifier?** Leaning **any C# identifier** — consistent with table-name convention where the provider snake-cases at generation time. Plan phase decision.
+
+2. **Should `IOntologyQuery.GetObjectTypeNames<T>()` return names sorted alphabetically or in registration order?** Leaning **registration order** — deterministic and aligned with how users typically think about their registrations. Plan phase decision.
+
+3. **Error message quality for `AONT040`.** Should the message include the file/line of each duplicate registration? Probably out of scope — that requires source-info threading through the builder, which is a Roslyn-generator-level concern not a runtime one. Document as a post-2.4.1 enhancement if users request it.
+
+4. **`.ValidFromState` + multi-registration interaction.** Does `.ValidFromState` on an action for a multi-registered type apply to all registrations? Yes, because `.ValidFromState` is a projection into the lifecycle (which is per-descriptor), and each registration has its own descriptor — so each registration gets its own lifecycle and its own projection. No special handling required. Plan phase should add one test to lock this in.
+
+---
+
+## 8. References
+
+### Primary
+
+- **Issue #31** — Bug report with the proposed 5-step fix (aligned with this design, minus the AONT041 link-participation rule)
+- **Issue #32** — Follow-up tracking Option Y (multi-registered link participation) for future work
+- **Design precedent:** `docs/designs/2026-04-06-ontology-2-4-0.md` §2 (single-source-of-truth principle), §3 (spec-aligned sugar discipline), §4 (what is not changing)
+- **Spec:** `docs/reference/platform-architecture.md` §4.14.4 (Core Primitives), §4.14.11 (Domain Definition)
+- **Basileus design:** Basileus 2.4.0 data fabric completion design — downstream consumer that drove the bug report
+
+### Current implementation (call sites touched)
+
+- `src/Strategos.Ontology/Builder/OntologyBuilder.cs:18` — `Object<T>` entry point
+- `src/Strategos.Ontology/Builder/ObjectTypeBuilder.cs:136` — descriptor name construction
+- `src/Strategos.Ontology/OntologyGraphBuilder.cs:59-61` — graph key and duplicate detection
+- `src/Strategos.Ontology/ObjectSets/ObjectSetExpression.cs:24` — `RootExpression`
+- `src/Strategos.Ontology/ObjectSets/ObjectSet.cs:22-33` — ObjectSet constructors
+- `src/Strategos.Ontology/Query/OntologyQueryService.cs:49-68` — the discard site
+- `src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs:21` — partition key
+- `src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs:60` — dispatch site
+- `src/Strategos.Ontology.Npgsql/Internal/TypeMapper.cs:53` — `GetTableName<T>()` removal
+
+### Downstream (not modified in this PR)
+
+- Basileus `OntologyContextAssembler.SearchViaObjectSetsAsync` — post-release migration target
+- Basileus `BasileusDataFabricOntology` — post-release replacement with per-collection registrations

--- a/docs/plans/2026-04-08-ontology-descriptor-name-dispatch.md
+++ b/docs/plans/2026-04-08-ontology-descriptor-name-dispatch.md
@@ -1,0 +1,922 @@
+# Implementation Plan: Strategos 2.4.1 — Ontology Descriptor-Name Dispatch
+
+## Source Design
+Link: `docs/designs/2026-04-08-ontology-descriptor-name-dispatch.md`
+
+## Scope
+
+**Target:** Approach 1 + Option X — name threads through the expression tree via walk-to-root; multi-registration is leaf-only (enforced by `AONT041`); writes get explicit-name overloads with graph-backed resolution for the default path.
+
+**Target packages:** `LevelUp.Strategos.Ontology` 2.4.1, `LevelUp.Strategos.Ontology.Npgsql` 2.4.1 (version auto-resolved by MinVer at release time via the `v2.4.1` git tag).
+
+**Excluded** (per design doc §4 — *What Is Not Changing*):
+- Any modification to `ActionDescriptor` / `LifecycleDescriptor` / `ObjectTypeDescriptor` schemas
+- Any modification to `IObjectSetProvider` interface shape
+- Any modification to `SimilarityExpression` / `FilterExpression` / `InterfaceNarrowExpression` / `RawFilterExpression` / `IncludeExpression` shapes
+- Any modification to link DSL (`HasMany`/`HasOne`/`ManyToMany`/`RequiresLink`/`CreatesLinked`) — multi-registration is leaf-only
+- Any modification to `.ValidFromState` lifecycle sugar (2.4.0 Track A)
+- Introduction of `IObjectSetProvider<T>` parallel generic interface
+- Generator-emitted code (users opt into explicit-name overload manually)
+- Basileus consumer-side migration (separate PR after NuGet bump)
+- Option Y (multi-registered types participating in structural links) — tracked in #32
+
+## Summary
+
+- **Total tasks:** 28 (grouped into 7 tracks)
+- **Parallel tracks:** 3 primary at Group 1 (A, B, F1 interface change); dependent tracks converge at Groups 2–5
+- **Estimated test count:** 34 new tests across builder, graph freeze, expression tree, query service, read path, write path, and end-to-end layers
+- **Design coverage:** 100% — every section in §3.1 through §3.7 and §5.1 through §5.8 has a task
+
+## Spec Traceability
+
+| Design Section | Task IDs | Status |
+|---|---|---|
+| §3.1 — `Object<T>(string? name, config)` builder overload | B1, B2, B3 | Covered |
+| §3.2 — Graph rekey + `AONT040` diagnostic | C1 | Covered |
+| §3.2 — Reverse index `ObjectTypeNamesByType` | C2 | Covered |
+| §3.2 — `AONT041 MultiRegisteredTypeInLink` | C3 | Covered |
+| §3.3 — `RootExpression.ObjectTypeName` required param | A1 | Covered |
+| §3.3 — `ObjectSetExpression.RootObjectTypeName` walk-to-root | A2 | Covered |
+| §3.3 — `TraverseLinkExpression` override | A3 | Covered |
+| §3.4 — `ObjectSet<T>` ctor threads descriptor name | D1 | Covered |
+| §3.4 — `OntologyQueryService.GetObjectSet<T>` threads name | D2 | Covered |
+| §3.5 — `PgVectorObjectSetProvider` read-path dispatch | E1, E2, E3 | Covered |
+| §3.5 — `InMemoryObjectSetProvider` read-path partition switch | E4 | Covered |
+| §3.5 — `TypeMapper.GetTableName<T>()` removal | E5 | Covered |
+| §3.6 — `IOntologyQuery.GetObjectTypeNames<T>()` | D3 | Covered |
+| §3.7 — `IObjectSetWriter` explicit-name overloads | F1 | Covered |
+| §3.7 — `InMemoryObjectSetProvider` explicit-name overload impl | F2 | Covered |
+| §3.7 — `PgVectorObjectSetProvider` explicit-name overload impl | F3 | Covered |
+| §3.7 — `PgVectorObjectSetProvider` graph-backed default resolution | F4 | Covered |
+| §3.7 — `PgVectorObjectSetProvider.EnsureSchemaAsync` name overload | F5 | Covered |
+| §3.7 — `IngestionPipelineBuilder<T>.WriteTo(writer, name)` | F6 | Covered |
+| §5.7 — End-to-end multi-registration integration test | G1 | Covered |
+| §5.8 — Close #28 and #29 housekeeping | G2 | Post-merge |
+
+## Open Decisions Resolved by This Plan
+
+The design doc §7 lists four open questions. The plan resolves them as follows:
+
+1. **Name validation regex.** **Any C# identifier** — `^[a-zA-Z_][a-zA-Z0-9_]*$`. Rationale: ensures safe dictionary keys and safe snake-case conversion at the provider layer. Validated in `ObjectTypeBuilder<T>` constructor. Task **B3**.
+
+2. **`GetObjectTypeNames<T>()` ordering.** **Registration order** (stable across graph builds). Rationale: matches user mental model; deterministic for snapshot/regression tests. Implementation: the reverse index is a `Dictionary<Type, List<string>>` populated by iterating `allObjectTypes` in the order the builder returned them. Task **D3**.
+
+3. **AONT040 message quality.** Plain-text error naming both CLR types and the conflicting descriptor name. Source-info threading is **out of scope** — deferred to post-2.4.1 as a Roslyn-generator-level enhancement.
+
+4. **`.ValidFromState` + multi-registration interaction.** Each descriptor has its own lifecycle projection, so no special handling required. Locked in via a single test in Task **B2** (projection works for the explicitly-named case).
+
+## Track A — Expression Tree Foundation (3 tasks)
+
+All Track A tasks operate on these files. They are sequenced within the track (A1 blocks A2, A3).
+
+**Production files:**
+- `src/Strategos.Ontology/ObjectSets/ObjectSetExpression.cs`
+
+**Test files:**
+- `src/Strategos.Ontology.Tests/ObjectSets/ObjectSetExpressionTests.cs`
+
+---
+
+### Task A1: `RootExpression.ObjectTypeName` required constructor parameter
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `RootExpression_Constructor_RequiresObjectTypeName`
+   - File: `src/Strategos.Ontology.Tests/ObjectSets/ObjectSetExpressionTests.cs`
+   - Body: assert `new RootExpression(typeof(string), "trading_documents").ObjectTypeName == "trading_documents"` and `new RootExpression(typeof(string), null!)` throws `ArgumentNullException`
+   - Expected failure: `RootExpression` only has a `(Type)` constructor; no `ObjectTypeName` property exists
+
+2. [GREEN] Update `RootExpression`
+   - File: `src/Strategos.Ontology/ObjectSets/ObjectSetExpression.cs`
+   - Add required parameter to constructor: `public RootExpression(Type objectType, string objectTypeName)`
+   - Add property: `public string ObjectTypeName { get; }`
+   - Validate `ArgumentNullException.ThrowIfNull(objectTypeName)` in constructor
+   - Update `ObjectSet<T>` ctor at `ObjectSet.cs:23` to temporarily pass `typeof(T).Name` as the name (proper threading happens in D1)
+   - Update any other direct `RootExpression` construction sites discovered during compile (if any exist in tests, update those tests to supply a default name)
+
+**Dependencies:** None
+**Parallelizable:** Yes (with B1, B2, B3, F1 — independent files)
+
+---
+
+### Task A2: `ObjectSetExpression.RootObjectTypeName` walk-to-root computed property
+
+**Phase:** RED → GREEN
+
+1. [RED] Write tests in `ObjectSetExpressionTests.cs`:
+   - `FilterExpression_RootObjectTypeName_WalksToSourceRoot` — construct `new FilterExpression(new RootExpression(typeof(Foo), "foo_table"), x => true)`, assert `.RootObjectTypeName == "foo_table"`
+   - `InterfaceNarrowExpression_RootObjectTypeName_WalksToSourceRoot` — analogous
+   - `IncludeExpression_RootObjectTypeName_WalksToSourceRoot` — analogous
+   - `RawFilterExpression_RootObjectTypeName_WalksToSourceRoot` — analogous
+   - `SimilarityExpression_RootObjectTypeName_WalksToSourceRoot` — analogous; this is the Basileus call site
+   - `ComposedExpression_Root_Filter_Similarity_ReturnsRootName` — nested: `Similarity(Filter(Root))` walks two hops
+   - Expected failure: `RootObjectTypeName` property does not exist on `ObjectSetExpression`
+
+2. [GREEN] Add walk-to-root property on the base class
+   - File: `src/Strategos.Ontology/ObjectSets/ObjectSetExpression.cs`
+   - Add virtual property on `ObjectSetExpression`:
+     ```csharp
+     public virtual string RootObjectTypeName => WalkToRoot(this).ObjectTypeName;
+
+     private static RootExpression WalkToRoot(ObjectSetExpression expr) => expr switch
+     {
+         RootExpression root => root,
+         FilterExpression f => WalkToRoot(f.Source),
+         InterfaceNarrowExpression i => WalkToRoot(i.Source),
+         RawFilterExpression r => WalkToRoot(r.Source),
+         IncludeExpression i => WalkToRoot(i.Source),
+         SimilarityExpression s => WalkToRoot(s.Source),
+         TraverseLinkExpression t => WalkToRoot(t.Source), // overridden in A3
+         _ => throw new InvalidOperationException($"Unknown expression type: {expr.GetType().Name}")
+     };
+     ```
+
+**Dependencies:** A1
+**Parallelizable:** No (same file as A1)
+
+---
+
+### Task A3: `TraverseLinkExpression.RootObjectTypeName` override
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `TraverseLinkExpression_RootObjectTypeName_ReturnsLinkedTypeName`
+   - File: `src/Strategos.Ontology.Tests/ObjectSets/ObjectSetExpressionTests.cs`
+   - Body: construct `new TraverseLinkExpression(new RootExpression(typeof(Position), "positions"), "Orders", typeof(TradeOrder))`, assert `.RootObjectTypeName == "TradeOrder"` (not `"positions"`)
+   - Expected failure: default walk-to-root returns the source root's name, which is the wrong answer after traversal
+   - Rationale: under Option X multi-registered types cannot be link targets (AONT041), so `typeof(TLinked).Name` is unambiguous
+
+2. [GREEN] Override `RootObjectTypeName` on `TraverseLinkExpression`
+   - File: `src/Strategos.Ontology/ObjectSets/ObjectSetExpression.cs`
+   - Add to `TraverseLinkExpression`:
+     ```csharp
+     public override string RootObjectTypeName => ObjectType.Name;
+     ```
+   - Note: `ObjectType` on `TraverseLinkExpression` is already set to `linkedType` (see ctor at `ObjectSetExpression.cs:50`), so this reads the target CLR type's name directly
+
+**Dependencies:** A2
+**Parallelizable:** No (same file)
+
+---
+
+## Track B — Builder Layer (3 tasks)
+
+**Production files:**
+- `src/Strategos.Ontology/Builder/IOntologyBuilder.cs`
+- `src/Strategos.Ontology/Builder/OntologyBuilder.cs`
+- `src/Strategos.Ontology/Builder/ObjectTypeBuilder.cs`
+
+**Test files:**
+- `src/Strategos.Ontology.Tests/Builder/ObjectTypeBuilderTests.cs`
+- `src/Strategos.Ontology.Tests/Builder/OntologyBuilderTests.cs`
+
+---
+
+### Task B1: `IOntologyBuilder.Object<T>(string? name, config)` overload
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `OntologyBuilder_ObjectWithExplicitName_RegistersDescriptorWithThatName`
+   - File: `src/Strategos.Ontology.Tests/Builder/OntologyBuilderTests.cs`
+   - Body: create `OntologyBuilder("trading")`, call `builder.Object<SemanticDocument>("trading_documents", obj => { })`, inspect `builder.ObjectTypes`, assert `ObjectTypes.Single().Name == "trading_documents"`
+   - Expected failure: no `Object<T>(string?, Action<...>)` overload exists
+
+2. [GREEN] Add overload to interface and implementation
+   - File: `src/Strategos.Ontology/Builder/IOntologyBuilder.cs` — add:
+     ```csharp
+     void Object<T>(string? name, Action<IObjectTypeBuilder<T>> configure) where T : class;
+     ```
+   - File: `src/Strategos.Ontology/Builder/OntologyBuilder.cs` — add:
+     ```csharp
+     public void Object<T>(string? name, Action<IObjectTypeBuilder<T>> configure) where T : class
+     {
+         var builder = new ObjectTypeBuilder<T>(domainName, explicitName: name);
+         configure(builder);
+         _objectTypes.Add(builder.Build());
+     }
+     ```
+   - Ensure the parameterless `Object<T>(config)` overload still works (it should delegate to the new one with `name: null`)
+
+**Dependencies:** None
+**Parallelizable:** Yes (with A, F1)
+
+---
+
+### Task B2: `ObjectTypeBuilder<T>` stores explicit name and uses it in `Build()`
+
+**Phase:** RED → GREEN
+
+1. [RED] Write tests in `src/Strategos.Ontology.Tests/Builder/ObjectTypeBuilderTests.cs`:
+   - `ObjectTypeBuilder_WithExplicitName_UsesExplicitNameInDescriptor` — construct `new ObjectTypeBuilder<Foo>("mydomain", "custom_name")`, call `Build()`, assert `descriptor.Name == "custom_name"` (CLR type is still `typeof(Foo)`)
+   - `ObjectTypeBuilder_WithNullExplicitName_FallsBackToTypeofTName` — regression guard: `new ObjectTypeBuilder<Foo>("mydomain", explicitName: null)` → `descriptor.Name == "Foo"`
+   - `ObjectTypeBuilder_WithExplicitName_LifecycleProjectionAppliesToThatDescriptor` — locks in the §7 open question: declare a lifecycle + `.ValidFromState()` on an action under an explicit name; assert the projection landed correctly on the explicit-named descriptor
+   - Expected failure: `ObjectTypeBuilder<T>` constructor has only one parameter (`domainName`)
+
+2. [GREEN] Update `ObjectTypeBuilder<T>`
+   - File: `src/Strategos.Ontology/Builder/ObjectTypeBuilder.cs`
+   - Update primary constructor: `internal sealed class ObjectTypeBuilder<T>(string domainName, string? explicitName = null) : IObjectTypeBuilder<T>`
+   - Update `Build()` at line 136: `var descriptorName = explicitName ?? typeof(T).Name;` → `return new(descriptorName, typeof(T), domainName) { ... };`
+
+**Dependencies:** B1
+**Parallelizable:** No (same file)
+
+---
+
+### Task B3: Explicit-name regex validation in `ObjectTypeBuilder<T>` constructor
+
+**Phase:** RED → GREEN
+
+1. [RED] Write tests in `ObjectTypeBuilderTests.cs`:
+   - `ObjectTypeBuilder_WithInvalidExplicitName_ThrowsArgumentException` — parameterized over `"has spaces"`, `"starts-with-hyphen"`, `"1starts_with_digit"`, `"has.dots"`; each should throw `ArgumentException` with a message naming the regex
+   - `ObjectTypeBuilder_WithValidExplicitName_Succeeds` — parameterized over `"trading_documents"`, `"KnowledgeChunk"`, `"_underscore_start"`, `"snake_case_123"`
+   - Expected failure: constructor accepts any name without validation
+
+2. [GREEN] Add validation at construction time
+   - File: `src/Strategos.Ontology/Builder/ObjectTypeBuilder.cs`
+   - At the top of the constructor body (or primary constructor init):
+     ```csharp
+     private static readonly System.Text.RegularExpressions.Regex _nameRegex =
+         new("^[a-zA-Z_][a-zA-Z0-9_]*$", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+     // In constructor:
+     if (explicitName is not null && !_nameRegex.IsMatch(explicitName))
+     {
+         throw new ArgumentException(
+             $"Object type name '{explicitName}' is not a valid identifier. " +
+             $"Names must match ^[a-zA-Z_][a-zA-Z0-9_]*$ (C# identifier rules).",
+             nameof(explicitName));
+     }
+     ```
+
+**Dependencies:** B2
+**Parallelizable:** No (same file)
+
+---
+
+## Track C — Graph Freeze Invariants (3 tasks)
+
+**Production files:**
+- `src/Strategos.Ontology/OntologyGraphBuilder.cs`
+- `src/Strategos.Ontology/OntologyGraph.cs`
+- `src/Strategos.Ontology/Diagnostics/OntologyDiagnostics.cs` (or wherever AONT codes are defined)
+
+**Test files:**
+- `src/Strategos.Ontology.Tests/OntologyGraphBuilderTests.cs`
+
+---
+
+### Task C1: `AONT040 DuplicateObjectTypeName` diagnostic
+
+**Phase:** RED → GREEN
+
+1. [RED] Write tests:
+   - `GraphBuilder_WithDuplicateDescriptorNameInSameDomain_ThrowsAONT040`
+     - Body: register `Object<Foo>("shared_name", ...)` twice in the same domain; call `Build()`; assert `OntologyCompositionException` (or `InvalidOperationException`, matching existing convention) naming the conflicting `shared_name` and both CLR types
+   - `GraphBuilder_WithSameDescriptorNameAcrossDifferentDomains_Succeeds`
+     - Body: register `Object<Foo>("shared_name", ...)` in domain A and `Object<Bar>("shared_name", ...)` in domain B; call `Build()`; assert no exception
+   - Expected failure: today this fails with a cryptic `ArgumentException` from `ToDictionary`
+
+2. [GREEN] Replace implicit failure with explicit diagnostic
+   - File: `src/Strategos.Ontology/OntologyGraphBuilder.cs`
+   - Before line 60 (`g.ToDictionary(ot => ot.Name)`), add a duplicate-name check per domain:
+     ```csharp
+     foreach (var group in allObjectTypes.GroupBy(ot => ot.DomainName))
+     {
+         var seen = new Dictionary<string, ObjectTypeDescriptor>();
+         foreach (var descriptor in group)
+         {
+             if (seen.TryGetValue(descriptor.Name, out var existing))
+             {
+                 throw new OntologyCompositionException(
+                     $"AONT040: Object type name '{descriptor.Name}' is registered twice in domain '{group.Key}'. " +
+                     $"First registration: CLR type '{existing.ClrType.FullName}'. " +
+                     $"Second registration: CLR type '{descriptor.ClrType.FullName}'. " +
+                     $"Either remove one registration, or specify distinct names via Object<T>(\"name\", ...).");
+             }
+             seen[descriptor.Name] = descriptor;
+         }
+     }
+     ```
+   - Verify the existing `ToDictionary` at line 61 now always succeeds (the duplicate check is before it)
+   - If `OntologyCompositionException` doesn't exist, use `InvalidOperationException` — check the existing codebase for the convention
+
+**Dependencies:** B1 (needs the builder overload to construct duplicates in the test)
+**Parallelizable:** Yes (with C2 once B is done — different files)
+
+---
+
+### Task C2: `OntologyGraph.ObjectTypeNamesByType` reverse index
+
+**Phase:** RED → GREEN
+
+1. [RED] Write tests in `OntologyGraphBuilderTests.cs`:
+   - `OntologyGraph_ObjectTypeNamesByType_PopulatedForSingleRegistration` — one `Object<Foo>(...)` registration → `graph.ObjectTypeNamesByType[typeof(Foo)]` returns `["Foo"]`
+   - `OntologyGraph_ObjectTypeNamesByType_PopulatedForMultiRegistration` — `Object<Foo>("a", ...)` and `Object<Foo>("b", ...)` → returns `["a", "b"]` in registration order
+   - `OntologyGraph_ObjectTypeNamesByType_UnregisteredTypeReturnsEmpty` — `graph.ObjectTypeNamesByType.GetValueOrDefault(typeof(Bar)) ?? []` returns empty
+   - Expected failure: property does not exist on `OntologyGraph`
+
+2. [GREEN] Add reverse index
+   - File: `src/Strategos.Ontology/OntologyGraph.cs`
+   - Add property: `public IReadOnlyDictionary<Type, IReadOnlyList<string>> ObjectTypeNamesByType { get; }`
+   - Accept in constructor as a new parameter
+   - File: `src/Strategos.Ontology/OntologyGraphBuilder.cs`
+   - Build the index after the duplicate check:
+     ```csharp
+     var namesByType = allObjectTypes
+         .GroupBy(ot => ot.ClrType)
+         .ToDictionary(
+             g => g.Key,
+             g => (IReadOnlyList<string>)g.Select(ot => ot.Name).ToList().AsReadOnly());
+     ```
+   - Pass `namesByType` into the `OntologyGraph` constructor
+
+**Dependencies:** B1 (for multi-registration test setup)
+**Parallelizable:** Yes with C1 after B
+
+---
+
+### Task C3: `AONT041 MultiRegisteredTypeInLink` check
+
+**Phase:** RED → GREEN
+
+1. [RED] Write tests:
+   - `GraphBuilder_WithMultiRegisteredTypeAsLinkTarget_ThrowsAONT041`
+     - Body: register `Object<SemanticDocument>("a", ...)` and `Object<SemanticDocument>("b", ...)`; in a different type, declare `HasMany<SemanticDocument>("Documents")`; call `Build()`; assert exception naming `SemanticDocument`, both registrations (`a`, `b`), and the referencing link (`Documents`)
+   - `GraphBuilder_WithMultiRegisteredTypeAsLinkSource_ThrowsAONT041`
+     - Body: same CLR type, but the multi-registered type declares an outgoing link; assert AONT041 fires
+   - `GraphBuilder_WithMultiRegisteredLeafType_NoLinks_Succeeds`
+     - Positive case: register `SemanticDocument` twice with no structural link references anywhere; assert `Build()` succeeds (this is the Basileus happy path)
+   - Expected failure: no AONT041 check exists
+
+2. [GREEN] Add the invariant check
+   - File: `src/Strategos.Ontology/OntologyGraphBuilder.cs`
+   - After the reverse index is built (C2), add a new private method:
+     ```csharp
+     private static void ValidateMultiRegisteredTypesNotInLinks(
+         IReadOnlyList<ObjectTypeDescriptor> allObjectTypes,
+         IReadOnlyDictionary<Type, IReadOnlyList<string>> namesByType)
+     {
+         var multiRegistered = namesByType
+             .Where(kvp => kvp.Value.Count > 1)
+             .Select(kvp => kvp.Key)
+             .ToHashSet();
+
+         if (multiRegistered.Count == 0) return;
+
+         foreach (var descriptor in allObjectTypes)
+         {
+             foreach (var link in descriptor.Links)
+             {
+                 if (multiRegistered.Contains(link.TargetType))
+                 {
+                     var names = namesByType[link.TargetType];
+                     throw new OntologyCompositionException(
+                         $"AONT041: CLR type '{link.TargetType.FullName}' has multiple registrations " +
+                         $"({string.Join(", ", names.Select(n => $"'{n}'"))}) but is also referenced as a link target " +
+                         $"in '{descriptor.Name}.{link.Name}'. Multi-registered types cannot participate in structural " +
+                         $"links. See #32 for a future relaxation path.");
+                 }
+             }
+
+             if (multiRegistered.Contains(descriptor.ClrType) && descriptor.Links.Count > 0)
+             {
+                 var names = namesByType[descriptor.ClrType];
+                 throw new OntologyCompositionException(
+                     $"AONT041: CLR type '{descriptor.ClrType.FullName}' has multiple registrations " +
+                     $"({string.Join(", ", names.Select(n => $"'{n}'"))}) but also declares outgoing links " +
+                     $"({string.Join(", ", descriptor.Links.Select(l => l.Name))}). Multi-registered types cannot " +
+                     $"participate in structural links. See #32 for a future relaxation path.");
+             }
+         }
+     }
+     ```
+   - Call this after `ValidateInverseLinks(allObjectTypes);` at line 72
+
+**Dependencies:** C2 (needs the reverse index)
+**Parallelizable:** No (same file as C1, C2)
+
+---
+
+## Track D — Query Service + ObjectSet Wiring (3 tasks)
+
+**Production files:**
+- `src/Strategos.Ontology/ObjectSets/ObjectSet.cs`
+- `src/Strategos.Ontology/Query/OntologyQueryService.cs`
+- `src/Strategos.Ontology/Query/IOntologyQuery.cs`
+
+**Test files:**
+- `src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTests.cs`
+- `src/Strategos.Ontology.Tests/Query/OntologyQueryServiceTests.cs`
+
+---
+
+### Task D1: `ObjectSet<T>` ctor takes `descriptorName` and threads to `RootExpression`
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `ObjectSet_Constructor_ThreadsDescriptorNameIntoRootExpression`
+   - File: `src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTests.cs`
+   - Body: construct `new ObjectSet<Foo>("trading_documents", mockProvider, mockDispatcher, mockEventStream)`, inspect `.Expression`, cast to `RootExpression`, assert `root.ObjectTypeName == "trading_documents"`
+   - Expected failure: `ObjectSet<T>` has no ctor accepting a descriptor name
+
+2. [GREEN] Update `ObjectSet<T>` ctor
+   - File: `src/Strategos.Ontology/ObjectSets/ObjectSet.cs`
+   - Replace the existing public ctor at line 22:
+     ```csharp
+     public ObjectSet(
+         string descriptorName,
+         IObjectSetProvider provider,
+         IActionDispatcher actionDispatcher,
+         IEventStreamProvider eventStreamProvider)
+         : this(new RootExpression(typeof(T), descriptorName), provider, actionDispatcher, eventStreamProvider)
+     {
+         ArgumentNullException.ThrowIfNull(descriptorName);
+     }
+     ```
+   - Audit and update any test code that constructs `ObjectSet<T>` directly (grep for `new ObjectSet<`); supply `typeof(T).Name` as the descriptor name in legacy test construction to preserve existing behavior
+
+**Dependencies:** A1
+**Parallelizable:** No (transitive on expression tree)
+
+---
+
+### Task D2: `OntologyQueryService.GetObjectSet<T>` threads descriptor name
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `GetObjectSet_ThreadsDescriptorNameIntoRootExpression`
+   - File: `src/Strategos.Ontology.Tests/Query/OntologyQueryServiceTests.cs`
+   - Body: build an ontology with `Object<Foo>("custom_name", ...)`, construct `OntologyQueryService` with mock provider, call `query.GetObjectSet<Foo>("custom_name")`, inspect `objectSet.Expression`, cast to `RootExpression`, assert `root.ObjectTypeName == "custom_name"`
+   - Follow-up test: `GetObjectSet_WithMultiRegistration_ReturnsDistinctRootExpressionsPerName`
+     - Register `Object<Foo>("a", ...)` and `Object<Foo>("b", ...)`; call `GetObjectSet<Foo>("a")` and `GetObjectSet<Foo>("b")`; assert `root.ObjectTypeName` differs between the two
+   - Expected failure: the root expression always has `typeof(T).Name`, not the passed descriptor name
+
+2. [GREEN] Update `OntologyQueryService.GetObjectSet<T>` at `OntologyQueryService.cs:49-68`
+   - Replace the `return new ObjectSet<T>(...)` at line 67 with:
+     ```csharp
+     return new ObjectSet<T>(
+         descriptorName: ot.Name,
+         _objectSetProvider,
+         _actionDispatcher,
+         _eventStreamProvider);
+     ```
+
+**Dependencies:** B1, B2 (for test setup with explicit names), D1 (for the ctor)
+**Parallelizable:** No
+
+---
+
+### Task D3: `IOntologyQuery.GetObjectTypeNames<T>()` public reverse-index API
+
+**Phase:** RED → GREEN
+
+1. [RED] Write tests in `OntologyQueryServiceTests.cs`:
+   - `GetObjectTypeNames_SingleRegistration_ReturnsOneName` — register `Object<Foo>(...)`; assert `query.GetObjectTypeNames<Foo>() == ["Foo"]`
+   - `GetObjectTypeNames_MultiRegistration_ReturnsAllNamesInRegistrationOrder` — register `Object<Foo>("a", ...)` then `Object<Foo>("b", ...)`; assert `query.GetObjectTypeNames<Foo>() == ["a", "b"]`
+   - `GetObjectTypeNames_UnregisteredType_ReturnsEmptyList` — no registration; assert empty list
+   - Expected failure: method does not exist on `IOntologyQuery`
+
+2. [GREEN] Add method
+   - File: `src/Strategos.Ontology/Query/IOntologyQuery.cs` — add:
+     ```csharp
+     IReadOnlyList<string> GetObjectTypeNames<T>() where T : class;
+     ```
+   - File: `src/Strategos.Ontology/Query/OntologyQueryService.cs` — add:
+     ```csharp
+     public IReadOnlyList<string> GetObjectTypeNames<T>() where T : class
+     {
+         return graph.ObjectTypeNamesByType.TryGetValue(typeof(T), out var names)
+             ? names
+             : Array.Empty<string>();
+     }
+     ```
+
+**Dependencies:** C2 (reverse index), B1 (multi-registration in test setup)
+**Parallelizable:** Yes with D2 after C2
+
+---
+
+## Track E — Read-Path Provider Dispatch (5 tasks)
+
+**Production files:**
+- `src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs`
+- `src/Strategos.Ontology.Npgsql/Internal/TypeMapper.cs`
+- `src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs`
+
+**Test files:**
+- `src/Strategos.Ontology.Npgsql.Tests/PgVectorObjectSetProviderTests.cs` (or wherever existing read tests live)
+- `src/Strategos.Ontology.Tests/ObjectSets/InMemoryObjectSetProviderTests.cs`
+
+---
+
+### Task E1: `PgVectorObjectSetProvider.ExecuteSimilarityAsync` reads descriptor name from expression
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `ExecuteSimilarityAsync_UsesDescriptorNameFromExpression_NotTypeofTName`
+   - File: `src/Strategos.Ontology.Npgsql.Tests/PgVectorObjectSetProviderTests.cs`
+   - Body: construct a `SimilarityExpression` whose source is `new RootExpression(typeof(SemanticDocument), "trading_documents")`; spy on the generated SQL via an injected `NpgsqlDataSource` mock or by calling `SqlGenerator.BuildSimilarityQuery` directly; assert the `FROM` clause references `trading_documents`, not `semantic_document`
+   - Expected failure: `ExecuteSimilarityAsync` calls `TypeMapper.GetTableName<T>()` at line 60 which returns `semantic_document`
+
+2. [GREEN] Update `ExecuteSimilarityAsync` at `PgVectorObjectSetProvider.cs:60`
+   - Replace `var tableName = TypeMapper.GetTableName<T>();` with:
+     ```csharp
+     var tableName = TypeMapper.ToSnakeCase(expression.RootObjectTypeName);
+     ```
+
+**Dependencies:** A1, A2
+**Parallelizable:** Yes with E2, E3 after A
+
+---
+
+### Task E2: `PgVectorObjectSetProvider.ExecuteAsync` reads descriptor name from expression
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `ExecuteAsync_UsesDescriptorNameFromExpression_NotTypeofTName`
+   - File: `src/Strategos.Ontology.Npgsql.Tests/PgVectorObjectSetProviderTests.cs`
+   - Body: construct a non-similarity expression (a plain `RootExpression` or `FilterExpression`) with explicit descriptor name; assert the generated `FROM` clause uses the descriptor name
+   - Expected failure: line 122 uses `TypeMapper.GetTableName<T>()`
+
+2. [GREEN] Update `ExecuteAsync` at `PgVectorObjectSetProvider.cs:122`
+   - Replace with `var tableName = TypeMapper.ToSnakeCase(expression.RootObjectTypeName);`
+
+**Dependencies:** A1, A2
+**Parallelizable:** Yes with E1, E3
+
+---
+
+### Task E3: `PgVectorObjectSetProvider.StreamAsync` reads descriptor name from expression
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `StreamAsync_UsesDescriptorNameFromExpression_NotTypeofTName`
+   - Analogous to E2 but for `StreamAsync`
+   - Expected failure: line 157 uses `TypeMapper.GetTableName<T>()`
+
+2. [GREEN] Update `StreamAsync` at `PgVectorObjectSetProvider.cs:157`
+   - Same replacement as E1 and E2
+
+**Dependencies:** A1, A2
+**Parallelizable:** Yes with E1, E2
+
+---
+
+### Task E4: `InMemoryObjectSetProvider` partitions by descriptor name
+
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Write tests in `src/Strategos.Ontology.Tests/ObjectSets/InMemoryObjectSetProviderTests.cs`:
+   - `InMemoryProvider_PartitionsByDescriptorName_NotClrType`
+     - Body: seed an item under name "trading_documents"; query via an `ObjectSet<T>` whose root has name "knowledge_documents"; assert result is empty (different partition)
+   - `InMemoryProvider_DefaultSeed_UsesTypeofTName` — regression guard: `Seed<Foo>(item, "content")` (no name) → queries via `RootExpression(typeof(Foo), "Foo")` find it
+   - Expected failure: provider partitions by `typeof(T)`, not by descriptor name
+
+2. [GREEN] Update `InMemoryObjectSetProvider`
+   - File: `src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs`
+   - Change field types from `ConcurrentDictionary<Type, List<object>>` to `ConcurrentDictionary<string, List<object>>` (all three fields: `_items`, `_searchableContent`, `_embeddings`)
+   - Update `Seed<T>` signature: `public void Seed<T>(T item, string searchableContent, string? descriptorName = null) where T : class`
+     - Key: `var key = descriptorName ?? typeof(T).Name;`
+   - Update `ExecuteAsync<T>`, `StreamAsync<T>`, `ExecuteSimilarityAsync<T>` to read the partition key from `expression.RootObjectTypeName`
+   - Retain the `IEmbeddingProvider` cosine path unchanged (it only affects scoring, not partitioning)
+
+3. [REFACTOR] Verify all existing tests using `Seed<T>(item, content)` still pass unchanged (no `descriptorName` arg, falls back to `typeof(T).Name`, matches default root expression names)
+
+**Dependencies:** A1, A2
+**Parallelizable:** Yes with E1-E3 (different file)
+
+---
+
+### Task E5: Remove `TypeMapper.GetTableName<T>()`
+
+**Phase:** REFACTOR
+
+1. [REFACTOR] Delete the method
+   - File: `src/Strategos.Ontology.Npgsql/Internal/TypeMapper.cs`
+   - Remove lines 50-53 (the `GetTableName<T>()` method)
+   - `ToSnakeCase(string)` is retained (it's now called directly by the provider)
+   - Verify the build succeeds — if any test or production code still references `GetTableName<T>`, fix that call site to use `ToSnakeCase(expression.RootObjectTypeName)` or (for write-path pre-F2/F3) a temporary `ToSnakeCase(typeof(T).Name)` that will be replaced in Track F
+
+2. [REFACTOR] Add compile-time guard test: `TypeMapper_GetTableName_Of_T_Is_Removed`
+   - File: `src/Strategos.Ontology.Npgsql.Tests/PgVectorObjectSetProviderTests.cs`
+   - Body: `typeof(TypeMapper).GetMethods(BindingFlags.NonPublic | BindingFlags.Static).Any(m => m.Name == "GetTableName" && m.IsGenericMethod).Should().BeFalse()` (or TUnit equivalent)
+   - This locks the footgun removal in place permanently
+
+**Dependencies:** E1, E2, E3, F3 (all read and write call sites updated first)
+**Parallelizable:** No
+
+---
+
+## Track F — Write-Path Provider Dispatch (6 tasks)
+
+**Production files:**
+- `src/Strategos.Ontology/ObjectSets/IObjectSetWriter.cs`
+- `src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs`
+- `src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs`
+- `src/Strategos.Ontology/Ingestion/IngestionPipeline.cs`
+- `src/Strategos.Ontology/Ingestion/IngestionPipelineBuilder.cs`
+
+**Test files:**
+- `src/Strategos.Ontology.Tests/ObjectSets/IObjectSetWriterTests.cs` (new)
+- `src/Strategos.Ontology.Npgsql.Tests/PgVectorWriteTests.cs`
+- `src/Strategos.Ontology.Tests/Ingestion/IngestionPipelineTests.cs`
+
+---
+
+### Task F1: `IObjectSetWriter` gains explicit-name overloads
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `IObjectSetWriter_HasExplicitNameOverloads_ForStoreAsyncAndStoreBatchAsync`
+   - File: `src/Strategos.Ontology.Tests/ObjectSets/IObjectSetWriterTests.cs` (new file)
+   - Body: reflection assertion that `IObjectSetWriter` exposes 4 methods — `StoreAsync<T>(T, CancellationToken)`, `StoreAsync<T>(string, T, CancellationToken)`, `StoreBatchAsync<T>(IReadOnlyList<T>, CancellationToken)`, `StoreBatchAsync<T>(string, IReadOnlyList<T>, CancellationToken)`
+   - Expected failure: only the default overloads exist
+
+2. [GREEN] Add overloads to `IObjectSetWriter`
+   - File: `src/Strategos.Ontology/ObjectSets/IObjectSetWriter.cs`
+   - Add two methods alongside the existing ones:
+     ```csharp
+     Task StoreAsync<T>(string descriptorName, T item, CancellationToken ct = default) where T : class;
+     Task StoreBatchAsync<T>(string descriptorName, IReadOnlyList<T> items, CancellationToken ct = default) where T : class;
+     ```
+   - The interface change breaks `InMemoryObjectSetProvider` and `PgVectorObjectSetProvider`; those are fixed in F2 and F3 respectively. To avoid a broken build between F1 GREEN and F2/F3, F1 also adds **throwing stubs** to both providers: `public Task StoreAsync<T>(string descriptorName, T item, CancellationToken ct = default) where T : class => throw new NotImplementedException();` — F2 and F3 replace these with real implementations
+
+**Dependencies:** None (interface-only change)
+**Parallelizable:** Yes (with A, B, C)
+
+---
+
+### Task F2: `InMemoryObjectSetProvider` implements explicit-name write overloads
+
+**Phase:** RED → GREEN
+
+1. [RED] Write tests in `IObjectSetWriterTests.cs`:
+   - `InMemoryWriter_StoreAsync_ExplicitName_UsesSuppliedName`
+     - Body: `provider.StoreAsync<Foo>("my_partition", item, ct)`; query via `ObjectSet<T>` with root name "my_partition"; assert item is found; query with root name "other_partition"; assert empty
+   - `InMemoryWriter_StoreBatchAsync_ExplicitName_PartitionsByName`
+     - Body: batch store under "my_partition"; assert all items queryable under that name only
+   - `InMemoryWriter_StoreAsync_DefaultOverload_UsesTypeofTName` (regression)
+     - Body: `provider.StoreAsync(item, ct)` (no name) → queryable under `typeof(T).Name`
+   - Expected failure: explicit-name overloads throw `NotImplementedException` from F1 stubs
+
+2. [GREEN] Implement overloads in `InMemoryObjectSetProvider`
+   - File: `src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs`
+   - `StoreAsync<T>(string descriptorName, T item, CancellationToken ct)`: validate name, write to `_items[descriptorName]` / `_searchableContent[descriptorName]` / `_embeddings[descriptorName]`
+   - `StoreBatchAsync<T>(string descriptorName, IReadOnlyList<T> items, CancellationToken ct)`: iterate and call the explicit-name `StoreAsync` variant
+   - Default overload (existing `StoreAsync<T>(T item, ct)`) delegates to the explicit overload with `descriptorName: typeof(T).Name`
+   - Refactor to share code between default and explicit paths
+
+**Dependencies:** F1, E4 (E4 already switched the partition key to string)
+**Parallelizable:** Yes with F3 after F1 + E4
+
+---
+
+### Task F3: `PgVectorObjectSetProvider` implements explicit-name write overloads
+
+**Phase:** RED → GREEN
+
+1. [RED] Write tests in `src/Strategos.Ontology.Npgsql.Tests/PgVectorWriteTests.cs`:
+   - `PgVectorProvider_StoreAsync_ExplicitName_WritesToNamedTable`
+     - Body: invoke `StoreAsync<SemanticDocument>("trading_documents", item, ct)`; verify the generated `INSERT` SQL targets `trading_documents` (use SQL capture via command interception or assert via `SqlGenerator.BuildInsertSql` directly)
+   - `PgVectorProvider_StoreBatchAsync_ExplicitName_UsesCopyToNamedTable`
+     - Body: invoke batch store with explicit name; assert the `COPY <schema>.trading_documents ... FROM STDIN` target
+   - Expected failure: stubs throw `NotImplementedException` (from F1)
+
+2. [GREEN] Implement overloads
+   - File: `src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs`
+   - Extract the existing `StoreAsync<T>` body into a private helper `StoreAsyncCore<T>(string tableName, T item, CancellationToken ct)` that takes an already-resolved table name
+   - Same for `StoreBatchAsync<T>` → `StoreBatchAsyncCore<T>(string tableName, ...)`
+   - Public `StoreAsync<T>(string descriptorName, T item, CancellationToken ct)`: validate name, `var tableName = TypeMapper.ToSnakeCase(descriptorName);`, call `StoreAsyncCore`
+   - Public `StoreBatchAsync<T>(string descriptorName, ...)`: analogous
+   - Default overload (`StoreAsync<T>(T item, ...)`) — wire up to graph-backed resolution in **F4**; for now, temporarily retain `TypeMapper.ToSnakeCase(typeof(T).Name)` to keep existing tests passing until F4 lands
+
+**Dependencies:** F1
+**Parallelizable:** Yes with F2 after F1
+
+---
+
+### Task F4: `PgVectorObjectSetProvider` graph-backed default overload resolution
+
+**Phase:** RED → GREEN
+
+1. [RED] Write tests in `PgVectorWriteTests.cs`:
+   - `PgVectorProvider_StoreAsync_DefaultOverload_ResolvesViaGraph_SingleRegistration`
+     - Body: register `Object<Foo>("foo", ...)` (single registration), inject the graph into the provider via constructor, call `provider.StoreAsync(foo, ct)`; assert the generated INSERT targets `foo`
+   - `PgVectorProvider_StoreAsync_DefaultOverload_WithMultiRegistration_ThrowsWithDiagnostic`
+     - Body: register `Object<Foo>("a", ...)` and `Object<Foo>("b", ...)`; call `provider.StoreAsync(foo, ct)`; assert `InvalidOperationException` whose message names both registrations and instructs the caller to use the explicit-name overload
+   - `PgVectorProvider_StoreAsync_DefaultOverload_FallsBackToTypeofTName_WhenGraphAbsent`
+     - Body: construct the provider without the graph parameter (null); call `provider.StoreAsync(foo, ct)`; assert the generated INSERT targets `foo` (the `typeof(T).Name` fallback)
+   - Expected failure: the default overload currently uses `typeof(T).Name` unconditionally (from F3 temporary behavior)
+
+2. [GREEN] Update provider to accept optional graph + implement resolution
+   - File: `src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs`
+   - Add optional constructor parameter: `OntologyGraph? graph = null` (keep the existing ctor shape; add the new one)
+   - Store `_graph` as a private field
+   - In default `StoreAsync<T>(T item, ...)`:
+     ```csharp
+     string descriptorName;
+     if (_graph is not null && _graph.ObjectTypeNamesByType.TryGetValue(typeof(T), out var names))
+     {
+         if (names.Count == 0) descriptorName = typeof(T).Name;   // unregistered → fallback
+         else if (names.Count == 1) descriptorName = names[0];
+         else throw new InvalidOperationException(
+             $"Type '{typeof(T).FullName}' has multiple registrations ({string.Join(", ", names.Select(n => $"'{n}'"))}). " +
+             $"Use StoreAsync<T>(string descriptorName, T item, ct) to specify the target descriptor.");
+     }
+     else
+     {
+         descriptorName = typeof(T).Name;   // graph absent → fallback
+     }
+     return StoreAsyncCore<T>(TypeMapper.ToSnakeCase(descriptorName), item, ct);
+     ```
+   - Same logic for `StoreBatchAsync<T>` default overload
+   - Update DI registration in `PgVectorServiceCollectionExtensions` (or equivalent) to pass the graph when available
+
+**Dependencies:** F3, C2 (reverse index)
+**Parallelizable:** No
+
+---
+
+### Task F5: `PgVectorObjectSetProvider.EnsureSchemaAsync(string? descriptorName)`
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `EnsureSchemaAsync_WithExplicitName_CreatesNamedTable`
+   - File: `src/Strategos.Ontology.Npgsql.Tests/PgVectorWriteTests.cs`
+   - Body: call `provider.EnsureSchemaAsync<SemanticDocument>("trading_documents", ct)`; assert the generated DDL creates table `trading_documents`
+   - Expected failure: `EnsureSchemaAsync<T>()` takes no name parameter and hardcodes `typeof(T).Name`
+
+2. [GREEN] Update signature and body
+   - File: `src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs:248-259`
+   - New signature: `public async Task EnsureSchemaAsync<T>(string? descriptorName = null, CancellationToken ct = default) where T : class`
+   - Use the same graph-backed resolution pattern from F4 when `descriptorName is null`
+   - Call `TypeMapper.ToSnakeCase(resolvedName)` to compute `tableName`
+
+**Dependencies:** F4 (same graph-backed resolution helper)
+**Parallelizable:** No
+
+---
+
+### Task F6: `IngestionPipelineBuilder<T>.WriteTo(writer, descriptorName)` overload
+
+**Phase:** RED → GREEN
+
+1. [RED] Write tests in `src/Strategos.Ontology.Tests/Ingestion/IngestionPipelineTests.cs`:
+   - `IngestionPipeline_WriteToWithDescriptorName_CallsExplicitStoreBatchAsync`
+     - Body: build a pipeline with `.WriteTo(writer, "trading_documents")`; execute over a single chunk; assert the mock writer's explicit-name `StoreBatchAsync<T>(string, IReadOnlyList<T>, CancellationToken)` was invoked with `"trading_documents"`
+   - `IngestionPipeline_WriteToWithoutDescriptorName_CallsDefaultStoreBatchAsync` (regression)
+     - Body: existing default path; assert the default-overload `StoreBatchAsync<T>(IReadOnlyList<T>, CancellationToken)` was invoked
+   - Expected failure: no `WriteTo(writer, string)` overload exists
+
+2. [GREEN] Update builder and pipeline
+   - File: `src/Strategos.Ontology/Ingestion/IngestionPipelineBuilder.cs`
+   - Add `public IngestionPipelineBuilder<T> WriteTo(IObjectSetWriter writer, string descriptorName)` alongside the existing `WriteTo(IObjectSetWriter writer)`
+   - Store `_descriptorName: string?` on the builder
+   - Pass `_descriptorName` into `IngestionPipeline<T>` via its internal constructor
+   - File: `src/Strategos.Ontology/Ingestion/IngestionPipeline.cs`
+   - Add `_descriptorName: string?` field
+   - In `ExecuteCoreAsync` at line 120, branch:
+     ```csharp
+     if (_descriptorName is not null)
+         await _writer.StoreBatchAsync<T>(_descriptorName, mappedItems, ct).ConfigureAwait(false);
+     else
+         await _writer.StoreBatchAsync<T>(mappedItems, ct).ConfigureAwait(false);
+     ```
+
+**Dependencies:** F1
+**Parallelizable:** Yes with F2, F3 after F1
+
+---
+
+## Track G — End-to-End Integration + Housekeeping (2 tasks)
+
+---
+
+### Task G1: End-to-end multi-registration integration test
+
+**Phase:** RED → GREEN (GREEN passes once all dependencies are met)
+
+1. [RED] Write test: `EndToEnd_MultiRegistration_FluentSimilarityChain_IsolatesByDescriptorName`
+   - File: `src/Strategos.Ontology.Tests/Query/OntologyQueryFluentSimilarityTests.cs` (extend the existing file)
+   - Body:
+     1. Build an ontology registering `SemanticDocument` twice under domain "basileus": `Object<SemanticDocument>("trading_documents", ...)` and `Object<SemanticDocument>("knowledge_documents", ...)`
+     2. Configure `InMemoryObjectSetProvider` with a deterministic fake `IEmbeddingProvider`
+     3. Seed two distinct sets of `SemanticDocument` items via the explicit-name `StoreAsync<T>(string, T, ct)` overload under each name
+     4. Execute the full fluent chain: `query.GetObjectSet<SemanticDocument>("trading_documents").SimilarTo("market data").WithMinRelevance(0.0).Take(10).ExecuteAsync(ct)`
+     5. Assert the result contains only the trading partition's items
+     6. Repeat for `"knowledge_documents"`; assert the result contains only the knowledge partition's items
+     7. Assert both result sets are disjoint — no cross-contamination
+   - This test is the regression guard for #31 — if any of the five wiring points (builder, graph, expression, query service, provider) breaks, this test fails
+   - Expected failure: depends on all prior tasks being complete; before then, likely fails at builder (multi-registration rejected), ObjectSet ctor (no descriptor name), or provider dispatch (wrong partition)
+
+2. [GREEN] No new code; test passes once A, B, C, D, E, F are complete
+
+**Dependencies:** A1-A3, B1-B3, C1-C3, D1-D3, E1-E5, F1-F6
+**Parallelizable:** No (integration test, runs last)
+
+---
+
+### Task G2: Close #28 and #29 as delivered in 2.4.0
+
+**Phase:** POST-MERGE (not code; workflow hygiene)
+
+1. After 2.4.1 PR merges, run:
+   ```bash
+   gh issue close 28 --comment "Delivered in 2.4.0 via #30 (commit 9e47550). Fluent similarity chain (ObjectSet<T>.SimilarTo() + fluent setters + IOntologyQuery.GetObjectSet<T>) shipped as planned. The descriptor-name dispatch follow-up (#31) was fixed in 2.4.1 via the ontology-descriptor-name-dispatch design."
+
+   gh issue close 29 --comment "Delivered in 2.4.0 via #30 (commit 9e47550). Lifecycle DSL sugar (InitialState/TerminalState/Transition overload) and .ValidFromState projection shipped as planned. GetActionsForState read-side was already correct per the 2.4.0 spec."
+   ```
+
+**Dependencies:** G1 passing + PR merge
+**Parallelizable:** N/A (post-merge)
+
+---
+
+## Parallelization Graph
+
+```
+Group 1 (start in parallel):
+    ├── A1 → A2 → A3                (expression tree foundation)
+    ├── B1 → B2 → B3                (builder layer)
+    └── F1                           (IObjectSetWriter interface)
+
+Group 2 (after Group 1):
+    ├── C1, C2 (parallel)            (graph freeze diagnostics + reverse index)
+    │
+    ├── D1 → D2                      (ObjectSet ctor + query service)
+    │
+    ├── E1, E2, E3 (parallel)        (PgVector read paths)
+    │
+    ├── E4                           (InMemory partition switch)
+    │
+    ├── F2                           (InMemory write overloads; needs E4)
+    │
+    └── F3                           (PgVector write overloads; needs F1)
+
+Group 3 (after Group 2):
+    ├── C3                           (AONT041; needs C2)
+    ├── D3                           (GetObjectTypeNames; needs C2)
+    ├── E5                           (TypeMapper cleanup; needs E1-E3 + F3)
+    └── F4 → F5 → F6                 (graph-backed default + ensure schema + ingestion pipeline)
+
+Group 4 (integration):
+    └── G1                           (end-to-end; needs everything)
+
+Group 5 (post-merge):
+    └── G2                           (close #28, #29)
+```
+
+## Worktree Strategy
+
+All tasks within Tracks A, B, and F1 can proceed in **three parallel worktrees** since they touch disjoint files:
+- Worktree 1: Track A (`ObjectSetExpression.cs`)
+- Worktree 2: Track B (`OntologyBuilder.cs`, `ObjectTypeBuilder.cs`, `IOntologyBuilder.cs`)
+- Worktree 3: Track F1 (`IObjectSetWriter.cs` + stub additions to both providers)
+
+After Group 1 lands on main, Tracks C, D, E, and F2–F6 can proceed in **four parallel worktrees**:
+- Worktree 1: Track C (graph freeze — `OntologyGraphBuilder.cs`, `OntologyGraph.cs`)
+- Worktree 2: Tracks D1–D3 (query service + ObjectSet — `OntologyQueryService.cs`, `ObjectSet.cs`, `IOntologyQuery.cs`)
+- Worktree 3: Tracks E1–E4 (provider read paths — `PgVectorObjectSetProvider.cs`, `InMemoryObjectSetProvider.cs`)
+- Worktree 4: Tracks F2–F6 (provider write paths + ingestion — overlaps Worktree 3 on provider files, so must sequence after E)
+
+E5 and G1 run last on main after all worktrees merge.
+
+## Risk & Mitigation
+
+1. **Compile-level breakage between A1 GREEN and D1 GREEN.** A1 makes `RootExpression.ObjectTypeName` a required parameter. The only existing caller is `ObjectSet<T>(...)` at `ObjectSet.cs:23`, which A1's GREEN must update to pass `typeof(T).Name` as a placeholder until D1 lands. **Mitigation:** A1's GREEN acceptance criteria explicitly include "all tests in `Strategos.Ontology.Tests` compile and pass with the placeholder name." D1 replaces the placeholder with a threaded value.
+
+2. **F1 interface change breaks both providers until F2/F3 ship.** **Mitigation:** F1's GREEN adds throwing `NotImplementedException` stubs to both providers to keep the build green; F2 and F3 replace the stubs.
+
+3. **E5 removal of `TypeMapper.GetTableName<T>()` might break F3 pre-F4.** F3's default overload initially uses `TypeMapper.ToSnakeCase(typeof(T).Name)` directly (not `GetTableName<T>`) to avoid this dependency. **Mitigation:** E5 can land after F3 without issue; F3 never re-references `GetTableName<T>`.
+
+4. **Existing `InMemoryObjectSetProvider` tests might break on E4's partition switch.** The partition is now keyed by string, not `Type`. **Mitigation:** E4's GREEN preserves `Seed<T>(item, content)` (no `descriptorName`) as equivalent to `Seed<T>(item, content, typeof(T).Name)`, and `ExecuteAsync<T>` etc. read from `expression.RootObjectTypeName` which defaults to `typeof(T).Name` when the ObjectSet is constructed via the legacy path. Concrete regression test: E4's test plan includes `InMemoryProvider_DefaultSeed_UsesTypeofTName`.
+
+5. **Basileus post-release migration blocked on NuGet publish.** Strategos 2.4.1 must publish before Basileus can migrate. **Mitigation:** Basileus migration is tracked in a separate issue; this plan scopes to Strategos-only changes.
+
+## Test Count Summary
+
+| Track | New test count | Files touched |
+|---|---|---|
+| A — expression tree | 8 | 1 |
+| B — builder | 5 | 3 |
+| C — graph freeze | 7 | 2 |
+| D — query service | 5 | 3 |
+| E — read paths | 5 | 3 |
+| F — write paths | 10 | 5 |
+| G — integration | 1 | 1 |
+| **Total** | **41** | **18** |
+
+(Design doc §5 listed 34 test names; the expansion to 41 reflects the §3.7 write-path coverage that was added during plan drafting.)
+
+## Success Criteria
+
+1. All 41 new tests pass (TUnit with `dotnet test -- --treenode-filter "/*/*/*/TestName"`)
+2. All existing tests in `Strategos.Ontology.Tests` and `Strategos.Ontology.Npgsql.Tests` continue to pass without modification (except for direct `new ObjectSet<T>(...)` test construction sites, which are updated mechanically)
+3. `dotnet build` succeeds across all packages with no warnings elevated to errors
+4. `dotnet format` clean per the 2.4.0 format-check convention
+5. `AONT040` fires on duplicate descriptor names with a clear error message
+6. `AONT041` fires on multi-registration + link participation with a clear error message + #32 reference
+7. `TypeMapper.GetTableName<T>()` does not exist in the built assembly (reflection guard)
+8. Issues #28 and #29 closed with delivery pointers to commit `9e47550`
+9. Issue #31 closed with pointer to the 2.4.1 merge commit
+10. Design doc `docs/designs/2026-04-08-ontology-descriptor-name-dispatch.md` remains the source of truth; any plan deviations documented in a §Plan Corrections appendix

--- a/docs/plans/2026-04-08-ontology-descriptor-name-dispatch.md
+++ b/docs/plans/2026-04-08-ontology-descriptor-name-dispatch.md
@@ -834,7 +834,7 @@ All Track A tasks operate on these files. They are sequenced within the track (A
 
 ## Parallelization Graph
 
-```
+```text
 Group 1 (start in parallel):
     ├── A1 → A2 → A3                (expression tree foundation)
     ├── B1 → B2 → B3                (builder layer)

--- a/src/Strategos.Generators.Tests/Emitters/ContextAssemblerEmitterTests.cs
+++ b/src/Strategos.Generators.Tests/Emitters/ContextAssemblerEmitterTests.cs
@@ -369,7 +369,7 @@ public class ContextAssemblerEmitterTests
 
         // Assert
         await Assert.That(source).Contains("new SimilarityExpression(");
-        await Assert.That(source).Contains("new RootExpression(typeof(ProductCatalog))");
+        await Assert.That(source).Contains("new RootExpression(typeof(ProductCatalog), nameof(ProductCatalog))");
     }
 
     /// <summary>

--- a/src/Strategos.Generators/Emitters/ContextAssemblerEmitter.cs
+++ b/src/Strategos.Generators/Emitters/ContextAssemblerEmitter.cs
@@ -236,7 +236,7 @@ internal static class ContextAssemblerEmitter
         // Build SimilarityExpression
         var minRelevanceLiteral = ((double)retrieval.MinRelevance).ToString(System.Globalization.CultureInfo.InvariantCulture);
         sb.AppendLine($"        var {resultsVarName}Expression = new SimilarityExpression(");
-        sb.AppendLine($"            new RootExpression(typeof({retrieval.CollectionTypeName})),");
+        sb.AppendLine($"            new RootExpression(typeof({retrieval.CollectionTypeName}), nameof({retrieval.CollectionTypeName})),");
         if (retrieval.Filters.Count > 0)
         {
             sb.AppendLine($"            {queryExpr}, {retrieval.TopK}, {minRelevanceLiteral},");

--- a/src/Strategos.Ontology.MCP.Tests/OntologyActionToolTests.cs
+++ b/src/Strategos.Ontology.MCP.Tests/OntologyActionToolTests.cs
@@ -1,5 +1,6 @@
 using Strategos.Ontology;
 using Strategos.Ontology.Actions;
+using Strategos.Ontology.Builder;
 using Strategos.Ontology.ObjectSets;
 
 namespace Strategos.Ontology.MCP.Tests;
@@ -164,5 +165,63 @@ public class OntologyActionToolTests
         await Assert.That(result.Results).HasCount().EqualTo(1);
         await Assert.That(result.Results[0].IsSuccess).IsFalse();
         await Assert.That(result.Results[0].Error).Contains("NonExistentType");
+    }
+
+    [Test]
+    public async Task ExecuteAsync_BatchWithExplicitDescriptorName_ThreadsNameIntoRootExpression()
+    {
+        // Arrange — register TestPosition under an explicit descriptor name (differs
+        // from typeof(TestPosition).Name). The batch dispatch path must use the
+        // descriptor name on the root expression so the provider targets the correct
+        // partition, not the CLR type name.
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain<ActionExplicitNameTestDomain>();
+        var graph = graphBuilder.Build();
+
+        var dispatcher = Substitute.For<IActionDispatcher>();
+        var provider = Substitute.For<IObjectSetProvider>();
+        var tool = new OntologyActionTool(graph, dispatcher, provider);
+
+        ObjectSetExpression? capturedExpression = null;
+        provider
+            .ExecuteAsync<object>(Arg.Any<ObjectSetExpression>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                capturedExpression = callInfo.Arg<ObjectSetExpression>();
+                return new ObjectSetResult<object>([], 0, ObjectSetInclusion.Properties);
+            });
+
+        // Act — batch dispatch (no objectId, so DispatchBatchAsync is reached)
+        var result = await tool.ExecuteAsync(
+            objectType: "trading_documents",
+            action: "execute_trade",
+            request: new { },
+            domain: "explicit-name-test");
+
+        // Assert — the RootExpression must carry the explicit descriptor name,
+        // not typeof(TestPosition).Name.
+        await Assert.That(capturedExpression).IsNotNull();
+        await Assert.That(capturedExpression!.RootObjectTypeName).IsEqualTo("trading_documents");
+
+        var root = capturedExpression as RootExpression;
+        await Assert.That(root).IsNotNull();
+        await Assert.That(root!.ObjectTypeName).IsEqualTo("trading_documents");
+        await Assert.That(root.ObjectType).IsEqualTo(typeof(TestPosition));
+    }
+}
+
+internal sealed class ActionExplicitNameTestDomain : DomainOntology
+{
+    public override string DomainName => "explicit-name-test";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TestPosition>("trading_documents", obj =>
+        {
+            obj.Key(p => p.Id);
+            obj.Property(p => p.Symbol).Required();
+            obj.Action("execute_trade")
+                .Description("Execute a trade on the position");
+        });
     }
 }

--- a/src/Strategos.Ontology.MCP.Tests/OntologyQueryToolTests.cs
+++ b/src/Strategos.Ontology.MCP.Tests/OntologyQueryToolTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging.Abstractions;
 
 using Strategos.Ontology;
+using Strategos.Ontology.Builder;
 using Strategos.Ontology.Events;
 using Strategos.Ontology.ObjectSets;
 
@@ -333,5 +334,62 @@ public class OntologyQueryToolTests
         await Assert.That(result).IsTypeOf<QueryResult>();
         await Assert.That(result.ObjectType).IsEqualTo("TestPosition");
         await Assert.That(result.Items).HasCount().EqualTo(1);
+    }
+
+    [Test]
+    public async Task QueryAsync_WithExplicitDescriptorName_ThreadsNameIntoRootExpression()
+    {
+        // Arrange — register TestPosition under an explicit descriptor name that
+        // differs from typeof(TestPosition).Name. The MCP tool receives the descriptor
+        // name as its "objectType" parameter and must carry it through into the root
+        // expression so providers dispatch against the correct partition.
+        var graph = BuildExplicitNameGraph();
+        var provider = Substitute.For<IObjectSetProvider>();
+        var eventStream = Substitute.For<IEventStreamProvider>();
+        var tool = new OntologyQueryTool(graph, provider, eventStream, NullLogger<OntologyQueryTool>.Instance);
+
+        ObjectSetExpression? capturedExpression = null;
+        provider
+            .ExecuteAsync<object>(Arg.Any<ObjectSetExpression>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                capturedExpression = callInfo.Arg<ObjectSetExpression>();
+                return new ObjectSetResult<object>([], 0, ObjectSetInclusion.Properties);
+            });
+
+        // Act
+        await tool.QueryAsync(objectType: "trading_documents", domain: "explicit-name-test");
+
+        // Assert — the RootExpression must carry the explicit descriptor name
+        // ("trading_documents"), NOT the CLR type name ("TestPosition").
+        await Assert.That(capturedExpression).IsNotNull();
+        await Assert.That(capturedExpression!.RootObjectTypeName).IsEqualTo("trading_documents");
+
+        var root = capturedExpression as RootExpression;
+        await Assert.That(root).IsNotNull();
+        await Assert.That(root!.ObjectTypeName).IsEqualTo("trading_documents");
+        // Ensure the CLR type was still correctly resolved from the graph.
+        await Assert.That(root.ObjectType).IsEqualTo(typeof(TestPosition));
+    }
+
+    private static OntologyGraph BuildExplicitNameGraph()
+    {
+        var builder = new OntologyGraphBuilder();
+        builder.AddDomain<ExplicitNameTestDomain>();
+        return builder.Build();
+    }
+}
+
+internal sealed class ExplicitNameTestDomain : DomainOntology
+{
+    public override string DomainName => "explicit-name-test";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TestPosition>("trading_documents", obj =>
+        {
+            obj.Key(p => p.Id);
+            obj.Property(p => p.Symbol).Required();
+        });
     }
 }

--- a/src/Strategos.Ontology.MCP/OntologyActionTool.cs
+++ b/src/Strategos.Ontology.MCP/OntologyActionTool.cs
@@ -119,7 +119,9 @@ public sealed class OntologyActionTool
         CancellationToken ct)
     {
         var clrType = _graph.GetObjectType(domain, objectType)?.ClrType ?? typeof(object);
-        ObjectSetExpression expression = new RootExpression(clrType);
+        // Track A placeholder: MCP tools use the descriptor name as declared by the caller.
+        // Track D will thread a resolved descriptor name once multi-registration support lands.
+        ObjectSetExpression expression = new RootExpression(clrType, objectType);
 
         if (filter is not null)
         {

--- a/src/Strategos.Ontology.MCP/OntologyActionTool.cs
+++ b/src/Strategos.Ontology.MCP/OntologyActionTool.cs
@@ -119,8 +119,10 @@ public sealed class OntologyActionTool
         CancellationToken ct)
     {
         var clrType = _graph.GetObjectType(domain, objectType)?.ClrType ?? typeof(object);
-        // Track A placeholder: MCP tools use the descriptor name as declared by the caller.
-        // Track D will thread a resolved descriptor name once multi-registration support lands.
+        // The MCP protocol passes the ontology descriptor name as the objectType parameter,
+        // which is exactly what RootExpression needs to dispatch against the correct descriptor
+        // partition when the same CLR type is registered under multiple names. See D2 tests in
+        // OntologyActionToolTests.ExecuteAsync_BatchWithExplicitDescriptorName_*.
         ObjectSetExpression expression = new RootExpression(clrType, objectType);
 
         if (filter is not null)

--- a/src/Strategos.Ontology.MCP/OntologyQueryTool.cs
+++ b/src/Strategos.Ontology.MCP/OntologyQueryTool.cs
@@ -136,7 +136,10 @@ public sealed class OntologyQueryTool
             ? _graph.GetObjectType(domain, objectType)?.ClrType ?? typeof(object)
             : typeof(object);
 
-        ObjectSetExpression expression = new RootExpression(clrType);
+        // Track A placeholder: MCP tools use the descriptor name as declared by the caller
+        // (or fall back to CLR type name when unresolved). Track D will thread a resolved
+        // descriptor name once multi-registration support lands.
+        ObjectSetExpression expression = new RootExpression(clrType, objectType ?? clrType.Name);
 
         if (filter is not null)
         {

--- a/src/Strategos.Ontology.MCP/OntologyQueryTool.cs
+++ b/src/Strategos.Ontology.MCP/OntologyQueryTool.cs
@@ -136,10 +136,11 @@ public sealed class OntologyQueryTool
             ? _graph.GetObjectType(domain, objectType)?.ClrType ?? typeof(object)
             : typeof(object);
 
-        // Track A placeholder: MCP tools use the descriptor name as declared by the caller
-        // (or fall back to CLR type name when unresolved). Track D will thread a resolved
-        // descriptor name once multi-registration support lands.
-        ObjectSetExpression expression = new RootExpression(clrType, objectType ?? clrType.Name);
+        // The MCP protocol passes the ontology descriptor name as the objectType parameter,
+        // which is exactly what RootExpression needs to dispatch against the correct descriptor
+        // partition when the same CLR type is registered under multiple names. See D2 tests in
+        // OntologyQueryToolTests.QueryAsync_WithExplicitDescriptorName_*.
+        ObjectSetExpression expression = new RootExpression(clrType, objectType);
 
         if (filter is not null)
         {

--- a/src/Strategos.Ontology.Npgsql.Tests/Integration/IngestionPipelineIntegrationTests.cs
+++ b/src/Strategos.Ontology.Npgsql.Tests/Integration/IngestionPipelineIntegrationTests.cs
@@ -120,7 +120,7 @@ public class IngestionPipelineIntegrationTests
 
         // Query -- similarity search against the ingested data
         var searchExpression = new SimilarityExpression(
-            new RootExpression(typeof(DocumentChunk)),
+            new RootExpression(typeof(DocumentChunk), nameof(DocumentChunk)),
             queryText: "machine learning training",
             topK: 5,
             minRelevance: 0.0);

--- a/src/Strategos.Ontology.Npgsql.Tests/Internal/ExpressionTranslatorTests.cs
+++ b/src/Strategos.Ontology.Npgsql.Tests/Internal/ExpressionTranslatorTests.cs
@@ -9,7 +9,7 @@ public class ExpressionTranslatorTests
     [Test]
     public async Task Translate_RootExpression_ReturnsNoWhere()
     {
-        var root = new RootExpression(typeof(TestEntity));
+        var root = new RootExpression(typeof(TestEntity), nameof(TestEntity));
         var result = ExpressionTranslator.Translate(root);
 
         await Assert.That(result.WhereClause).IsNull();
@@ -19,7 +19,7 @@ public class ExpressionTranslatorTests
     [Test]
     public async Task Translate_EqualityFilter_GeneratesCorrectSql()
     {
-        var root = new RootExpression(typeof(TestEntity));
+        var root = new RootExpression(typeof(TestEntity), nameof(TestEntity));
         Expression<Func<TestEntity, bool>> predicate = x => x.Name == "foo";
         var filter = new FilterExpression(root, predicate);
 
@@ -34,7 +34,7 @@ public class ExpressionTranslatorTests
     [Test]
     public async Task Translate_NotEqualFilter_GeneratesCorrectSql()
     {
-        var root = new RootExpression(typeof(TestEntity));
+        var root = new RootExpression(typeof(TestEntity), nameof(TestEntity));
         Expression<Func<TestEntity, bool>> predicate = x => x.Name != "bar";
         var filter = new FilterExpression(root, predicate);
 
@@ -46,7 +46,7 @@ public class ExpressionTranslatorTests
     [Test]
     public async Task Translate_GreaterThanFilter_GeneratesCorrectSql()
     {
-        var root = new RootExpression(typeof(TestEntity));
+        var root = new RootExpression(typeof(TestEntity), nameof(TestEntity));
         Expression<Func<TestEntity, bool>> predicate = x => x.Age > 30;
         var filter = new FilterExpression(root, predicate);
 
@@ -59,7 +59,7 @@ public class ExpressionTranslatorTests
     [Test]
     public async Task Translate_ChainedFilters_CombinesWithAnd()
     {
-        var root = new RootExpression(typeof(TestEntity));
+        var root = new RootExpression(typeof(TestEntity), nameof(TestEntity));
         Expression<Func<TestEntity, bool>> pred1 = x => x.Name == "foo";
         Expression<Func<TestEntity, bool>> pred2 = x => x.Age > 25;
 
@@ -75,7 +75,7 @@ public class ExpressionTranslatorTests
     [Test]
     public async Task Translate_AndExpression_GeneratesAndClause()
     {
-        var root = new RootExpression(typeof(TestEntity));
+        var root = new RootExpression(typeof(TestEntity), nameof(TestEntity));
         Expression<Func<TestEntity, bool>> predicate = x => x.Name == "foo" && x.Age > 25;
         var filter = new FilterExpression(root, predicate);
 
@@ -88,7 +88,7 @@ public class ExpressionTranslatorTests
     [Test]
     public async Task Translate_OrExpression_GeneratesOrClause()
     {
-        var root = new RootExpression(typeof(TestEntity));
+        var root = new RootExpression(typeof(TestEntity), nameof(TestEntity));
         Expression<Func<TestEntity, bool>> predicate = x => x.Name == "foo" || x.Name == "bar";
         var filter = new FilterExpression(root, predicate);
 
@@ -102,7 +102,7 @@ public class ExpressionTranslatorTests
     public async Task Translate_UnsupportedExpression_ThrowsNotSupportedException()
     {
         // TraverseLinkExpression is not supported for SQL translation
-        var root = new RootExpression(typeof(TestEntity));
+        var root = new RootExpression(typeof(TestEntity), nameof(TestEntity));
         var traverse = new TraverseLinkExpression(root, "link", typeof(TestEntity));
 
         await Assert.That(() => ExpressionTranslator.Translate(traverse))

--- a/src/Strategos.Ontology.Npgsql.Tests/Internal/TypeMapperTests.cs
+++ b/src/Strategos.Ontology.Npgsql.Tests/Internal/TypeMapperTests.cs
@@ -1,9 +1,32 @@
+using System.Reflection;
 using Strategos.Ontology.Npgsql.Internal;
 
 namespace Strategos.Ontology.Npgsql.Tests.Internal;
 
 public class TypeMapperTests
 {
+    // -----------------------------------------------------------------------
+    // Track E5 — TypeMapper.GetTableName<T>() removal guard.
+    //
+    // After F4 and F5 land, the graph-backed dispatch helpers on
+    // PgVectorObjectSetProvider handle all write-path table-name resolution,
+    // and the legacy generic GetTableName<T>() footgun — which silently
+    // collapsed to typeof(T).Name and routed writes to the wrong physical
+    // table when a CLR type was registered under multiple descriptors
+    // (bug #31) — can be removed. This reflection guard fails loudly if a
+    // future change re-introduces it.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task TypeMapper_GetTableName_Of_T_Is_Removed()
+    {
+        var method = typeof(TypeMapper)
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)
+            .FirstOrDefault(m => m.Name == "GetTableName" && m.IsGenericMethod);
+
+        await Assert.That(method).IsNull();
+    }
+
     [Test]
     public async Task ToSnakeCase_PascalCase_ConvertsCorrectly()
     {
@@ -61,24 +84,10 @@ public class TypeMapperTests
         await Assert.That(result).IsEqualTo("xmlhttp_request");
     }
 
-    [Test]
-    public async Task GetTableName_ReturnsSnakeCasedTypeName()
-    {
-        var result = TypeMapper.GetTableName<TestDocument>();
-        await Assert.That(result).IsEqualTo("test_document");
-    }
-
-    [Test]
-    public async Task GetTableName_SimpleType_ReturnsLowered()
-    {
-        var result = TypeMapper.GetTableName<string>();
-        await Assert.That(result).IsEqualTo("string");
-    }
-
-    private sealed class TestDocument
-    {
-        public Guid Id { get; set; }
-
-        public string Name { get; set; } = string.Empty;
-    }
+    // Note: the prior GetTableName_ReturnsSnakeCasedTypeName /
+    // GetTableName_SimpleType_ReturnsLowered tests were removed alongside
+    // TypeMapper.GetTableName<T>() itself (E5). Callers now route through
+    // PgVectorObjectSetProvider.ResolveTableNameForDefaultOverload<T>
+    // (graph-backed with a typeof(T).Name fallback) or
+    // ResolveTableNameForDescriptor (explicit-name writes).
 }

--- a/src/Strategos.Ontology.Npgsql.Tests/PgVectorObjectSetProviderTests.cs
+++ b/src/Strategos.Ontology.Npgsql.Tests/PgVectorObjectSetProviderTests.cs
@@ -169,22 +169,16 @@ public class PgVectorObjectSetProviderTests
     }
 
     [Test]
-    public async Task WriteOverloads_TypeMapperGetTableName_StillUsedByDefaultOverloads()
+    public async Task WriteOverloads_DefaultResolver_FallsBackToTypeofTName_WhenGraphAbsent()
     {
-        // Regression guard — pins the F4 seam. The default StoreAsync<T>(T)
-        // and StoreBatchAsync<T>(IReadOnlyList<T>) overloads must continue
-        // to resolve the table name via TypeMapper.GetTableName<T>() — i.e.
-        // typeof(T).Name → snake_case — so back-compat holds while F4 in
-        // Group 3 prepares to swap this for graph-backed lookup.
-        //
-        // We assert against the still-present TypeMapper.GetTableName<T>()
-        // helper directly. F4 will replace the default-overload call site
-        // and update this test to assert the new resolution path.
-        var defaultTableName = TypeMapper.GetTableName<SemanticDocument>();
+        // Post-F4/E5: the default StoreAsync<T>(T) / StoreBatchAsync<T>
+        // overloads dispatch via ResolveTableNameForDefaultOverload<T>,
+        // which falls back to typeof(T).Name → snake_case when no graph
+        // is in scope. Pins the back-compat fallback so direct
+        // instantiation without DI wiring keeps working.
+        var defaultTableName = PgVectorObjectSetProvider
+            .ResolveTableNameForDefaultOverload<SemanticDocument>(graph: null);
 
-        // Assert — TypeMapper.GetTableName<T>() still exists, still returns
-        // the typeof(T).Name-derived snake_case name, and matches what
-        // SqlGenerator emits for the default write path.
         await Assert.That(defaultTableName).IsEqualTo("semantic_document");
         var defaultInsertSql = SqlGenerator.BuildInsertSql("public", defaultTableName, hasEmbedding: false);
         await Assert.That(defaultInsertSql).Contains("\"public\".\"semantic_document\"");

--- a/src/Strategos.Ontology.Npgsql.Tests/PgVectorObjectSetProviderTests.cs
+++ b/src/Strategos.Ontology.Npgsql.Tests/PgVectorObjectSetProviderTests.cs
@@ -1,3 +1,4 @@
+using Strategos.Ontology.Builder;
 using Strategos.Ontology.Npgsql.Internal;
 using Strategos.Ontology.ObjectSets;
 
@@ -195,6 +196,88 @@ public class PgVectorObjectSetProviderTests
         await Assert.That(explicitTableName).IsNotEqualTo(defaultTableName);
     }
 
+    // ---------------------------------------------------------------------
+    // Track F4 — graph-backed default-overload write-path dispatch tests.
+    //
+    // The default StoreAsync<T>(T) / StoreBatchAsync<T>(IReadOnlyList<T>)
+    // overloads must resolve the target table via the ontology graph when
+    // one is available, honouring single-registration names, throwing with
+    // a diagnostic for multi-registered types, and falling back to
+    // typeof(T).Name only when no graph is in scope (e.g. direct unit-test
+    // instantiation without DI wiring).
+    //
+    // The dispatch step is exposed as the internal static helper
+    // PgVectorObjectSetProvider.ResolveTableNameForDefaultOverload<T>(graph)
+    // so the assertions below pin the full code path without needing a
+    // live NpgsqlDataSource.
+    // ---------------------------------------------------------------------
+
+    [Test]
+    public async Task StoreAsync_DefaultOverload_ResolvesViaGraph_SingleRegistration()
+    {
+        // Arrange — one Object<F4Foo>("foo_table", ...) registration. The
+        // graph's reverse index should map typeof(F4Foo) → ["foo_table"].
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<F4SingleRegistrationOntology>()
+            .Build();
+
+        // Act — default-overload dispatch helper with the graph in scope.
+        var tableName = PgVectorObjectSetProvider.ResolveTableNameForDefaultOverload<F4Foo>(graph);
+
+        // Assert — the descriptor name "foo_table" is honoured, NOT the
+        // typeof(F4Foo).Name → "f4_foo" fallback path.
+        await Assert.That(tableName).IsEqualTo("foo_table");
+        await Assert.That(tableName).IsNotEqualTo("f4_foo");
+    }
+
+    [Test]
+    public async Task StoreAsync_DefaultOverload_WithMultiRegistration_ThrowsWithDiagnostic()
+    {
+        // Arrange — two registrations of the same CLR type under different
+        // descriptor names. The default overload CANNOT safely pick one
+        // automatically and must throw with a diagnostic pointing the
+        // caller at the explicit-name overload.
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<F4MultiRegistrationOntology>()
+            .Build();
+
+        // Act + Assert — the dispatch helper throws InvalidOperationException
+        // naming the type, both descriptor names, and the explicit-name
+        // overload as the remediation.
+        await Assert.That(() => PgVectorObjectSetProvider.ResolveTableNameForDefaultOverload<F4Foo>(graph))
+            .ThrowsException()
+            .WithExceptionType(typeof(InvalidOperationException));
+
+        await Assert.That(() => PgVectorObjectSetProvider.ResolveTableNameForDefaultOverload<F4Foo>(graph))
+            .ThrowsException()
+            .WithMessageContaining(typeof(F4Foo).FullName!);
+
+        await Assert.That(() => PgVectorObjectSetProvider.ResolveTableNameForDefaultOverload<F4Foo>(graph))
+            .ThrowsException()
+            .WithMessageContaining("'a'");
+
+        await Assert.That(() => PgVectorObjectSetProvider.ResolveTableNameForDefaultOverload<F4Foo>(graph))
+            .ThrowsException()
+            .WithMessageContaining("'b'");
+
+        await Assert.That(() => PgVectorObjectSetProvider.ResolveTableNameForDefaultOverload<F4Foo>(graph))
+            .ThrowsException()
+            .WithMessageContaining("StoreAsync");
+    }
+
+    [Test]
+    public async Task StoreAsync_DefaultOverload_FallsBackToTypeofTName_WhenGraphAbsent()
+    {
+        // Arrange — no graph available (direct unit-test call). The helper
+        // must fall back to typeof(T).Name → snake_case so existing
+        // provider constructions without a graph continue to work.
+        // Act
+        var tableName = PgVectorObjectSetProvider.ResolveTableNameForDefaultOverload<F4Foo>(graph: null);
+
+        // Assert — snake_case form of typeof(F4Foo).Name ("F4Foo" → "f4_foo").
+        await Assert.That(tableName).IsEqualTo(TypeMapper.ToSnakeCase(nameof(F4Foo)));
+    }
+
     /// <summary>
     /// Test CLR type whose <c>Name</c> deliberately differs from any expected
     /// descriptor name, so we can detect if the provider is still reaching for
@@ -205,5 +288,46 @@ public class PgVectorObjectSetProviderTests
         public Guid Id { get; set; }
 
         public string Content { get; set; } = string.Empty;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Track F4 test fixtures — top-level so OntologyGraphBuilder.AddDomain<T>()
+// can instantiate them (requires a public parameterless constructor).
+// ---------------------------------------------------------------------------
+
+public class F4Foo
+{
+    public string Id { get; set; } = string.Empty;
+}
+
+public class F4SingleRegistrationOntology : DomainOntology
+{
+    public override string DomainName => "f4-single";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<F4Foo>("foo_table", obj =>
+        {
+            obj.Key(f => f.Id);
+        });
+    }
+}
+
+public class F4MultiRegistrationOntology : DomainOntology
+{
+    public override string DomainName => "f4-multi";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<F4Foo>("a", obj =>
+        {
+            obj.Key(f => f.Id);
+        });
+
+        builder.Object<F4Foo>("b", obj =>
+        {
+            obj.Key(f => f.Id);
+        });
     }
 }

--- a/src/Strategos.Ontology.Npgsql.Tests/PgVectorObjectSetProviderTests.cs
+++ b/src/Strategos.Ontology.Npgsql.Tests/PgVectorObjectSetProviderTests.cs
@@ -1,0 +1,59 @@
+using Strategos.Ontology.Npgsql.Internal;
+using Strategos.Ontology.ObjectSets;
+
+namespace Strategos.Ontology.Npgsql.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="PgVectorObjectSetProvider"/>'s read-path dispatch.
+///
+/// The provider's dispatch step — resolving a table name from an incoming
+/// <see cref="ObjectSetExpression"/> — is exposed as the internal static helper
+/// <c>PgVectorObjectSetProvider.ResolveTableName</c> so it can be verified
+/// without needing a live <see cref="Npgsql.NpgsqlDataSource"/>. The production
+/// <c>ExecuteSimilarityAsync</c>, <c>ExecuteAsync</c>, and <c>StreamAsync</c>
+/// methods all delegate to this helper so the assertions below pin the
+/// behavior of the full code path.
+/// </summary>
+public class PgVectorObjectSetProviderTests
+{
+    [Test]
+    public async Task ExecuteSimilarityAsync_UsesDescriptorNameFromExpression_NotTypeofTName()
+    {
+        // Arrange — build a SimilarityExpression whose root declares an explicit
+        // descriptor name ("trading_documents") that differs from typeof(T).Name
+        // ("SemanticDocument" → "semantic_document"). Track A requires the root
+        // expression to carry the descriptor name; the provider must honor it.
+        var root = new RootExpression(typeof(SemanticDocument), "trading_documents");
+        var similarity = new SimilarityExpression(
+            root,
+            queryText: "equity volatility",
+            topK: 5,
+            minRelevance: 0.0,
+            metric: DistanceMetric.Cosine,
+            queryVector: new float[] { 0.1f, 0.2f, 0.3f });
+
+        // Act — invoke the provider's resolution step directly. This is the
+        // single table-name lookup the production ExecuteSimilarityAsync uses
+        // to build the FROM clause via SqlGenerator.BuildSimilarityQuery.
+        var tableName = PgVectorObjectSetProvider.ResolveTableName(similarity);
+        var sql = SqlGenerator.BuildSimilarityQuery("public", tableName, similarity.Metric);
+
+        // Assert — FROM clause must reference "trading_documents" (the declared
+        // descriptor), NOT "semantic_document" (typeof(T).Name).
+        await Assert.That(tableName).IsEqualTo("trading_documents");
+        await Assert.That(sql).Contains("\"public\".\"trading_documents\"");
+        await Assert.That(sql).DoesNotContain("\"semantic_document\"");
+    }
+
+    /// <summary>
+    /// Test CLR type whose <c>Name</c> deliberately differs from any expected
+    /// descriptor name, so we can detect if the provider is still reaching for
+    /// <c>typeof(T).Name</c> instead of <c>expression.RootObjectTypeName</c>.
+    /// </summary>
+    private sealed class SemanticDocument
+    {
+        public Guid Id { get; set; }
+
+        public string Content { get; set; } = string.Empty;
+    }
+}

--- a/src/Strategos.Ontology.Npgsql.Tests/PgVectorObjectSetProviderTests.cs
+++ b/src/Strategos.Ontology.Npgsql.Tests/PgVectorObjectSetProviderTests.cs
@@ -83,6 +83,24 @@ public class PgVectorObjectSetProviderTests
         await Assert.That(sql).Contains("\"public\".\"knowledge_documents\"");
     }
 
+    [Test]
+    public async Task StreamAsync_UsesDescriptorNameFromExpression_NotTypeofTName()
+    {
+        // Arrange — StreamAsync shares the non-similarity read-path dispatch
+        // with ExecuteAsync. Pin the behavior explicitly so a future refactor
+        // that diverges the two code paths cannot silently regress streaming.
+        var root = new RootExpression(typeof(SemanticDocument), "streaming_documents");
+
+        // Act
+        var tableName = PgVectorObjectSetProvider.ResolveTableName(root);
+        var sql = SqlGenerator.BuildSelectQuery("public", tableName);
+
+        // Assert
+        await Assert.That(tableName).IsEqualTo("streaming_documents");
+        await Assert.That(sql).Contains("\"public\".\"streaming_documents\"");
+        await Assert.That(sql).DoesNotContain("\"semantic_document\"");
+    }
+
     /// <summary>
     /// Test CLR type whose <c>Name</c> deliberately differs from any expected
     /// descriptor name, so we can detect if the provider is still reaching for

--- a/src/Strategos.Ontology.Npgsql.Tests/PgVectorObjectSetProviderTests.cs
+++ b/src/Strategos.Ontology.Npgsql.Tests/PgVectorObjectSetProviderTests.cs
@@ -350,7 +350,7 @@ public class PgVectorObjectSetProviderTests
 // can instantiate them (requires a public parameterless constructor).
 // ---------------------------------------------------------------------------
 
-public class F4Foo
+public sealed class F4Foo
 {
     public string Id { get; set; } = string.Empty;
 }

--- a/src/Strategos.Ontology.Npgsql.Tests/PgVectorObjectSetProviderTests.cs
+++ b/src/Strategos.Ontology.Npgsql.Tests/PgVectorObjectSetProviderTests.cs
@@ -278,6 +278,66 @@ public class PgVectorObjectSetProviderTests
         await Assert.That(tableName).IsEqualTo(TypeMapper.ToSnakeCase(nameof(F4Foo)));
     }
 
+    // ---------------------------------------------------------------------
+    // Track F5 — EnsureSchemaAsync descriptor-name overload tests.
+    //
+    // EnsureSchemaAsync<T>(string? descriptorName = null, ct) must resolve
+    // its target table from the explicit descriptor name when supplied and
+    // otherwise delegate to the same graph-backed default-overload
+    // resolution used by the write path. Pinned via the internal static
+    // seam PgVectorObjectSetProvider.ResolveEnsureSchemaTableName so the
+    // assertions reach the DDL-building step without needing a live
+    // NpgsqlDataSource.
+    // ---------------------------------------------------------------------
+
+    [Test]
+    public async Task EnsureSchemaAsync_WithExplicitName_CreatesNamedTable()
+    {
+        // Arrange — an explicit descriptor name. Even without a graph in
+        // scope the caller's choice wins.
+        // Act
+        var tableName = PgVectorObjectSetProvider
+            .ResolveEnsureSchemaTableName<SemanticDocument>("trading_documents", graph: null);
+        var ddl = SqlGenerator.BuildSchemaCreationDdl(
+            "public",
+            tableName,
+            vectorDimensions: 1536,
+            indexType: PgVectorIndexType.IvfFlat);
+
+        // Assert — DDL creates "trading_documents", NOT "semantic_document".
+        await Assert.That(tableName).IsEqualTo("trading_documents");
+        await Assert.That(ddl)
+            .Contains("CREATE TABLE IF NOT EXISTS \"public\".\"trading_documents\"");
+        await Assert.That(ddl).DoesNotContain("\"semantic_document\"");
+    }
+
+    [Test]
+    public async Task EnsureSchemaAsync_WithoutName_FallsBackToDefaultResolution()
+    {
+        // Arrange — a graph containing a single Object<F4Foo>("foo_table")
+        // registration. Calling EnsureSchemaAsync<F4Foo>() with no
+        // descriptor name must route through the default-overload
+        // resolution (F4) and honour the descriptor name "foo_table".
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<F4SingleRegistrationOntology>()
+            .Build();
+
+        // Act
+        var tableName = PgVectorObjectSetProvider
+            .ResolveEnsureSchemaTableName<F4Foo>(descriptorName: null, graph);
+        var ddl = SqlGenerator.BuildSchemaCreationDdl(
+            "public",
+            tableName,
+            vectorDimensions: 1536,
+            indexType: PgVectorIndexType.IvfFlat);
+
+        // Assert — DDL creates "foo_table", NOT "f4_foo".
+        await Assert.That(tableName).IsEqualTo("foo_table");
+        await Assert.That(ddl)
+            .Contains("CREATE TABLE IF NOT EXISTS \"public\".\"foo_table\"");
+        await Assert.That(ddl).DoesNotContain("\"f4_foo\"");
+    }
+
     /// <summary>
     /// Test CLR type whose <c>Name</c> deliberately differs from any expected
     /// descriptor name, so we can detect if the provider is still reaching for

--- a/src/Strategos.Ontology.Npgsql.Tests/PgVectorObjectSetProviderTests.cs
+++ b/src/Strategos.Ontology.Npgsql.Tests/PgVectorObjectSetProviderTests.cs
@@ -45,6 +45,44 @@ public class PgVectorObjectSetProviderTests
         await Assert.That(sql).DoesNotContain("\"semantic_document\"");
     }
 
+    [Test]
+    public async Task ExecuteAsync_UsesDescriptorNameFromExpression_NotTypeofTName()
+    {
+        // Arrange — a plain RootExpression with an explicit descriptor name.
+        // The non-similarity read path (ExecuteAsync) must honour the
+        // declared name the same way ExecuteSimilarityAsync does.
+        var root = new RootExpression(typeof(SemanticDocument), "trading_documents");
+
+        // Act
+        var tableName = PgVectorObjectSetProvider.ResolveTableName(root);
+        var sql = SqlGenerator.BuildSelectQuery("public", tableName);
+
+        // Assert
+        await Assert.That(tableName).IsEqualTo("trading_documents");
+        await Assert.That(sql).Contains("\"public\".\"trading_documents\"");
+        await Assert.That(sql).DoesNotContain("\"semantic_document\"");
+    }
+
+    [Test]
+    public async Task ExecuteAsync_FilterExpressionOverRoot_WalksToRootDescriptorName()
+    {
+        // Arrange — a FilterExpression wrapping a RootExpression with a
+        // non-default descriptor name. The walk-to-root helper on
+        // ObjectSetExpression (Track A2) must surface the root's declared
+        // name, and the provider's dispatch must reach it.
+        var root = new RootExpression(typeof(SemanticDocument), "knowledge_documents");
+        System.Linq.Expressions.Expression<Func<SemanticDocument, bool>> pred = d => d.Id != Guid.Empty;
+        var filter = new FilterExpression(root, pred);
+
+        // Act
+        var tableName = PgVectorObjectSetProvider.ResolveTableName(filter);
+        var sql = SqlGenerator.BuildSelectQuery("public", tableName);
+
+        // Assert
+        await Assert.That(tableName).IsEqualTo("knowledge_documents");
+        await Assert.That(sql).Contains("\"public\".\"knowledge_documents\"");
+    }
+
     /// <summary>
     /// Test CLR type whose <c>Name</c> deliberately differs from any expected
     /// descriptor name, so we can detect if the provider is still reaching for

--- a/src/Strategos.Ontology.Npgsql.Tests/PgVectorObjectSetProviderTests.cs
+++ b/src/Strategos.Ontology.Npgsql.Tests/PgVectorObjectSetProviderTests.cs
@@ -101,6 +101,100 @@ public class PgVectorObjectSetProviderTests
         await Assert.That(sql).DoesNotContain("\"semantic_document\"");
     }
 
+    // ---------------------------------------------------------------------
+    // Track F3 — explicit-descriptor-name write-path dispatch tests.
+    //
+    // The write-path equivalent of ResolveTableName is exposed as the
+    // internal static helper PgVectorObjectSetProvider.ResolveTableNameForDescriptor,
+    // which the explicit-name StoreAsync/StoreBatchAsync overloads delegate to.
+    // Asserting against the helper plus the SQL/COPY strings produced by
+    // SqlGenerator pins the full code path without needing a live
+    // NpgsqlDataSource.
+    // ---------------------------------------------------------------------
+
+    [Test]
+    public async Task StoreAsync_ExplicitName_WritesToNamedTable()
+    {
+        // Arrange — descriptor name "trading_documents" deliberately differs
+        // from typeof(SemanticDocument).Name so we can detect a regression to
+        // the typeof(T).Name path.
+        const string descriptorName = "trading_documents";
+
+        // Act — invoke the dispatch helper the explicit-name StoreAsync<T>
+        // overload uses. Then build the INSERT SQL the production code path
+        // emits via SqlGenerator.BuildInsertSql.
+        var tableName = PgVectorObjectSetProvider.ResolveTableNameForDescriptor(descriptorName);
+        var insertSql = SqlGenerator.BuildInsertSql("public", tableName, hasEmbedding: false);
+        var insertSqlWithEmbedding = SqlGenerator.BuildInsertSql("public", tableName, hasEmbedding: true);
+
+        // Assert — table name resolves verbatim (already snake_case) and the
+        // generated INSERT statements target "trading_documents", NOT
+        // "semantic_document".
+        await Assert.That(tableName).IsEqualTo("trading_documents");
+        await Assert.That(TypeMapper.ToSnakeCase("trading_documents")).IsEqualTo("trading_documents");
+        await Assert.That(insertSql).Contains("\"public\".\"trading_documents\"");
+        await Assert.That(insertSql).DoesNotContain("\"semantic_document\"");
+        await Assert.That(insertSqlWithEmbedding).Contains("\"public\".\"trading_documents\"");
+        await Assert.That(insertSqlWithEmbedding).Contains("embedding");
+    }
+
+    [Test]
+    public async Task StoreBatchAsync_ExplicitName_UsesCopyToNamedTable()
+    {
+        // Arrange — same dispatch step. The batch path uses the resolved
+        // table name to build a fully-qualified COPY target identifier.
+        const string descriptorName = "trading_documents";
+
+        // Act
+        var tableName = PgVectorObjectSetProvider.ResolveTableNameForDescriptor(descriptorName);
+        var qualifiedTable =
+            $"{SqlGenerator.QuoteIdentifier("public")}.{SqlGenerator.QuoteIdentifier(tableName)}";
+        var copyColumnsNoEmbedding = $"{qualifiedTable} (id, data)";
+        var copyColumnsWithEmbedding = $"{qualifiedTable} (id, data, embedding)";
+        var copyCommandNoEmbedding = $"COPY {copyColumnsNoEmbedding} FROM STDIN (FORMAT BINARY)";
+        var copyCommandWithEmbedding = $"COPY {copyColumnsWithEmbedding} FROM STDIN (FORMAT BINARY)";
+
+        // Assert — COPY target table matches the explicit descriptor, not
+        // typeof(T).Name. The qualified identifier is the exact string
+        // PgVectorObjectSetProvider.StoreBatchAsync passes to
+        // NpgsqlConnection.BeginBinaryImportAsync.
+        await Assert.That(tableName).IsEqualTo("trading_documents");
+        await Assert.That(qualifiedTable).IsEqualTo("\"public\".\"trading_documents\"");
+        await Assert.That(copyCommandNoEmbedding)
+            .IsEqualTo("COPY \"public\".\"trading_documents\" (id, data) FROM STDIN (FORMAT BINARY)");
+        await Assert.That(copyCommandWithEmbedding)
+            .IsEqualTo("COPY \"public\".\"trading_documents\" (id, data, embedding) FROM STDIN (FORMAT BINARY)");
+        await Assert.That(copyCommandNoEmbedding).DoesNotContain("semantic_document");
+    }
+
+    [Test]
+    public async Task WriteOverloads_TypeMapperGetTableName_StillUsedByDefaultOverloads()
+    {
+        // Regression guard — pins the F4 seam. The default StoreAsync<T>(T)
+        // and StoreBatchAsync<T>(IReadOnlyList<T>) overloads must continue
+        // to resolve the table name via TypeMapper.GetTableName<T>() — i.e.
+        // typeof(T).Name → snake_case — so back-compat holds while F4 in
+        // Group 3 prepares to swap this for graph-backed lookup.
+        //
+        // We assert against the still-present TypeMapper.GetTableName<T>()
+        // helper directly. F4 will replace the default-overload call site
+        // and update this test to assert the new resolution path.
+        var defaultTableName = TypeMapper.GetTableName<SemanticDocument>();
+
+        // Assert — TypeMapper.GetTableName<T>() still exists, still returns
+        // the typeof(T).Name-derived snake_case name, and matches what
+        // SqlGenerator emits for the default write path.
+        await Assert.That(defaultTableName).IsEqualTo("semantic_document");
+        var defaultInsertSql = SqlGenerator.BuildInsertSql("public", defaultTableName, hasEmbedding: false);
+        await Assert.That(defaultInsertSql).Contains("\"public\".\"semantic_document\"");
+
+        // Sanity — the explicit-name dispatch helper produces a different
+        // table name from the same CLR type when given a non-matching
+        // descriptor, proving the two paths are independently resolvable.
+        var explicitTableName = PgVectorObjectSetProvider.ResolveTableNameForDescriptor("trading_documents");
+        await Assert.That(explicitTableName).IsNotEqualTo(defaultTableName);
+    }
+
     /// <summary>
     /// Test CLR type whose <c>Name</c> deliberately differs from any expected
     /// descriptor name, so we can detect if the provider is still reaching for

--- a/src/Strategos.Ontology.Npgsql.Tests/PgVectorSimilarityTests.cs
+++ b/src/Strategos.Ontology.Npgsql.Tests/PgVectorSimilarityTests.cs
@@ -38,7 +38,7 @@ public class PgVectorSimilarityTests
     {
         // Verify that when QueryVector is null, the provider would need to call EmbedAsync.
         // We test this indirectly through the SimilarityExpression construction.
-        var root = new RootExpression(typeof(TestDoc));
+        var root = new RootExpression(typeof(TestDoc), nameof(TestDoc));
         var expression = new SimilarityExpression(
             root,
             queryText: "search term",
@@ -64,7 +64,7 @@ public class PgVectorSimilarityTests
     public async Task ExecuteSimilarityAsync_WithQueryVector_BypassesEmbedding()
     {
         var queryVector = new float[] { 0.1f, 0.2f, 0.3f };
-        var root = new RootExpression(typeof(TestDoc));
+        var root = new RootExpression(typeof(TestDoc), nameof(TestDoc));
         var expression = new SimilarityExpression(
             root,
             queryText: "search term",
@@ -89,7 +89,7 @@ public class PgVectorSimilarityTests
     [Test]
     public async Task SimilarityExpression_DefaultMetric_IsCosine()
     {
-        var root = new RootExpression(typeof(TestDoc));
+        var root = new RootExpression(typeof(TestDoc), nameof(TestDoc));
         var expression = new SimilarityExpression(root, "query", 10, 0.5);
 
         await Assert.That(expression.Metric).IsEqualTo(DistanceMetric.Cosine);
@@ -98,7 +98,7 @@ public class PgVectorSimilarityTests
     [Test]
     public async Task SimilarityExpression_PreservesAllProperties()
     {
-        var root = new RootExpression(typeof(TestDoc));
+        var root = new RootExpression(typeof(TestDoc), nameof(TestDoc));
         var vector = new float[] { 1.0f, 2.0f };
         var filters = new Dictionary<string, object> { { "category", "test" } };
 

--- a/src/Strategos.Ontology.Npgsql.Tests/PgVectorWriteTests.cs
+++ b/src/Strategos.Ontology.Npgsql.Tests/PgVectorWriteTests.cs
@@ -56,7 +56,12 @@ public class PgVectorWriteTests
     [Test]
     public async Task TypeMapper_ForISearchableType_ProducesTableName()
     {
-        var tableName = TypeMapper.GetTableName<SearchableDocument>();
+        // Post-E5 the write-path default-overload resolver delegates to
+        // graph lookup and falls back to typeof(T).Name → snake_case when
+        // no graph is in scope. Assert the fallback path produces the
+        // expected table name for a searchable type.
+        var tableName = PgVectorObjectSetProvider
+            .ResolveTableNameForDefaultOverload<SearchableDocument>(graph: null);
 
         await Assert.That(tableName).IsEqualTo("searchable_document");
     }

--- a/src/Strategos.Ontology.Npgsql/Internal/TypeMapper.cs
+++ b/src/Strategos.Ontology.Npgsql/Internal/TypeMapper.cs
@@ -46,9 +46,4 @@ internal static class TypeMapper
 
         return sb.ToString();
     }
-
-    /// <summary>
-    /// Gets the snake_case table name for a CLR type.
-    /// </summary>
-    internal static string GetTableName<T>() => ToSnakeCase(typeof(T).Name);
 }

--- a/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
+++ b/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
@@ -242,6 +242,21 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
         await writer.CompleteAsync(ct).ConfigureAwait(false);
     }
 
+    // The two explicit-descriptor-name overloads below are INTENTIONAL temporary placeholders
+    // landed by Task F1 (Strategos 2.4.1 Ontology Descriptor-Name Dispatch, bug #31). They exist
+    // solely so PgVectorObjectSetProvider continues to satisfy IObjectSetWriter while the interface
+    // change lands ahead of the real implementation. Task F3 (graph-backed explicit-name write path)
+    // will replace the NotImplementedException throws with the descriptor-partition-aware
+    // SQL/COPY logic. Do not call these overloads yet.
+
+    /// <inheritdoc />
+    public Task StoreAsync<T>(string descriptorName, T item, CancellationToken ct = default) where T : class
+        => throw new NotImplementedException("Implemented in Task F3");
+
+    /// <inheritdoc />
+    public Task StoreBatchAsync<T>(string descriptorName, IReadOnlyList<T> items, CancellationToken ct = default) where T : class
+        => throw new NotImplementedException("Implemented in Task F3");
+
     /// <summary>
     /// Ensures the database schema (extension, table, index) exists for the given type.
     /// </summary>

--- a/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
+++ b/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
@@ -181,7 +181,9 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
     {
         ArgumentNullException.ThrowIfNull(expression);
 
-        var tableName = TypeMapper.GetTableName<T>();
+        // Resolve table name from the expression's declared descriptor name
+        // via the shared read-path dispatch helper (bug #31).
+        var tableName = ResolveTableName(expression);
         var translation = ExpressionTranslator.Translate(expression);
         var sql = SqlGenerator.BuildSelectQuery(_options.Schema, tableName, translation.WhereClause);
 

--- a/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
+++ b/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
@@ -44,6 +44,29 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
         _logger = logger;
     }
 
+    /// <summary>
+    /// Resolves the snake_case PostgreSQL table name for a read-path expression
+    /// from the descriptor name declared on the expression's root, normalising
+    /// it via <see cref="TypeMapper.ToSnakeCase(string)"/>.
+    ///
+    /// Replaces the prior <c>TypeMapper.GetTableName&lt;T&gt;()</c> lookup,
+    /// which silently collapsed to <c>typeof(T).Name</c> and routed queries to
+    /// the wrong physical table when a CLR type was registered under multiple
+    /// ontology descriptors (bug #31 / Strategos 2.4.1).
+    /// </summary>
+    /// <remarks>
+    /// Exposed as <c>internal</c> so the three read-path methods
+    /// (<see cref="ExecuteSimilarityAsync{T}"/>, <see cref="ExecuteAsync{T}"/>,
+    /// <see cref="StreamAsync{T}"/>) share a single dispatch step and unit tests
+    /// can pin its behavior without needing a live
+    /// <see cref="NpgsqlDataSource"/>.
+    /// </remarks>
+    internal static string ResolveTableName(ObjectSetExpression expression)
+    {
+        ArgumentNullException.ThrowIfNull(expression);
+        return TypeMapper.ToSnakeCase(expression.RootObjectTypeName);
+    }
+
     /// <inheritdoc />
     public async Task<ScoredObjectSetResult<T>> ExecuteSimilarityAsync<T>(
         SimilarityExpression expression, CancellationToken ct = default) where T : class
@@ -56,8 +79,10 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
 
         ValidateEmbedding<T>(queryVector);
 
-        // 2. Get table name from TypeMapper
-        var tableName = TypeMapper.GetTableName<T>();
+        // 2. Resolve table name from the expression's declared descriptor name
+        //    (honors explicit names supplied via GetObjectSet<T>(descriptorName);
+        //    see ResolveTableName docs / bug #31).
+        var tableName = ResolveTableName(expression);
 
         // 3. Translate Source expression (handles Filter, Include, Root transparently)
         var sourceTranslation = ExpressionTranslator.Translate(expression.Source);

--- a/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
+++ b/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
@@ -410,9 +410,19 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
     /// <summary>
     /// Ensures the database schema (extension, table, index) exists for the given type.
     /// </summary>
-    public async Task EnsureSchemaAsync<T>(CancellationToken ct = default) where T : class
+    /// <typeparam name="T">The CLR type whose backing table should be created.</typeparam>
+    /// <param name="descriptorName">
+    /// Optional explicit descriptor name identifying the target table. When
+    /// <c>null</c>, the target is resolved via
+    /// <see cref="ResolveTableNameForDefaultOverload{T}(OntologyGraph?)"/>
+    /// using the provider's optional <see cref="OntologyGraph"/>; for
+    /// multi-registered types the resolution throws and callers must
+    /// specify the name explicitly (one call per descriptor).
+    /// </param>
+    /// <param name="ct">The cancellation token.</param>
+    public async Task EnsureSchemaAsync<T>(string? descriptorName = null, CancellationToken ct = default) where T : class
     {
-        var tableName = TypeMapper.GetTableName<T>();
+        var tableName = ResolveEnsureSchemaTableName<T>(descriptorName, _graph);
         var ddl = SqlGenerator.BuildSchemaCreationDdl(
             _options.Schema,
             tableName,
@@ -421,6 +431,29 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
 
         await using var cmd = _dataSource.CreateCommand(ddl);
         await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Resolves the snake_case PostgreSQL table name for an
+    /// <see cref="EnsureSchemaAsync{T}(string?, CancellationToken)"/> call.
+    /// Honours an explicit <paramref name="descriptorName"/> when supplied;
+    /// otherwise delegates to the shared default-overload resolution
+    /// (<see cref="ResolveTableNameForDefaultOverload{T}(OntologyGraph?)"/>)
+    /// so schema creation and writes stay in lockstep.
+    /// </summary>
+    /// <remarks>
+    /// Exposed as <c>internal static</c> so unit tests can pin its behavior
+    /// without a live <see cref="NpgsqlDataSource"/>, matching the seam used
+    /// by the write-path helpers.
+    /// </remarks>
+    internal static string ResolveEnsureSchemaTableName<T>(string? descriptorName, OntologyGraph? graph)
+    {
+        if (descriptorName is not null)
+        {
+            return TypeMapper.ToSnakeCase(descriptorName);
+        }
+
+        return ResolveTableNameForDefaultOverload<T>(graph);
     }
 
     private static double ConvertDistanceToSimilarity(double distance, DistanceMetric metric) => metric switch

--- a/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
+++ b/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
@@ -144,7 +144,9 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
     {
         ArgumentNullException.ThrowIfNull(expression);
 
-        var tableName = TypeMapper.GetTableName<T>();
+        // Resolve table name from the expression's declared descriptor name
+        // via the shared read-path dispatch helper (bug #31).
+        var tableName = ResolveTableName(expression);
         var translation = ExpressionTranslator.Translate(expression);
         var sql = SqlGenerator.BuildSelectQuery(_options.Schema, tableName, translation.WhereClause);
 

--- a/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
+++ b/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
@@ -23,15 +23,30 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
     private readonly IEmbeddingProvider _embeddingProvider;
     private readonly ILogger<PgVectorObjectSetProvider> _logger;
     private readonly PgVectorOptions _options;
+    private readonly OntologyGraph? _graph;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PgVectorObjectSetProvider"/> class.
     /// </summary>
+    /// <param name="dataSource">The PostgreSQL data source.</param>
+    /// <param name="embeddingProvider">The embedding provider used for vector generation.</param>
+    /// <param name="options">The pgvector provider options.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="graph">
+    /// Optional ontology graph used by the default-named write overloads
+    /// (<see cref="StoreAsync{T}(T, CancellationToken)"/>,
+    /// <see cref="StoreBatchAsync{T}(IReadOnlyList{T}, CancellationToken)"/>,
+    /// <see cref="EnsureSchemaAsync{T}(string?, CancellationToken)"/>) to look up
+    /// the registered descriptor name for a CLR type. When <c>null</c> (e.g. in
+    /// direct unit-test instantiation) the default-overload resolution falls back
+    /// to <c>typeof(T).Name</c> via <see cref="TypeMapper.ToSnakeCase(string)"/>.
+    /// </param>
     public PgVectorObjectSetProvider(
         NpgsqlDataSource dataSource,
         IEmbeddingProvider embeddingProvider,
         IOptions<PgVectorOptions> options,
-        ILogger<PgVectorObjectSetProvider> logger)
+        ILogger<PgVectorObjectSetProvider> logger,
+        OntologyGraph? graph = null)
     {
         ArgumentNullException.ThrowIfNull(dataSource);
         ArgumentNullException.ThrowIfNull(embeddingProvider);
@@ -42,6 +57,7 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
         _embeddingProvider = embeddingProvider;
         _options = options.Value;
         _logger = logger;
+        _graph = graph;
     }
 
     /// <summary>
@@ -78,13 +94,60 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
     /// <c>StoreBatchAsync</c> overloads share a single dispatch step and unit
     /// tests can pin its behavior without needing a live
     /// <see cref="NpgsqlDataSource"/>. The default-named write overloads
-    /// continue to dispatch via <c>TypeMapper.GetTableName&lt;T&gt;()</c>
-    /// pending the F4/F5 graph-backed lookup.
+    /// dispatch via <see cref="ResolveTableNameForDefaultOverload{T}(OntologyGraph?)"/>.
     /// </remarks>
     internal static string ResolveTableNameForDescriptor(string descriptorName)
     {
         ArgumentNullException.ThrowIfNull(descriptorName);
         return TypeMapper.ToSnakeCase(descriptorName);
+    }
+
+    /// <summary>
+    /// Resolves the snake_case PostgreSQL table name for a write-path call
+    /// made via the default (no-name) overloads, using the ontology graph's
+    /// reverse index to look up the descriptor name registered for
+    /// <typeparamref name="T"/>. Falls back to <c>typeof(T).Name</c> when
+    /// <paramref name="graph"/> is <c>null</c> or the type is absent from
+    /// the graph.
+    /// </summary>
+    /// <remarks>
+    /// Symmetric write-path counterpart to <see cref="ResolveTableName(ObjectSetExpression)"/>
+    /// for callers that do not thread an <see cref="ObjectSetExpression"/>.
+    /// Replaces the prior <c>TypeMapper.GetTableName&lt;T&gt;()</c> lookup
+    /// which silently collapsed to <c>typeof(T).Name</c> and routed writes
+    /// to the wrong physical table when a CLR type was registered under
+    /// multiple ontology descriptors (bug #31 / Strategos 2.4.1). Throws
+    /// <see cref="InvalidOperationException"/> when the graph contains more
+    /// than one descriptor for the type — the default overload cannot
+    /// safely pick one and callers must use the explicit-name overload.
+    /// Exposed as <c>internal static</c> so unit tests can pin its behavior
+    /// without a live <see cref="NpgsqlDataSource"/>.
+    /// </remarks>
+    internal static string ResolveTableNameForDefaultOverload<T>(OntologyGraph? graph)
+    {
+        if (graph is not null && graph.ObjectTypeNamesByType.TryGetValue(typeof(T), out var names))
+        {
+            if (names.Count == 1)
+            {
+                return TypeMapper.ToSnakeCase(names[0]);
+            }
+
+            if (names.Count > 1)
+            {
+                throw new InvalidOperationException(
+                    $"Type '{typeof(T).FullName}' has multiple registrations " +
+                    $"({string.Join(", ", names.Select(n => $"'{n}'"))}). " +
+                    $"Use StoreAsync<T>(string descriptorName, T item, ct) or " +
+                    $"StoreBatchAsync<T>(string descriptorName, IReadOnlyList<T> items, ct) " +
+                    $"to specify the target descriptor.");
+            }
+        }
+
+        // Graph absent, type unregistered, or empty name list — fall back to
+        // typeof(T).Name → snake_case for back-compat with direct unit-test
+        // instantiation and DI configurations that do not resolve an
+        // OntologyGraph.
+        return TypeMapper.ToSnakeCase(typeof(T).Name);
     }
 
     /// <inheritdoc />
@@ -233,9 +296,10 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
     {
         ArgumentNullException.ThrowIfNull(item);
 
-        // Default overload: resolve via TypeMapper.GetTableName<T>() (typeof(T).Name → snake_case).
-        // Task F4 (Group 3) will replace this call site with graph-backed descriptor lookup.
-        var tableName = TypeMapper.GetTableName<T>();
+        // Default overload: resolve via the ontology graph's reverse index
+        // (F4). Throws if the type is multi-registered — callers must use
+        // the explicit-name overload to disambiguate.
+        var tableName = ResolveTableNameForDefaultOverload<T>(_graph);
         return StoreAsyncCore<T>(tableName, item, ct);
     }
 
@@ -244,9 +308,10 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
     {
         ArgumentNullException.ThrowIfNull(items);
 
-        // Default overload: resolve via TypeMapper.GetTableName<T>() (typeof(T).Name → snake_case).
-        // Task F4 (Group 3) will replace this call site with graph-backed descriptor lookup.
-        var tableName = TypeMapper.GetTableName<T>();
+        // Default overload: resolve via the ontology graph's reverse index
+        // (F4). Throws if the type is multi-registered — callers must use
+        // the explicit-name overload to disambiguate.
+        var tableName = ResolveTableNameForDefaultOverload<T>(_graph);
         return StoreBatchAsyncCore<T>(tableName, items, ct);
     }
 
@@ -277,9 +342,10 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
     /// <summary>
     /// Core single-item write helper. Takes a pre-resolved <paramref name="tableName"/>
     /// so both the default <see cref="StoreAsync{T}(T, CancellationToken)"/> overload
-    /// (resolving via <see cref="TypeMapper.GetTableName{T}"/>) and the explicit-name
-    /// overload (resolving via <see cref="ResolveTableNameForDescriptor"/>) share a
-    /// single SQL/parameter-binding code path.
+    /// (resolving via <see cref="ResolveTableNameForDefaultOverload{T}(OntologyGraph?)"/>)
+    /// and the explicit-name overload (resolving via
+    /// <see cref="ResolveTableNameForDescriptor"/>) share a single SQL /
+    /// parameter-binding code path.
     /// </summary>
     private async Task StoreAsyncCore<T>(string tableName, T item, CancellationToken ct) where T : class
     {

--- a/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
+++ b/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
@@ -67,6 +67,26 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
         return TypeMapper.ToSnakeCase(expression.RootObjectTypeName);
     }
 
+    /// <summary>
+    /// Resolves the snake_case PostgreSQL table name for a write-path call
+    /// from an explicit descriptor name supplied by the caller (typically
+    /// via the <see cref="IObjectSetWriter"/> explicit-name overloads).
+    /// </summary>
+    /// <remarks>
+    /// Symmetric write-path counterpart to <see cref="ResolveTableName(ObjectSetExpression)"/>.
+    /// Exposed as <c>internal</c> so the explicit-name <c>StoreAsync</c> /
+    /// <c>StoreBatchAsync</c> overloads share a single dispatch step and unit
+    /// tests can pin its behavior without needing a live
+    /// <see cref="NpgsqlDataSource"/>. The default-named write overloads
+    /// continue to dispatch via <c>TypeMapper.GetTableName&lt;T&gt;()</c>
+    /// pending the F4/F5 graph-backed lookup.
+    /// </remarks>
+    internal static string ResolveTableNameForDescriptor(string descriptorName)
+    {
+        ArgumentNullException.ThrowIfNull(descriptorName);
+        return TypeMapper.ToSnakeCase(descriptorName);
+    }
+
     /// <inheritdoc />
     public async Task<ScoredObjectSetResult<T>> ExecuteSimilarityAsync<T>(
         SimilarityExpression expression, CancellationToken ct = default) where T : class
@@ -209,11 +229,60 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
     }
 
     /// <inheritdoc />
-    public async Task StoreAsync<T>(T item, CancellationToken ct = default) where T : class
+    public Task StoreAsync<T>(T item, CancellationToken ct = default) where T : class
     {
         ArgumentNullException.ThrowIfNull(item);
 
+        // Default overload: resolve via TypeMapper.GetTableName<T>() (typeof(T).Name → snake_case).
+        // Task F4 (Group 3) will replace this call site with graph-backed descriptor lookup.
         var tableName = TypeMapper.GetTableName<T>();
+        return StoreAsyncCore<T>(tableName, item, ct);
+    }
+
+    /// <inheritdoc />
+    public Task StoreBatchAsync<T>(IReadOnlyList<T> items, CancellationToken ct = default) where T : class
+    {
+        ArgumentNullException.ThrowIfNull(items);
+
+        // Default overload: resolve via TypeMapper.GetTableName<T>() (typeof(T).Name → snake_case).
+        // Task F4 (Group 3) will replace this call site with graph-backed descriptor lookup.
+        var tableName = TypeMapper.GetTableName<T>();
+        return StoreBatchAsyncCore<T>(tableName, items, ct);
+    }
+
+    /// <inheritdoc />
+    public Task StoreAsync<T>(string descriptorName, T item, CancellationToken ct = default) where T : class
+    {
+        ArgumentNullException.ThrowIfNull(descriptorName);
+        ArgumentNullException.ThrowIfNull(item);
+
+        // Explicit-name overload: dispatch via the shared write-path helper so
+        // the descriptor selects which physical partition to write to (bug #31).
+        var tableName = ResolveTableNameForDescriptor(descriptorName);
+        return StoreAsyncCore<T>(tableName, item, ct);
+    }
+
+    /// <inheritdoc />
+    public Task StoreBatchAsync<T>(string descriptorName, IReadOnlyList<T> items, CancellationToken ct = default) where T : class
+    {
+        ArgumentNullException.ThrowIfNull(descriptorName);
+        ArgumentNullException.ThrowIfNull(items);
+
+        // Explicit-name overload: dispatch via the shared write-path helper so
+        // the descriptor selects which physical partition to write to (bug #31).
+        var tableName = ResolveTableNameForDescriptor(descriptorName);
+        return StoreBatchAsyncCore<T>(tableName, items, ct);
+    }
+
+    /// <summary>
+    /// Core single-item write helper. Takes a pre-resolved <paramref name="tableName"/>
+    /// so both the default <see cref="StoreAsync{T}(T, CancellationToken)"/> overload
+    /// (resolving via <see cref="TypeMapper.GetTableName{T}"/>) and the explicit-name
+    /// overload (resolving via <see cref="ResolveTableNameForDescriptor"/>) share a
+    /// single SQL/parameter-binding code path.
+    /// </summary>
+    private async Task StoreAsyncCore<T>(string tableName, T item, CancellationToken ct) where T : class
+    {
         var hasEmbedding = item is ISearchable;
         var sql = SqlGenerator.BuildInsertSql(_options.Schema, tableName, hasEmbedding);
 
@@ -230,17 +299,18 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
         await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
     }
 
-    /// <inheritdoc />
-    public async Task StoreBatchAsync<T>(IReadOnlyList<T> items, CancellationToken ct = default) where T : class
+    /// <summary>
+    /// Core batch write helper. Takes a pre-resolved <paramref name="tableName"/>
+    /// so both the default <see cref="StoreBatchAsync{T}(IReadOnlyList{T}, CancellationToken)"/>
+    /// overload and the explicit-name overload share a single COPY pipeline.
+    /// </summary>
+    private async Task StoreBatchAsyncCore<T>(string tableName, IReadOnlyList<T> items, CancellationToken ct) where T : class
     {
-        ArgumentNullException.ThrowIfNull(items);
-
         if (items.Count == 0)
         {
             return;
         }
 
-        var tableName = TypeMapper.GetTableName<T>();
         var hasEmbedding = items[0] is ISearchable;
 
         await using var connection = await _dataSource.OpenConnectionAsync(ct).ConfigureAwait(false);
@@ -270,21 +340,6 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
 
         await writer.CompleteAsync(ct).ConfigureAwait(false);
     }
-
-    // The two explicit-descriptor-name overloads below are INTENTIONAL temporary placeholders
-    // landed by Task F1 (Strategos 2.4.1 Ontology Descriptor-Name Dispatch, bug #31). They exist
-    // solely so PgVectorObjectSetProvider continues to satisfy IObjectSetWriter while the interface
-    // change lands ahead of the real implementation. Task F3 (graph-backed explicit-name write path)
-    // will replace the NotImplementedException throws with the descriptor-partition-aware
-    // SQL/COPY logic. Do not call these overloads yet.
-
-    /// <inheritdoc />
-    public Task StoreAsync<T>(string descriptorName, T item, CancellationToken ct = default) where T : class
-        => throw new NotImplementedException("Implemented in Task F3");
-
-    /// <inheritdoc />
-    public Task StoreBatchAsync<T>(string descriptorName, IReadOnlyList<T> items, CancellationToken ct = default) where T : class
-        => throw new NotImplementedException("Implemented in Task F3");
 
     /// <summary>
     /// Ensures the database schema (extension, table, index) exists for the given type.

--- a/src/Strategos.Ontology.Npgsql/PgVectorServiceCollectionExtensions.cs
+++ b/src/Strategos.Ontology.Npgsql/PgVectorServiceCollectionExtensions.cs
@@ -1,7 +1,10 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Npgsql;
 using Strategos.Ontology.Configuration;
+using Strategos.Ontology.Embeddings;
 using Strategos.Ontology.ObjectSets;
 
 namespace Strategos.Ontology.Npgsql;
@@ -26,7 +29,7 @@ public static class PgVectorServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(configure);
 
         services.Configure(configure);
-        services.AddSingleton<PgVectorObjectSetProvider>();
+        services.AddSingleton<PgVectorObjectSetProvider>(sp => CreateProvider(sp));
         services.AddSingleton<IObjectSetProvider>(sp => sp.GetRequiredService<PgVectorObjectSetProvider>());
         services.AddSingleton<IObjectSetWriter>(sp => sp.GetRequiredService<PgVectorObjectSetProvider>());
 
@@ -55,11 +58,29 @@ public static class PgVectorServiceCollectionExtensions
             dataSourceBuilder.UseVector();
             services.AddSingleton(dataSourceBuilder.Build());
 
-            services.AddSingleton<PgVectorObjectSetProvider>();
+            services.AddSingleton<PgVectorObjectSetProvider>(sp => CreateProvider(sp));
             services.AddSingleton<IObjectSetProvider>(sp => sp.GetRequiredService<PgVectorObjectSetProvider>());
             services.AddSingleton<IObjectSetWriter>(sp => sp.GetRequiredService<PgVectorObjectSetProvider>());
         });
 
         return options;
+    }
+
+    /// <summary>
+    /// Activation factory that resolves the required dependencies and passes the
+    /// optional <see cref="OntologyGraph"/> through to the provider constructor
+    /// so the default-named write overloads can honour graph-registered
+    /// descriptor names (F4 / bug #31).
+    /// </summary>
+    [RequiresDynamicCode("PgVectorObjectSetProvider uses JSON serialization which requires dynamic code.")]
+    [RequiresUnreferencedCode("PgVectorObjectSetProvider uses JSON serialization which requires unreferenced code.")]
+    private static PgVectorObjectSetProvider CreateProvider(IServiceProvider sp)
+    {
+        var dataSource = sp.GetRequiredService<NpgsqlDataSource>();
+        var embeddingProvider = sp.GetRequiredService<IEmbeddingProvider>();
+        var providerOptions = sp.GetRequiredService<IOptions<PgVectorOptions>>();
+        var logger = sp.GetRequiredService<ILogger<PgVectorObjectSetProvider>>();
+        var graph = sp.GetService<OntologyGraph>();
+        return new PgVectorObjectSetProvider(dataSource, embeddingProvider, providerOptions, logger, graph);
     }
 }

--- a/src/Strategos.Ontology.Tests/Builder/ObjectTypeBuilderTests.cs
+++ b/src/Strategos.Ontology.Tests/Builder/ObjectTypeBuilderTests.cs
@@ -237,4 +237,31 @@ public class ObjectTypeBuilderTests
             .FirstOrDefault(t => t.FromState == "Open" && t.ToState == "Open" && t.TriggerActionName == "ViewItem");
         await Assert.That(selfLoop).IsNotNull();
     }
+
+    [Test]
+    [Arguments("has spaces")]
+    [Arguments("starts-with-hyphen")]
+    [Arguments("1starts_with_digit")]
+    [Arguments("has.dots")]
+    public async Task ObjectTypeBuilder_WithInvalidExplicitName_ThrowsArgumentException(string invalidName)
+    {
+        await Assert.That(() => new ObjectTypeBuilder<TestPosition>("Trading", explicitName: invalidName))
+            .ThrowsException()
+            .WithExceptionType(typeof(ArgumentException));
+    }
+
+    [Test]
+    [Arguments("trading_documents")]
+    [Arguments("KnowledgeChunk")]
+    [Arguments("_underscore_start")]
+    [Arguments("snake_case_123")]
+    public async Task ObjectTypeBuilder_WithValidExplicitName_Succeeds(string validName)
+    {
+        var builder = new ObjectTypeBuilder<TestPosition>("Trading", explicitName: validName);
+
+        builder.Key(p => p.Id);
+        var descriptor = builder.Build();
+
+        await Assert.That(descriptor.Name).IsEqualTo(validName);
+    }
 }

--- a/src/Strategos.Ontology.Tests/Builder/ObjectTypeBuilderTests.cs
+++ b/src/Strategos.Ontology.Tests/Builder/ObjectTypeBuilderTests.cs
@@ -193,4 +193,48 @@ public class ObjectTypeBuilderTests
         await Assert.That(pending).IsTrue();
         await Assert.That(active).IsTrue();
     }
+
+    [Test]
+    public async Task ObjectTypeBuilder_WithExplicitName_UsesExplicitNameInDescriptor()
+    {
+        var builder = new ObjectTypeBuilder<TestPosition>("Trading", explicitName: "trading_documents");
+
+        builder.Key(p => p.Id);
+        builder.Property(p => p.Symbol).Required();
+        var descriptor = builder.Build();
+
+        await Assert.That(descriptor.Name).IsEqualTo("trading_documents");
+        await Assert.That(descriptor.ClrType).IsEqualTo(typeof(TestPosition));
+    }
+
+    [Test]
+    public async Task ObjectTypeBuilder_WithNullExplicitName_FallsBackToTypeofTName()
+    {
+        var builder = new ObjectTypeBuilder<TestPosition>("Trading", explicitName: null);
+
+        builder.Key(p => p.Id);
+        var descriptor = builder.Build();
+
+        await Assert.That(descriptor.Name).IsEqualTo("TestPosition");
+        await Assert.That(descriptor.ClrType).IsEqualTo(typeof(TestPosition));
+    }
+
+    [Test]
+    public async Task ObjectTypeBuilder_WithExplicitName_LifecycleProjectionAppliesToThatDescriptor()
+    {
+        var builder = new ObjectTypeBuilder<TrackATestType>("test-domain", explicitName: "archived_items");
+        builder.Lifecycle<TrackATestState>(t => t.Status, lc =>
+        {
+            lc.State(TrackATestState.Open).Initial();
+            lc.State(TrackATestState.Closed).Terminal();
+        });
+        builder.Action("ViewItem").ValidFromState(TrackATestState.Open);
+
+        var descriptor = builder.Build();
+
+        await Assert.That(descriptor.Name).IsEqualTo("archived_items");
+        var selfLoop = descriptor.Lifecycle!.Transitions
+            .FirstOrDefault(t => t.FromState == "Open" && t.ToState == "Open" && t.TriggerActionName == "ViewItem");
+        await Assert.That(selfLoop).IsNotNull();
+    }
 }

--- a/src/Strategos.Ontology.Tests/Builder/OntologyBuilderTests.cs
+++ b/src/Strategos.Ontology.Tests/Builder/OntologyBuilderTests.cs
@@ -66,4 +66,20 @@ public class OntologyBuilderTests
         await Assert.That(builder.ObjectTypes[0].Name).IsEqualTo("TestPosition");
         await Assert.That(builder.ObjectTypes[1].Name).IsEqualTo("TestTradeOrder");
     }
+
+    [Test]
+    public async Task OntologyBuilder_ObjectWithExplicitName_RegistersDescriptorWithThatName()
+    {
+        var builder = new OntologyBuilder("Trading");
+
+        builder.Object<TestPosition>("trading_documents", obj =>
+        {
+            obj.Key(p => p.Id);
+            obj.Property(p => p.Symbol).Required();
+        });
+
+        await Assert.That(builder.ObjectTypes.Count).IsEqualTo(1);
+        await Assert.That(builder.ObjectTypes[0].Name).IsEqualTo("trading_documents");
+        await Assert.That(builder.ObjectTypes[0].ClrType).IsEqualTo(typeof(TestPosition));
+    }
 }

--- a/src/Strategos.Ontology.Tests/Configuration/EmbeddingProviderRegistrationTests.cs
+++ b/src/Strategos.Ontology.Tests/Configuration/EmbeddingProviderRegistrationTests.cs
@@ -23,6 +23,14 @@ public class StubObjectSetWriterForDI : IObjectSetWriter
 
     public Task StoreBatchAsync<T>(IReadOnlyList<T> items, CancellationToken ct = default) where T : class =>
         Task.CompletedTask;
+
+    // Explicit-name overloads added for Task F1; this DI test double does not need
+    // partition-aware behavior.
+    public Task StoreAsync<T>(string descriptorName, T item, CancellationToken ct = default) where T : class =>
+        Task.CompletedTask;
+
+    public Task StoreBatchAsync<T>(string descriptorName, IReadOnlyList<T> items, CancellationToken ct = default) where T : class =>
+        Task.CompletedTask;
 }
 
 public class DualProvider : IObjectSetProvider, IObjectSetWriter
@@ -43,6 +51,14 @@ public class DualProvider : IObjectSetProvider, IObjectSetWriter
         Task.CompletedTask;
 
     public Task StoreBatchAsync<T>(IReadOnlyList<T> items, CancellationToken ct = default) where T : class =>
+        Task.CompletedTask;
+
+    // Explicit-name overloads added for Task F1; this DI test double does not need
+    // partition-aware behavior.
+    public Task StoreAsync<T>(string descriptorName, T item, CancellationToken ct = default) where T : class =>
+        Task.CompletedTask;
+
+    public Task StoreBatchAsync<T>(string descriptorName, IReadOnlyList<T> items, CancellationToken ct = default) where T : class =>
         Task.CompletedTask;
 }
 

--- a/src/Strategos.Ontology.Tests/Ingestion/IngestionPipelineTests.cs
+++ b/src/Strategos.Ontology.Tests/Ingestion/IngestionPipelineTests.cs
@@ -216,4 +216,64 @@ public class IngestionPipelineTests
         await Assert.That(result.ItemsStored).IsEqualTo(3);
         await Assert.That(result.Duration).IsGreaterThanOrEqualTo(TimeSpan.Zero);
     }
+
+    [Test]
+    public async Task IngestionPipeline_WriteToWithDescriptorName_CallsExplicitStoreBatchAsync()
+    {
+        // Arrange — F6: when WriteTo(writer, descriptorName) is used, the pipeline
+        // must dispatch through the explicit-name StoreBatchAsync overload so that
+        // multi-registered domain types land in the correct descriptor partition.
+        var chunker = CreateMockChunker(new TextChunk("hello world", 0, 0, 11));
+        var embedder = CreateMockEmbedder([1f, 2f]);
+        var writer = Substitute.For<IObjectSetWriter>();
+
+        var pipeline = IngestionPipeline<PipelineTestEntity>.Create()
+            .Chunk(chunker)
+            .Embed(embedder)
+            .Map((chunk, embedding) => new PipelineTestEntity(chunk.Content, embedding))
+            .WriteTo(writer, "trading_documents")
+            .Build();
+
+        // Act
+        await pipeline.ExecuteAsync(["hello world"]);
+
+        // Assert — explicit-name overload invoked with "trading_documents", default overload NOT invoked
+        await writer.Received(1).StoreBatchAsync(
+            "trading_documents",
+            Arg.Any<IReadOnlyList<PipelineTestEntity>>(),
+            Arg.Any<CancellationToken>());
+        await writer.DidNotReceive().StoreBatchAsync(
+            Arg.Any<IReadOnlyList<PipelineTestEntity>>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task IngestionPipeline_WriteToWithoutDescriptorName_CallsDefaultStoreBatchAsync()
+    {
+        // Arrange — regression guard: when WriteTo(writer) (no descriptor name) is
+        // used, the pipeline must continue to dispatch through the default
+        // StoreBatchAsync overload (conventional descriptor resolution).
+        var chunker = CreateMockChunker(new TextChunk("hello world", 0, 0, 11));
+        var embedder = CreateMockEmbedder([1f, 2f]);
+        var writer = Substitute.For<IObjectSetWriter>();
+
+        var pipeline = IngestionPipeline<PipelineTestEntity>.Create()
+            .Chunk(chunker)
+            .Embed(embedder)
+            .Map((chunk, embedding) => new PipelineTestEntity(chunk.Content, embedding))
+            .WriteTo(writer)
+            .Build();
+
+        // Act
+        await pipeline.ExecuteAsync(["hello world"]);
+
+        // Assert — default overload invoked, explicit-name overload NOT invoked
+        await writer.Received(1).StoreBatchAsync(
+            Arg.Any<IReadOnlyList<PipelineTestEntity>>(),
+            Arg.Any<CancellationToken>());
+        await writer.DidNotReceive().StoreBatchAsync(
+            Arg.Any<string>(),
+            Arg.Any<IReadOnlyList<PipelineTestEntity>>(),
+            Arg.Any<CancellationToken>());
+    }
 }

--- a/src/Strategos.Ontology.Tests/Integration/OntologyIntegrationTests.cs
+++ b/src/Strategos.Ontology.Tests/Integration/OntologyIntegrationTests.cs
@@ -258,7 +258,8 @@ public class OntologyIntegrationTests
         var eventStreamProvider = provider.GetRequiredService<IEventStreamProvider>();
 
         // Verify we can construct an ObjectSet with the resolved providers
-        var positionSet = new ObjectSet<Position>(objectSetProvider, actionDispatcher, eventStreamProvider);
+        var positionSet = new ObjectSet<Position>(
+            nameof(Position), objectSetProvider, actionDispatcher, eventStreamProvider);
         var result = await positionSet.ExecuteAsync();
 
         await Assert.That(result).IsNotNull();

--- a/src/Strategos.Ontology.Tests/ObjectSets/IObjectSetProviderTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/IObjectSetProviderTests.cs
@@ -9,7 +9,7 @@ public class IObjectSetProviderTests
     {
         // Arrange
         var provider = Substitute.For<IObjectSetProvider>();
-        var expression = new RootExpression(typeof(string));
+        var expression = new RootExpression(typeof(string), typeof(string).Name);
         var expected = new ObjectSetResult<string>(["hello"], 1, ObjectSetInclusion.Properties);
         provider.ExecuteAsync<string>(expression, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(expected));
@@ -27,7 +27,7 @@ public class IObjectSetProviderTests
     {
         // Arrange
         var provider = Substitute.For<IObjectSetProvider>();
-        var expression = new RootExpression(typeof(string));
+        var expression = new RootExpression(typeof(string), typeof(string).Name);
 
         static async IAsyncEnumerable<string> CreateStream()
         {
@@ -55,7 +55,7 @@ public class IObjectSetProviderTests
     {
         // Arrange
         var provider = Substitute.For<IObjectSetProvider>();
-        var root = new RootExpression(typeof(string));
+        var root = new RootExpression(typeof(string), typeof(string).Name);
         var similarity = new SimilarityExpression(root, "search query", 5, 0.7);
         var expected = new ScoredObjectSetResult<string>(
             ["match1", "match2"], 2, ObjectSetInclusion.Properties, [0.95, 0.80]);
@@ -77,7 +77,7 @@ public class IObjectSetProviderTests
     {
         // Arrange
         var provider = Substitute.For<IObjectSetProvider>();
-        var root = new RootExpression(typeof(string));
+        var root = new RootExpression(typeof(string), typeof(string).Name);
         var similarity = new SimilarityExpression(root, "no matches", 5, 0.9);
         var expected = new ScoredObjectSetResult<string>(
             [], 0, ObjectSetInclusion.Properties, []);

--- a/src/Strategos.Ontology.Tests/ObjectSets/IObjectSetWriterTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/IObjectSetWriterTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 using Strategos.Ontology.ObjectSets;
 
 namespace Strategos.Ontology.Tests.ObjectSets;
@@ -13,6 +15,21 @@ public class StubObjectSetWriter : IObjectSetWriter
     }
 
     public Task StoreBatchAsync<T>(IReadOnlyList<T> items, CancellationToken ct = default) where T : class
+    {
+        StoredItems.AddRange(items);
+        return Task.CompletedTask;
+    }
+
+    // Explicit-name overloads added for Task F1 (Strategos 2.4.1 Ontology Descriptor-Name Dispatch).
+    // Real behavior is exercised by InMemoryObjectSetProvider in Task E4; this stub is only here
+    // so the test fixture continues to satisfy the interface.
+    public Task StoreAsync<T>(string descriptorName, T item, CancellationToken ct = default) where T : class
+    {
+        StoredItems.Add(item);
+        return Task.CompletedTask;
+    }
+
+    public Task StoreBatchAsync<T>(string descriptorName, IReadOnlyList<T> items, CancellationToken ct = default) where T : class
     {
         StoredItems.AddRange(items);
         return Task.CompletedTask;
@@ -45,5 +62,120 @@ public class IObjectSetWriterTests
         await writer.StoreBatchAsync(items);
 
         await Assert.That(writer.StoredItems).HasCount().EqualTo(3);
+    }
+
+    /// <summary>
+    /// Verifies <see cref="IObjectSetWriter"/> exposes both the default and the
+    /// explicit-descriptor-name overloads of <c>StoreAsync</c> and <c>StoreBatchAsync</c>.
+    /// The explicit-name overloads are required for descriptor-name dispatch
+    /// (Strategos 2.4.1 Ontology Descriptor-Name Dispatch, bug #31) so callers can
+    /// target a specific descriptor partition on the write path when a domain type
+    /// is registered against multiple descriptors.
+    /// </summary>
+    [Test]
+    public async Task IObjectSetWriter_HasExplicitNameOverloads_ForStoreAsyncAndStoreBatchAsync()
+    {
+        // Arrange
+        var interfaceType = typeof(IObjectSetWriter);
+        var methods = interfaceType.GetMethods(BindingFlags.Public | BindingFlags.Instance);
+
+        // Act — locate each of the four required overloads by signature
+        var defaultStoreAsync = methods.SingleOrDefault(m =>
+            m.Name == nameof(IObjectSetWriter.StoreAsync)
+            && m.IsGenericMethodDefinition
+            && HasParameterShape(m, expectDescriptorName: false, batched: false));
+
+        var defaultStoreBatchAsync = methods.SingleOrDefault(m =>
+            m.Name == nameof(IObjectSetWriter.StoreBatchAsync)
+            && m.IsGenericMethodDefinition
+            && HasParameterShape(m, expectDescriptorName: false, batched: true));
+
+        var namedStoreAsync = methods.SingleOrDefault(m =>
+            m.Name == nameof(IObjectSetWriter.StoreAsync)
+            && m.IsGenericMethodDefinition
+            && HasParameterShape(m, expectDescriptorName: true, batched: false));
+
+        var namedStoreBatchAsync = methods.SingleOrDefault(m =>
+            m.Name == nameof(IObjectSetWriter.StoreBatchAsync)
+            && m.IsGenericMethodDefinition
+            && HasParameterShape(m, expectDescriptorName: true, batched: true));
+
+        // Assert — all four overloads exist
+        await Assert.That(defaultStoreAsync)
+            .IsNotNull()
+            .Because("IObjectSetWriter must keep the default StoreAsync<T>(T, CancellationToken) overload");
+        await Assert.That(defaultStoreBatchAsync)
+            .IsNotNull()
+            .Because("IObjectSetWriter must keep the default StoreBatchAsync<T>(IReadOnlyList<T>, CancellationToken) overload");
+        await Assert.That(namedStoreAsync)
+            .IsNotNull()
+            .Because("IObjectSetWriter must expose StoreAsync<T>(string descriptorName, T, CancellationToken) for explicit descriptor dispatch");
+        await Assert.That(namedStoreBatchAsync)
+            .IsNotNull()
+            .Because("IObjectSetWriter must expose StoreBatchAsync<T>(string descriptorName, IReadOnlyList<T>, CancellationToken) for explicit descriptor dispatch");
+    }
+
+    /// <summary>
+    /// Returns true when <paramref name="method"/> matches one of the four expected
+    /// <see cref="IObjectSetWriter"/> overload shapes.
+    /// </summary>
+    private static bool HasParameterShape(MethodInfo method, bool expectDescriptorName, bool batched)
+    {
+        var parameters = method.GetParameters();
+        var expectedCount = expectDescriptorName ? 3 : 2;
+        if (parameters.Length != expectedCount)
+        {
+            return false;
+        }
+
+        var index = 0;
+        if (expectDescriptorName)
+        {
+            if (parameters[index].ParameterType != typeof(string)
+                || parameters[index].Name != "descriptorName")
+            {
+                return false;
+            }
+
+            index++;
+        }
+
+        // The item/items parameter is expressed in terms of the method's generic parameter T.
+        var genericArgs = method.GetGenericArguments();
+        if (genericArgs.Length != 1)
+        {
+            return false;
+        }
+
+        var t = genericArgs[0];
+        var itemParam = parameters[index];
+
+        if (batched)
+        {
+            if (!itemParam.ParameterType.IsGenericType
+                || itemParam.ParameterType.GetGenericTypeDefinition() != typeof(IReadOnlyList<>)
+                || itemParam.ParameterType.GetGenericArguments()[0] != t)
+            {
+                return false;
+            }
+        }
+        else
+        {
+            if (itemParam.ParameterType != t)
+            {
+                return false;
+            }
+        }
+
+        index++;
+
+        // Final parameter must be an optional CancellationToken.
+        var ctParam = parameters[index];
+        if (ctParam.ParameterType != typeof(CancellationToken) || !ctParam.IsOptional)
+        {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/IObjectSetWriterTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/IObjectSetWriterTests.cs
@@ -4,6 +4,13 @@ using Strategos.Ontology.ObjectSets;
 
 namespace Strategos.Ontology.Tests.ObjectSets;
 
+/// <summary>
+/// Test domain type used by the F2 explicit-name dispatch tests. Top-level so its
+/// CLR name is exactly <c>"Foo"</c> (i.e. <c>typeof(Foo).Name == "Foo"</c>), which
+/// the default-overload partition test asserts against.
+/// </summary>
+public sealed record Foo(string Name);
+
 public class StubObjectSetWriter : IObjectSetWriter
 {
     public List<object> StoredItems { get; } = [];
@@ -113,6 +120,95 @@ public class IObjectSetWriterTests
         await Assert.That(namedStoreBatchAsync)
             .IsNotNull()
             .Because("IObjectSetWriter must expose StoreBatchAsync<T>(string descriptorName, IReadOnlyList<T>, CancellationToken) for explicit descriptor dispatch");
+    }
+
+    /// <summary>
+    /// Verifies the explicit-name <c>StoreAsync</c> overload routes the item into the
+    /// supplied descriptor partition. A subsequent query under that descriptor name
+    /// must see the item, while a query under any other descriptor name must not
+    /// (Strategos 2.4.1 Ontology Descriptor-Name Dispatch, bug #31).
+    /// </summary>
+    [Test]
+    public async Task InMemoryWriter_StoreAsync_ExplicitName_UsesSuppliedName()
+    {
+        // Arrange
+        var provider = new InMemoryObjectSetProvider();
+        IObjectSetWriter writer = provider;
+        var item = new Foo("alpha");
+
+        // Act — write under an explicit descriptor partition that does NOT match typeof(Foo).Name
+        await writer.StoreAsync<Foo>("my_partition", item);
+
+        // Assert — query under "my_partition" finds the item
+        var hit = await provider.ExecuteAsync<Foo>(
+            new RootExpression(typeof(Foo), "my_partition"));
+        await Assert.That(hit.Items).HasCount().EqualTo(1);
+        await Assert.That(hit.Items[0].Name).IsEqualTo("alpha");
+
+        // Assert — query under a different descriptor name returns nothing
+        var miss = await provider.ExecuteAsync<Foo>(
+            new RootExpression(typeof(Foo), "other_partition"));
+        await Assert.That(miss.Items).IsEmpty();
+    }
+
+    /// <summary>
+    /// Verifies the explicit-name <c>StoreBatchAsync</c> overload routes every item in
+    /// the batch into the supplied descriptor partition (and only that partition).
+    /// </summary>
+    [Test]
+    public async Task InMemoryWriter_StoreBatchAsync_ExplicitName_PartitionsByName()
+    {
+        // Arrange
+        var provider = new InMemoryObjectSetProvider();
+        IObjectSetWriter writer = provider;
+        var items = new List<Foo> { new("one"), new("two") };
+
+        // Act
+        await writer.StoreBatchAsync<Foo>("my_partition", items);
+
+        // Assert — both items found under "my_partition"
+        var hit = await provider.ExecuteAsync<Foo>(
+            new RootExpression(typeof(Foo), "my_partition"));
+        await Assert.That(hit.Items).HasCount().EqualTo(2);
+
+        // Assert — nothing leaked into "other"
+        var miss = await provider.ExecuteAsync<Foo>(
+            new RootExpression(typeof(Foo), "other"));
+        await Assert.That(miss.Items).IsEmpty();
+    }
+
+    /// <summary>
+    /// Regression / interaction test confirming the default <c>StoreAsync&lt;T&gt;(T, ct)</c>
+    /// overload partitions on <c>typeof(T).Name</c> and does not bleed across an
+    /// explicit-named partition seeded under a different descriptor. After F2 wires the
+    /// default overload to delegate into the explicit-name path, both code paths must
+    /// continue to partition cleanly.
+    /// </summary>
+    [Test]
+    public async Task InMemoryWriter_StoreAsync_DefaultOverload_UsesTypeofTName_AfterExplicitSeedIntoDifferentPartition()
+    {
+        // Arrange
+        var provider = new InMemoryObjectSetProvider();
+        IObjectSetWriter writer = provider;
+        var seeded = new Foo("seeded");
+        provider.Seed(seeded, "seeded content", descriptorName: "other_partition");
+
+        var defaultStored = new Foo("default");
+
+        // Act — default overload (no descriptor name) should land under typeof(Foo).Name
+        await writer.StoreAsync(defaultStored);
+
+        // Assert — default partition (typeof(Foo).Name == "Foo") sees only the default-stored item
+        var defaultHit = await provider.ExecuteAsync<Foo>(
+            new RootExpression(typeof(Foo), nameof(Foo)));
+        await Assert.That(defaultHit.Items).HasCount().EqualTo(1);
+        await Assert.That(defaultHit.Items[0].Name).IsEqualTo("default");
+
+        // Assert — "other_partition" still sees only the explicitly-seeded item
+        var otherHit = await provider.ExecuteAsync<Foo>(
+            new RootExpression(typeof(Foo), "other_partition"));
+        await Assert.That(otherHit.Items).HasCount().EqualTo(1);
+        await Assert.That(otherHit.Items[0].Name).IsEqualTo("seeded");
     }
 
     /// <summary>

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryObjectSetProviderTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryObjectSetProviderTests.cs
@@ -13,7 +13,7 @@ public class InMemoryObjectSetProviderTests
         provider.Seed(new TestEntity("Alice"), "alice document");
         provider.Seed(new TestEntity("Bob"), "bob document");
 
-        var expression = new RootExpression(typeof(TestEntity));
+        var expression = new RootExpression(typeof(TestEntity), nameof(TestEntity));
 
         // Act
         var result = await provider.ExecuteAsync<TestEntity>(expression);
@@ -33,7 +33,7 @@ public class InMemoryObjectSetProviderTests
         provider.Seed(new TestEntity("High"), "machine learning deep neural network");
         provider.Seed(new TestEntity("Mid"), "machine learning basics");
 
-        var expression = new SimilarityExpression(new RootExpression(typeof(TestEntity)), "machine learning neural", 10, 0.0);
+        var expression = new SimilarityExpression(new RootExpression(typeof(TestEntity), nameof(TestEntity)), "machine learning neural", 10, 0.0);
 
         // Act
         var result = await provider.ExecuteSimilarityAsync<TestEntity>(expression);
@@ -51,7 +51,7 @@ public class InMemoryObjectSetProviderTests
         provider.Seed(new TestEntity("Match"), "alpha beta gamma delta");
         provider.Seed(new TestEntity("NoMatch"), "completely unrelated content");
 
-        var expression = new SimilarityExpression(new RootExpression(typeof(TestEntity)), "alpha beta gamma delta", 10, 0.9);
+        var expression = new SimilarityExpression(new RootExpression(typeof(TestEntity), nameof(TestEntity)), "alpha beta gamma delta", 10, 0.9);
 
         // Act
         var result = await provider.ExecuteSimilarityAsync<TestEntity>(expression);
@@ -72,7 +72,7 @@ public class InMemoryObjectSetProviderTests
         provider.Seed(new TestEntity("D"), "query match content");
         provider.Seed(new TestEntity("E"), "query match content");
 
-        var expression = new SimilarityExpression(new RootExpression(typeof(TestEntity)), "query match content", 2, 0.0);
+        var expression = new SimilarityExpression(new RootExpression(typeof(TestEntity), nameof(TestEntity)), "query match content", 2, 0.0);
 
         // Act
         var result = await provider.ExecuteSimilarityAsync<TestEntity>(expression);
@@ -86,7 +86,7 @@ public class InMemoryObjectSetProviderTests
     {
         // Arrange
         var provider = new InMemoryObjectSetProvider();
-        var expression = new SimilarityExpression(new RootExpression(typeof(TestEntity)), "some query", 10, 0.0);
+        var expression = new SimilarityExpression(new RootExpression(typeof(TestEntity), nameof(TestEntity)), "some query", 10, 0.0);
 
         // Act
         var result = await provider.ExecuteSimilarityAsync<TestEntity>(expression);
@@ -103,7 +103,7 @@ public class InMemoryObjectSetProviderTests
         var provider = new InMemoryObjectSetProvider();
         provider.Seed(new TestEntity("Item"), "MACHINE LEARNING DEEP");
 
-        var expression = new SimilarityExpression(new RootExpression(typeof(TestEntity)), "machine learning deep", 10, 0.0);
+        var expression = new SimilarityExpression(new RootExpression(typeof(TestEntity), nameof(TestEntity)), "machine learning deep", 10, 0.0);
 
         // Act
         var result = await provider.ExecuteSimilarityAsync<TestEntity>(expression);
@@ -121,7 +121,7 @@ public class InMemoryObjectSetProviderTests
         provider.Seed(new TestEntity("One"), "one");
         provider.Seed(new TestEntity("Two"), "two");
 
-        var expression = new RootExpression(typeof(TestEntity));
+        var expression = new RootExpression(typeof(TestEntity), nameof(TestEntity));
 
         // Act
         var items = new List<TestEntity>();
@@ -144,7 +144,7 @@ public class InMemoryObjectSetProviderTests
         provider.Seed(new TestEntity("Charlie"), "charlie");
 
         Expression<Func<TestEntity, bool>> predicate = e => e.Name.StartsWith("A");
-        var root = new RootExpression(typeof(TestEntity));
+        var root = new RootExpression(typeof(TestEntity), nameof(TestEntity));
         var filter = new FilterExpression(root, predicate);
 
         // Act
@@ -163,7 +163,7 @@ public class InMemoryObjectSetProviderTests
         provider.Seed(new TestEntity("A"), "word1 word2");
         provider.Seed(new TestEntity("B"), "word1");
 
-        var expression = new SimilarityExpression(new RootExpression(typeof(TestEntity)), "word1 word2", 10, 0.0);
+        var expression = new SimilarityExpression(new RootExpression(typeof(TestEntity), nameof(TestEntity)), "word1 word2", 10, 0.0);
 
         // Act
         var result = await provider.ExecuteSimilarityAsync<TestEntity>(expression);
@@ -180,8 +180,8 @@ public class InMemoryObjectSetProviderTests
         provider.Seed(new TestEntity("Entity1"), "entity");
         provider.Seed(new OtherEntity(42), "other");
 
-        var entityExpression = new RootExpression(typeof(TestEntity));
-        var otherExpression = new RootExpression(typeof(OtherEntity));
+        var entityExpression = new RootExpression(typeof(TestEntity), nameof(TestEntity));
+        var otherExpression = new RootExpression(typeof(OtherEntity), nameof(OtherEntity));
 
         // Act
         var entityResult = await provider.ExecuteAsync<TestEntity>(entityExpression);

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryObjectSetProviderTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryObjectSetProviderTests.cs
@@ -193,6 +193,50 @@ public class InMemoryObjectSetProviderTests
         await Assert.That(entityResult.Items[0].Name).IsEqualTo("Entity1");
         await Assert.That(otherResult.Items[0].Value).IsEqualTo(42);
     }
+
+    [Test]
+    public async Task InMemoryProvider_PartitionsByDescriptorName_NotClrType()
+    {
+        // Track E4: the provider must partition seeded items by the
+        // descriptor name supplied at Seed time, NOT by typeof(T). A single
+        // CLR type may be registered under multiple ontology descriptors
+        // (bug #31); a query against one descriptor must not see items from
+        // another even when both live in the same CLR collection.
+        var provider = new InMemoryObjectSetProvider();
+        provider.Seed(new TestEntity("TradingOnly"), "trading content", descriptorName: "trading_documents");
+
+        // Query via a root whose descriptor name differs from where we seeded.
+        var wrongPartition = new RootExpression(typeof(TestEntity), "knowledge_documents");
+        var wrongResult = await provider.ExecuteAsync<TestEntity>(wrongPartition);
+
+        // The item was seeded under "trading_documents" and must NOT be
+        // visible from the "knowledge_documents" partition.
+        await Assert.That(wrongResult.Items).HasCount().EqualTo(0);
+
+        // Querying the correct partition finds it.
+        var rightPartition = new RootExpression(typeof(TestEntity), "trading_documents");
+        var rightResult = await provider.ExecuteAsync<TestEntity>(rightPartition);
+
+        await Assert.That(rightResult.Items).HasCount().EqualTo(1);
+        await Assert.That(rightResult.Items[0].Name).IsEqualTo("TradingOnly");
+    }
+
+    [Test]
+    public async Task InMemoryProvider_DefaultSeed_UsesTypeofTName()
+    {
+        // Track E4 back-compat: existing Seed<T>(item, content) call sites
+        // (no descriptorName) must continue to work. The default key is
+        // typeof(T).Name, which matches the default root expression built
+        // by ObjectSet<T> when no explicit descriptor name is supplied.
+        var provider = new InMemoryObjectSetProvider();
+        provider.Seed(new TestEntity("Default"), "default content");
+
+        var expression = new RootExpression(typeof(TestEntity), nameof(TestEntity));
+        var result = await provider.ExecuteAsync<TestEntity>(expression);
+
+        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items[0].Name).IsEqualTo("Default");
+    }
 }
 
 // Test helpers

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryObjectSetWriterTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryObjectSetWriterTests.cs
@@ -22,7 +22,7 @@ public class InMemoryObjectSetWriterTests
 
         // Act
         await writer.StoreAsync(entity);
-        var result = await provider.ExecuteAsync<SimpleEntity>(new RootExpression(typeof(SimpleEntity)));
+        var result = await provider.ExecuteAsync<SimpleEntity>(new RootExpression(typeof(SimpleEntity), nameof(SimpleEntity)));
 
         // Assert
         await Assert.That(result.Items).HasCount().EqualTo(1);
@@ -40,7 +40,7 @@ public class InMemoryObjectSetWriterTests
 
         // Act
         await writer.StoreAsync(entity);
-        var result = await provider.ExecuteAsync<WriterTestEntity>(new RootExpression(typeof(WriterTestEntity)));
+        var result = await provider.ExecuteAsync<WriterTestEntity>(new RootExpression(typeof(WriterTestEntity), nameof(WriterTestEntity)));
 
         // Assert
         await Assert.That(result.Items).HasCount().EqualTo(1);
@@ -63,7 +63,7 @@ public class InMemoryObjectSetWriterTests
 
         // Act
         await writer.StoreBatchAsync<SimpleEntity>(items);
-        var result = await provider.ExecuteAsync<SimpleEntity>(new RootExpression(typeof(SimpleEntity)));
+        var result = await provider.ExecuteAsync<SimpleEntity>(new RootExpression(typeof(SimpleEntity), nameof(SimpleEntity)));
 
         // Assert
         await Assert.That(result.Items).HasCount().EqualTo(3);
@@ -88,7 +88,7 @@ public class InMemoryObjectSetWriterTests
         await writer.StoreAsync(far);
 
         var expression = new SimilarityExpression(
-            new RootExpression(typeof(WriterTestEntity)),
+            new RootExpression(typeof(WriterTestEntity), nameof(WriterTestEntity)),
             "search query",
             topK: 10,
             minRelevance: 0.0);
@@ -110,7 +110,7 @@ public class InMemoryObjectSetWriterTests
         provider.Seed(new WriterTestEntity("nomatch") { Embedding = [0f, 1f] }, "unrelated content");
 
         var expression = new SimilarityExpression(
-            new RootExpression(typeof(WriterTestEntity)),
+            new RootExpression(typeof(WriterTestEntity), nameof(WriterTestEntity)),
             "search query",
             topK: 10,
             minRelevance: 0.0);
@@ -131,7 +131,7 @@ public class InMemoryObjectSetWriterTests
         provider.Seed(new SimpleEntity("seeded"), "seeded content");
 
         // Act
-        var result = await provider.ExecuteAsync<SimpleEntity>(new RootExpression(typeof(SimpleEntity)));
+        var result = await provider.ExecuteAsync<SimpleEntity>(new RootExpression(typeof(SimpleEntity), nameof(SimpleEntity)));
 
         // Assert
         await Assert.That(result.Items).HasCount().EqualTo(1);

--- a/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetActionEventTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetActionEventTests.cs
@@ -29,7 +29,7 @@ public class ObjectSetActionEventTests
             .Returns(Task.FromResult(new ObjectSetResult<string>(items, 1, ObjectSetInclusion.Properties)));
         _dispatcher.DispatchAsync(Arg.Any<ActionContext>(), Arg.Any<object>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(new ActionResult(true)));
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
+        var set = new ObjectSet<string>(typeof(string).Name, _provider, _dispatcher, _eventProvider);
 
         // Act
         var results = await set.ApplyAsync("DoSomething", new { Value = 1 });
@@ -48,7 +48,7 @@ public class ObjectSetActionEventTests
             .Returns(Task.FromResult(new ObjectSetResult<string>(items, 1, ObjectSetInclusion.Properties)));
         _dispatcher.DispatchAsync(Arg.Any<ActionContext>(), Arg.Any<object>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(new ActionResult(true)));
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
+        var set = new ObjectSet<string>(typeof(string).Name, _provider, _dispatcher, _eventProvider);
         var request = new { To = "test@example.com" };
 
         // Act
@@ -69,7 +69,7 @@ public class ObjectSetActionEventTests
 
         _eventProvider.QueryEventsAsync(Arg.Any<EventQuery>(), Arg.Any<CancellationToken>())
             .Returns(ToAsyncEnumerable(evt));
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
+        var set = new ObjectSet<string>(typeof(string).Name, _provider, _dispatcher, _eventProvider);
 
         // Act
         var events = new List<OntologyEvent>();
@@ -92,7 +92,7 @@ public class ObjectSetActionEventTests
 
         _eventProvider.QueryEventsAsync(Arg.Any<EventQuery>(), Arg.Any<CancellationToken>())
             .Returns(ToAsyncEnumerable<OntologyEvent>());
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
+        var set = new ObjectSet<string>(typeof(string).Name, _provider, _dispatcher, _eventProvider);
 
         // Act
         await foreach (var _ in set.EventsAsync(since, eventTypes))

--- a/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetActionEventTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetActionEventTests.cs
@@ -105,6 +105,55 @@ public class ObjectSetActionEventTests
             Arg.Any<CancellationToken>());
     }
 
+    // -----------------------------------------------------------------------
+    // Regression: descriptor-name dispatch — ApplyAsync and EventsAsync must
+    // route against the descriptor name carried on the expression root, not
+    // typeof(T).Name. Guards against the bug CodeRabbit flagged on PR #34
+    // where multi-registered CLR types dispatched under the wrong descriptor.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task ObjectSet_ApplyAsync_RoutesAgainstDescriptorName_NotClrTypeName()
+    {
+        // Arrange — construct with an explicit descriptor name that differs from typeof(T).Name
+        const string descriptorName = "trading_documents";
+        var items = new List<string> { "doc-1" };
+        _provider.ExecuteAsync<string>(Arg.Any<ObjectSetExpression>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ObjectSetResult<string>(items, 1, ObjectSetInclusion.Properties)));
+        _dispatcher.DispatchAsync(Arg.Any<ActionContext>(), Arg.Any<object>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ActionResult(true)));
+        var set = new ObjectSet<string>(descriptorName, _provider, _dispatcher, _eventProvider);
+
+        // Act
+        await set.ApplyAsync("Archive", new { });
+
+        // Assert — dispatcher receives the descriptor name, not "String"
+        await _dispatcher.Received(1).DispatchAsync(
+            Arg.Is<ActionContext>(c => c.ObjectType == descriptorName),
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ObjectSet_EventsAsync_RoutesAgainstDescriptorName_NotClrTypeName()
+    {
+        // Arrange
+        const string descriptorName = "trading_documents";
+        _eventProvider.QueryEventsAsync(Arg.Any<EventQuery>(), Arg.Any<CancellationToken>())
+            .Returns(ToAsyncEnumerable<OntologyEvent>());
+        var set = new ObjectSet<string>(descriptorName, _provider, _dispatcher, _eventProvider);
+
+        // Act
+        await foreach (var _ in set.EventsAsync())
+        {
+        }
+
+        // Assert — event query carries the descriptor name, not "String"
+        _eventProvider.Received(1).QueryEventsAsync(
+            Arg.Is<EventQuery>(q => q.ObjectTypeName == descriptorName),
+            Arg.Any<CancellationToken>());
+    }
+
     private static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(params T[] items)
     {
         foreach (var item in items)

--- a/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetExpressionTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetExpressionTests.cs
@@ -9,17 +9,31 @@ public class ObjectSetExpressionTests
     public async Task RootExpression_Create_HasObjectType()
     {
         // Arrange & Act
-        var expression = new RootExpression(typeof(string));
+        var expression = new RootExpression(typeof(string), "string");
 
         // Assert
         await Assert.That(expression.ObjectType).IsEqualTo(typeof(string));
     }
 
     [Test]
+    public async Task RootExpression_Constructor_RequiresObjectTypeName()
+    {
+        // Arrange & Act
+        var expression = new RootExpression(typeof(string), "trading_documents");
+
+        // Assert — explicit descriptor name is stored on the expression
+        await Assert.That(expression.ObjectTypeName).IsEqualTo("trading_documents");
+
+        // Assert — null descriptor name is rejected
+        await Assert.That(() => new RootExpression(typeof(string), null!))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
     public async Task FilterExpression_Create_HasPredicateAndObjectType()
     {
         // Arrange
-        var root = new RootExpression(typeof(string));
+        var root = new RootExpression(typeof(string), typeof(string).Name);
         Expression<Func<string, bool>> predicate = s => s.Length > 0;
 
         // Act
@@ -35,7 +49,7 @@ public class ObjectSetExpressionTests
     public async Task TraverseLinkExpression_Create_HasLinkNameAndSourceExpression()
     {
         // Arrange
-        var root = new RootExpression(typeof(string));
+        var root = new RootExpression(typeof(string), typeof(string).Name);
 
         // Act
         var traverse = new TraverseLinkExpression(root, "Children", typeof(int));
@@ -50,7 +64,7 @@ public class ObjectSetExpressionTests
     public async Task InterfaceNarrowExpression_Create_HasInterfaceType()
     {
         // Arrange
-        var root = new RootExpression(typeof(string));
+        var root = new RootExpression(typeof(string), typeof(string).Name);
 
         // Act
         var narrow = new InterfaceNarrowExpression(root, typeof(IDisposable));
@@ -65,7 +79,7 @@ public class ObjectSetExpressionTests
     public async Task SimilarityExpression_Create_HasAllProperties()
     {
         // Arrange
-        var root = new RootExpression(typeof(string));
+        var root = new RootExpression(typeof(string), typeof(string).Name);
 
         // Act
         var similarity = new SimilarityExpression(
@@ -88,7 +102,7 @@ public class ObjectSetExpressionTests
     public async Task SimilarityExpression_WithQueryVector_StoresVector()
     {
         // Arrange
-        var root = new RootExpression(typeof(string));
+        var root = new RootExpression(typeof(string), typeof(string).Name);
         var vector = new float[] { 0.1f, 0.2f, 0.3f };
 
         // Act
@@ -105,7 +119,7 @@ public class ObjectSetExpressionTests
     public async Task SimilarityExpression_WithFilters_StoresFilters()
     {
         // Arrange
-        var root = new RootExpression(typeof(string));
+        var root = new RootExpression(typeof(string), typeof(string).Name);
         var filters = new Dictionary<string, object> { ["category"] = "tech" };
 
         // Act
@@ -122,7 +136,7 @@ public class ObjectSetExpressionTests
     public async Task SimilarityExpression_DefaultMetric_IsCosine()
     {
         // Arrange
-        var root = new RootExpression(typeof(string));
+        var root = new RootExpression(typeof(string), typeof(string).Name);
 
         // Act
         var similarity = new SimilarityExpression(root, "query", 5, 0.7);

--- a/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetExpressionTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetExpressionTests.cs
@@ -220,9 +220,38 @@ public class ObjectSetExpressionTests
         await Assert.That(similarity.RootObjectTypeName).IsEqualTo("foo_table");
     }
 
-    // Helper type for A2/A3 tests
+    // -----------------------------------------------------------------------
+    // A3: TraverseLinkExpression.RootObjectTypeName override
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task TraverseLinkExpression_RootObjectTypeName_ReturnsLinkedTypeName()
+    {
+        // Arrange — traverse from Position into TradeOrder via the "Orders" link.
+        // After traversal, further query operations target the linked type's
+        // descriptor, not the source's. Under Option X multi-registered types
+        // cannot be link targets (AONT041, later track), so typeof(TLinked).Name
+        // is always unambiguous here.
+        var root = new RootExpression(typeof(Position), "positions");
+        var traverse = new TraverseLinkExpression(root, "Orders", typeof(TradeOrder));
+
+        // Assert — walking should not return "positions"; it should return "TradeOrder"
+        await Assert.That(traverse.RootObjectTypeName).IsEqualTo(nameof(TradeOrder));
+    }
+
+    // Helper types for A2/A3 tests
     private sealed class Foo
     {
         public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class Position
+    {
+        public string Symbol { get; set; } = string.Empty;
+    }
+
+    private sealed class TradeOrder
+    {
+        public string Id { get; set; } = string.Empty;
     }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetExpressionTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetExpressionTests.cs
@@ -144,4 +144,85 @@ public class ObjectSetExpressionTests
         // Assert
         await Assert.That(similarity.Metric).IsEqualTo(DistanceMetric.Cosine);
     }
+
+    // -----------------------------------------------------------------------
+    // A2: ObjectSetExpression.RootObjectTypeName walk-to-root computed property
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task FilterExpression_RootObjectTypeName_WalksToSourceRoot()
+    {
+        // Arrange
+        var root = new RootExpression(typeof(Foo), "foo_table");
+        Expression<Func<Foo, bool>> predicate = x => true;
+        var filter = new FilterExpression(root, predicate);
+
+        // Assert — walks through the filter to the root and returns the explicit name
+        await Assert.That(filter.RootObjectTypeName).IsEqualTo("foo_table");
+    }
+
+    [Test]
+    public async Task InterfaceNarrowExpression_RootObjectTypeName_WalksToSourceRoot()
+    {
+        // Arrange
+        var root = new RootExpression(typeof(Foo), "foo_table");
+        var narrow = new InterfaceNarrowExpression(root, typeof(IDisposable));
+
+        // Assert
+        await Assert.That(narrow.RootObjectTypeName).IsEqualTo("foo_table");
+    }
+
+    [Test]
+    public async Task IncludeExpression_RootObjectTypeName_WalksToSourceRoot()
+    {
+        // Arrange
+        var root = new RootExpression(typeof(Foo), "foo_table");
+        var include = new IncludeExpression(root, ObjectSetInclusion.Properties);
+
+        // Assert
+        await Assert.That(include.RootObjectTypeName).IsEqualTo("foo_table");
+    }
+
+    [Test]
+    public async Task RawFilterExpression_RootObjectTypeName_WalksToSourceRoot()
+    {
+        // Arrange
+        var root = new RootExpression(typeof(Foo), "foo_table");
+        var raw = new RawFilterExpression(root, "Name = 'bar'");
+
+        // Assert
+        await Assert.That(raw.RootObjectTypeName).IsEqualTo("foo_table");
+    }
+
+    [Test]
+    public async Task SimilarityExpression_RootObjectTypeName_WalksToSourceRoot()
+    {
+        // Arrange — this is the Basileus call site: similarity queries must
+        // route to the descriptor the caller dispatched against, not typeof(T).Name
+        var root = new RootExpression(typeof(Foo), "foo_table");
+        var similarity = new SimilarityExpression(root, "query", 10, 0.5);
+
+        // Assert
+        await Assert.That(similarity.RootObjectTypeName).IsEqualTo("foo_table");
+    }
+
+    [Test]
+    public async Task ComposedExpression_Root_Filter_Similarity_ReturnsRootName()
+    {
+        // Arrange — nested composition: Similarity(Filter(Root)) must walk two hops
+        // back to the original RootExpression's descriptor name.
+        var root = new RootExpression(typeof(Foo), "foo_table");
+        Expression<Func<Foo, bool>> predicate = x => true;
+        var filter = new FilterExpression(root, predicate);
+        var similarity = new SimilarityExpression(filter, "query", 10, 0.5);
+
+        // Assert
+        await Assert.That(similarity.RootObjectTypeName).IsEqualTo("foo_table");
+    }
+
+    // Helper type for A2/A3 tests
+    private sealed class Foo
+    {
+        public string Name { get; set; } = string.Empty;
+    }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetIncludeTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetIncludeTests.cs
@@ -23,7 +23,7 @@ public class ObjectSetIncludeTests
     public async Task ObjectSet_Include_SetsInclusionOnExpression()
     {
         // Arrange
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
+        var set = new ObjectSet<string>(typeof(string).Name, _provider, _dispatcher, _eventProvider);
 
         // Act
         var included = set.Include(ObjectSetInclusion.Properties);
@@ -38,7 +38,7 @@ public class ObjectSetIncludeTests
     public async Task ObjectSet_Include_Schema_IncludesPropertiesActionsLinksInterfaces()
     {
         // Arrange
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
+        var set = new ObjectSet<string>(typeof(string).Name, _provider, _dispatcher, _eventProvider);
 
         // Act
         var included = set.Include(ObjectSetInclusion.Schema);
@@ -56,7 +56,7 @@ public class ObjectSetIncludeTests
     public async Task ObjectSet_Include_Full_IncludesEverything()
     {
         // Arrange
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
+        var set = new ObjectSet<string>(typeof(string).Name, _provider, _dispatcher, _eventProvider);
 
         // Act
         var included = set.Include(ObjectSetInclusion.Full);

--- a/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetMaterializationTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetMaterializationTests.cs
@@ -26,7 +26,7 @@ public class ObjectSetMaterializationTests
         var expected = new ObjectSetResult<string>(["a", "b"], 2, ObjectSetInclusion.Properties);
         _provider.ExecuteAsync<string>(Arg.Any<ObjectSetExpression>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(expected));
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
+        var set = new ObjectSet<string>(typeof(string).Name, _provider, _dispatcher, _eventProvider);
 
         // Act
         var result = await set.ExecuteAsync();
@@ -49,7 +49,7 @@ public class ObjectSetMaterializationTests
 
         _provider.StreamAsync<string>(Arg.Any<ObjectSetExpression>(), Arg.Any<CancellationToken>())
             .Returns(CreateStream());
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
+        var set = new ObjectSet<string>(typeof(string).Name, _provider, _dispatcher, _eventProvider);
 
         // Act
         var items = new List<string>();
@@ -70,7 +70,7 @@ public class ObjectSetMaterializationTests
         var expected = new ObjectSetResult<string>(["a"], 1, ObjectSetInclusion.Properties);
         _provider.ExecuteAsync<string>(Arg.Any<ObjectSetExpression>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(expected));
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider)
+        var set = new ObjectSet<string>(typeof(string).Name, _provider, _dispatcher, _eventProvider)
             .Where(s => s.Length > 0);
 
         // Act

--- a/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTests.cs
@@ -24,7 +24,7 @@ public class ObjectSetTests
     public async Task ObjectSet_Create_HasRootExpression()
     {
         // Arrange & Act
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
+        var set = new ObjectSet<string>(typeof(string).Name, _provider, _dispatcher, _eventProvider);
 
         // Assert
         await Assert.That(set.Expression).IsTypeOf<RootExpression>();
@@ -35,7 +35,7 @@ public class ObjectSetTests
     public async Task ObjectSet_Where_ReturnsNewObjectSetWithFilterExpression()
     {
         // Arrange
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
+        var set = new ObjectSet<string>(typeof(string).Name, _provider, _dispatcher, _eventProvider);
 
         // Act
         var filtered = set.Where(s => s.Length > 5);
@@ -50,7 +50,7 @@ public class ObjectSetTests
     public async Task ObjectSet_Where_PreservesOriginalObjectSet()
     {
         // Arrange
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
+        var set = new ObjectSet<string>(typeof(string).Name, _provider, _dispatcher, _eventProvider);
 
         // Act
         var filtered = set.Where(s => s.Length > 5);
@@ -64,7 +64,7 @@ public class ObjectSetTests
     public async Task ObjectSet_MultipleWheres_ChainsExpressions()
     {
         // Arrange
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
+        var set = new ObjectSet<string>(typeof(string).Name, _provider, _dispatcher, _eventProvider);
 
         // Act
         var filtered = set
@@ -83,7 +83,7 @@ public class ObjectSetTests
     public async Task ObjectSet_SimilarTo_ReturnsSimilarObjectSet()
     {
         // Arrange
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
+        var set = new ObjectSet<string>(typeof(string).Name, _provider, _dispatcher, _eventProvider);
 
         // Act
         var similar = set.SimilarTo("search query");
@@ -97,7 +97,7 @@ public class ObjectSetTests
     public async Task ObjectSet_SimilarTo_FluentChain_ProducesCorrectExpression()
     {
         // Arrange
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
+        var set = new ObjectSet<string>(typeof(string).Name, _provider, _dispatcher, _eventProvider);
 
         // Act — fluent chain replaces the legacy positional/optional-arg API
         var similar = set
@@ -119,7 +119,7 @@ public class ObjectSetTests
     public async Task ObjectSet_SimilarTo_AfterWhere_ChainsExpressions()
     {
         // Arrange
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
+        var set = new ObjectSet<string>(typeof(string).Name, _provider, _dispatcher, _eventProvider);
 
         // Act
         var similar = set.Where(s => s.Length > 5).SimilarTo("query");
@@ -133,7 +133,7 @@ public class ObjectSetTests
     public async Task SimilarTo_WithOnlyQueryText_ReturnsSimilarObjectSetWithDefaults()
     {
         // Arrange
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
+        var set = new ObjectSet<string>(typeof(string).Name, _provider, _dispatcher, _eventProvider);
 
         // Act
         var similar = set.SimilarTo("query text");
@@ -155,5 +155,24 @@ public class ObjectSetTests
         var parameters = method!.GetParameters();
         await Assert.That(parameters.Length).IsEqualTo(1);
         await Assert.That(parameters[0].ParameterType).IsEqualTo(typeof(string));
+    }
+
+    [Test]
+    public async Task ObjectSet_Constructor_ThreadsDescriptorNameIntoRootExpression()
+    {
+        // Arrange & Act — use the new descriptor-name-first constructor
+        var set = new ObjectSet<Foo>(
+            "trading_documents", _provider, _dispatcher, _eventProvider);
+
+        // Assert — the root expression must carry the explicit descriptor name,
+        // not the CLR type name (which would be "Foo").
+        await Assert.That(set.Expression).IsTypeOf<RootExpression>();
+        var root = (RootExpression)set.Expression;
+        await Assert.That(root.ObjectTypeName).IsEqualTo("trading_documents");
+        await Assert.That(root.ObjectType).IsEqualTo(typeof(Foo));
+    }
+
+    private sealed class Foo
+    {
     }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTraversalTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTraversalTests.cs
@@ -23,7 +23,7 @@ public class ObjectSetTraversalTests
     public async Task ObjectSet_TraverseLink_ReturnsObjectSetOfLinkedType()
     {
         // Arrange
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
+        var set = new ObjectSet<string>(typeof(string).Name, _provider, _dispatcher, _eventProvider);
 
         // Act
         var linked = set.TraverseLink<object>("Children");
@@ -37,7 +37,7 @@ public class ObjectSetTraversalTests
     public async Task ObjectSet_TraverseLink_AddsTraverseLinkExpression()
     {
         // Arrange
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
+        var set = new ObjectSet<string>(typeof(string).Name, _provider, _dispatcher, _eventProvider);
 
         // Act
         var linked = set.TraverseLink<object>("Children");
@@ -53,7 +53,7 @@ public class ObjectSetTraversalTests
     public async Task ObjectSet_OfInterface_ReturnsObjectSetOfInterfaceType()
     {
         // Arrange
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
+        var set = new ObjectSet<string>(typeof(string).Name, _provider, _dispatcher, _eventProvider);
 
         // Act
         var narrowed = set.OfInterface<IDisposable>();
@@ -67,7 +67,7 @@ public class ObjectSetTraversalTests
     public async Task ObjectSet_OfInterface_AddsInterfaceNarrowExpression()
     {
         // Arrange
-        var set = new ObjectSet<string>(_provider, _dispatcher, _eventProvider);
+        var set = new ObjectSet<string>(typeof(string).Name, _provider, _dispatcher, _eventProvider);
 
         // Act
         var narrowed = set.OfInterface<IDisposable>();

--- a/src/Strategos.Ontology.Tests/ObjectSets/SimilarObjectSetTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/SimilarObjectSetTests.cs
@@ -8,7 +8,7 @@ public class SimilarObjectSetTests
     public async Task SimilarObjectSet_Create_HasExpression()
     {
         // Arrange
-        var root = new RootExpression(typeof(string));
+        var root = new RootExpression(typeof(string), typeof(string).Name);
         var similarity = new SimilarityExpression(root, "query", 5, 0.7);
         var provider = Substitute.For<IObjectSetProvider>();
 
@@ -23,7 +23,7 @@ public class SimilarObjectSetTests
     public async Task SimilarObjectSet_ExecuteAsync_DelegatesToProvider()
     {
         // Arrange
-        var root = new RootExpression(typeof(string));
+        var root = new RootExpression(typeof(string), typeof(string).Name);
         var similarity = new SimilarityExpression(root, "query", 5, 0.7);
         var provider = Substitute.For<IObjectSetProvider>();
         var expected = new ScoredObjectSetResult<string>(
@@ -46,7 +46,7 @@ public class SimilarObjectSetTests
     public async Task SimilarObjectSet_ExecuteAsync_PassesCancellationToken()
     {
         // Arrange
-        var root = new RootExpression(typeof(string));
+        var root = new RootExpression(typeof(string), typeof(string).Name);
         var similarity = new SimilarityExpression(root, "query", 5, 0.7);
         var provider = Substitute.For<IObjectSetProvider>();
         var expected = new ScoredObjectSetResult<string>(
@@ -69,7 +69,7 @@ public class SimilarObjectSetTests
     public async Task WithMinRelevance_ReturnsNewInstanceWithUpdatedMinRelevance()
     {
         // Arrange
-        var root = new RootExpression(typeof(string));
+        var root = new RootExpression(typeof(string), typeof(string).Name);
         var original = new SimilarityExpression(root, "query", topK: 5, minRelevance: 0.7);
         var provider = Substitute.For<IObjectSetProvider>();
         var originalSet = new SimilarObjectSet<string>(original, provider);
@@ -87,7 +87,7 @@ public class SimilarObjectSetTests
     public async Task Take_ReturnsNewInstanceWithUpdatedTopK()
     {
         // Arrange
-        var root = new RootExpression(typeof(string));
+        var root = new RootExpression(typeof(string), typeof(string).Name);
         var original = new SimilarityExpression(root, "query", topK: 5, minRelevance: 0.7);
         var provider = Substitute.For<IObjectSetProvider>();
         var originalSet = new SimilarObjectSet<string>(original, provider);
@@ -105,7 +105,7 @@ public class SimilarObjectSetTests
     public async Task WithMetric_ReturnsNewInstanceWithUpdatedMetric()
     {
         // Arrange
-        var root = new RootExpression(typeof(string));
+        var root = new RootExpression(typeof(string), typeof(string).Name);
         var original = new SimilarityExpression(
             root, "query", topK: 5, minRelevance: 0.7, metric: DistanceMetric.Cosine);
         var provider = Substitute.For<IObjectSetProvider>();
@@ -124,7 +124,7 @@ public class SimilarObjectSetTests
     public async Task FluentChain_PreservesQueryTextAndIsImmutable()
     {
         // Arrange
-        var root = new RootExpression(typeof(string));
+        var root = new RootExpression(typeof(string), typeof(string).Name);
         var original = new SimilarityExpression(root, "find docs", topK: 5, minRelevance: 0.7);
         var provider = Substitute.For<IObjectSetProvider>();
         var originalSet = new SimilarObjectSet<string>(original, provider);

--- a/src/Strategos.Ontology.Tests/OntologyGraphBuilderTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphBuilderTests.cs
@@ -372,4 +372,79 @@ public class OntologyGraphBuilderTests
 
         await Assert.That(names).HasCount().EqualTo(0);
     }
+
+    // -----------------------------------------------------------------------
+    // Track C3 — AONT041 MultiRegisteredTypeInLink invariant
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task GraphBuilder_WithMultiRegisteredTypeAsLinkTarget_ThrowsAONT041()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain<TrackCMultiRegLinkTargetOntology>();
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithExceptionType(typeof(OntologyCompositionException));
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithMessageContaining("AONT041");
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithMessageContaining(typeof(TrackCSemanticDocument).FullName!);
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithMessageContaining("'a'");
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithMessageContaining("'b'");
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithMessageContaining("Documents");
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithMessageContaining("#32");
+    }
+
+    [Test]
+    public async Task GraphBuilder_WithMultiRegisteredTypeAsLinkSource_ThrowsAONT041()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain<TrackCMultiRegLinkSourceOntology>();
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithExceptionType(typeof(OntologyCompositionException));
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithMessageContaining("AONT041");
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithMessageContaining(typeof(TrackCSemanticDocument).FullName!);
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithMessageContaining("#32");
+    }
+
+    [Test]
+    public async Task GraphBuilder_WithMultiRegisteredLeafType_NoLinks_Succeeds()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain<TrackCMultiRegLeafOnlyOntology>();
+
+        var graph = graphBuilder.Build();
+
+        await Assert.That(graph.ObjectTypes).HasCount().EqualTo(2);
+        await Assert.That(graph.ObjectTypeNamesByType[typeof(TrackCSemanticDocument)])
+            .HasCount().EqualTo(2);
+    }
 }

--- a/src/Strategos.Ontology.Tests/OntologyGraphBuilderTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphBuilderTests.cs
@@ -322,4 +322,54 @@ public class OntologyGraphBuilderTests
         await Assert.That(graph.ObjectTypes).HasCount().EqualTo(2);
         await Assert.That(graph.ObjectTypes.Count(ot => ot.Name == "shared_name")).IsEqualTo(2);
     }
+
+    // -----------------------------------------------------------------------
+    // Track C2 — OntologyGraph.ObjectTypeNamesByType reverse index
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task OntologyGraph_ObjectTypeNamesByType_PopulatedForSingleRegistration()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain<TrackCSingleRegistrationOntology>();
+
+        var graph = graphBuilder.Build();
+
+        await Assert.That(graph.ObjectTypeNamesByType).IsNotNull();
+        await Assert.That(graph.ObjectTypeNamesByType.ContainsKey(typeof(TrackCFoo))).IsTrue();
+
+        var names = graph.ObjectTypeNamesByType[typeof(TrackCFoo)];
+        await Assert.That(names).HasCount().EqualTo(1);
+        await Assert.That(names[0]).IsEqualTo(nameof(TrackCFoo));
+    }
+
+    [Test]
+    public async Task OntologyGraph_ObjectTypeNamesByType_PopulatedForMultiRegistration()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain<TrackCMultiRegistrationOntology>();
+
+        var graph = graphBuilder.Build();
+
+        await Assert.That(graph.ObjectTypeNamesByType.ContainsKey(typeof(TrackCFoo))).IsTrue();
+
+        var names = graph.ObjectTypeNamesByType[typeof(TrackCFoo)];
+        await Assert.That(names).HasCount().EqualTo(2);
+        await Assert.That(names[0]).IsEqualTo("a");
+        await Assert.That(names[1]).IsEqualTo("b");
+    }
+
+    [Test]
+    public async Task OntologyGraph_ObjectTypeNamesByType_UnregisteredTypeReturnsEmpty()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain<TrackCSingleRegistrationOntology>();
+
+        var graph = graphBuilder.Build();
+
+        IReadOnlyList<string> names = graph.ObjectTypeNamesByType
+            .GetValueOrDefault(typeof(TrackCBar), Array.Empty<string>());
+
+        await Assert.That(names).HasCount().EqualTo(0);
+    }
 }

--- a/src/Strategos.Ontology.Tests/OntologyGraphBuilderTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphBuilderTests.cs
@@ -1,5 +1,6 @@
 using Strategos.Ontology.Builder;
 using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Extensions;
 
 namespace Strategos.Ontology.Tests;
 
@@ -313,6 +314,54 @@ public class TrackCCrossDomainSourceOnlyOntology : DomainOntology
     }
 }
 
+// Workflow chain ambiguity fixtures: AmbiguousFoo is registered under its default
+// CLR-name in TWO different domains, so allObjectTypes has two entries with Name
+// "AmbiguousFoo". A workflow metadata that Consumes<AmbiguousFoo>() sets the
+// ConsumedTypeName to "AmbiguousFoo" — which now matches both descriptors. Under
+// the warn-and-skip semantics, BuildWorkflowChains must emit a warning naming
+// both domains and skip the chain rather than silently first-wins-binding.
+
+public class AmbiguousFoo
+{
+    public string Id { get; set; } = string.Empty;
+}
+
+public class AmbiguousBar
+{
+    public string Id { get; set; } = string.Empty;
+}
+
+public class AmbiguousDomainAOntology : DomainOntology
+{
+    public override string DomainName => "ambiguous-a";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<AmbiguousFoo>(obj => obj.Key(f => f.Id));
+    }
+}
+
+public class AmbiguousDomainBOntology : DomainOntology
+{
+    public override string DomainName => "ambiguous-b";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<AmbiguousFoo>(obj => obj.Key(f => f.Id));
+    }
+}
+
+public class UnambiguousDomainOntology : DomainOntology
+{
+    public override string DomainName => "unambiguous";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<AmbiguousFoo>(obj => obj.Key(f => f.Id));
+        builder.Object<AmbiguousBar>(obj => obj.Key(b => b.Id));
+    }
+}
+
 public class OntologyGraphBuilderTests
 {
     [Test]
@@ -569,6 +618,80 @@ public class OntologyGraphBuilderTests
         await Assert.That(() => graphBuilder.Build())
             .ThrowsException()
             .WithMessageContaining("#32");
+    }
+
+    // -----------------------------------------------------------------------
+    // BuildWorkflowChains — warn-and-skip on ambiguous workflow type names
+    // (closes follow-up review feedback on PR #34 finding #5)
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task GraphBuilder_WorkflowMetadata_WithAmbiguousConsumedType_EmitsWarningAndSkipsChain()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain<AmbiguousDomainAOntology>();
+        graphBuilder.AddDomain<AmbiguousDomainBOntology>();
+        graphBuilder.AddWorkflowMetadata(new[]
+        {
+            new WorkflowMetadataBuilder("ambiguous-workflow")
+                .Consumes<AmbiguousFoo>()
+                .Produces<AmbiguousFoo>(),
+        });
+
+        var graph = graphBuilder.Build();
+
+        // Chain must NOT be silently first-wins bound — it must be skipped entirely.
+        await Assert.That(graph.WorkflowChains).HasCount().EqualTo(0);
+
+        // A warning must name the workflow, the ambiguous type, and both domains.
+        var ambiguityWarnings = graph.Warnings
+            .Where(w => w.Contains("ambiguous-workflow") && w.Contains("AmbiguousFoo") && w.Contains("ambiguous"))
+            .ToList();
+        await Assert.That(ambiguityWarnings.Count).IsGreaterThanOrEqualTo(1);
+        await Assert.That(ambiguityWarnings[0]).Contains("ambiguous-a");
+        await Assert.That(ambiguityWarnings[0]).Contains("ambiguous-b");
+    }
+
+    [Test]
+    public async Task GraphBuilder_WorkflowMetadata_WithUnambiguousTypes_BuildsChainCleanly()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain<UnambiguousDomainOntology>();
+        graphBuilder.AddWorkflowMetadata(new[]
+        {
+            new WorkflowMetadataBuilder("unambiguous-workflow")
+                .Consumes<AmbiguousFoo>()
+                .Produces<AmbiguousBar>(),
+        });
+
+        var graph = graphBuilder.Build();
+
+        await Assert.That(graph.WorkflowChains).HasCount().EqualTo(1);
+        await Assert.That(graph.WorkflowChains[0].WorkflowName).IsEqualTo("unambiguous-workflow");
+        await Assert.That(graph.WorkflowChains[0].ConsumedType.Name).IsEqualTo(nameof(AmbiguousFoo));
+        await Assert.That(graph.WorkflowChains[0].ProducedType.Name).IsEqualTo(nameof(AmbiguousBar));
+        await Assert.That(graph.Warnings.Where(w => w.Contains("unambiguous-workflow"))).HasCount().EqualTo(0);
+    }
+
+    [Test]
+    public async Task GraphBuilder_WorkflowMetadata_WithUnknownConsumedType_EmitsWarningAndSkipsChain()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain<UnambiguousDomainOntology>();
+        graphBuilder.AddWorkflowMetadata(new[]
+        {
+            new WorkflowMetadataBuilder("unknown-consumed-workflow")
+                .Consumes<TrackCBar>() // not registered in UnambiguousDomainOntology
+                .Produces<AmbiguousBar>(),
+        });
+
+        var graph = graphBuilder.Build();
+
+        await Assert.That(graph.WorkflowChains).HasCount().EqualTo(0);
+        var unknownWarnings = graph.Warnings
+            .Where(w => w.Contains("unknown-consumed-workflow") && w.Contains("unknown") && w.Contains("TrackCBar"))
+            .ToList();
+        await Assert.That(unknownWarnings.Count).IsGreaterThanOrEqualTo(1);
     }
 
     [Test]

--- a/src/Strategos.Ontology.Tests/OntologyGraphBuilderTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphBuilderTests.cs
@@ -226,6 +226,93 @@ public class TrackCMultiRegLeafOnlyOntology : DomainOntology
     }
 }
 
+// C3 (cross-domain): multi-registered type declared as a cross-domain link SOURCE.
+// SourceDomain registers TrackCSemanticDocument under "a" and "b" and then declares
+// CrossDomainLink("doc_to_target").From<TrackCSemanticDocument>().ToExternal("xd-target", "Target").
+// AONT041 must fire because the From<T>() resolution would have to silently bind to one of two
+// registered descriptors.
+public class TrackCMultiRegCrossDomainSourceOntology : DomainOntology
+{
+    public override string DomainName => "xd-source";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TrackCSemanticDocument>("a", obj =>
+        {
+            obj.Key(d => d.Id);
+        });
+
+        builder.Object<TrackCSemanticDocument>("b", obj =>
+        {
+            obj.Key(d => d.Id);
+        });
+
+        builder.CrossDomainLink("doc_to_target")
+            .From<TrackCSemanticDocument>()
+            .ToExternal("xd-target", "Target")
+            .ManyToMany();
+    }
+}
+
+// Companion target domain for the cross-domain SOURCE test. Registers a single-registration
+// target type so the cross-domain link can resolve its target half successfully.
+public class TrackCCrossDomainTargetOnlyOntology : DomainOntology
+{
+    public override string DomainName => "xd-target";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TrackCCollection>("Target", obj =>
+        {
+            obj.Key(c => c.Id);
+        });
+    }
+}
+
+// C3 (cross-domain): multi-registered type declared as a cross-domain link TARGET.
+// TargetDomain registers TrackCSemanticDocument under "x" and "y" — both names are unique
+// within the target domain (AONT040 satisfied) but the underlying CLR type is multi-registered.
+// SourceDomain declares CrossDomainLink("source_to_doc").From<NormalSource>().ToExternal("xd-mr-target", "x").
+// AONT041 must fire because the resolved target descriptor's CLR type appears multiple times
+// in the reverse index.
+public class TrackCMultiRegCrossDomainTargetOntology : DomainOntology
+{
+    public override string DomainName => "xd-mr-target";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TrackCSemanticDocument>("x", obj =>
+        {
+            obj.Key(d => d.Id);
+        });
+
+        builder.Object<TrackCSemanticDocument>("y", obj =>
+        {
+            obj.Key(d => d.Id);
+        });
+    }
+}
+
+// Companion source domain for the cross-domain TARGET test. Registers a normal,
+// single-registration source and declares the cross-domain link pointing at "x".
+public class TrackCCrossDomainSourceOnlyOntology : DomainOntology
+{
+    public override string DomainName => "xd-mr-source";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TrackCCollection>("Collection", obj =>
+        {
+            obj.Key(c => c.Id);
+        });
+
+        builder.CrossDomainLink("source_to_doc")
+            .From<TrackCCollection>()
+            .ToExternal("xd-mr-target", "x")
+            .ManyToMany();
+    }
+}
+
 public class OntologyGraphBuilderTests
 {
     [Test]
@@ -446,5 +533,73 @@ public class OntologyGraphBuilderTests
         await Assert.That(graph.ObjectTypes).HasCount().EqualTo(2);
         await Assert.That(graph.ObjectTypeNamesByType[typeof(TrackCSemanticDocument)])
             .HasCount().EqualTo(2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Track C3 — AONT041 cross-domain coverage (closes finding #6 on PR #34)
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task GraphBuilder_WithMultiRegisteredTypeAsCrossDomainLinkSource_ThrowsAONT041()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain<TrackCMultiRegCrossDomainSourceOntology>();
+        graphBuilder.AddDomain<TrackCCrossDomainTargetOnlyOntology>();
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithExceptionType(typeof(OntologyCompositionException));
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithMessageContaining("AONT041");
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithMessageContaining(typeof(TrackCSemanticDocument).FullName!);
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithMessageContaining("doc_to_target");
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithMessageContaining("xd-source");
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithMessageContaining("#32");
+    }
+
+    [Test]
+    public async Task GraphBuilder_WithMultiRegisteredTypeAsCrossDomainLinkTarget_ThrowsAONT041()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain<TrackCCrossDomainSourceOnlyOntology>();
+        graphBuilder.AddDomain<TrackCMultiRegCrossDomainTargetOntology>();
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithExceptionType(typeof(OntologyCompositionException));
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithMessageContaining("AONT041");
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithMessageContaining(typeof(TrackCSemanticDocument).FullName!);
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithMessageContaining("source_to_doc");
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithMessageContaining("xd-mr-target");
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithMessageContaining("#32");
     }
 }

--- a/src/Strategos.Ontology.Tests/OntologyGraphBuilderTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphBuilderTests.cs
@@ -43,6 +43,189 @@ public class TestMarketDataOntology : DomainOntology
     }
 }
 
+// ---------------------------------------------------------------------------
+// Track C fixtures — multi-registration and duplicate descriptor names
+// ---------------------------------------------------------------------------
+
+public class TrackCFoo1
+{
+    public string Id { get; set; } = "";
+}
+
+public class TrackCFoo2
+{
+    public string Id { get; set; } = "";
+}
+
+public class TrackCBar
+{
+    public string Id { get; set; } = "";
+}
+
+public class TrackCFoo
+{
+    public string Id { get; set; } = "";
+}
+
+public class TrackCSemanticDocument
+{
+    public string Id { get; set; } = "";
+    public string Title { get; set; } = "";
+}
+
+public class TrackCCollection
+{
+    public string Id { get; set; } = "";
+}
+
+// C1: duplicate descriptor name in same domain (two different CLR types share name)
+public class TrackCDuplicateNameSameDomainOntology : DomainOntology
+{
+    public override string DomainName => "track-c-dup";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TrackCFoo1>("shared_name", obj =>
+        {
+            obj.Key(f => f.Id);
+        });
+
+        builder.Object<TrackCFoo2>("shared_name", obj =>
+        {
+            obj.Key(f => f.Id);
+        });
+    }
+}
+
+// C1: same descriptor name across different domains — happy path
+public class TrackCSharedNameDomainAOntology : DomainOntology
+{
+    public override string DomainName => "track-c-domain-a";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TrackCFoo>("shared_name", obj =>
+        {
+            obj.Key(f => f.Id);
+        });
+    }
+}
+
+public class TrackCSharedNameDomainBOntology : DomainOntology
+{
+    public override string DomainName => "track-c-domain-b";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TrackCBar>("shared_name", obj =>
+        {
+            obj.Key(b => b.Id);
+        });
+    }
+}
+
+// C2: single explicit-name registration (TrackCFoo is registered once by its CLR type name)
+public class TrackCSingleRegistrationOntology : DomainOntology
+{
+    public override string DomainName => "track-c-single";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TrackCFoo>(obj =>
+        {
+            obj.Key(f => f.Id);
+        });
+    }
+}
+
+// C2: multi-registration — same CLR type registered under two distinct names
+public class TrackCMultiRegistrationOntology : DomainOntology
+{
+    public override string DomainName => "track-c-multi";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TrackCFoo>("a", obj =>
+        {
+            obj.Key(f => f.Id);
+        });
+
+        builder.Object<TrackCFoo>("b", obj =>
+        {
+            obj.Key(f => f.Id);
+        });
+    }
+}
+
+// C3: multi-registered type referenced as a link TARGET from another type (should throw AONT041)
+public class TrackCMultiRegLinkTargetOntology : DomainOntology
+{
+    public override string DomainName => "track-c-link-target";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TrackCSemanticDocument>("a", obj =>
+        {
+            obj.Key(d => d.Id);
+        });
+
+        builder.Object<TrackCSemanticDocument>("b", obj =>
+        {
+            obj.Key(d => d.Id);
+        });
+
+        builder.Object<TrackCCollection>(obj =>
+        {
+            obj.Key(c => c.Id);
+            obj.HasMany<TrackCSemanticDocument>("Documents");
+        });
+    }
+}
+
+// C3: multi-registered type declares an outgoing link from one of its registrations (should throw AONT041)
+public class TrackCMultiRegLinkSourceOntology : DomainOntology
+{
+    public override string DomainName => "track-c-link-source";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TrackCSemanticDocument>("a", obj =>
+        {
+            obj.Key(d => d.Id);
+            obj.HasMany<TrackCCollection>("Collections");
+        });
+
+        builder.Object<TrackCSemanticDocument>("b", obj =>
+        {
+            obj.Key(d => d.Id);
+        });
+
+        builder.Object<TrackCCollection>(obj =>
+        {
+            obj.Key(c => c.Id);
+        });
+    }
+}
+
+// C3: multi-registered leaf type with no link references anywhere — Basileus happy path
+public class TrackCMultiRegLeafOnlyOntology : DomainOntology
+{
+    public override string DomainName => "track-c-leaf-only";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TrackCSemanticDocument>("a", obj =>
+        {
+            obj.Key(d => d.Id);
+        });
+
+        builder.Object<TrackCSemanticDocument>("b", obj =>
+        {
+            obj.Key(d => d.Id);
+        });
+    }
+}
+
 public class OntologyGraphBuilderTests
 {
     [Test]
@@ -93,5 +276,50 @@ public class OntologyGraphBuilderTests
         await Assert.That(graph.Domains[0].ObjectTypes[0].Name).IsEqualTo("TestPosition");
         await Assert.That(graph.ObjectTypes).HasCount().EqualTo(1);
         await Assert.That(graph.ObjectTypes[0].Name).IsEqualTo("TestPosition");
+    }
+
+    // -----------------------------------------------------------------------
+    // Track C1 — AONT040 DuplicateObjectTypeName diagnostic
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task GraphBuilder_WithDuplicateDescriptorNameInSameDomain_ThrowsAONT040()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain<TrackCDuplicateNameSameDomainOntology>();
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithExceptionType(typeof(OntologyCompositionException));
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithMessageContaining("AONT040");
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithMessageContaining("shared_name");
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithMessageContaining(typeof(TrackCFoo1).FullName!);
+
+        await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithMessageContaining(typeof(TrackCFoo2).FullName!);
+    }
+
+    [Test]
+    public async Task GraphBuilder_WithSameDescriptorNameAcrossDifferentDomains_Succeeds()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain<TrackCSharedNameDomainAOntology>();
+        graphBuilder.AddDomain<TrackCSharedNameDomainBOntology>();
+
+        var graph = graphBuilder.Build();
+
+        await Assert.That(graph.Domains).HasCount().EqualTo(2);
+        await Assert.That(graph.ObjectTypes).HasCount().EqualTo(2);
+        await Assert.That(graph.ObjectTypes.Count(ot => ot.Name == "shared_name")).IsEqualTo(2);
     }
 }

--- a/src/Strategos.Ontology.Tests/Query/OntologyQueryFluentSimilarityTests.cs
+++ b/src/Strategos.Ontology.Tests/Query/OntologyQueryFluentSimilarityTests.cs
@@ -1,7 +1,9 @@
 using Strategos.Ontology.Actions;
 using Strategos.Ontology.Builder;
+using Strategos.Ontology.Chunking;
 using Strategos.Ontology.Embeddings;
 using Strategos.Ontology.Events;
+using Strategos.Ontology.Ingestion;
 using Strategos.Ontology.ObjectSets;
 using Strategos.Ontology.Query;
 
@@ -83,5 +85,241 @@ public class OntologyQueryFluentSimilarityTests
         // The closest match (doc-1, exact embedding) must be the top hit.
         await Assert.That(hits.Items.Count).IsGreaterThan(0);
         await Assert.That(hits.Items[0].Id).IsEqualTo("doc-1");
+    }
+
+    // ---- G1: End-to-end multi-registration regression guard (bug #31) ----
+    //
+    // These fixtures exercise the full fluent similarity chain against an
+    // ontology where a single CLR type (SemanticDocument) is registered twice
+    // under distinct descriptor names in one domain. The test asserts that
+    // every read and write through the chain is dispatched against the
+    // caller-supplied descriptor name — not typeof(T).Name — so items seeded
+    // into one partition never leak into a query routed to the other.
+    //
+    // Wiring points covered:
+    //   Track A — RootExpression.ObjectTypeName walked by SimilarityExpression
+    //   Track B — Object<T>(name, ...) builder overload registers two descriptors
+    //   Track C — graph freeze accepts leaf multi-registration (no AONT041)
+    //   Track D — OntologyQueryService.GetObjectSet<T>(name) threads ot.Name
+    //             into the RootExpression; GetObjectTypeNames<T>() reverse index
+    //   Track E — InMemoryObjectSetProvider partitions reads by descriptor name
+    //   Track F — IObjectSetWriter.StoreAsync(name, item) seeds into the
+    //             chosen partition
+    //
+    // If any of the above regresses, this test is expected to fail with
+    // bleed-through between the two partitions.
+
+    public sealed record SemanticDocument : ISearchable
+    {
+        public string Id { get; init; } = string.Empty;
+        public string Content { get; init; } = string.Empty;
+        public float[] Embedding { get; init; } = [];
+    }
+
+    public sealed class MultiRegistrationTestDomain : DomainOntology
+    {
+        public override string DomainName => "multi-reg-test";
+
+        protected override void Define(IOntologyBuilder builder)
+        {
+            // Two descriptor registrations of the same leaf CLR type. No links
+            // are declared on either registration — multi-registered types
+            // cannot participate in structural links under AONT041, and this
+            // test intentionally models the Basileus happy path (a content
+            // carrier type partitioned across logical collections).
+            builder.Object<SemanticDocument>("trading_documents", obj =>
+            {
+                obj.Key(d => d.Id);
+                obj.Property(d => d.Content);
+            });
+
+            builder.Object<SemanticDocument>("knowledge_documents", obj =>
+            {
+                obj.Key(d => d.Id);
+                obj.Property(d => d.Content);
+            });
+        }
+    }
+
+    [Test]
+    public async Task EndToEnd_MultiRegistration_FluentSimilarityChain_IsolatesByDescriptorName()
+    {
+        // Arrange — build an ontology with SemanticDocument registered twice
+        // under distinct descriptor names in the same domain.
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain(new MultiRegistrationTestDomain());
+        var ontology = graphBuilder.Build();
+
+        // Use the InMemory provider with no embedding provider — scoring
+        // falls back to keyword matching, and with MinRelevance(0.0) every
+        // item in the queried partition passes the filter. The assertion is
+        // about partition isolation, not ranking quality.
+        var provider = new InMemoryObjectSetProvider();
+
+        var dispatcher = Substitute.For<IActionDispatcher>();
+        var eventStream = Substitute.For<IEventStreamProvider>();
+        var query = new OntologyQueryService(ontology, provider, dispatcher, eventStream);
+
+        var tradingDoc1 = new SemanticDocument { Id = "t-1", Content = "market data for AAPL" };
+        var tradingDoc2 = new SemanticDocument { Id = "t-2", Content = "bond yields" };
+        var knowledgeDoc1 = new SemanticDocument { Id = "k-1", Content = "how authentication works" };
+        var knowledgeDoc2 = new SemanticDocument { Id = "k-2", Content = "kubernetes pod lifecycle" };
+
+        // Write path — seed each partition through the explicit-name
+        // StoreAsync overload. If the writer still reached for typeof(T).Name
+        // instead of descriptorName, all four items would collide on a single
+        // "SemanticDocument" partition and the isolation assertions below
+        // would fail with 4-item bleed-through.
+        IObjectSetWriter writer = provider;
+        await writer.StoreAsync("trading_documents", tradingDoc1);
+        await writer.StoreAsync("trading_documents", tradingDoc2);
+        await writer.StoreAsync("knowledge_documents", knowledgeDoc1);
+        await writer.StoreAsync("knowledge_documents", knowledgeDoc2);
+
+        // Act — execute the full fluent similarity chain for the trading
+        // partition. The whole chain (GetObjectSet → SimilarTo →
+        // WithMinRelevance → Take → ExecuteAsync) must thread the descriptor
+        // name from the ObjectSet root through the SimilarityExpression into
+        // the provider's partition lookup.
+        var tradingResults = await query
+            .GetObjectSet<SemanticDocument>("trading_documents")
+            .SimilarTo("market data")
+            .WithMinRelevance(0.0)
+            .Take(10)
+            .ExecuteAsync();
+
+        // Assert — only items seeded under trading_documents are returned.
+        var tradingContent = tradingResults.Items.Select(d => d.Content).ToList();
+        await Assert.That(tradingResults.Items).HasCount().EqualTo(2);
+        await Assert.That(tradingContent).Contains("market data for AAPL");
+        await Assert.That(tradingContent).Contains("bond yields");
+        await Assert.That(tradingContent).DoesNotContain("how authentication works");
+        await Assert.That(tradingContent).DoesNotContain("kubernetes pod lifecycle");
+
+        // Act — execute the chain for the knowledge partition with a distinct
+        // query. The same service instance must dispatch to a different
+        // partition based solely on the descriptor name passed to GetObjectSet.
+        var knowledgeResults = await query
+            .GetObjectSet<SemanticDocument>("knowledge_documents")
+            .SimilarTo("auth flow")
+            .WithMinRelevance(0.0)
+            .Take(10)
+            .ExecuteAsync();
+
+        // Assert — only items seeded under knowledge_documents are returned.
+        var knowledgeContent = knowledgeResults.Items.Select(d => d.Content).ToList();
+        await Assert.That(knowledgeResults.Items).HasCount().EqualTo(2);
+        await Assert.That(knowledgeContent).Contains("how authentication works");
+        await Assert.That(knowledgeContent).Contains("kubernetes pod lifecycle");
+        await Assert.That(knowledgeContent).DoesNotContain("market data for AAPL");
+        await Assert.That(knowledgeContent).DoesNotContain("bond yields");
+
+        // Assert — the public reverse-index API surfaces both registrations
+        // in registration order (Track D3).
+        var allNames = query.GetObjectTypeNames<SemanticDocument>();
+        await Assert.That(allNames).HasCount().EqualTo(2);
+        await Assert.That(allNames).Contains("trading_documents");
+        await Assert.That(allNames).Contains("knowledge_documents");
+    }
+
+    // ---- G1 optional extras ----
+
+    [Test]
+    public async Task EndToEnd_MultiRegistration_NonSimilarityExecute_IsolatesByDescriptorName()
+    {
+        // Mirror of the G1 test but exercising the non-similarity materialization
+        // path (ObjectSet<T>.ExecuteAsync → provider.ExecuteAsync) — confirms
+        // that plain read dispatch respects the descriptor name too, not only
+        // the similarity path. Guards against a regression that re-introduces
+        // typeof(T).Name lookup on the Execute path while leaving similarity
+        // correct.
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain(new MultiRegistrationTestDomain());
+        var ontology = graphBuilder.Build();
+
+        var provider = new InMemoryObjectSetProvider();
+        var dispatcher = Substitute.For<IActionDispatcher>();
+        var eventStream = Substitute.For<IEventStreamProvider>();
+        var query = new OntologyQueryService(ontology, provider, dispatcher, eventStream);
+
+        IObjectSetWriter writer = provider;
+        await writer.StoreAsync("trading_documents", new SemanticDocument { Id = "t-1", Content = "trade-1" });
+        await writer.StoreAsync("trading_documents", new SemanticDocument { Id = "t-2", Content = "trade-2" });
+        await writer.StoreAsync("knowledge_documents", new SemanticDocument { Id = "k-1", Content = "knowledge-1" });
+
+        var tradingResult = await query
+            .GetObjectSet<SemanticDocument>("trading_documents")
+            .ExecuteAsync();
+
+        var knowledgeResult = await query
+            .GetObjectSet<SemanticDocument>("knowledge_documents")
+            .ExecuteAsync();
+
+        await Assert.That(tradingResult.Items).HasCount().EqualTo(2);
+        await Assert.That(tradingResult.Items.Select(d => d.Id)).Contains("t-1");
+        await Assert.That(tradingResult.Items.Select(d => d.Id)).Contains("t-2");
+        await Assert.That(tradingResult.Items.Select(d => d.Id)).DoesNotContain("k-1");
+
+        await Assert.That(knowledgeResult.Items).HasCount().EqualTo(1);
+        await Assert.That(knowledgeResult.Items.Select(d => d.Id)).Contains("k-1");
+    }
+
+    [Test]
+    public async Task EndToEnd_MultiRegistration_IngestionPipeline_WritesToCorrectPartition()
+    {
+        // Exercises the end-to-end ingestion pipeline with an explicit
+        // descriptor name (Track F6). The pipeline must dispatch its batch
+        // write through the explicit-name StoreBatchAsync overload so the
+        // seeded chunks land in the named partition, not under typeof(T).Name.
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain(new MultiRegistrationTestDomain());
+        var ontology = graphBuilder.Build();
+
+        var provider = new InMemoryObjectSetProvider();
+        var dispatcher = Substitute.For<IActionDispatcher>();
+        var eventStream = Substitute.For<IEventStreamProvider>();
+        var query = new OntologyQueryService(ontology, provider, dispatcher, eventStream);
+
+        // Deterministic fake embedder — IngestionPipeline requires an
+        // embedding provider to Build(); content correctness is asserted
+        // by the downstream ObjectSet read, not by embedding fidelity.
+        var embedder = Substitute.For<IEmbeddingProvider>();
+        embedder.Dimensions.Returns(3);
+        embedder.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new float[] { 0f, 0f, 0f }));
+        embedder.EmbedBatchAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var texts = ci.Arg<IReadOnlyList<string>>();
+                IReadOnlyList<float[]> batch = texts.Select(_ => new float[] { 0f, 0f, 0f }).ToList();
+                return Task.FromResult(batch);
+            });
+
+        var pipeline = IngestionPipeline<SemanticDocument>.Create()
+            .Embed(embedder)
+            .Map((chunk, emb) => new SemanticDocument
+            {
+                Id = Guid.NewGuid().ToString(),
+                Content = chunk.Content,
+                Embedding = emb,
+            })
+            .WriteTo(provider, "trading_documents")
+            .Build();
+
+        await pipeline.ExecuteAsync(new[] { "AAPL spot price", "bond yield curve" });
+
+        // Both chunks should land in trading_documents only.
+        var tradingResult = await query
+            .GetObjectSet<SemanticDocument>("trading_documents")
+            .ExecuteAsync();
+
+        var knowledgeResult = await query
+            .GetObjectSet<SemanticDocument>("knowledge_documents")
+            .ExecuteAsync();
+
+        await Assert.That(tradingResult.Items).HasCount().EqualTo(2);
+        await Assert.That(tradingResult.Items.Select(d => d.Content)).Contains("AAPL spot price");
+        await Assert.That(tradingResult.Items.Select(d => d.Content)).Contains("bond yield curve");
+        await Assert.That(knowledgeResult.Items).HasCount().EqualTo(0);
     }
 }

--- a/src/Strategos.Ontology.Tests/Query/OntologyQueryTests.cs
+++ b/src/Strategos.Ontology.Tests/Query/OntologyQueryTests.cs
@@ -939,6 +939,96 @@ public class OntologyQueryServiceDiTests
     }
 }
 
+// --- Track D3 (2.4.1) — IOntologyQuery.GetObjectTypeNames<T>() reverse-index API fixtures ---
+
+public sealed class D3Foo
+{
+    public string Id { get; set; } = "";
+}
+
+public sealed class D3Bar
+{
+    public string Id { get; set; } = "";
+}
+
+public sealed class D3SingleRegistrationOntology : DomainOntology
+{
+    public override string DomainName => "d3-single";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<D3Foo>(obj =>
+        {
+            obj.Key(f => f.Id);
+        });
+    }
+}
+
+public sealed class D3MultiRegistrationOntology : DomainOntology
+{
+    public override string DomainName => "d3-multi";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<D3Foo>("a", obj =>
+        {
+            obj.Key(f => f.Id);
+        });
+
+        builder.Object<D3Foo>("b", obj =>
+        {
+            obj.Key(f => f.Id);
+        });
+    }
+}
+
+public class OntologyQueryServiceGetObjectTypeNamesTests
+{
+    [Test]
+    public async Task GetObjectTypeNames_SingleRegistration_ReturnsOneName()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain(new D3SingleRegistrationOntology());
+        var graph = graphBuilder.Build();
+        var query = new OntologyQueryService(graph);
+
+        var names = query.GetObjectTypeNames<D3Foo>();
+
+        await Assert.That(names).IsNotNull();
+        await Assert.That(names).HasCount().EqualTo(1);
+        await Assert.That(names[0]).IsEqualTo(nameof(D3Foo));
+    }
+
+    [Test]
+    public async Task GetObjectTypeNames_MultiRegistration_ReturnsAllNamesInRegistrationOrder()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain(new D3MultiRegistrationOntology());
+        var graph = graphBuilder.Build();
+        var query = new OntologyQueryService(graph);
+
+        var names = query.GetObjectTypeNames<D3Foo>();
+
+        await Assert.That(names).HasCount().EqualTo(2);
+        await Assert.That(names[0]).IsEqualTo("a");
+        await Assert.That(names[1]).IsEqualTo("b");
+    }
+
+    [Test]
+    public async Task GetObjectTypeNames_UnregisteredType_ReturnsEmptyList()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain(new D3SingleRegistrationOntology());
+        var graph = graphBuilder.Build();
+        var query = new OntologyQueryService(graph);
+
+        var names = query.GetObjectTypeNames<D3Bar>();
+
+        await Assert.That(names).IsNotNull();
+        await Assert.That(names).HasCount().EqualTo(0);
+    }
+}
+
 public class OntologyQueryServiceGetObjectSetTests
 {
     [Test]

--- a/src/Strategos.Ontology.Tests/Query/OntologyQueryTests.cs
+++ b/src/Strategos.Ontology.Tests/Query/OntologyQueryTests.cs
@@ -950,7 +950,8 @@ public class OntologyQueryServiceGetObjectSetTests
         var dispatcher = Substitute.For<Strategos.Ontology.Actions.IActionDispatcher>();
         var eventStream = Substitute.For<Strategos.Ontology.Events.IEventStreamProvider>();
         mock.GetObjectSet<QueryPosition>("QueryPosition")
-            .Returns(new Strategos.Ontology.ObjectSets.ObjectSet<QueryPosition>(provider, dispatcher, eventStream));
+            .Returns(new Strategos.Ontology.ObjectSets.ObjectSet<QueryPosition>(
+                nameof(QueryPosition), provider, dispatcher, eventStream));
 
         // Act
         var result = mock.GetObjectSet<QueryPosition>("QueryPosition");

--- a/src/Strategos.Ontology.Tests/Query/OntologyQueryTests.cs
+++ b/src/Strategos.Ontology.Tests/Query/OntologyQueryTests.cs
@@ -1011,4 +1011,103 @@ public class OntologyQueryServiceGetObjectSetTests
             .Throws<InvalidOperationException>()
             .WithMessageContaining(nameof(Strategos.Ontology.ObjectSets.IObjectSetProvider));
     }
+
+    [Test]
+    public async Task GetObjectSet_ThreadsDescriptorNameIntoRootExpression()
+    {
+        // Arrange — register a single explicit descriptor name for QueryDescriptorFoo.
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain(new DescriptorNameTestDomain(registrations:
+        [
+            ("custom_name", typeof(QueryDescriptorFoo)),
+        ]));
+        var graph = graphBuilder.Build();
+
+        var provider = Substitute.For<Strategos.Ontology.ObjectSets.IObjectSetProvider>();
+        var dispatcher = Substitute.For<Strategos.Ontology.Actions.IActionDispatcher>();
+        var eventStream = Substitute.For<Strategos.Ontology.Events.IEventStreamProvider>();
+        var query = new OntologyQueryService(graph, provider, dispatcher, eventStream);
+
+        // Act
+        var set = query.GetObjectSet<QueryDescriptorFoo>("custom_name");
+
+        // Assert — the root expression must carry the descriptor name that was
+        // *looked up* from the graph (ot.Name), not typeof(T).Name.
+        await Assert.That(set.Expression).IsTypeOf<Strategos.Ontology.ObjectSets.RootExpression>();
+        var root = (Strategos.Ontology.ObjectSets.RootExpression)set.Expression;
+        await Assert.That(root.ObjectTypeName).IsEqualTo("custom_name");
+        await Assert.That(root.ObjectType).IsEqualTo(typeof(QueryDescriptorFoo));
+    }
+
+    [Test]
+    public async Task GetObjectSet_WithMultiRegistration_ReturnsDistinctRootExpressionsPerName()
+    {
+        // Arrange — register the SAME CLR type under two different descriptor names
+        // ("descriptor_a" and "descriptor_b"). This exercises the multi-registration path.
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain(new DescriptorNameTestDomain(registrations:
+        [
+            ("descriptor_a", typeof(QueryDescriptorFoo)),
+            ("descriptor_b", typeof(QueryDescriptorFoo)),
+        ]));
+        var graph = graphBuilder.Build();
+
+        var provider = Substitute.For<Strategos.Ontology.ObjectSets.IObjectSetProvider>();
+        var dispatcher = Substitute.For<Strategos.Ontology.Actions.IActionDispatcher>();
+        var eventStream = Substitute.For<Strategos.Ontology.Events.IEventStreamProvider>();
+        var query = new OntologyQueryService(graph, provider, dispatcher, eventStream);
+
+        // Act
+        var setA = query.GetObjectSet<QueryDescriptorFoo>("descriptor_a");
+        var setB = query.GetObjectSet<QueryDescriptorFoo>("descriptor_b");
+
+        // Assert — the two root expressions MUST carry the two distinct descriptor names,
+        // not a shared typeof(T).Name fallback (which is the bug being fixed).
+        var rootA = (Strategos.Ontology.ObjectSets.RootExpression)setA.Expression;
+        var rootB = (Strategos.Ontology.ObjectSets.RootExpression)setB.Expression;
+        await Assert.That(rootA.ObjectTypeName).IsEqualTo("descriptor_a");
+        await Assert.That(rootB.ObjectTypeName).IsEqualTo("descriptor_b");
+        await Assert.That(rootA.ObjectTypeName).IsNotEqualTo(rootB.ObjectTypeName);
+    }
+}
+
+// --- Test domain for descriptor-name dispatch tests (D2) ---
+
+public sealed class QueryDescriptorFoo
+{
+    public Guid Id { get; set; }
+}
+
+/// <summary>
+/// Test-only domain ontology that accepts a list of (descriptorName, clrType)
+/// registrations and emits them via <see cref="IOntologyBuilder.Object{T}(string?, Action{IObjectTypeBuilder{T}})"/>.
+/// Used to exercise multi-registration of the same CLR type under different descriptor names.
+/// </summary>
+internal sealed class DescriptorNameTestDomain : DomainOntology
+{
+    private readonly IReadOnlyList<(string Name, Type ClrType)> _registrations;
+
+    public DescriptorNameTestDomain(IReadOnlyList<(string Name, Type ClrType)> registrations)
+    {
+        _registrations = registrations;
+    }
+
+    public override string DomainName => "descriptor-name-test";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        foreach (var (name, clrType) in _registrations)
+        {
+            if (clrType != typeof(QueryDescriptorFoo))
+            {
+                throw new InvalidOperationException(
+                    $"DescriptorNameTestDomain only supports QueryDescriptorFoo; got {clrType.Name}");
+            }
+
+            builder.Object<QueryDescriptorFoo>(name, obj =>
+            {
+                obj.Key(f => f.Id);
+            });
+        }
+    }
 }

--- a/src/Strategos.Ontology/Builder/IOntologyBuilder.cs
+++ b/src/Strategos.Ontology/Builder/IOntologyBuilder.cs
@@ -5,6 +5,20 @@ public interface IOntologyBuilder
     void Object<T>(Action<IObjectTypeBuilder<T>> configure)
         where T : class;
 
+    /// <summary>
+    /// Registers an object type with an explicit descriptor name, allowing the same CLR
+    /// type to be registered under multiple logical descriptor names (e.g. one CLR type
+    /// backing multiple object sets).
+    /// </summary>
+    /// <param name="name">
+    /// Explicit descriptor name. When <c>null</c>, falls back to <c>typeof(T).Name</c>
+    /// (parity with the parameterless overload). When non-null, must match
+    /// <c>^[a-zA-Z_][a-zA-Z0-9_]*$</c>.
+    /// </param>
+    /// <param name="configure">Configuration callback for the object type builder.</param>
+    void Object<T>(string? name, Action<IObjectTypeBuilder<T>> configure)
+        where T : class;
+
     void Interface<T>(string name, Action<IInterfaceBuilder<T>> configure)
         where T : class;
 

--- a/src/Strategos.Ontology/Builder/IOntologyBuilder.cs
+++ b/src/Strategos.Ontology/Builder/IOntologyBuilder.cs
@@ -10,6 +10,7 @@ public interface IOntologyBuilder
     /// type to be registered under multiple logical descriptor names (e.g. one CLR type
     /// backing multiple object sets).
     /// </summary>
+    /// <typeparam name="T">CLR type the descriptor is bound to.</typeparam>
     /// <param name="name">
     /// Explicit descriptor name. When <c>null</c>, falls back to <c>typeof(T).Name</c>
     /// (parity with the parameterless overload). When non-null, must match

--- a/src/Strategos.Ontology/Builder/ObjectTypeBuilder.cs
+++ b/src/Strategos.Ontology/Builder/ObjectTypeBuilder.cs
@@ -1,11 +1,41 @@
 using System.Linq.Expressions;
+using System.Text.RegularExpressions;
+
 using Strategos.Ontology.Descriptors;
 
 namespace Strategos.Ontology.Builder;
 
-internal sealed class ObjectTypeBuilder<T>(string domainName, string? explicitName = null) : IObjectTypeBuilder<T>
+internal sealed class ObjectTypeBuilder<T> : IObjectTypeBuilder<T>
     where T : class
 {
+    /// <summary>
+    /// Allowed explicit descriptor name shape: C#-identifier-compatible ASCII, i.e.
+    /// a letter or underscore followed by any number of letters, digits, or underscores.
+    /// This is a deliberately strict subset so that descriptor names are safe to use in
+    /// generated code paths (identifiers, dictionary keys) without additional escaping.
+    /// </summary>
+    private static readonly Regex ExplicitNamePattern = new(
+        "^[a-zA-Z_][a-zA-Z0-9_]*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private readonly string _domainName;
+    private readonly string? _explicitName;
+
+    public ObjectTypeBuilder(string domainName, string? explicitName = null)
+    {
+        if (explicitName is not null && !ExplicitNamePattern.IsMatch(explicitName))
+        {
+            throw new ArgumentException(
+                $"Explicit descriptor name '{explicitName}' is not a valid identifier. " +
+                $"Names must match '{ExplicitNamePattern}' — start with a letter or underscore, " +
+                "followed by letters, digits, or underscores only.",
+                nameof(explicitName));
+        }
+
+        _domainName = domainName;
+        _explicitName = explicitName;
+    }
+
     private PropertyDescriptor? _keyProperty;
     private readonly List<PropertyBuilder<T>> _propertyBuilders = [];
     private readonly List<LinkBuilder> _linkBuilders = [];
@@ -133,7 +163,7 @@ internal sealed class ObjectTypeBuilder<T>(string domainName, string? explicitNa
 
         ProjectValidFromStatesIntoLifecycle();
 
-        return new(explicitName ?? typeof(T).Name, typeof(T), domainName)
+        return new(_explicitName ?? typeof(T).Name, typeof(T), _domainName)
         {
             Kind = _objectKind,
             KeyProperty = _keyProperty,

--- a/src/Strategos.Ontology/Builder/ObjectTypeBuilder.cs
+++ b/src/Strategos.Ontology/Builder/ObjectTypeBuilder.cs
@@ -3,7 +3,7 @@ using Strategos.Ontology.Descriptors;
 
 namespace Strategos.Ontology.Builder;
 
-internal sealed class ObjectTypeBuilder<T>(string domainName) : IObjectTypeBuilder<T>
+internal sealed class ObjectTypeBuilder<T>(string domainName, string? explicitName = null) : IObjectTypeBuilder<T>
     where T : class
 {
     private PropertyDescriptor? _keyProperty;
@@ -133,7 +133,7 @@ internal sealed class ObjectTypeBuilder<T>(string domainName) : IObjectTypeBuild
 
         ProjectValidFromStatesIntoLifecycle();
 
-        return new(typeof(T).Name, typeof(T), domainName)
+        return new(explicitName ?? typeof(T).Name, typeof(T), domainName)
         {
             Kind = _objectKind,
             KeyProperty = _keyProperty,

--- a/src/Strategos.Ontology/Builder/OntologyBuilder.cs
+++ b/src/Strategos.Ontology/Builder/OntologyBuilder.cs
@@ -22,15 +22,9 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
     public void Object<T>(string? name, Action<IObjectTypeBuilder<T>> configure)
         where T : class
     {
-        var builder = new ObjectTypeBuilder<T>(domainName);
+        var builder = new ObjectTypeBuilder<T>(domainName, explicitName: name);
         configure(builder);
-        var descriptor = builder.Build();
-        if (name is not null)
-        {
-            descriptor = descriptor with { Name = name };
-        }
-
-        _objectTypes.Add(descriptor);
+        _objectTypes.Add(builder.Build());
     }
 
     public void Interface<T>(string name, Action<IInterfaceBuilder<T>> configure)

--- a/src/Strategos.Ontology/Builder/OntologyBuilder.cs
+++ b/src/Strategos.Ontology/Builder/OntologyBuilder.cs
@@ -22,6 +22,8 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
     public void Object<T>(string? name, Action<IObjectTypeBuilder<T>> configure)
         where T : class
     {
+        ArgumentNullException.ThrowIfNull(configure);
+
         var builder = new ObjectTypeBuilder<T>(domainName, explicitName: name);
         configure(builder);
         _objectTypes.Add(builder.Build());

--- a/src/Strategos.Ontology/Builder/OntologyBuilder.cs
+++ b/src/Strategos.Ontology/Builder/OntologyBuilder.cs
@@ -17,10 +17,20 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
 
     public void Object<T>(Action<IObjectTypeBuilder<T>> configure)
         where T : class
+        => Object<T>(name: null, configure);
+
+    public void Object<T>(string? name, Action<IObjectTypeBuilder<T>> configure)
+        where T : class
     {
         var builder = new ObjectTypeBuilder<T>(domainName);
         configure(builder);
-        _objectTypes.Add(builder.Build());
+        var descriptor = builder.Build();
+        if (name is not null)
+        {
+            descriptor = descriptor with { Name = name };
+        }
+
+        _objectTypes.Add(descriptor);
     }
 
     public void Interface<T>(string name, Action<IInterfaceBuilder<T>> configure)

--- a/src/Strategos.Ontology/Ingestion/IngestionPipeline.cs
+++ b/src/Strategos.Ontology/Ingestion/IngestionPipeline.cs
@@ -19,6 +19,7 @@ public sealed class IngestionPipeline<T> : IIngestionPipeline<T>
     private readonly Func<TextChunk, float[], T> _mapper;
     private readonly IObjectSetWriter _writer;
     private readonly IProgress<IngestionProgress>? _progress;
+    private readonly string? _descriptorName;
 
     /// <summary>
     /// Creates a new <see cref="IngestionPipelineBuilder{T}"/> for fluent pipeline construction.
@@ -29,13 +30,20 @@ public sealed class IngestionPipeline<T> : IIngestionPipeline<T>
     /// <summary>
     /// Initializes a new instance of the <see cref="IngestionPipeline{T}"/> class.
     /// </summary>
+    /// <remarks>
+    /// When <paramref name="descriptorName"/> is <c>null</c>, the pipeline dispatches
+    /// through the default <see cref="IObjectSetWriter.StoreBatchAsync{T}(IReadOnlyList{T}, CancellationToken)"/>
+    /// overload (conventional descriptor resolution). When non-null, it dispatches
+    /// through the explicit-name overload, targeting the chosen descriptor partition.
+    /// </remarks>
     internal IngestionPipeline(
         ITextChunker chunker,
         ChunkOptions? chunkOptions,
         IEmbeddingProvider embedder,
         Func<TextChunk, float[], T> mapper,
         IObjectSetWriter writer,
-        IProgress<IngestionProgress>? progress)
+        IProgress<IngestionProgress>? progress,
+        string? descriptorName = null)
     {
         _chunker = chunker;
         _chunkOptions = chunkOptions;
@@ -43,6 +51,7 @@ public sealed class IngestionPipeline<T> : IIngestionPipeline<T>
         _mapper = mapper;
         _writer = writer;
         _progress = progress;
+        _descriptorName = descriptorName;
     }
 
     /// <inheritdoc />
@@ -116,8 +125,17 @@ public sealed class IngestionPipeline<T> : IIngestionPipeline<T>
             mappedItems.Add(mapped);
         }
 
-        // Phase 4: Store via writer
-        await _writer.StoreBatchAsync<T>(mappedItems, ct).ConfigureAwait(false);
+        // Phase 4: Store via writer — dispatch through the explicit-name overload
+        // when a descriptor name was configured, otherwise use the default overload
+        // (conventional descriptor resolution).
+        if (_descriptorName is not null)
+        {
+            await _writer.StoreBatchAsync<T>(_descriptorName, mappedItems, ct).ConfigureAwait(false);
+        }
+        else
+        {
+            await _writer.StoreBatchAsync<T>(mappedItems, ct).ConfigureAwait(false);
+        }
 
         _progress?.Report(new IngestionProgress(totalChunks, totalChunks, "Storing"));
 

--- a/src/Strategos.Ontology/Ingestion/IngestionPipelineBuilder.cs
+++ b/src/Strategos.Ontology/Ingestion/IngestionPipelineBuilder.cs
@@ -16,6 +16,7 @@ public sealed class IngestionPipelineBuilder<T>
     private IEmbeddingProvider? _embedder;
     private Func<TextChunk, float[], T>? _mapper;
     private IObjectSetWriter? _writer;
+    private string? _descriptorName;
     private IProgress<IngestionProgress>? _progress;
 
     /// <summary>
@@ -69,7 +70,9 @@ public sealed class IngestionPipelineBuilder<T>
     }
 
     /// <summary>
-    /// Sets the writer to use for storing mapped items.
+    /// Sets the writer to use for storing mapped items. The pipeline will dispatch
+    /// through the default <see cref="IObjectSetWriter.StoreBatchAsync{T}(IReadOnlyList{T}, CancellationToken)"/>
+    /// overload, which targets the descriptor resolved by convention for <typeparamref name="T"/>.
     /// </summary>
     /// <param name="writer">The object set writer implementation.</param>
     /// <returns>This builder for fluent chaining.</returns>
@@ -77,6 +80,30 @@ public sealed class IngestionPipelineBuilder<T>
     {
         ArgumentNullException.ThrowIfNull(writer);
         _writer = writer;
+        _descriptorName = null;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the writer and the descriptor name to use for storing mapped items.
+    /// The pipeline will dispatch through the explicit-name
+    /// <see cref="IObjectSetWriter.StoreBatchAsync{T}(string, IReadOnlyList{T}, CancellationToken)"/>
+    /// overload, targeting the descriptor partition identified by
+    /// <paramref name="descriptorName"/>. Use this overload when <typeparamref name="T"/>
+    /// is registered against multiple descriptors and the target partition must
+    /// be chosen explicitly.
+    /// </summary>
+    /// <param name="writer">The object set writer implementation.</param>
+    /// <param name="descriptorName">
+    /// The descriptor name selecting which registered partition to write to.
+    /// </param>
+    /// <returns>This builder for fluent chaining.</returns>
+    public IngestionPipelineBuilder<T> WriteTo(IObjectSetWriter writer, string descriptorName)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentException.ThrowIfNullOrEmpty(descriptorName);
+        _writer = writer;
+        _descriptorName = descriptorName;
         return this;
     }
 
@@ -117,7 +144,7 @@ public sealed class IngestionPipelineBuilder<T>
         // When no chunker is set, use a default that returns the full text as a single chunk.
         var chunker = _chunker ?? new PassthroughChunker();
 
-        return new IngestionPipeline<T>(chunker, _chunkOptions, _embedder, _mapper, _writer, _progress);
+        return new IngestionPipeline<T>(chunker, _chunkOptions, _embedder, _mapper, _writer, _progress, _descriptorName);
     }
 
     /// <summary>

--- a/src/Strategos.Ontology/ObjectSets/IObjectSetWriter.cs
+++ b/src/Strategos.Ontology/ObjectSets/IObjectSetWriter.cs
@@ -3,21 +3,61 @@ namespace Strategos.Ontology.ObjectSets;
 /// <summary>
 /// Provider abstraction for storing objects in an object set backend.
 /// </summary>
+/// <remarks>
+/// The default <c>StoreAsync</c>/<c>StoreBatchAsync</c> overloads target the
+/// descriptor resolved by convention for <typeparamref name="T"/>. When a domain
+/// type is registered against multiple descriptors, use the explicit-name
+/// overloads to target a specific descriptor partition.
+/// </remarks>
 public interface IObjectSetWriter
 {
     /// <summary>
-    /// Stores a single item in the backend.
+    /// Stores a single item in the backend under the conventionally-resolved
+    /// descriptor for <typeparamref name="T"/>.
     /// </summary>
     /// <typeparam name="T">The domain object type to store.</typeparam>
     /// <param name="item">The item to store.</param>
     /// <param name="ct">Cancellation token.</param>
+    /// <returns>A task that completes when the item has been written.</returns>
     Task StoreAsync<T>(T item, CancellationToken ct = default) where T : class;
 
     /// <summary>
-    /// Stores a batch of items in the backend.
+    /// Stores a batch of items in the backend under the conventionally-resolved
+    /// descriptor for <typeparamref name="T"/>.
     /// </summary>
     /// <typeparam name="T">The domain object type to store.</typeparam>
     /// <param name="items">The items to store.</param>
     /// <param name="ct">Cancellation token.</param>
+    /// <returns>A task that completes when all items have been written.</returns>
     Task StoreBatchAsync<T>(IReadOnlyList<T> items, CancellationToken ct = default) where T : class;
+
+    /// <summary>
+    /// Stores a single item in the backend under the descriptor partition
+    /// identified by <paramref name="descriptorName"/>. Use this overload when
+    /// <typeparamref name="T"/> is registered against multiple descriptors and
+    /// the target partition must be chosen explicitly.
+    /// </summary>
+    /// <typeparam name="T">The domain object type to store.</typeparam>
+    /// <param name="descriptorName">
+    /// The descriptor name selecting which registered partition to write to.
+    /// </param>
+    /// <param name="item">The item to store.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A task that completes when the item has been written.</returns>
+    Task StoreAsync<T>(string descriptorName, T item, CancellationToken ct = default) where T : class;
+
+    /// <summary>
+    /// Stores a batch of items in the backend under the descriptor partition
+    /// identified by <paramref name="descriptorName"/>. Use this overload when
+    /// <typeparamref name="T"/> is registered against multiple descriptors and
+    /// the target partition must be chosen explicitly.
+    /// </summary>
+    /// <typeparam name="T">The domain object type to store.</typeparam>
+    /// <param name="descriptorName">
+    /// The descriptor name selecting which registered partition to write to.
+    /// </param>
+    /// <param name="items">The items to store.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A task that completes when all items have been written.</returns>
+    Task StoreBatchAsync<T>(string descriptorName, IReadOnlyList<T> items, CancellationToken ct = default) where T : class;
 }

--- a/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
@@ -18,9 +18,18 @@ namespace Strategos.Ontology.ObjectSets;
 /// </remarks>
 public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWriter
 {
-    private readonly ConcurrentDictionary<Type, List<object>> _items = new();
-    private readonly ConcurrentDictionary<Type, List<string>> _searchableContent = new();
-    private readonly ConcurrentDictionary<Type, List<float[]>> _embeddings = new();
+    // Partitioned by ontology descriptor name (string), NOT by CLR type. A
+    // single CLR type may be registered under multiple descriptors (e.g.
+    // trading_documents vs. knowledge_documents, both backed by
+    // SemanticDocument); each descriptor must own its own partition so
+    // queries routed to one do not accidentally see items from another
+    // (bug #31 / Strategos 2.4.1). The default partition key for a
+    // Seed<T>(item, content) call with no explicit descriptor name is
+    // typeof(T).Name, which matches the default root expression built by
+    // ObjectSet<T> when no descriptor name is supplied.
+    private readonly ConcurrentDictionary<string, List<object>> _items = new();
+    private readonly ConcurrentDictionary<string, List<string>> _searchableContent = new();
+    private readonly ConcurrentDictionary<string, List<float[]>> _embeddings = new();
     private readonly IEmbeddingProvider? _embeddingProvider;
 
     /// <summary>
@@ -49,18 +58,25 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
     /// <typeparam name="T">The domain object type.</typeparam>
     /// <param name="item">The item to seed.</param>
     /// <param name="searchableContent">The text content used for keyword-based similarity scoring.</param>
-    public void Seed<T>(T item, string searchableContent) where T : class
+    /// <param name="descriptorName">
+    /// Optional ontology descriptor name to partition the seeded item under.
+    /// When omitted, defaults to <c>typeof(T).Name</c>, which matches the
+    /// default root expression built by <c>ObjectSet&lt;T&gt;</c> with no
+    /// explicit descriptor. Supply an explicit name when a single CLR type
+    /// is registered under multiple descriptors (bug #31).
+    /// </param>
+    public void Seed<T>(T item, string searchableContent, string? descriptorName = null) where T : class
     {
         ArgumentNullException.ThrowIfNull(item);
         ArgumentNullException.ThrowIfNull(searchableContent);
 
-        var type = typeof(T);
-        _items.GetOrAdd(type, _ => new List<object>()).Add(item);
-        _searchableContent.GetOrAdd(type, _ => new List<string>()).Add(searchableContent);
+        var key = descriptorName ?? typeof(T).Name;
+        _items.GetOrAdd(key, _ => new List<object>()).Add(item);
+        _searchableContent.GetOrAdd(key, _ => new List<string>()).Add(searchableContent);
 
         // Store embedding (or empty placeholder) to maintain index alignment with _items
         var embedding = item is ISearchable searchable ? searchable.Embedding : [];
-        _embeddings.GetOrAdd(type, _ => new List<float[]>()).Add(embedding);
+        _embeddings.GetOrAdd(key, _ => new List<float[]>()).Add(embedding);
     }
 
     /// <inheritdoc />
@@ -68,15 +84,19 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
     {
         ArgumentNullException.ThrowIfNull(item);
 
-        var type = typeof(T);
+        // Default partition key for the no-descriptor overload is
+        // typeof(T).Name, preserving the established behavior of the
+        // implicit (single-registration) write path. Task F2 will land
+        // a descriptor-name-aware overload for the multi-registered case.
+        var key = typeof(T).Name;
         var searchableText = item.ToString() ?? string.Empty;
 
-        _items.GetOrAdd(type, _ => new List<object>()).Add(item);
-        _searchableContent.GetOrAdd(type, _ => new List<string>()).Add(searchableText);
+        _items.GetOrAdd(key, _ => new List<object>()).Add(item);
+        _searchableContent.GetOrAdd(key, _ => new List<string>()).Add(searchableText);
 
         // Store embedding (or empty placeholder) to maintain index alignment with _items
         var embedding = item is ISearchable searchable ? searchable.Embedding : [];
-        _embeddings.GetOrAdd(type, _ => new List<float[]>()).Add(embedding);
+        _embeddings.GetOrAdd(key, _ => new List<float[]>()).Add(embedding);
 
         return Task.CompletedTask;
     }
@@ -113,7 +133,7 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         where T : class
     {
         ArgumentNullException.ThrowIfNull(expression);
-        var items = GetSeededItems<T>();
+        var items = GetSeededItems<T>(expression.RootObjectTypeName);
         var filtered = ApplyExpression(items, expression);
         var result = new ObjectSetResult<T>(filtered, filtered.Count, ObjectSetInclusion.Properties);
         return Task.FromResult(result);
@@ -125,7 +145,7 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         [EnumeratorCancellation] CancellationToken ct = default) where T : class
     {
         ArgumentNullException.ThrowIfNull(expression);
-        var items = GetSeededItems<T>();
+        var items = GetSeededItems<T>(expression.RootObjectTypeName);
         var filtered = ApplyExpression(items, expression);
 
         foreach (var item in filtered)
@@ -144,7 +164,12 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
     {
         ArgumentNullException.ThrowIfNull(expression);
 
-        var items = GetSeededItems<T>();
+        // Partition lookups route through the expression's declared descriptor
+        // name so queries honor the same dispatch as ExecuteAsync / StreamAsync
+        // (bug #31). The walk-to-root helper on ObjectSetExpression surfaces
+        // the name from the root even when wrapped by filters, includes, etc.
+        var partitionKey = expression.RootObjectTypeName;
+        var items = GetSeededItems<T>(partitionKey);
 
         if (items.Count == 0)
         {
@@ -157,19 +182,20 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
 
         // When an embedding provider is available and non-placeholder embeddings exist, use cosine similarity
         if (_embeddingProvider is not null
-            && _embeddings.TryGetValue(typeof(T), out var storedEmbeddings)
+            && _embeddings.TryGetValue(partitionKey, out var storedEmbeddings)
             && storedEmbeddings.Any(static e => e.Length > 0))
         {
-            return await ExecuteCosineSimilarityAsync(items, storedEmbeddings, expression, ct).ConfigureAwait(false);
+            return await ExecuteCosineSimilarityAsync(items, storedEmbeddings, partitionKey, expression, ct).ConfigureAwait(false);
         }
 
         // Fall back to keyword scoring
-        return ExecuteKeywordSimilarity(items, expression);
+        return ExecuteKeywordSimilarity(items, partitionKey, expression);
     }
 
     private async Task<ScoredObjectSetResult<T>> ExecuteCosineSimilarityAsync<T>(
         List<T> items,
         List<float[]> storedEmbeddings,
+        string partitionKey,
         SimilarityExpression expression,
         CancellationToken ct) where T : class
     {
@@ -178,7 +204,7 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
             ?? await _embeddingProvider!.EmbedAsync(expression.QueryText, ct).ConfigureAwait(false);
 
         // Build identity-based index map to avoid O(n^2) IndexOf lookups and duplicate-item misalignment
-        var allItems = GetSeededItems<T>();
+        var allItems = GetSeededItems<T>(partitionKey);
         var indexMap = BuildIdentityIndexMap(allItems);
 
         var scored = items
@@ -208,11 +234,12 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
 
     private ScoredObjectSetResult<T> ExecuteKeywordSimilarity<T>(
         List<T> items,
+        string partitionKey,
         SimilarityExpression expression) where T : class
     {
         // Build identity-based index map to avoid O(n^2) IndexOf lookups and duplicate-item misalignment
-        var allItems = GetSeededItems<T>();
-        var allContent = GetSearchableContent<T>();
+        var allItems = GetSeededItems<T>(partitionKey);
+        var allContent = GetSearchableContent(partitionKey);
         var indexMap = BuildIdentityIndexMap(allItems);
 
         var scored = items
@@ -255,9 +282,9 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         return map;
     }
 
-    private List<T> GetSeededItems<T>() where T : class
+    private List<T> GetSeededItems<T>(string partitionKey) where T : class
     {
-        if (!_items.TryGetValue(typeof(T), out var items))
+        if (!_items.TryGetValue(partitionKey, out var items))
         {
             return new List<T>();
         }
@@ -265,9 +292,9 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         return items.Cast<T>().ToList();
     }
 
-    private List<string> GetSearchableContent<T>() where T : class
+    private List<string> GetSearchableContent(string partitionKey)
     {
-        if (!_searchableContent.TryGetValue(typeof(T), out var content))
+        if (!_searchableContent.TryGetValue(partitionKey, out var content))
         {
             return new List<string>();
         }

--- a/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
@@ -93,6 +93,21 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         }
     }
 
+    // The two explicit-descriptor-name overloads below are INTENTIONAL temporary placeholders
+    // landed by Task F1 (Strategos 2.4.1 Ontology Descriptor-Name Dispatch, bug #31). They exist
+    // solely so InMemoryObjectSetProvider continues to satisfy IObjectSetWriter while the interface
+    // change lands ahead of the real implementation. Task E4 (InMemory partition switch) + Task F2
+    // (in-memory explicit-name write path) will replace the NotImplementedException throws with the
+    // descriptor-partition-aware store logic. Do not call these overloads yet.
+
+    /// <inheritdoc />
+    public Task StoreAsync<T>(string descriptorName, T item, CancellationToken ct = default) where T : class
+        => throw new NotImplementedException("Implemented in Task F2");
+
+    /// <inheritdoc />
+    public Task StoreBatchAsync<T>(string descriptorName, IReadOnlyList<T> items, CancellationToken ct = default) where T : class
+        => throw new NotImplementedException("Implemented in Task F2");
+
     /// <inheritdoc />
     public Task<ObjectSetResult<T>> ExecuteAsync<T>(ObjectSetExpression expression, CancellationToken ct = default)
         where T : class

--- a/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
@@ -79,54 +79,51 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         _embeddings.GetOrAdd(key, _ => new List<float[]>()).Add(embedding);
     }
 
+    // Both default overloads delegate into the explicit-name variants with
+    // typeof(T).Name as the partition key. This keeps the two write paths in
+    // sync (a single source of truth for partition layout, embedding alignment,
+    // and searchable content extraction) and matches the dispatch convention
+    // used on the read side: ObjectSet<T> built without an explicit descriptor
+    // name produces a RootExpression whose RootObjectTypeName is typeof(T).Name.
+
     /// <inheritdoc />
     public Task StoreAsync<T>(T item, CancellationToken ct = default) where T : class
+        => StoreAsync(typeof(T).Name, item, ct);
+
+    /// <inheritdoc />
+    public Task StoreBatchAsync<T>(IReadOnlyList<T> items, CancellationToken ct = default) where T : class
+        => StoreBatchAsync(typeof(T).Name, items, ct);
+
+    /// <inheritdoc />
+    public Task StoreAsync<T>(string descriptorName, T item, CancellationToken ct = default) where T : class
     {
+        ArgumentNullException.ThrowIfNull(descriptorName);
         ArgumentNullException.ThrowIfNull(item);
 
-        // Default partition key for the no-descriptor overload is
-        // typeof(T).Name, preserving the established behavior of the
-        // implicit (single-registration) write path. Task F2 will land
-        // a descriptor-name-aware overload for the multi-registered case.
-        var key = typeof(T).Name;
         var searchableText = item.ToString() ?? string.Empty;
 
-        _items.GetOrAdd(key, _ => new List<object>()).Add(item);
-        _searchableContent.GetOrAdd(key, _ => new List<string>()).Add(searchableText);
+        _items.GetOrAdd(descriptorName, _ => new List<object>()).Add(item);
+        _searchableContent.GetOrAdd(descriptorName, _ => new List<string>()).Add(searchableText);
 
         // Store embedding (or empty placeholder) to maintain index alignment with _items
         var embedding = item is ISearchable searchable ? searchable.Embedding : [];
-        _embeddings.GetOrAdd(key, _ => new List<float[]>()).Add(embedding);
+        _embeddings.GetOrAdd(descriptorName, _ => new List<float[]>()).Add(embedding);
 
         return Task.CompletedTask;
     }
 
     /// <inheritdoc />
-    public async Task StoreBatchAsync<T>(IReadOnlyList<T> items, CancellationToken ct = default) where T : class
+    public async Task StoreBatchAsync<T>(string descriptorName, IReadOnlyList<T> items, CancellationToken ct = default) where T : class
     {
+        ArgumentNullException.ThrowIfNull(descriptorName);
         ArgumentNullException.ThrowIfNull(items);
 
         foreach (var item in items)
         {
             ct.ThrowIfCancellationRequested();
-            await StoreAsync(item, ct).ConfigureAwait(false);
+            await StoreAsync(descriptorName, item, ct).ConfigureAwait(false);
         }
     }
-
-    // The two explicit-descriptor-name overloads below are INTENTIONAL temporary placeholders
-    // landed by Task F1 (Strategos 2.4.1 Ontology Descriptor-Name Dispatch, bug #31). They exist
-    // solely so InMemoryObjectSetProvider continues to satisfy IObjectSetWriter while the interface
-    // change lands ahead of the real implementation. Task E4 (InMemory partition switch) + Task F2
-    // (in-memory explicit-name write path) will replace the NotImplementedException throws with the
-    // descriptor-partition-aware store logic. Do not call these overloads yet.
-
-    /// <inheritdoc />
-    public Task StoreAsync<T>(string descriptorName, T item, CancellationToken ct = default) where T : class
-        => throw new NotImplementedException("Implemented in Task F2");
-
-    /// <inheritdoc />
-    public Task StoreBatchAsync<T>(string descriptorName, IReadOnlyList<T> items, CancellationToken ct = default) where T : class
-        => throw new NotImplementedException("Implemented in Task F2");
 
     /// <inheritdoc />
     public Task<ObjectSetResult<T>> ExecuteAsync<T>(ObjectSetExpression expression, CancellationToken ct = default)

--- a/src/Strategos.Ontology/ObjectSets/ObjectSet.cs
+++ b/src/Strategos.Ontology/ObjectSets/ObjectSet.cs
@@ -17,14 +17,26 @@ public sealed class ObjectSet<T> where T : class
     private readonly IEventStreamProvider _eventStreamProvider;
 
     /// <summary>
-    /// Creates a new root ObjectSet for the given type.
+    /// Creates a new root ObjectSet for the given type, carrying an explicit ontology
+    /// descriptor name on the root expression so the provider can dispatch against the
+    /// correct registration when the CLR type is registered under multiple names.
+    /// Callers constructing an <see cref="ObjectSet{T}"/> directly (rather than through
+    /// <see cref="Strategos.Ontology.Query.IOntologyQuery.GetObjectSet{T}"/>) must supply
+    /// the descriptor name they want dispatched.
     /// </summary>
-    public ObjectSet(IObjectSetProvider provider, IActionDispatcher actionDispatcher, IEventStreamProvider eventStreamProvider)
-        : this(new RootExpression(typeof(T), typeof(T).Name), provider, actionDispatcher, eventStreamProvider)
+    /// <param name="descriptorName">
+    /// The ontology descriptor name registered for this type in the graph. For
+    /// single-registered types this is typically <c>typeof(T).Name</c>; for multi-registered
+    /// types this is the explicit name passed to <c>Object&lt;T&gt;(name, ...)</c>.
+    /// </param>
+    public ObjectSet(
+        string descriptorName,
+        IObjectSetProvider provider,
+        IActionDispatcher actionDispatcher,
+        IEventStreamProvider eventStreamProvider)
+        : this(new RootExpression(typeof(T), descriptorName), provider, actionDispatcher, eventStreamProvider)
     {
-        // NOTE: the descriptor name defaults to typeof(T).Name here as a temporary
-        // placeholder. Track D1 threads the real descriptor name through
-        // OntologyQueryService.GetObjectSet<T>(string) → this constructor.
+        ArgumentNullException.ThrowIfNull(descriptorName);
     }
 
     internal ObjectSet(ObjectSetExpression expression, IObjectSetProvider provider, IActionDispatcher actionDispatcher, IEventStreamProvider eventStreamProvider)

--- a/src/Strategos.Ontology/ObjectSets/ObjectSet.cs
+++ b/src/Strategos.Ontology/ObjectSets/ObjectSet.cs
@@ -119,17 +119,20 @@ public sealed class ObjectSet<T> where T : class
 
     /// <summary>
     /// Applies an action to all objects in the set by first materializing the query,
-    /// then dispatching the action to each object.
+    /// then dispatching the action to each object. The dispatch routes against the
+    /// descriptor name carried on the expression's root, so a multi-registered CLR
+    /// type reaches the registration the caller selected.
     /// </summary>
     public async Task<IReadOnlyList<ActionResult>> ApplyAsync(string actionName, object request, CancellationToken ct = default)
     {
         var result = await _provider.ExecuteAsync<T>(Expression, ct).ConfigureAwait(false);
         var results = new List<ActionResult>(result.Items.Count);
+        var descriptorName = Expression.RootObjectTypeName;
 
         foreach (var item in result.Items)
         {
             var objectId = item?.ToString() ?? string.Empty;
-            var context = new ActionContext(typeof(T).Name, typeof(T).Name, objectId, actionName);
+            var context = new ActionContext(descriptorName, descriptorName, objectId, actionName);
             var actionResult = await _actionDispatcher.DispatchAsync(context, request, ct).ConfigureAwait(false);
             results.Add(actionResult);
         }
@@ -138,12 +141,15 @@ public sealed class ObjectSet<T> where T : class
     }
 
     /// <summary>
-    /// Queries events for the object type represented by this set.
+    /// Queries events for the object type represented by this set. The query carries
+    /// the descriptor name from the expression root, so multi-registered CLR types
+    /// resolve against the caller-selected registration rather than the raw CLR name.
     /// </summary>
     public IAsyncEnumerable<OntologyEvent> EventsAsync(TimeSpan? since = null, IReadOnlyList<string>? eventTypes = null)
     {
         var sinceTimestamp = since.HasValue ? DateTimeOffset.UtcNow - since.Value : (DateTimeOffset?)null;
-        var query = new EventQuery(typeof(T).Name, typeof(T).Name, Since: sinceTimestamp, EventTypes: eventTypes);
+        var descriptorName = Expression.RootObjectTypeName;
+        var query = new EventQuery(descriptorName, descriptorName, Since: sinceTimestamp, EventTypes: eventTypes);
         return _eventStreamProvider.QueryEventsAsync(query);
     }
 }

--- a/src/Strategos.Ontology/ObjectSets/ObjectSet.cs
+++ b/src/Strategos.Ontology/ObjectSets/ObjectSet.cs
@@ -20,8 +20,11 @@ public sealed class ObjectSet<T> where T : class
     /// Creates a new root ObjectSet for the given type.
     /// </summary>
     public ObjectSet(IObjectSetProvider provider, IActionDispatcher actionDispatcher, IEventStreamProvider eventStreamProvider)
-        : this(new RootExpression(typeof(T)), provider, actionDispatcher, eventStreamProvider)
+        : this(new RootExpression(typeof(T), typeof(T).Name), provider, actionDispatcher, eventStreamProvider)
     {
+        // NOTE: the descriptor name defaults to typeof(T).Name here as a temporary
+        // placeholder. Track D1 threads the real descriptor name through
+        // OntologyQueryService.GetObjectSet<T>(string) → this constructor.
     }
 
     internal ObjectSet(ObjectSetExpression expression, IObjectSetProvider provider, IActionDispatcher actionDispatcher, IEventStreamProvider eventStreamProvider)

--- a/src/Strategos.Ontology/ObjectSets/ObjectSetExpression.cs
+++ b/src/Strategos.Ontology/ObjectSets/ObjectSetExpression.cs
@@ -89,6 +89,14 @@ public sealed class TraverseLinkExpression : ObjectSetExpression
 
     public ObjectSetExpression Source { get; }
     public string LinkName { get; }
+
+    /// <summary>
+    /// Traversal breaks the walk-to-root chain: once we've traversed a link,
+    /// the query targets the linked type's descriptor, not the source root's.
+    /// Under Option X (multi-registered types cannot be link targets — enforced
+    /// by AONT041), <c>ObjectType.Name</c> is always unambiguous here.
+    /// </summary>
+    public override string RootObjectTypeName => ObjectType.Name;
 }
 
 /// <summary>

--- a/src/Strategos.Ontology/ObjectSets/ObjectSetExpression.cs
+++ b/src/Strategos.Ontology/ObjectSets/ObjectSetExpression.cs
@@ -16,6 +16,27 @@ public abstract class ObjectSetExpression
     /// The CLR type this expression node produces.
     /// </summary>
     public Type ObjectType { get; }
+
+    /// <summary>
+    /// The ontology descriptor name this expression's query targets. Walks the
+    /// expression tree back to its <see cref="RootExpression"/> by following
+    /// <c>Source</c> references and returns the root's declared
+    /// <see cref="RootExpression.ObjectTypeName"/>. <see cref="TraverseLinkExpression"/>
+    /// overrides this to return the linked type's descriptor name (see A3).
+    /// </summary>
+    public virtual string RootObjectTypeName => WalkToRoot(this).ObjectTypeName;
+
+    private static RootExpression WalkToRoot(ObjectSetExpression expr) => expr switch
+    {
+        RootExpression root => root,
+        FilterExpression f => WalkToRoot(f.Source),
+        InterfaceNarrowExpression i => WalkToRoot(i.Source),
+        RawFilterExpression r => WalkToRoot(r.Source),
+        IncludeExpression inc => WalkToRoot(inc.Source),
+        SimilarityExpression s => WalkToRoot(s.Source),
+        TraverseLinkExpression t => WalkToRoot(t.Source),
+        _ => throw new InvalidOperationException($"Unknown expression type: {expr.GetType().Name}")
+    };
 }
 
 /// <summary>

--- a/src/Strategos.Ontology/ObjectSets/ObjectSetExpression.cs
+++ b/src/Strategos.Ontology/ObjectSets/ObjectSetExpression.cs
@@ -23,7 +23,19 @@ public abstract class ObjectSetExpression
 /// </summary>
 public sealed class RootExpression : ObjectSetExpression
 {
-    public RootExpression(Type objectType) : base(objectType) { }
+    public RootExpression(Type objectType, string objectTypeName) : base(objectType)
+    {
+        ArgumentNullException.ThrowIfNull(objectTypeName);
+        ObjectTypeName = objectTypeName;
+    }
+
+    /// <summary>
+    /// The ontology descriptor name this root was dispatched against.
+    /// For a single-registered type this equals <c>ObjectType.Name</c>; for a
+    /// multi-registered type this is the explicit descriptor name supplied by
+    /// the caller (e.g., via <c>query.GetObjectSet&lt;T&gt;("trading_documents")</c>).
+    /// </summary>
+    public string ObjectTypeName { get; }
 }
 
 /// <summary>

--- a/src/Strategos.Ontology/OntologyGraph.cs
+++ b/src/Strategos.Ontology/OntologyGraph.cs
@@ -15,12 +15,24 @@ public sealed class OntologyGraph
     public IReadOnlyList<WorkflowChain> WorkflowChains { get; }
     public IReadOnlyList<string> Warnings { get; }
 
+    /// <summary>
+    /// Reverse index from CLR type to the list of descriptor names it was registered
+    /// under. Preserves registration order. A type registered once (either implicitly
+    /// or via <c>Object&lt;T&gt;(name, ...)</c>) has a single-element list; a type
+    /// registered multiple times appears with every name in the order they were added.
+    /// Unknown types are absent from the dictionary — callers should use
+    /// <see cref="System.Collections.Generic.CollectionExtensions.GetValueOrDefault{TKey,TValue}(System.Collections.Generic.IReadOnlyDictionary{TKey,TValue},TKey,TValue)"/>
+    /// with an empty default.
+    /// </summary>
+    public IReadOnlyDictionary<Type, IReadOnlyList<string>> ObjectTypeNamesByType { get; }
+
     internal OntologyGraph(
         IReadOnlyList<DomainDescriptor> domains,
         IReadOnlyList<ObjectTypeDescriptor> objectTypes,
         IReadOnlyList<InterfaceDescriptor> interfaces,
         IReadOnlyList<ResolvedCrossDomainLink> crossDomainLinks,
         IReadOnlyList<WorkflowChain> workflowChains,
+        IReadOnlyDictionary<Type, IReadOnlyList<string>>? objectTypeNamesByType = null,
         IReadOnlyList<string>? warnings = null)
     {
         Domains = domains;
@@ -28,6 +40,8 @@ public sealed class OntologyGraph
         Interfaces = interfaces;
         CrossDomainLinks = crossDomainLinks;
         WorkflowChains = workflowChains;
+        ObjectTypeNamesByType = objectTypeNamesByType
+            ?? new Dictionary<Type, IReadOnlyList<string>>();
         Warnings = warnings ?? [];
 
         _objectTypeLookup = BuildObjectTypeLookup(objectTypes);

--- a/src/Strategos.Ontology/OntologyGraph.cs
+++ b/src/Strategos.Ontology/OntologyGraph.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using Strategos.Ontology.Descriptors;
 
 namespace Strategos.Ontology;
@@ -40,8 +41,15 @@ public sealed class OntologyGraph
         Interfaces = interfaces;
         CrossDomainLinks = crossDomainLinks;
         WorkflowChains = workflowChains;
-        ObjectTypeNamesByType = objectTypeNamesByType
-            ?? new Dictionary<Type, IReadOnlyList<string>>();
+        // Defensive snapshot: copy the outer dictionary and wrap each inner list as a
+        // ReadOnlyCollection so external callers cannot downcast and mutate the graph's
+        // reverse index after construction.
+        ObjectTypeNamesByType = objectTypeNamesByType is null
+            ? new ReadOnlyDictionary<Type, IReadOnlyList<string>>(new Dictionary<Type, IReadOnlyList<string>>())
+            : new ReadOnlyDictionary<Type, IReadOnlyList<string>>(
+                objectTypeNamesByType.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => (IReadOnlyList<string>)kvp.Value.ToList().AsReadOnly()));
         Warnings = warnings ?? [];
 
         _objectTypeLookup = BuildObjectTypeLookup(objectTypes);

--- a/src/Strategos.Ontology/OntologyGraphBuilder.cs
+++ b/src/Strategos.Ontology/OntologyGraphBuilder.cs
@@ -82,6 +82,15 @@ public sealed class OntologyGraphBuilder
             .GroupBy(ot => ot.DomainName)
             .ToDictionary(g => g.Key, g => g.ToDictionary(ot => ot.Name));
 
+        // Track C2 — reverse index from CLR type → descriptor names in registration order.
+        // Built after the AONT040 check so callers can trust name uniqueness-per-domain,
+        // and used by C3 below to detect multi-registered types in link positions.
+        var namesByType = allObjectTypes
+            .GroupBy(ot => ot.ClrType)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<string>)g.Select(ot => ot.Name).ToList().AsReadOnly());
+
         var resolvedLinks = ResolveCrossDomainLinks(
             allCrossDomainLinkDescriptors, domainLookup, objectTypeLookup, allObjectTypes);
 
@@ -104,6 +113,7 @@ public sealed class OntologyGraphBuilder
             interfaces: allInterfaces.ToArray(),
             crossDomainLinks: resolvedLinks.ToArray(),
             workflowChains: workflowChains.ToArray(),
+            objectTypeNamesByType: namesByType,
             warnings: warnings.AsReadOnly());
     }
 

--- a/src/Strategos.Ontology/OntologyGraphBuilder.cs
+++ b/src/Strategos.Ontology/OntologyGraphBuilder.cs
@@ -91,6 +91,14 @@ public sealed class OntologyGraphBuilder
                 g => g.Key,
                 g => (IReadOnlyList<string>)g.Select(ot => ot.Name).ToList().AsReadOnly());
 
+        // AONT041 must run before ResolveCrossDomainLinks: that resolver does a
+        // first-wins ClrType match on (sourceDomain, ClrType) which would silently
+        // bind a multi-registered source type to one descriptor without surfacing
+        // the violation. Fail fast here so the diagnostic points at the original
+        // multi-registration rather than a downstream "unresolvable" error.
+        ValidateMultiRegisteredTypesNotInLinks(
+            allObjectTypes, allCrossDomainLinkDescriptors, namesByType);
+
         var resolvedLinks = ResolveCrossDomainLinks(
             allCrossDomainLinkDescriptors, domainLookup, objectTypeLookup, allObjectTypes);
 
@@ -101,7 +109,6 @@ public sealed class OntologyGraphBuilder
         ComputeTransitiveDerivationChains(allObjectTypes);
         InferPropertyKinds(allObjectTypes);
         ValidateInverseLinks(allObjectTypes);
-        ValidateMultiRegisteredTypesNotInLinks(allObjectTypes, namesByType);
 
         var warnings = new List<string>();
         MatchExtensionPoints(allObjectTypes, resolvedLinks, warnings);
@@ -572,20 +579,24 @@ public sealed class OntologyGraphBuilder
     /// <summary>
     /// AONT041 — MultiRegisteredTypeInLink (Track C3).
     /// Enforces the Option X freeze invariant that a CLR type registered under more than
-    /// one descriptor name cannot participate in structural links (neither as a link
-    /// target nor as a link source). The Basileus happy path is a multi-registered leaf
-    /// type with no links anywhere — that remains legal.
+    /// one descriptor name cannot participate in structural links — neither as a link
+    /// target nor as a link source, and neither in intra-domain <see cref="LinkDescriptor"/>s
+    /// nor in <see cref="CrossDomainLinkDescriptor"/>s. The Basileus happy path is a
+    /// multi-registered leaf type with no links anywhere — that remains legal.
     /// </summary>
     /// <remarks>
-    /// Link targets carry only a <see cref="LinkDescriptor.TargetTypeName"/> string. Under
-    /// the Track B builder, <c>HasMany&lt;TLinked&gt;(name)</c> writes
-    /// <c>typeof(TLinked).Name</c> into that field. We therefore match multi-registered
-    /// CLR types against the link target by the simple type name — consistent with how
-    /// the rest of the builder resolves link targets. Future relaxation (see #32) can
-    /// carry the source CLR <see cref="Type"/> directly instead.
+    /// Intra-domain link targets carry only a <see cref="LinkDescriptor.TargetTypeName"/>
+    /// string. Under the Track B builder, <c>HasMany&lt;TLinked&gt;(name)</c> writes
+    /// <c>typeof(TLinked).Name</c> into that field, so we match multi-registered CLR types
+    /// against the link target by simple type name. Cross-domain links carry the source
+    /// CLR <see cref="Type"/> directly on the descriptor and identify their target by
+    /// <c>(TargetDomain, TargetTypeName)</c>, so we resolve those positionally. Future
+    /// relaxation (see #32) can carry the source CLR <see cref="Type"/> on intra-domain
+    /// links too.
     /// </remarks>
     private static void ValidateMultiRegisteredTypesNotInLinks(
         IReadOnlyList<ObjectTypeDescriptor> allObjectTypes,
+        IReadOnlyList<(string SourceDomain, CrossDomainLinkDescriptor Descriptor)> crossDomainLinks,
         IReadOnlyDictionary<Type, IReadOnlyList<string>> namesByType)
     {
         var multiRegistered = namesByType
@@ -629,6 +640,40 @@ public sealed class OntologyGraphBuilder
                     $"({string.Join(", ", ownNames.Select(n => $"'{n}'"))}) but also declares outgoing links " +
                     $"({string.Join(", ", descriptor.Links.Select(l => $"'{l.Name}'"))}). Multi-registered types cannot " +
                     $"participate in structural links. See #32 for a future relaxation path.");
+            }
+        }
+
+        // Cross-domain link checks. Carries the source CLR type on the descriptor and
+        // identifies the target by (TargetDomain, TargetTypeName). We deliberately reject
+        // ANY cross-domain link whose source or target CLR type appears more than once
+        // in the reverse index, even if the (sourceDomain, ClrType) lookup would itself
+        // be unambiguous — Option X says multi-registered types are leaf-only, full stop.
+        foreach (var (sourceDomain, link) in crossDomainLinks)
+        {
+            // Source side: descriptor.SourceType is the CLR type the From<T>() builder set.
+            if (multiRegistered.TryGetValue(link.SourceType, out var srcNames))
+            {
+                throw new OntologyCompositionException(
+                    $"AONT041: CLR type '{link.SourceType.FullName}' has multiple registrations " +
+                    $"({string.Join(", ", srcNames.Select(n => $"'{n}'"))}) but is declared as the source " +
+                    $"of cross-domain link '{link.Name}' in domain '{sourceDomain}'. Multi-registered " +
+                    $"types cannot participate in structural links. See #32 for a future relaxation path.");
+            }
+
+            // Target side: resolve the target descriptor by (TargetDomain, TargetTypeName)
+            // and check whether its CLR type is multi-registered. If the target is
+            // unresolvable here, leave the diagnostic to ResolveCrossDomainLinks below.
+            var targetDescriptor = allObjectTypes.FirstOrDefault(
+                ot => ot.DomainName == link.TargetDomain && ot.Name == link.TargetTypeName);
+
+            if (targetDescriptor is not null
+                && multiRegistered.TryGetValue(targetDescriptor.ClrType, out var tgtNames))
+            {
+                throw new OntologyCompositionException(
+                    $"AONT041: CLR type '{targetDescriptor.ClrType.FullName}' has multiple registrations " +
+                    $"({string.Join(", ", tgtNames.Select(n => $"'{n}'"))}) but is the target of cross-domain link " +
+                    $"'{link.Name}' from domain '{sourceDomain}' to '{link.TargetDomain}.{link.TargetTypeName}'. " +
+                    $"Multi-registered types cannot participate in structural links. See #32 for a future relaxation path.");
             }
         }
     }

--- a/src/Strategos.Ontology/OntologyGraphBuilder.cs
+++ b/src/Strategos.Ontology/OntologyGraphBuilder.cs
@@ -113,7 +113,7 @@ public sealed class OntologyGraphBuilder
         var warnings = new List<string>();
         MatchExtensionPoints(allObjectTypes, resolvedLinks, warnings);
 
-        var workflowChains = BuildWorkflowChains(allObjectTypes, _workflowMetadata);
+        var workflowChains = BuildWorkflowChains(allObjectTypes, _workflowMetadata, warnings);
 
         return new OntologyGraph(
             domains: domains.ToArray(),
@@ -754,31 +754,36 @@ public sealed class OntologyGraphBuilder
 
     private static List<WorkflowChain> BuildWorkflowChains(
         List<ObjectTypeDescriptor> allObjectTypes,
-        List<WorkflowMetadataBuilder> workflowMetadata)
+        List<WorkflowMetadataBuilder> workflowMetadata,
+        List<string> warnings)
     {
         var chains = new List<WorkflowChain>();
 
         // Workflow metadata uses unqualified type names; under the AONT040 invariant the
-        // same simple name can legitimately appear in two domains. Use GroupBy/First here
-        // so the lookup doesn't blow up on legal cross-domain name overlap. First-wins
-        // semantics match the pre-C1 behaviour for the single-domain common case.
-        var objectTypeByName = allObjectTypes
+        // same simple name can legitimately appear in two domains. Build a multi-valued
+        // index so we can detect ambiguity rather than silently first-wins-binding to
+        // one descriptor and producing a wrong workflow chain.
+        var objectTypesByName = allObjectTypes
             .GroupBy(ot => ot.Name)
-            .ToDictionary(g => g.Key, g => g.First());
+            .ToDictionary(g => g.Key, g => g.ToList());
 
         foreach (var metadata in workflowMetadata)
         {
             if (metadata.ConsumedTypeName is null || metadata.ProducedTypeName is null)
             {
+                warnings.Add(
+                    $"Workflow '{metadata.WorkflowName}' is missing consumed or produced type metadata; skipping.");
                 continue;
             }
 
-            if (!objectTypeByName.TryGetValue(metadata.ConsumedTypeName, out var consumedType))
+            if (!TryResolveUnambiguous(
+                    objectTypesByName, metadata.ConsumedTypeName, metadata.WorkflowName, "consumed", warnings, out var consumedType))
             {
                 continue;
             }
 
-            if (!objectTypeByName.TryGetValue(metadata.ProducedTypeName, out var producedType))
+            if (!TryResolveUnambiguous(
+                    objectTypesByName, metadata.ProducedTypeName, metadata.WorkflowName, "produced", warnings, out var producedType))
             {
                 continue;
             }
@@ -787,5 +792,34 @@ public sealed class OntologyGraphBuilder
         }
 
         return chains;
+    }
+
+    private static bool TryResolveUnambiguous(
+        Dictionary<string, List<ObjectTypeDescriptor>> objectTypesByName,
+        string typeName,
+        string workflowName,
+        string role,
+        List<string> warnings,
+        out ObjectTypeDescriptor resolved)
+    {
+        resolved = null!;
+
+        if (!objectTypesByName.TryGetValue(typeName, out var matches) || matches.Count == 0)
+        {
+            warnings.Add(
+                $"Workflow '{workflowName}' references unknown {role} type '{typeName}'; skipping.");
+            return false;
+        }
+
+        if (matches.Count > 1)
+        {
+            var domains = string.Join(", ", matches.Select(m => $"'{m.DomainName}'"));
+            warnings.Add(
+                $"Workflow '{workflowName}' references {role} type '{typeName}' which is ambiguous across domains ({domains}); skipping.");
+            return false;
+        }
+
+        resolved = matches[0];
+        return true;
     }
 }

--- a/src/Strategos.Ontology/OntologyGraphBuilder.cs
+++ b/src/Strategos.Ontology/OntologyGraphBuilder.cs
@@ -56,6 +56,28 @@ public sealed class OntologyGraphBuilder
         }
 
         var domainLookup = domains.ToDictionary(d => d.DomainName);
+
+        // AONT040 — DuplicateObjectTypeName (Track C1)
+        // Enforce per-domain uniqueness of descriptor names with an explicit diagnostic,
+        // before the ToDictionary call below would otherwise throw a cryptic ArgumentException.
+        foreach (var group in allObjectTypes.GroupBy(ot => ot.DomainName))
+        {
+            var seen = new Dictionary<string, ObjectTypeDescriptor>();
+            foreach (var descriptor in group)
+            {
+                if (seen.TryGetValue(descriptor.Name, out var existing))
+                {
+                    throw new OntologyCompositionException(
+                        $"AONT040: Object type name '{descriptor.Name}' is registered twice in domain '{group.Key}'. " +
+                        $"First registration: CLR type '{existing.ClrType.FullName}'. " +
+                        $"Second registration: CLR type '{descriptor.ClrType.FullName}'. " +
+                        $"Either remove one registration, or specify distinct names via Object<T>(\"name\", ...).");
+                }
+
+                seen[descriptor.Name] = descriptor;
+            }
+        }
+
         var objectTypeLookup = allObjectTypes
             .GroupBy(ot => ot.DomainName)
             .ToDictionary(g => g.Key, g => g.ToDictionary(ot => ot.Name));
@@ -216,7 +238,9 @@ public sealed class OntologyGraphBuilder
 
     private static void ValidateIsAHierarchy(List<ObjectTypeDescriptor> allObjectTypes)
     {
-        var typesByName = allObjectTypes.ToDictionary(ot => ot.Name);
+        // Keys are (DomainName, Name) so that two domains can legally host descriptors
+        // that share a simple name (enforced by the AONT040 per-domain check above).
+        var typesByKey = allObjectTypes.ToDictionary(ot => (ot.DomainName, ot.Name));
 
         foreach (var objectType in allObjectTypes)
         {
@@ -225,14 +249,14 @@ public sealed class OntologyGraphBuilder
                 continue;
             }
 
-            if (!typesByName.ContainsKey(objectType.ParentTypeName))
+            if (!typesByKey.ContainsKey((objectType.DomainName, objectType.ParentTypeName)))
             {
                 throw new OntologyCompositionException(
                     $"Object type '{objectType.Name}' declares IS-A relationship with unregistered parent type '{objectType.ParentTypeName}'.");
             }
         }
 
-        // Detect cycles using DFS
+        // Detect cycles using DFS (domain-scoped)
         foreach (var objectType in allObjectTypes)
         {
             if (objectType.ParentTypeName is null)
@@ -241,19 +265,20 @@ public sealed class OntologyGraphBuilder
             }
 
             var visited = new HashSet<string>();
-            var current = objectType.Name;
+            var currentName = objectType.Name;
+            var currentDomain = objectType.DomainName;
 
-            while (current is not null)
+            while (currentName is not null)
             {
-                if (!visited.Add(current))
+                if (!visited.Add(currentName))
                 {
                     throw new OntologyCompositionException(
-                        $"IS-A hierarchy cycle detected involving type '{current}'.");
+                        $"IS-A hierarchy cycle detected involving type '{currentName}'.");
                 }
 
-                if (typesByName.TryGetValue(current, out var currentType))
+                if (typesByKey.TryGetValue((currentDomain, currentName), out var currentType))
                 {
-                    current = currentType.ParentTypeName;
+                    currentName = currentType.ParentTypeName;
                 }
                 else
                 {
@@ -498,7 +523,9 @@ public sealed class OntologyGraphBuilder
 
     private static void ValidateInverseLinks(List<ObjectTypeDescriptor> allObjectTypes)
     {
-        var typesByName = allObjectTypes.ToDictionary(ot => ot.Name);
+        // Keyed by (DomainName, Name) because descriptor names are unique only within a
+        // domain — cross-domain name collisions are legal under the AONT040 invariant.
+        var typesByKey = allObjectTypes.ToDictionary(ot => (ot.DomainName, ot.Name));
 
         foreach (var objectType in allObjectTypes)
         {
@@ -509,7 +536,7 @@ public sealed class OntologyGraphBuilder
                     continue;
                 }
 
-                if (!typesByName.TryGetValue(link.TargetTypeName, out var targetType))
+                if (!typesByKey.TryGetValue((objectType.DomainName, link.TargetTypeName), out var targetType))
                 {
                     continue; // Target type not found; other validations handle this
                 }
@@ -610,7 +637,14 @@ public sealed class OntologyGraphBuilder
         List<WorkflowMetadataBuilder> workflowMetadata)
     {
         var chains = new List<WorkflowChain>();
-        var objectTypeByName = allObjectTypes.ToDictionary(ot => ot.Name);
+
+        // Workflow metadata uses unqualified type names; under the AONT040 invariant the
+        // same simple name can legitimately appear in two domains. Use GroupBy/First here
+        // so the lookup doesn't blow up on legal cross-domain name overlap. First-wins
+        // semantics match the pre-C1 behaviour for the single-domain common case.
+        var objectTypeByName = allObjectTypes
+            .GroupBy(ot => ot.Name)
+            .ToDictionary(g => g.Key, g => g.First());
 
         foreach (var metadata in workflowMetadata)
         {

--- a/src/Strategos.Ontology/OntologyGraphBuilder.cs
+++ b/src/Strategos.Ontology/OntologyGraphBuilder.cs
@@ -101,6 +101,7 @@ public sealed class OntologyGraphBuilder
         ComputeTransitiveDerivationChains(allObjectTypes);
         InferPropertyKinds(allObjectTypes);
         ValidateInverseLinks(allObjectTypes);
+        ValidateMultiRegisteredTypesNotInLinks(allObjectTypes, namesByType);
 
         var warnings = new List<string>();
         MatchExtensionPoints(allObjectTypes, resolvedLinks, warnings);
@@ -564,6 +565,70 @@ public sealed class OntologyGraphBuilder
                     throw new OntologyCompositionException(
                         $"Asymmetric inverse declaration: '{objectType.Name}.{link.Name}' declares inverse '{link.InverseLinkName}', but '{link.TargetTypeName}.{link.InverseLinkName}' declares inverse '{inverseLink.InverseLinkName}' instead of '{link.Name}'.");
                 }
+            }
+        }
+    }
+
+    /// <summary>
+    /// AONT041 — MultiRegisteredTypeInLink (Track C3).
+    /// Enforces the Option X freeze invariant that a CLR type registered under more than
+    /// one descriptor name cannot participate in structural links (neither as a link
+    /// target nor as a link source). The Basileus happy path is a multi-registered leaf
+    /// type with no links anywhere — that remains legal.
+    /// </summary>
+    /// <remarks>
+    /// Link targets carry only a <see cref="LinkDescriptor.TargetTypeName"/> string. Under
+    /// the Track B builder, <c>HasMany&lt;TLinked&gt;(name)</c> writes
+    /// <c>typeof(TLinked).Name</c> into that field. We therefore match multi-registered
+    /// CLR types against the link target by the simple type name — consistent with how
+    /// the rest of the builder resolves link targets. Future relaxation (see #32) can
+    /// carry the source CLR <see cref="Type"/> directly instead.
+    /// </remarks>
+    private static void ValidateMultiRegisteredTypesNotInLinks(
+        IReadOnlyList<ObjectTypeDescriptor> allObjectTypes,
+        IReadOnlyDictionary<Type, IReadOnlyList<string>> namesByType)
+    {
+        var multiRegistered = namesByType
+            .Where(kvp => kvp.Value.Count > 1)
+            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+        if (multiRegistered.Count == 0)
+        {
+            return;
+        }
+
+        // Map simple CLR-type names → CLR Type, restricted to multi-registered types.
+        // Simple names match what HasMany<TLinked>(name) writes into LinkDescriptor.TargetTypeName.
+        var multiRegisteredByClrSimpleName = multiRegistered
+            .GroupBy(kvp => kvp.Key.Name)
+            .ToDictionary(g => g.Key, g => g.First().Key);
+
+        foreach (var descriptor in allObjectTypes)
+        {
+            // Check: does this descriptor declare an outgoing link whose target
+            // resolves to a multi-registered CLR type?
+            foreach (var link in descriptor.Links)
+            {
+                if (multiRegisteredByClrSimpleName.TryGetValue(link.TargetTypeName, out var targetClrType))
+                {
+                    var names = multiRegistered[targetClrType];
+                    throw new OntologyCompositionException(
+                        $"AONT041: CLR type '{targetClrType.FullName}' has multiple registrations " +
+                        $"({string.Join(", ", names.Select(n => $"'{n}'"))}) but is also referenced as a link target " +
+                        $"in '{descriptor.Name}.{link.Name}'. Multi-registered types cannot participate in structural " +
+                        $"links. See #32 for a future relaxation path.");
+                }
+            }
+
+            // Check: does this descriptor's own CLR type have multiple registrations
+            // AND declare outgoing links? The source side is just as invalid as the target side.
+            if (descriptor.Links.Count > 0 && multiRegistered.TryGetValue(descriptor.ClrType, out var ownNames))
+            {
+                throw new OntologyCompositionException(
+                    $"AONT041: CLR type '{descriptor.ClrType.FullName}' has multiple registrations " +
+                    $"({string.Join(", ", ownNames.Select(n => $"'{n}'"))}) but also declares outgoing links " +
+                    $"({string.Join(", ", descriptor.Links.Select(l => $"'{l.Name}'"))}). Multi-registered types cannot " +
+                    $"participate in structural links. See #32 for a future relaxation path.");
             }
         }
     }

--- a/src/Strategos.Ontology/Query/IOntologyQuery.cs
+++ b/src/Strategos.Ontology/Query/IOntologyQuery.cs
@@ -62,4 +62,13 @@ public interface IOntologyQuery
 
     // Object set queries
     ObjectSet<T> GetObjectSet<T>(string objectType) where T : class;
+
+    /// <summary>
+    /// Returns all descriptor names registered for the given CLR type across
+    /// the composed ontology, in registration order. Returns an empty list if
+    /// <typeparamref name="T"/> is not registered. Enables consumers (e.g. Basileus)
+    /// to enumerate per-collection partitions of a shared content-carrier type
+    /// without hardcoding descriptor names at call sites.
+    /// </summary>
+    IReadOnlyList<string> GetObjectTypeNames<T>() where T : class;
 }

--- a/src/Strategos.Ontology/Query/OntologyQueryService.cs
+++ b/src/Strategos.Ontology/Query/OntologyQueryService.cs
@@ -64,10 +64,12 @@ internal sealed class OntologyQueryService : IOntologyQuery
                 "when constructing the OntologyQueryService.");
         }
 
-        // Stop-gap descriptor name (task D1): passes typeof(T).Name until task D2 threads
-        // the resolved descriptor name (ot.Name) so multi-registration dispatches correctly.
+        // Thread the resolved descriptor name (ot.Name) — which may differ from
+        // typeof(T).Name when the caller registered the type under an explicit
+        // name via Object<T>(name, ...) — into the RootExpression so providers
+        // dispatch against the correct descriptor partition.
         return new ObjectSet<T>(
-            typeof(T).Name,
+            descriptorName: ot.Name,
             _objectSetProvider,
             _actionDispatcher,
             _eventStreamProvider);

--- a/src/Strategos.Ontology/Query/OntologyQueryService.cs
+++ b/src/Strategos.Ontology/Query/OntologyQueryService.cs
@@ -64,7 +64,13 @@ internal sealed class OntologyQueryService : IOntologyQuery
                 "when constructing the OntologyQueryService.");
         }
 
-        return new ObjectSet<T>(_objectSetProvider, _actionDispatcher, _eventStreamProvider);
+        // Stop-gap descriptor name (task D1): passes typeof(T).Name until task D2 threads
+        // the resolved descriptor name (ot.Name) so multi-registration dispatches correctly.
+        return new ObjectSet<T>(
+            typeof(T).Name,
+            _objectSetProvider,
+            _actionDispatcher,
+            _eventStreamProvider);
     }
 
     public IReadOnlyList<ObjectTypeDescriptor> GetObjectTypes(

--- a/src/Strategos.Ontology/Query/OntologyQueryService.cs
+++ b/src/Strategos.Ontology/Query/OntologyQueryService.cs
@@ -75,6 +75,13 @@ internal sealed class OntologyQueryService : IOntologyQuery
             _eventStreamProvider);
     }
 
+    public IReadOnlyList<string> GetObjectTypeNames<T>() where T : class
+    {
+        return graph.ObjectTypeNamesByType.TryGetValue(typeof(T), out var names)
+            ? names
+            : Array.Empty<string>();
+    }
+
     public IReadOnlyList<ObjectTypeDescriptor> GetObjectTypes(
         string? domain = null,
         string? implementsInterface = null,


### PR DESCRIPTION
## Summary

Fixes #31 — `GetObjectSet<T>(string objectType)` was silently discarding the descriptor name, making multi-registration of a CLR type under multiple descriptor names impossible and blocking Basileus's per-collection `SemanticDocument` isolation.

**Approach 1 + Option X**: descriptor name threads through the expression tree via walk-to-root (`RootExpression.ObjectTypeName` + `ObjectSetExpression.RootObjectTypeName` + `TraverseLinkExpression` override); multi-registration is leaf-only (enforced by `AONT041 MultiRegisteredTypeInLink`); writes get explicit-name overloads on `IObjectSetWriter` with graph-backed default resolution.

### What ships

- **§3.1 Builder** — `Object<T>(string? name, config)` overload with C# identifier regex validation; existing `Object<T>(config)` is zero-churn
- **§3.2 Graph freeze** — `AONT040 DuplicateObjectTypeName` diagnostic, `AONT041 MultiRegisteredTypeInLink`, `OntologyGraph.ObjectTypeNamesByType` reverse index, cross-domain collision fix for `ValidateIsAHierarchy` and `ValidateInverseLinks` (pre-existing latent bug exposed by §3.1)
- **§3.3 Expression tree** — `RootExpression.ObjectTypeName` required field, `ObjectSetExpression.RootObjectTypeName` walk-to-root helper (handles all 7 expression types), `TraverseLinkExpression` override returning the linked CLR type's name
- **§3.4 Query service + ObjectSet** — `ObjectSet<T>` ctor threads descriptor name into root expression; `OntologyQueryService.GetObjectSet<T>` threads `ot.Name` from graph lookup; MCP tools (`OntologyQueryTool`, `OntologyActionTool`) pinned with regression tests
- **§3.5 Read-path dispatch** — `PgVectorObjectSetProvider` read methods use `ResolveTableName(expression)` helper; `InMemoryObjectSetProvider` partitions by string descriptor name; `TypeMapper.GetTableName<T>()` **removed** with reflection guard
- **§3.6 Public API** — `IOntologyQuery.GetObjectTypeNames<T>()` with registration-order semantics
- **§3.7 Write-path dispatch** — `IObjectSetWriter` explicit-name overloads; both providers implement them; `PgVectorObjectSetProvider` has graph-backed default resolution with multi-registration guard; `EnsureSchemaAsync(descriptorName)`; `IngestionPipelineBuilder.WriteTo(writer, name)` plumbing
- **G1 regression guard** — `EndToEnd_MultiRegistration_FluentSimilarityChain_IsolatesByDescriptorName` + 2 bonus end-to-end tests

### Housekeeping

- Closes #31 — primary bug
- Closes #28 — `ObjectSet<T>.SimilarTo()` (delivered in 2.4.0 via #30, commit 9e47550)
- Closes #29 — `GetActionsForState()` + lifecycle model (delivered in 2.4.0 via #30, commit 9e47550)
- References #32 — deferred Option Y follow-up for multi-registered types in structural links
- References #33 — 2.4.1 review follow-ups (4 MEDIUM findings tracked for 2.4.2)

### Back-compat

**Zero churn for single-registration consumers.** Every existing `Object<T>(config)` call site continues to work with identical dispatch semantics. All 505 pre-existing Ontology tests, 68 Npgsql tests, 49 MCP tests, and 69 Generators tests continue to pass unchanged — only test files that directly construct `ObjectSet<T>` or `RootExpression` were mechanically updated to pass explicit names.

No Strategos NuGet consumers outside Basileus (unshipped), so no migration cost for the CLR-type-to-descriptor-name pivot.

### Test plan

- [x] 41 new tests across 11 test files (exceeded the plan's 34-test estimate)
- [x] Full solution: **3391 passed / 0 failed / 0 skipped** (was 3360 baseline + 41 − 10 obsolete)
- [x] Build clean: 0 warnings, 0 errors across 22 projects
- [x] All 7 tracks (A, B, C, D, E, F, G) delivered per plan
- [x] Iron Law honored — every production change preceded by a failing test
- [x] Spec review: PASS (no gaps, every §3.x clause covered by at least one test)
- [x] Quality review: APPROVED (0 HIGH / 4 MEDIUM / 6 LOW; all MEDIUMs tracked in #33)

### Design artifacts

- `docs/designs/2026-04-08-ontology-descriptor-name-dispatch.md` — authoritative design
- `docs/plans/2026-04-08-ontology-descriptor-name-dispatch.md` — TDD implementation plan (25 tasks, 7 tracks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)