### PR TITLE
feat(ontology): agent-first engine support — evaluator extraction + link descriptions

### DIFF
--- a/src/Strategos.Ontology.MCP.Tests/OntologyExploreToolTests.cs
+++ b/src/Strategos.Ontology.MCP.Tests/OntologyExploreToolTests.cs
@@ -124,6 +124,38 @@ public class OntologyExploreToolTests
     }
 
     [Test]
+    public async Task OntologyExplore_Links_IncludesDescription()
+    {
+        // Act
+        var result = _tool.Explore(scope: "links", domain: "trading", objectType: "TestPosition");
+
+        // Assert
+        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items[0].ContainsKey("description")).IsTrue();
+        await Assert.That(result.Items[0]["description"]?.ToString())
+            .IsEqualTo("Orders placed against this position");
+    }
+
+    [Test]
+    public async Task OntologyExplore_Traversal_IncludesDescription()
+    {
+        // Act
+        var result = _tool.Explore(
+            scope: "links",
+            domain: "trading",
+            objectType: "TestPosition",
+            traverseFrom: "TestPosition",
+            maxDepth: 1);
+
+        // Assert — traversal from TestPosition should find TestOrder via "Orders" link
+        await Assert.That(result.Items.Count).IsGreaterThanOrEqualTo(1);
+        var orderResult = result.Items.First(i => i["objectType"]?.ToString() == "TestOrder");
+        await Assert.That(orderResult.ContainsKey("description")).IsTrue();
+        await Assert.That(orderResult["description"]?.ToString())
+            .IsEqualTo("Orders placed against this position");
+    }
+
+    [Test]
     public async Task Explore_ObjectTypes_IncludesIsSemanticSearchable()
     {
         // Arrange — use vector graph which has TestDocument (vector) and TestImage (no vector)

--- a/src/Strategos.Ontology.MCP.Tests/TestOntologyGraphFactory.cs
+++ b/src/Strategos.Ontology.MCP.Tests/TestOntologyGraphFactory.cs
@@ -62,7 +62,8 @@ public class TestTradingDomainOntology : DomainOntology
             obj.Key(p => p.Id);
             obj.Property(p => p.Symbol).Required();
             obj.Property(p => p.Quantity);
-            obj.HasMany<TestOrder>("Orders");
+            obj.HasMany<TestOrder>("Orders")
+                .Description("Orders placed against this position");
             obj.Action("execute_trade")
                 .Description("Execute a trade on the position")
                 .Accepts<TestTradeExecutionRequest>()

--- a/src/Strategos.Ontology.MCP/OntologyExploreTool.cs
+++ b/src/Strategos.Ontology.MCP/OntologyExploreTool.cs
@@ -109,6 +109,7 @@ public sealed class OntologyExploreTool
             ["targetTypeName"] = l.TargetTypeName,
             ["cardinality"] = l.Cardinality.ToString(),
             ["edgePropertyCount"] = l.EdgeProperties.Count,
+            ["description"] = l.Description,
         }).ToList();
 
         return new ExploreResult("links", items);
@@ -166,6 +167,7 @@ public sealed class OntologyExploreTool
             ["objectType"] = r.ObjectType.Name,
             ["linkName"] = r.LinkName,
             ["depth"] = r.Depth,
+            ["description"] = r.Description,
         }).ToList();
 
         return new ExploreResult("links", items);

--- a/src/Strategos.Ontology.Tests/Builder/CrossDomainLinkBuilderTests.cs
+++ b/src/Strategos.Ontology.Tests/Builder/CrossDomainLinkBuilderTests.cs
@@ -60,4 +60,28 @@ public class CrossDomainLinkBuilderTests
         await Assert.That(descriptor.EdgeProperties[0].Name).IsEqualTo("Relevance");
         await Assert.That(descriptor.EdgeProperties[1].Name).IsEqualTo("Rationale");
     }
+
+    [Test]
+    public async Task CrossDomainLinkBuilder_WithDescription_SetsDescription()
+    {
+        var builder = new CrossDomainLinkBuilder("KnowledgeInformsStrategy");
+
+        builder.From<TestAtomicNote>()
+            .ToExternal("trading", "Strategy")
+            .Description("Cross-domain knowledge-to-strategy link");
+        var descriptor = builder.Build();
+
+        await Assert.That(descriptor.Description).IsEqualTo("Cross-domain knowledge-to-strategy link");
+    }
+
+    [Test]
+    public async Task CrossDomainLinkDescriptor_Description_DefaultsToNull()
+    {
+        var builder = new CrossDomainLinkBuilder("KnowledgeInformsStrategy");
+
+        builder.From<TestAtomicNote>().ToExternal("trading", "Strategy");
+        var descriptor = builder.Build();
+
+        await Assert.That(descriptor.Description).IsNull();
+    }
 }

--- a/src/Strategos.Ontology.Tests/Builder/IObjectTypeBuilderTests.cs
+++ b/src/Strategos.Ontology.Tests/Builder/IObjectTypeBuilderTests.cs
@@ -97,4 +97,76 @@ public class IObjectTypeBuilderTests
 
         await Assert.That(true).IsTrue();
     }
+
+    [Test]
+    public async Task HasMany_WithDescription_SetsDescriptorDescription()
+    {
+        // Arrange — build a real ontology with a described link
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain(new HasManyDescriptionTestOntology());
+        var graph = graphBuilder.Build();
+
+        // Act
+        var positionType = graph.ObjectTypes.First(t => t.Name == nameof(TestPosition));
+        var ordersLink = positionType.Links.First(l => l.Name == "Orders");
+
+        // Assert
+        await Assert.That(ordersLink.Description).IsEqualTo("Orders placed against this position");
+    }
+
+    [Test]
+    public async Task HasOne_WithDescription_SetsDescriptorDescription()
+    {
+        // Arrange — build a real ontology with a described HasOne link
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain(new HasOneDescriptionTestOntology());
+        var graph = graphBuilder.Build();
+
+        // Act
+        var orderType = graph.ObjectTypes.First(t => t.Name == nameof(TestTradeOrder));
+        var strategyLink = orderType.Links.First(l => l.Name == "Strategy");
+
+        // Assert
+        await Assert.That(strategyLink.Description).IsEqualTo("The strategy that generated this order");
+    }
+}
+
+public class HasManyDescriptionTestOntology : DomainOntology
+{
+    public override string DomainName => "test-link-desc";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TestPosition>(obj =>
+        {
+            obj.Key(p => p.Id);
+            obj.HasMany<TestTradeOrder>("Orders")
+                .Description("Orders placed against this position");
+        });
+
+        builder.Object<TestTradeOrder>(obj =>
+        {
+            obj.Key(o => o.Id);
+        });
+    }
+}
+
+public class HasOneDescriptionTestOntology : DomainOntology
+{
+    public override string DomainName => "test-link-desc";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TestTradeOrder>(obj =>
+        {
+            obj.Key(o => o.Id);
+            obj.HasOne<TestStrategy>("Strategy")
+                .Description("The strategy that generated this order");
+        });
+
+        builder.Object<TestStrategy>(obj =>
+        {
+            obj.Key(s => s.Id);
+        });
+    }
 }

--- a/src/Strategos.Ontology.Tests/Descriptors/LinkDescriptorTests.cs
+++ b/src/Strategos.Ontology.Tests/Descriptors/LinkDescriptorTests.cs
@@ -35,4 +35,27 @@ public class LinkDescriptorTests
         await Assert.That(descriptor.EdgeProperties).IsNotNull();
         await Assert.That(descriptor.EdgeProperties.Count).IsEqualTo(0);
     }
+
+    [Test]
+    public async Task LinkDescriptor_Description_DefaultsToNull()
+    {
+        // Arrange & Act
+        var descriptor = new LinkDescriptor("Orders", "TradeOrder", LinkCardinality.OneToMany);
+
+        // Assert
+        await Assert.That(descriptor.Description).IsNull();
+    }
+
+    [Test]
+    public async Task LinkDescriptor_WithDescription_StoresValue()
+    {
+        // Arrange & Act
+        var descriptor = new LinkDescriptor("Orders", "TradeOrder", LinkCardinality.OneToMany)
+        {
+            Description = "Orders placed against this position",
+        };
+
+        // Assert
+        await Assert.That(descriptor.Description).IsEqualTo("Orders placed against this position");
+    }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryExpressionEvaluatorTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryExpressionEvaluatorTests.cs
@@ -254,8 +254,44 @@ public class InMemoryExpressionEvaluatorTests
         await Assert.That(result).HasCount().EqualTo(0);
     }
 
+    [Test]
+    public async Task Evaluate_TraverseLink_WithFilterOnSource_IgnoresSourceFilter()
+    {
+        // Schema-level traversal: source filters don't affect target items.
+        // Even with a filter that eliminates all source items, traversal
+        // returns ALL target items because it follows the link schema.
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var root = new RootExpression(typeof(EvalSource), "EvalSource");
+        Expression<Func<EvalSource, bool>> predicate = s => s.Value > 9999; // matches nothing
+        var filter = new FilterExpression(root, predicate);
+        var traverse = new TraverseLinkExpression(filter, "targets", typeof(EvalTarget));
+        var resolver = BuildTestResolver();
+
+        var result = evaluator.Evaluate<EvalTarget>(traverse, resolver);
+
+        // All target items returned despite source filter — schema-level traversal
+        await Assert.That(result).HasCount().EqualTo(2);
+    }
+
+    [Test]
+    public async Task Evaluate_TraverseLink_UnknownSourceDescriptor_Throws()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var root = new RootExpression(typeof(EvalSource), "NonexistentType");
+        var traverse = new TraverseLinkExpression(root, "targets", typeof(EvalTarget));
+        var resolver = BuildTestResolver();
+
+        await Assert.That(() => evaluator.Evaluate<EvalTarget>(traverse, resolver))
+            .ThrowsException()
+            .WithExceptionType(typeof(InvalidOperationException));
+
+        await Assert.That(() => evaluator.Evaluate<EvalTarget>(traverse, resolver))
+            .ThrowsException()
+            .WithMessageContaining("not found in ontology graph");
+    }
+
     // -----------------------------------------------------------------------
-    // Task 10 tests — RawFilter, error handling, thread safety
+    // Task 10 tests — RawFilter, Similarity, error handling, thread safety
     // -----------------------------------------------------------------------
 
     [Test]
@@ -273,6 +309,23 @@ public class InMemoryExpressionEvaluatorTests
         await Assert.That(() => evaluator.Evaluate<EvalSource>(rawFilter, resolver))
             .ThrowsException()
             .WithMessageContaining("RawFilterExpression evaluation is not supported by InMemoryExpressionEvaluator");
+    }
+
+    [Test]
+    public async Task Evaluate_SimilarityExpression_ThrowsNotSupported()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var root = new RootExpression(typeof(EvalSource), "EvalSource");
+        var similarity = new SimilarityExpression(root, "test query", 5, 0.7);
+        var resolver = BuildTestResolver();
+
+        await Assert.That(() => evaluator.Evaluate<EvalSource>(similarity, resolver))
+            .ThrowsException()
+            .WithExceptionType(typeof(NotSupportedException));
+
+        await Assert.That(() => evaluator.Evaluate<EvalSource>(similarity, resolver))
+            .ThrowsException()
+            .WithMessageContaining("SimilarityExpression evaluation is not supported");
     }
 
     [Test]

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryExpressionEvaluatorTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryExpressionEvaluatorTests.cs
@@ -1,0 +1,166 @@
+using System.Linq.Expressions;
+using Strategos.Ontology.Builder;
+using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.ObjectSets;
+
+namespace Strategos.Ontology.Tests.ObjectSets;
+
+// ---------------------------------------------------------------------------
+// Test domain types
+// ---------------------------------------------------------------------------
+
+public interface IEvalInterface;
+
+public class EvalSource : IEvalInterface
+{
+    public string Name { get; set; } = "";
+    public int Value { get; set; }
+}
+
+public class EvalTarget
+{
+    public string Label { get; set; } = "";
+}
+
+// ---------------------------------------------------------------------------
+// Test domain ontology
+// ---------------------------------------------------------------------------
+
+public class EvalTestOntology : DomainOntology
+{
+    public override string DomainName => "eval";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<EvalSource>(obj =>
+        {
+            obj.Key(s => s.Name);
+            obj.Property(s => s.Value);
+            obj.HasMany<EvalTarget>("targets");
+        });
+
+        builder.Object<EvalTarget>(obj =>
+        {
+            obj.Key(t => t.Label);
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+public class InMemoryExpressionEvaluatorTests
+{
+    private OntologyGraph _graph = null!;
+
+    [Before(Test)]
+    public void Setup()
+    {
+        _graph = BuildTestGraph();
+    }
+
+    private static OntologyGraph BuildTestGraph()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain<EvalTestOntology>();
+        return graphBuilder.Build();
+    }
+
+    private static Func<string, IReadOnlyList<object>> BuildTestResolver(
+        IReadOnlyList<EvalSource>? sources = null,
+        IReadOnlyList<EvalTarget>? targets = null)
+    {
+        sources ??= [new EvalSource { Name = "A", Value = 10 }, new EvalSource { Name = "B", Value = 3 }];
+        targets ??= [new EvalTarget { Label = "X" }, new EvalTarget { Label = "Y" }];
+
+        return descriptorName => descriptorName switch
+        {
+            "EvalSource" => sources.Cast<object>().ToList(),
+            "EvalTarget" => targets.Cast<object>().ToList(),
+            _ => []
+        };
+    }
+
+    // -----------------------------------------------------------------------
+    // Task 7 tests
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task Evaluate_RootExpression_ReturnsAllItems()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var expression = new RootExpression(typeof(EvalSource), "EvalSource");
+        var resolver = BuildTestResolver();
+
+        var result = evaluator.Evaluate<EvalSource>(expression, resolver);
+
+        await Assert.That(result).HasCount().EqualTo(2);
+        await Assert.That(result[0].Name).IsEqualTo("A");
+        await Assert.That(result[1].Name).IsEqualTo("B");
+    }
+
+    [Test]
+    public async Task Evaluate_FilterExpression_AppliesPredicate()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var root = new RootExpression(typeof(EvalSource), "EvalSource");
+        Expression<Func<EvalSource, bool>> predicate = s => s.Value > 5;
+        var filter = new FilterExpression(root, predicate);
+        var resolver = BuildTestResolver();
+
+        var result = evaluator.Evaluate<EvalSource>(filter, resolver);
+
+        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result[0].Name).IsEqualTo("A");
+    }
+
+    [Test]
+    public async Task Evaluate_FilterChain_AppliesAllPredicates()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var sources = new List<EvalSource>
+        {
+            new() { Name = "A", Value = 10 },
+            new() { Name = "B", Value = 3 },
+            new() { Name = "C", Value = 8 }
+        };
+        var resolver = BuildTestResolver(sources: sources);
+
+        var root = new RootExpression(typeof(EvalSource), "EvalSource");
+        Expression<Func<EvalSource, bool>> pred1 = s => s.Value > 5;
+        Expression<Func<EvalSource, bool>> pred2 = s => s.Name != "C";
+        var filter1 = new FilterExpression(root, pred1);
+        var filter2 = new FilterExpression(filter1, pred2);
+
+        var result = evaluator.Evaluate<EvalSource>(filter2, resolver);
+
+        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result[0].Name).IsEqualTo("A");
+    }
+
+    [Test]
+    public async Task Evaluate_IncludeExpression_PassesThrough()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var root = new RootExpression(typeof(EvalSource), "EvalSource");
+        var include = new IncludeExpression(root, ObjectSetInclusion.Properties);
+        var resolver = BuildTestResolver();
+
+        var result = evaluator.Evaluate<EvalSource>(include, resolver);
+
+        await Assert.That(result).HasCount().EqualTo(2);
+    }
+
+    [Test]
+    public async Task Evaluate_EmptyItemResolver_ReturnsEmpty()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var root = new RootExpression(typeof(EvalSource), "EvalSource");
+        Func<string, IReadOnlyList<object>> emptyResolver = _ => [];
+
+        var result = evaluator.Evaluate<EvalSource>(root, emptyResolver);
+
+        await Assert.That(result).HasCount().EqualTo(0);
+    }
+}

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryExpressionEvaluatorTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryExpressionEvaluatorTests.cs
@@ -211,4 +211,46 @@ public class InMemoryExpressionEvaluatorTests
             .ThrowsException()
             .WithExceptionType(typeof(InvalidOperationException));
     }
+
+    // -----------------------------------------------------------------------
+    // Task 9 tests — InterfaceNarrowExpression
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task Evaluate_InterfaceNarrow_FiltersToImplementors()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        // Seed both EvalSource (implements IEvalInterface) and EvalTarget (does not)
+        var sources = new List<EvalSource> { new() { Name = "S1", Value = 1 } };
+        var resolver = BuildTestResolver(sources: sources);
+
+        // Start from Root("EvalSource"), then narrow to IEvalInterface
+        var root = new RootExpression(typeof(EvalSource), "EvalSource");
+        var narrow = new InterfaceNarrowExpression(root, typeof(IEvalInterface));
+
+        var result = evaluator.Evaluate<IEvalInterface>(narrow, resolver);
+
+        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result[0]).IsTypeOf<EvalSource>();
+    }
+
+    [Test]
+    public async Task Evaluate_InterfaceNarrow_NoImplementors_ReturnsEmpty()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        // EvalTarget does NOT implement IEvalInterface
+        var targets = new List<EvalTarget> { new() { Label = "T1" } };
+        Func<string, IReadOnlyList<object>> resolver = name => name switch
+        {
+            "EvalTarget" => targets.Cast<object>().ToList(),
+            _ => []
+        };
+
+        var root = new RootExpression(typeof(EvalTarget), "EvalTarget");
+        var narrow = new InterfaceNarrowExpression(root, typeof(IEvalInterface));
+
+        var result = evaluator.Evaluate<IEvalInterface>(narrow, resolver);
+
+        await Assert.That(result).HasCount().EqualTo(0);
+    }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryExpressionEvaluatorTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryExpressionEvaluatorTests.cs
@@ -163,4 +163,52 @@ public class InMemoryExpressionEvaluatorTests
 
         await Assert.That(result).HasCount().EqualTo(0);
     }
+
+    // -----------------------------------------------------------------------
+    // Task 8 tests — TraverseLinkExpression
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task Evaluate_TraverseLink_ReturnsTargetTypeItems()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var root = new RootExpression(typeof(EvalSource), "EvalSource");
+        var traverse = new TraverseLinkExpression(root, "targets", typeof(EvalTarget));
+        var resolver = BuildTestResolver();
+
+        var result = evaluator.Evaluate<EvalTarget>(traverse, resolver);
+
+        await Assert.That(result).HasCount().EqualTo(2);
+        await Assert.That(result[0].Label).IsEqualTo("X");
+        await Assert.That(result[1].Label).IsEqualTo("Y");
+    }
+
+    [Test]
+    public async Task Evaluate_TraverseLink_ThenFilter_FiltersTargetItems()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var root = new RootExpression(typeof(EvalSource), "EvalSource");
+        var traverse = new TraverseLinkExpression(root, "targets", typeof(EvalTarget));
+        Expression<Func<EvalTarget, bool>> predicate = t => t.Label == "X";
+        var filter = new FilterExpression(traverse, predicate);
+        var resolver = BuildTestResolver();
+
+        var result = evaluator.Evaluate<EvalTarget>(filter, resolver);
+
+        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result[0].Label).IsEqualTo("X");
+    }
+
+    [Test]
+    public async Task Evaluate_TraverseLink_UnknownLink_Throws()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var root = new RootExpression(typeof(EvalSource), "EvalSource");
+        var traverse = new TraverseLinkExpression(root, "nonexistent", typeof(EvalTarget));
+        var resolver = BuildTestResolver();
+
+        await Assert.That(() => evaluator.Evaluate<EvalTarget>(traverse, resolver))
+            .ThrowsException()
+            .WithExceptionType(typeof(InvalidOperationException));
+    }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryExpressionEvaluatorTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryExpressionEvaluatorTests.cs
@@ -253,4 +253,57 @@ public class InMemoryExpressionEvaluatorTests
 
         await Assert.That(result).HasCount().EqualTo(0);
     }
+
+    // -----------------------------------------------------------------------
+    // Task 10 tests — RawFilter, error handling, thread safety
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task Evaluate_RawFilter_ThrowsNotSupported()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var root = new RootExpression(typeof(EvalSource), "EvalSource");
+        var rawFilter = new RawFilterExpression(root, "Value > 5");
+        var resolver = BuildTestResolver();
+
+        await Assert.That(() => evaluator.Evaluate<EvalSource>(rawFilter, resolver))
+            .ThrowsException()
+            .WithExceptionType(typeof(NotSupportedException));
+
+        await Assert.That(() => evaluator.Evaluate<EvalSource>(rawFilter, resolver))
+            .ThrowsException()
+            .WithMessageContaining("RawFilterExpression evaluation is not supported by InMemoryExpressionEvaluator");
+    }
+
+    [Test]
+    public async Task Evaluate_UnknownDescriptor_ReturnsEmpty()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        // Use a descriptor name that the resolver doesn't know about — returns empty
+        var root = new RootExpression(typeof(EvalSource), "UnknownType");
+        Func<string, IReadOnlyList<object>> resolver = _ => [];
+
+        var result = evaluator.Evaluate<EvalSource>(root, resolver);
+
+        await Assert.That(result).HasCount().EqualTo(0);
+    }
+
+    [Test]
+    public async Task Evaluate_ConcurrentCalls_ThreadSafe()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var root = new RootExpression(typeof(EvalSource), "EvalSource");
+        var resolver = BuildTestResolver();
+
+        var tasks = Enumerable.Range(0, 10)
+            .Select(_ => Task.Run(() => evaluator.Evaluate<EvalSource>(root, resolver)))
+            .ToArray();
+
+        var results = await Task.WhenAll(tasks);
+
+        foreach (var result in results)
+        {
+            await Assert.That(result).HasCount().EqualTo(2);
+        }
+    }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryExpressionEvaluatorTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryExpressionEvaluatorTests.cs
@@ -1,0 +1,250 @@
+using System.Linq.Expressions;
+using Strategos.Ontology.Builder;
+using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.ObjectSets;
+
+namespace Strategos.Ontology.Tests.ObjectSets;
+
+// ── Test domain types ──────────────────────────────────────────────────────
+public interface IEvalInterface
+{
+    string Name { get; }
+}
+
+public sealed record EvalSource(string Name, int Value) : IEvalInterface;
+
+public sealed record EvalTarget(string Label);
+
+// ── Test ontology ──────────────────────────────────────────────────────────
+public class EvalDomainOntology : DomainOntology
+{
+    public override string DomainName => "eval-test";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Interface<IEvalInterface>("IEvalInterface", iface =>
+        {
+            iface.Property(e => e.Name);
+        });
+
+        builder.Object<EvalSource>(obj =>
+        {
+            obj.Property(s => s.Name).Required();
+            obj.Property(s => s.Value);
+            obj.HasMany<EvalTarget>("targets");
+            obj.Implements<IEvalInterface>(map => { });
+        });
+
+        builder.Object<EvalTarget>(obj =>
+        {
+            obj.Property(t => t.Label).Required();
+        });
+    }
+}
+
+public class InMemoryExpressionEvaluatorTests
+{
+    private OntologyGraph _graph = null!;
+    private Func<string, IReadOnlyList<object>> _resolver = null!;
+
+    private readonly List<EvalSource> _sources =
+    [
+        new("Alpha", 10),
+        new("Beta", 3),
+        new("Gamma", 20),
+    ];
+
+    private readonly List<EvalTarget> _targets =
+    [
+        new("A"),
+        new("B"),
+    ];
+
+    [Before(Test)]
+    public void Setup()
+    {
+        _graph = new OntologyGraphBuilder()
+            .AddDomain<EvalDomainOntology>()
+            .Build();
+
+        _resolver = descriptorName => descriptorName switch
+        {
+            nameof(EvalSource) => _sources.Cast<object>().ToList(),
+            nameof(EvalTarget) => _targets.Cast<object>().ToList(),
+            _ => [],
+        };
+    }
+
+    // ── Root expression ────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Evaluate_RootExpression_ReturnsAllItems()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var expression = new RootExpression(typeof(EvalSource), nameof(EvalSource));
+
+        var result = evaluator.Evaluate<EvalSource>(expression, _resolver);
+
+        await Assert.That(result).HasCount().EqualTo(3);
+        await Assert.That(result[0].Name).IsEqualTo("Alpha");
+    }
+
+    // ── Filter expression ──────────────────────────────────────────────────
+
+    [Test]
+    public async Task Evaluate_FilterExpression_AppliesPredicate()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var root = new RootExpression(typeof(EvalSource), nameof(EvalSource));
+        Expression<Func<EvalSource, bool>> predicate = s => s.Value > 5;
+        var filter = new FilterExpression(root, predicate);
+
+        var result = evaluator.Evaluate<EvalSource>(filter, _resolver);
+
+        await Assert.That(result).HasCount().EqualTo(2);
+        await Assert.That(result.Select(s => s.Name)).IsEquivalentTo(new[] { "Alpha", "Gamma" });
+    }
+
+    [Test]
+    public async Task Evaluate_FilterChain_AppliesAllPredicates()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var root = new RootExpression(typeof(EvalSource), nameof(EvalSource));
+        Expression<Func<EvalSource, bool>> pred1 = s => s.Value > 5;
+        Expression<Func<EvalSource, bool>> pred2 = s => s.Name.StartsWith("A");
+        var filter1 = new FilterExpression(root, pred1);
+        var filter2 = new FilterExpression(filter1, pred2);
+
+        var result = evaluator.Evaluate<EvalSource>(filter2, _resolver);
+
+        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result[0].Name).IsEqualTo("Alpha");
+    }
+
+    // ── Include expression ─────────────────────────────────────────────────
+
+    [Test]
+    public async Task Evaluate_IncludeExpression_PassesThrough()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var root = new RootExpression(typeof(EvalSource), nameof(EvalSource));
+        var include = new IncludeExpression(root, ObjectSetInclusion.Properties);
+
+        var result = evaluator.Evaluate<EvalSource>(include, _resolver);
+
+        await Assert.That(result).HasCount().EqualTo(3);
+    }
+
+    // ── TraverseLink expression ────────────────────────────────────────────
+
+    [Test]
+    public async Task Evaluate_TraverseLink_ReturnsTargetTypeItems()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var root = new RootExpression(typeof(EvalSource), nameof(EvalSource));
+        var traverse = new TraverseLinkExpression(root, "targets", typeof(EvalTarget));
+
+        var result = evaluator.Evaluate<EvalTarget>(traverse, _resolver);
+
+        await Assert.That(result).HasCount().EqualTo(2);
+        await Assert.That(result[0].Label).IsEqualTo("A");
+    }
+
+    [Test]
+    public async Task Evaluate_TraverseLink_ThenFilter_FiltersTargetItems()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var root = new RootExpression(typeof(EvalSource), nameof(EvalSource));
+        var traverse = new TraverseLinkExpression(root, "targets", typeof(EvalTarget));
+        Expression<Func<EvalTarget, bool>> predicate = t => t.Label == "A";
+        var filter = new FilterExpression(traverse, predicate);
+
+        var result = evaluator.Evaluate<EvalTarget>(filter, _resolver);
+
+        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result[0].Label).IsEqualTo("A");
+    }
+
+    [Test]
+    public void Evaluate_TraverseLink_UnknownLink_Throws()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var root = new RootExpression(typeof(EvalSource), nameof(EvalSource));
+        var traverse = new TraverseLinkExpression(root, "nonexistent", typeof(EvalTarget));
+
+        Assert.Throws<InvalidOperationException>(() =>
+            evaluator.Evaluate<EvalTarget>(traverse, _resolver));
+    }
+
+    // ── InterfaceNarrow expression ─────────────────────────────────────────
+
+    [Test]
+    public async Task Evaluate_InterfaceNarrow_FiltersToImplementors()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var root = new RootExpression(typeof(EvalSource), nameof(EvalSource));
+        var narrow = new InterfaceNarrowExpression(root, typeof(IEvalInterface));
+
+        var result = evaluator.Evaluate<IEvalInterface>(narrow, _resolver);
+
+        await Assert.That(result).HasCount().EqualTo(3);
+    }
+
+    [Test]
+    public async Task Evaluate_InterfaceNarrow_NoImplementors_ReturnsEmpty()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        // EvalTarget does not implement IEvalInterface
+        var root = new RootExpression(typeof(EvalTarget), nameof(EvalTarget));
+        var narrow = new InterfaceNarrowExpression(root, typeof(IEvalInterface));
+
+        var result = evaluator.Evaluate<IEvalInterface>(narrow, _resolver);
+
+        await Assert.That(result).HasCount().EqualTo(0);
+    }
+
+    // ── RawFilter expression ───────────────────────────────────────────────
+
+    [Test]
+    public void Evaluate_RawFilter_ThrowsNotSupported()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var root = new RootExpression(typeof(EvalSource), nameof(EvalSource));
+        var raw = new RawFilterExpression(root, "Value > 5");
+
+        Assert.Throws<NotSupportedException>(() =>
+            evaluator.Evaluate<EvalSource>(raw, _resolver));
+    }
+
+    // ── Empty resolver ─────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Evaluate_EmptyItemResolver_ReturnsEmpty()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var expression = new RootExpression(typeof(EvalSource), nameof(EvalSource));
+
+        var result = evaluator.Evaluate<EvalSource>(expression, _ => []);
+
+        await Assert.That(result).HasCount().EqualTo(0);
+    }
+
+    // ── Thread safety ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Evaluate_ConcurrentCalls_ThreadSafe()
+    {
+        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        var expression = new RootExpression(typeof(EvalSource), nameof(EvalSource));
+
+        var tasks = Enumerable.Range(0, 10).Select(_ => Task.Run(() =>
+            evaluator.Evaluate<EvalSource>(expression, _resolver)));
+
+        var results = await Task.WhenAll(tasks);
+
+        foreach (var result in results)
+        {
+            await Assert.That(result).HasCount().EqualTo(3);
+        }
+    }
+}

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryObjectSetProviderTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryObjectSetProviderTests.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using Strategos.Ontology.Builder;
 using Strategos.Ontology.ObjectSets;
 
 namespace Strategos.Ontology.Tests.ObjectSets;
@@ -237,8 +238,140 @@ public class InMemoryObjectSetProviderTests
         await Assert.That(result.Items).HasCount().EqualTo(1);
         await Assert.That(result.Items[0].Name).IsEqualTo("Default");
     }
+
+    // ── Task 11: Graph-aware constructors + delegation ────────────────────
+
+    [Test]
+    public async Task ExecuteAsync_WithGraph_TraverseLink_Works()
+    {
+        // Arrange — build a graph with ProvSource -> "targets" -> ProvTarget
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<ProviderTestOntology>()
+            .Build();
+
+        var provider = new InMemoryObjectSetProvider(graph);
+        provider.Seed(new ProvSource("S1", 10), "source 1");
+        provider.Seed(new ProvTarget("T1"), "target 1", descriptorName: nameof(ProvTarget));
+        provider.Seed(new ProvTarget("T2"), "target 2", descriptorName: nameof(ProvTarget));
+
+        var root = new RootExpression(typeof(ProvSource), nameof(ProvSource));
+        var traverse = new TraverseLinkExpression(root, "targets", typeof(ProvTarget));
+
+        // Act
+        var result = await provider.ExecuteAsync<ProvTarget>(traverse);
+
+        // Assert
+        await Assert.That(result.Items).HasCount().EqualTo(2);
+        await Assert.That(result.Items[0].Label).IsEqualTo("T1");
+        await Assert.That(result.Items[1].Label).IsEqualTo("T2");
+    }
+
+    [Test]
+    public async Task ExecuteAsync_WithGraph_InterfaceNarrow_Works()
+    {
+        // Arrange
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<ProviderTestOntology>()
+            .Build();
+
+        var provider = new InMemoryObjectSetProvider(graph);
+        provider.Seed(new ProvSource("S1", 10), "source 1");
+        provider.Seed(new ProvSource("S2", 20), "source 2");
+
+        var root = new RootExpression(typeof(ProvSource), nameof(ProvSource));
+        var narrow = new InterfaceNarrowExpression(root, typeof(IProvInterface));
+
+        // Act
+        var result = await provider.ExecuteAsync<IProvInterface>(narrow);
+
+        // Assert — ProvSource implements IProvInterface
+        await Assert.That(result.Items).HasCount().EqualTo(2);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_WithoutGraph_LegacyBehavior()
+    {
+        // Arrange — parameterless constructor, no graph
+        var provider = new InMemoryObjectSetProvider();
+        provider.Seed(new TestEntity("Alice"), "alice");
+        provider.Seed(new TestEntity("Bob"), "bob");
+
+        Expression<Func<TestEntity, bool>> predicate = e => e.Name == "Alice";
+        var root = new RootExpression(typeof(TestEntity), nameof(TestEntity));
+        var filter = new FilterExpression(root, predicate);
+
+        // Act
+        var result = await provider.ExecuteAsync<TestEntity>(filter);
+
+        // Assert — backward compat: filter still works without graph
+        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items[0].Name).IsEqualTo("Alice");
+    }
+
+    [Test]
+    public async Task StreamAsync_WithGraph_DelegatesToEvaluator()
+    {
+        // Arrange
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<ProviderTestOntology>()
+            .Build();
+
+        var provider = new InMemoryObjectSetProvider(graph);
+        provider.Seed(new ProvSource("S1", 10), "source 1");
+        provider.Seed(new ProvTarget("T1"), "target 1", descriptorName: nameof(ProvTarget));
+        provider.Seed(new ProvTarget("T2"), "target 2", descriptorName: nameof(ProvTarget));
+
+        var root = new RootExpression(typeof(ProvSource), nameof(ProvSource));
+        var traverse = new TraverseLinkExpression(root, "targets", typeof(ProvTarget));
+
+        // Act
+        var items = new List<ProvTarget>();
+        await foreach (var item in provider.StreamAsync<ProvTarget>(traverse))
+        {
+            items.Add(item);
+        }
+
+        // Assert
+        await Assert.That(items).HasCount().EqualTo(2);
+        await Assert.That(items[0].Label).IsEqualTo("T1");
+    }
 }
 
-// Test helpers
+// ── Test helpers ───────────────────────────────────────────────────────────
 public sealed record TestEntity(string Name);
 public sealed record OtherEntity(int Value);
+
+// ── Task 11 test domain types ──────────────────────────────────────────────
+public interface IProvInterface
+{
+    string Name { get; }
+}
+
+public sealed record ProvSource(string Name, int Value) : IProvInterface;
+public sealed record ProvTarget(string Label);
+
+public class ProviderTestOntology : DomainOntology
+{
+    public override string DomainName => "provider-test";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Interface<IProvInterface>("IProvInterface", iface =>
+        {
+            iface.Property(e => e.Name);
+        });
+
+        builder.Object<ProvSource>(obj =>
+        {
+            obj.Property(s => s.Name).Required();
+            obj.Property(s => s.Value);
+            obj.HasMany<ProvTarget>("targets");
+            obj.Implements<IProvInterface>(map => { });
+        });
+
+        builder.Object<ProvTarget>(obj =>
+        {
+            obj.Property(t => t.Label).Required();
+        });
+    }
+}

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryObjectSetProviderTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryObjectSetProviderTests.cs
@@ -335,6 +335,62 @@ public class InMemoryObjectSetProviderTests
         await Assert.That(items).HasCount().EqualTo(2);
         await Assert.That(items[0].Label).IsEqualTo("T1");
     }
+
+    // ── Task 12: ExecuteSimilarityAsync source filtering + backward compat ─
+
+    [Test]
+    public async Task ExecuteSimilarityAsync_WithGraph_SourceFiltered()
+    {
+        // Arrange — graph-aware provider with filter on source
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<ProviderTestOntology>()
+            .Build();
+
+        var provider = new InMemoryObjectSetProvider(graph);
+        provider.Seed(new ProvSource("Alpha", 10), "alpha machine learning");
+        provider.Seed(new ProvSource("Beta", 3), "beta machine learning deep");
+        provider.Seed(new ProvSource("Gamma", 20), "gamma unrelated content");
+
+        // Source expression: root + filter (Value > 5 keeps Alpha and Gamma)
+        var root = new RootExpression(typeof(ProvSource), nameof(ProvSource));
+        Expression<Func<ProvSource, bool>> predicate = s => s.Value > 5;
+        var filter = new FilterExpression(root, predicate);
+
+        // Similarity on filtered source — "machine learning" matches Alpha but not Gamma
+        var similarity = new SimilarityExpression(filter, "machine learning", 10, 0.0);
+
+        // Act
+        var result = await provider.ExecuteSimilarityAsync<ProvSource>(similarity);
+
+        // Assert — Beta (Value=3) is excluded by filter; Gamma has no keyword match
+        // Only Alpha (Value=10, "alpha machine learning") and Gamma (Value=20, but score=0.0 passes minRelevance=0.0)
+        // should be in the results. Alpha should rank highest.
+        await Assert.That(result.Items.Count).IsGreaterThanOrEqualTo(1);
+        await Assert.That(result.Items[0].Name).IsEqualTo("Alpha");
+
+        // Beta must NOT be in results (filtered out by Value > 5)
+        var betaItems = result.Items.Where(i => i.Name == "Beta").ToList();
+        await Assert.That(betaItems).HasCount().EqualTo(0);
+    }
+
+    [Test]
+    public async Task ExecuteSimilarityAsync_WithoutGraph_LegacyBehavior()
+    {
+        // Arrange — parameterless constructor, no graph, legacy path
+        var provider = new InMemoryObjectSetProvider();
+        provider.Seed(new TestEntity("Match"), "alpha beta gamma");
+        provider.Seed(new TestEntity("NoMatch"), "completely unrelated");
+
+        var root = new RootExpression(typeof(TestEntity), nameof(TestEntity));
+        var similarity = new SimilarityExpression(root, "alpha beta gamma", 10, 0.9);
+
+        // Act
+        var result = await provider.ExecuteSimilarityAsync<TestEntity>(similarity);
+
+        // Assert — "Match" should score 1.0 (all 3 terms match), "NoMatch" 0.0
+        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items[0].Name).IsEqualTo("Match");
+    }
 }
 
 // ── Test helpers ───────────────────────────────────────────────────────────

--- a/src/Strategos.Ontology.Tests/OntologyGraphBuilderTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphBuilderTests.cs
@@ -694,6 +694,23 @@ public class OntologyGraphBuilderTests
         await Assert.That(unknownWarnings.Count).IsGreaterThanOrEqualTo(1);
     }
 
+    // -----------------------------------------------------------------------
+    // Track A — CrossDomainLink.Description threading to ResolvedCrossDomainLink
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task CrossDomainLink_Description_ThreadedToResolved()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain(new CrossDomainDescriptionSourceOntology());
+        graphBuilder.AddDomain(new CrossDomainDescriptionTargetOntology());
+
+        var graph = graphBuilder.Build();
+
+        await Assert.That(graph.CrossDomainLinks).HasCount().EqualTo(1);
+        await Assert.That(graph.CrossDomainLinks[0].Description).IsEqualTo("Market data informs position pricing");
+    }
+
     [Test]
     public async Task GraphBuilder_WithMultiRegisteredTypeAsCrossDomainLinkTarget_ThrowsAONT041()
     {
@@ -724,5 +741,42 @@ public class OntologyGraphBuilderTests
         await Assert.That(() => graphBuilder.Build())
             .ThrowsException()
             .WithMessageContaining("#32");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Track A — cross-domain link description threading fixtures
+// ---------------------------------------------------------------------------
+
+public class CrossDomainDescriptionSourceOntology : DomainOntology
+{
+    public override string DomainName => "trading";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TestPosition>(obj =>
+        {
+            obj.Key(p => p.Id);
+            obj.Property(p => p.Symbol).Required();
+        });
+
+        builder.CrossDomainLink("market_data_informs")
+            .From<TestPosition>()
+            .ToExternal("market-data", "TestInstrument")
+            .Description("Market data informs position pricing");
+    }
+}
+
+public class CrossDomainDescriptionTargetOntology : DomainOntology
+{
+    public override string DomainName => "market-data";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TestInstrument>(obj =>
+        {
+            obj.Key(i => i.Ticker);
+            obj.Property(i => i.Price).Required();
+        });
     }
 }

--- a/src/Strategos.Ontology.Tests/OntologyGraphTraversalTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphTraversalTests.cs
@@ -155,6 +155,20 @@ public class OntologyGraphTraversalTests
     }
 
     [Test]
+    public async Task TraverseLinks_ResultIncludesLinkDescription()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain(new TestDescribedLinkOntology());
+        var graph = graphBuilder.Build();
+
+        var results = graph.TraverseLinks("trading", "TestPosition", maxDepth: 1);
+
+        await Assert.That(results).HasCount().EqualTo(1);
+        await Assert.That(results[0].LinkName).IsEqualTo("Orders");
+        await Assert.That(results[0].Description).IsEqualTo("Orders placed against this position");
+    }
+
+    [Test]
     public async Task OntologyGraph_FindWorkflowChains_UnknownWorkflow_ReturnsEmpty()
     {
         var graphBuilder = new OntologyGraphBuilder();
@@ -164,5 +178,26 @@ public class OntologyGraphTraversalTests
         var result = graph.FindWorkflowChains("NonExistent");
 
         await Assert.That(result).HasCount().EqualTo(0);
+    }
+}
+
+public class TestDescribedLinkOntology : DomainOntology
+{
+    public override string DomainName => "trading";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TestPosition>(obj =>
+        {
+            obj.Key(p => p.Id);
+            obj.Property(p => p.Symbol).Required();
+            obj.HasMany<TestOrder>("Orders")
+                .Description("Orders placed against this position");
+        });
+
+        builder.Object<TestOrder>(obj =>
+        {
+            obj.Key(o => o.OrderId);
+        });
     }
 }

--- a/src/Strategos.Ontology/Builder/CrossDomainLinkBuilder.cs
+++ b/src/Strategos.Ontology/Builder/CrossDomainLinkBuilder.cs
@@ -9,6 +9,7 @@ internal sealed class CrossDomainLinkBuilder(string name) : ICrossDomainLinkBuil
     private string _targetTypeName = string.Empty;
     private LinkCardinality _cardinality = LinkCardinality.OneToOne;
     private IReadOnlyList<PropertyDescriptor> _edgeProperties = [];
+    private string? _description;
 
     public ICrossDomainLinkBuilder From<T>()
     {
@@ -37,9 +38,16 @@ internal sealed class CrossDomainLinkBuilder(string name) : ICrossDomainLinkBuil
         return this;
     }
 
+    public ICrossDomainLinkBuilder Description(string description)
+    {
+        _description = description;
+        return this;
+    }
+
     public CrossDomainLinkDescriptor Build() =>
         new(name, _sourceType, _targetDomain, _targetTypeName, _cardinality)
         {
             EdgeProperties = _edgeProperties,
+            Description = _description,
         };
 }

--- a/src/Strategos.Ontology/Builder/ICrossDomainLinkBuilder.cs
+++ b/src/Strategos.Ontology/Builder/ICrossDomainLinkBuilder.cs
@@ -9,4 +9,6 @@ public interface ICrossDomainLinkBuilder
     ICrossDomainLinkBuilder ManyToMany();
 
     ICrossDomainLinkBuilder WithEdge(Action<IEdgeBuilder> configure);
+
+    ICrossDomainLinkBuilder Description(string description);
 }

--- a/src/Strategos.Ontology/Builder/ILinkBuilder.cs
+++ b/src/Strategos.Ontology/Builder/ILinkBuilder.cs
@@ -9,4 +9,6 @@ namespace Strategos.Ontology.Builder;
 public interface ILinkBuilder
 {
     ILinkBuilder Inverse(string inverseLinkName);
+
+    ILinkBuilder Description(string description);
 }

--- a/src/Strategos.Ontology/Builder/LinkBuilder.cs
+++ b/src/Strategos.Ontology/Builder/LinkBuilder.cs
@@ -11,6 +11,7 @@ namespace Strategos.Ontology.Builder;
 internal sealed class LinkBuilder(LinkDescriptor baseDescriptor) : ILinkBuilder
 {
     private string? _inverseLinkName;
+    private string? _description;
 
     public ILinkBuilder Inverse(string inverseLinkName)
     {
@@ -18,8 +19,19 @@ internal sealed class LinkBuilder(LinkDescriptor baseDescriptor) : ILinkBuilder
         return this;
     }
 
-    public LinkDescriptor Build() =>
-        _inverseLinkName is not null
-            ? baseDescriptor with { InverseLinkName = _inverseLinkName }
-            : baseDescriptor;
+    public ILinkBuilder Description(string description)
+    {
+        _description = description;
+        return this;
+    }
+
+    public LinkDescriptor Build()
+    {
+        var descriptor = baseDescriptor;
+        if (_inverseLinkName is not null)
+            descriptor = descriptor with { InverseLinkName = _inverseLinkName };
+        if (_description is not null)
+            descriptor = descriptor with { Description = _description };
+        return descriptor;
+    }
 }

--- a/src/Strategos.Ontology/Descriptors/CrossDomainLinkDescriptor.cs
+++ b/src/Strategos.Ontology/Descriptors/CrossDomainLinkDescriptor.cs
@@ -8,4 +8,6 @@ public sealed record CrossDomainLinkDescriptor(
     LinkCardinality Cardinality)
 {
     public IReadOnlyList<PropertyDescriptor> EdgeProperties { get; init; } = [];
+
+    public string? Description { get; init; }
 }

--- a/src/Strategos.Ontology/Descriptors/LinkDescriptor.cs
+++ b/src/Strategos.Ontology/Descriptors/LinkDescriptor.cs
@@ -10,4 +10,6 @@ public sealed record LinkDescriptor(
         EdgeProperties ?? [];
 
     public string? InverseLinkName { get; init; }
+
+    public string? Description { get; init; }
 }

--- a/src/Strategos.Ontology/LinkTraversalResult.cs
+++ b/src/Strategos.Ontology/LinkTraversalResult.cs
@@ -5,4 +5,5 @@ namespace Strategos.Ontology;
 public sealed record LinkTraversalResult(
     ObjectTypeDescriptor ObjectType,
     string LinkName,
-    int Depth);
+    int Depth,
+    string? Description = null);

--- a/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
@@ -1,0 +1,93 @@
+using System.Linq.Expressions;
+using Strategos.Ontology.Descriptors;
+
+namespace Strategos.Ontology.ObjectSets;
+
+/// <summary>
+/// Evaluates <see cref="ObjectSetExpression"/> trees against in-memory item collections
+/// resolved from an external source. Graph-aware: resolves link traversals and interface
+/// narrowing against the frozen <see cref="OntologyGraph"/>.
+/// </summary>
+/// <remarks>
+/// This evaluator handles structural expressions (Filter, TraverseLink, InterfaceNarrow,
+/// Include, Root). It does NOT handle <see cref="SimilarityExpression"/> (provider-specific
+/// scoring) or <see cref="RawFilterExpression"/> (throws <see cref="NotSupportedException"/>).
+/// <para>
+/// Link traversal is schema-level: <c>TraverseLink("countered_by")</c> resolves the link
+/// descriptor from the graph and returns all items of the target type. It does not follow
+/// materialized link instances between specific objects.
+/// </para>
+/// </remarks>
+public sealed class InMemoryExpressionEvaluator
+{
+    private readonly OntologyGraph _graph;
+    private readonly Dictionary<string, ObjectTypeDescriptor> _descriptorIndex;
+
+    /// <summary>
+    /// Initializes a new instance with the specified ontology graph.
+    /// </summary>
+    /// <param name="graph">
+    /// The frozen ontology graph used to resolve link descriptors and interface implementors.
+    /// </param>
+    public InMemoryExpressionEvaluator(OntologyGraph graph)
+    {
+        _graph = graph;
+        _descriptorIndex = graph.ObjectTypes.ToDictionary(t => t.Name);
+    }
+
+    /// <summary>
+    /// Evaluates an expression tree against items resolved from the given source.
+    /// </summary>
+    /// <typeparam name="T">The expected result element type.</typeparam>
+    /// <param name="expression">The expression tree to evaluate.</param>
+    /// <param name="itemResolver">
+    /// Resolves items by ontology descriptor name. Called with a descriptor name (e.g.,
+    /// "WedgeFormation"), returns all items of that type as an untyped list. The evaluator
+    /// handles casting and filtering.
+    /// </param>
+    /// <returns>Filtered, traversed, or narrowed items matching the expression.</returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown for <see cref="RawFilterExpression"/> or <see cref="SimilarityExpression"/>
+    /// (string filter parsing and similarity scoring not implemented).
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a link name or interface cannot be resolved from the ontology graph.
+    /// </exception>
+    public List<T> Evaluate<T>(
+        ObjectSetExpression expression,
+        Func<string, IReadOnlyList<object>> itemResolver) where T : class
+    {
+        return expression switch
+        {
+            RootExpression root => EvaluateRoot<T>(root, itemResolver),
+            FilterExpression filter => EvaluateFilter<T>(filter, itemResolver),
+            IncludeExpression include => Evaluate<T>(include.Source, itemResolver),
+            _ => throw new NotSupportedException(
+                $"Expression type '{expression.GetType().Name}' is not supported by InMemoryExpressionEvaluator.")
+        };
+    }
+
+    private static List<T> EvaluateRoot<T>(
+        RootExpression root,
+        Func<string, IReadOnlyList<object>> itemResolver) where T : class
+    {
+        var items = itemResolver(root.ObjectTypeName);
+        return items.Cast<T>().ToList();
+    }
+
+    private List<T> EvaluateFilter<T>(
+        FilterExpression filter,
+        Func<string, IReadOnlyList<object>> itemResolver) where T : class
+    {
+        var sourceItems = Evaluate<T>(filter.Source, itemResolver);
+        var compiled = filter.Predicate.Compile();
+
+        if (compiled is Func<T, bool> typedPredicate)
+        {
+            return sourceItems.Where(typedPredicate).ToList();
+        }
+
+        throw new InvalidOperationException(
+            $"Filter predicate type '{compiled.GetType().Name}' is not compatible with Func<{typeof(T).Name}, bool>.");
+    }
+}

--- a/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
@@ -20,7 +20,6 @@ namespace Strategos.Ontology.ObjectSets;
 /// </remarks>
 public sealed class InMemoryExpressionEvaluator
 {
-    private readonly OntologyGraph _graph;
     private readonly Dictionary<string, ObjectTypeDescriptor> _descriptorIndex;
 
     /// <summary>
@@ -29,10 +28,27 @@ public sealed class InMemoryExpressionEvaluator
     /// <param name="graph">
     /// The frozen ontology graph used to resolve link descriptors and interface implementors.
     /// </param>
+    /// <exception cref="ArgumentException">
+    /// Thrown if the graph contains multiple object types with the same descriptor name
+    /// across different domains. Use unique descriptor names or qualify with domain.
+    /// </exception>
     public InMemoryExpressionEvaluator(OntologyGraph graph)
     {
-        _graph = graph;
-        _descriptorIndex = graph.ObjectTypes.ToDictionary(t => t.Name);
+        ArgumentNullException.ThrowIfNull(graph);
+
+        _descriptorIndex = new Dictionary<string, ObjectTypeDescriptor>();
+        foreach (var ot in graph.ObjectTypes)
+        {
+            if (!_descriptorIndex.TryAdd(ot.Name, ot))
+            {
+                var existing = _descriptorIndex[ot.Name];
+                throw new ArgumentException(
+                    $"Descriptor name '{ot.Name}' is registered in both domain '{existing.DomainName}' " +
+                    $"and domain '{ot.DomainName}'. InMemoryExpressionEvaluator requires globally unique " +
+                    $"descriptor names. Rename one of the registrations to disambiguate.",
+                    nameof(graph));
+            }
+        }
     }
 
     /// <summary>

--- a/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
@@ -1,0 +1,157 @@
+using Strategos.Ontology.Descriptors;
+
+namespace Strategos.Ontology.ObjectSets;
+
+/// <summary>
+/// Evaluates <see cref="ObjectSetExpression"/> trees against in-memory item collections
+/// resolved from an external source. Graph-aware: resolves link traversals and interface
+/// narrowing against the frozen <see cref="OntologyGraph"/>.
+/// </summary>
+/// <remarks>
+/// This evaluator handles structural expressions (Filter, TraverseLink, InterfaceNarrow,
+/// Include, Root). It does NOT handle <see cref="SimilarityExpression"/> (provider-specific
+/// scoring) or <see cref="RawFilterExpression"/> (throws <see cref="NotSupportedException"/>).
+/// <para>
+/// Link traversal is schema-level: <c>TraverseLink("countered_by")</c> resolves the link
+/// descriptor from the graph and returns all items of the target type. It does not follow
+/// materialized link instances between specific objects.
+/// </para>
+/// </remarks>
+public sealed class InMemoryExpressionEvaluator
+{
+    private readonly OntologyGraph _graph;
+    private readonly Dictionary<string, ObjectTypeDescriptor> _descriptorIndex;
+
+    /// <summary>
+    /// Initializes a new instance with the specified ontology graph.
+    /// </summary>
+    /// <param name="graph">
+    /// The frozen ontology graph used to resolve link descriptors and interface implementors.
+    /// </param>
+    public InMemoryExpressionEvaluator(OntologyGraph graph)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+        _graph = graph;
+        _descriptorIndex = graph.ObjectTypes.ToDictionary(t => t.Name);
+    }
+
+    /// <summary>
+    /// Evaluates an expression tree against items resolved from the given source.
+    /// </summary>
+    /// <typeparam name="T">The expected result element type.</typeparam>
+    /// <param name="expression">The expression tree to evaluate.</param>
+    /// <param name="itemResolver">
+    /// Resolves items by ontology descriptor name. Called with a descriptor name (e.g.,
+    /// "WedgeFormation"), returns all items of that type as an untyped list. The evaluator
+    /// handles casting and filtering.
+    /// </param>
+    /// <returns>Filtered, traversed, or narrowed items matching the expression.</returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown for <see cref="RawFilterExpression"/> (string filter parsing not implemented).
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a link name or interface cannot be resolved from the ontology graph.
+    /// </exception>
+    public List<T> Evaluate<T>(
+        ObjectSetExpression expression,
+        Func<string, IReadOnlyList<object>> itemResolver) where T : class
+    {
+        ArgumentNullException.ThrowIfNull(expression);
+        ArgumentNullException.ThrowIfNull(itemResolver);
+
+        return expression switch
+        {
+            RootExpression root => EvaluateRoot<T>(root, itemResolver),
+            FilterExpression filter => EvaluateFilter<T>(filter, itemResolver),
+            IncludeExpression include => Evaluate<T>(include.Source, itemResolver),
+            TraverseLinkExpression traverse => EvaluateTraverseLink<T>(traverse, itemResolver),
+            InterfaceNarrowExpression narrow => EvaluateInterfaceNarrow<T>(narrow, itemResolver),
+            RawFilterExpression => throw new NotSupportedException(
+                "RawFilterExpression evaluation is not supported by InMemoryExpressionEvaluator. " +
+                "Use ObjectSet<T>.Where() with typed predicates instead of raw filter strings."),
+            _ => throw new NotSupportedException(
+                $"Expression type '{expression.GetType().Name}' is not supported by InMemoryExpressionEvaluator."),
+        };
+    }
+
+    private static List<T> EvaluateRoot<T>(
+        RootExpression root,
+        Func<string, IReadOnlyList<object>> itemResolver) where T : class
+    {
+        var items = itemResolver(root.ObjectTypeName);
+        return items.OfType<T>().ToList();
+    }
+
+    private List<T> EvaluateFilter<T>(
+        FilterExpression filter,
+        Func<string, IReadOnlyList<object>> itemResolver) where T : class
+    {
+        var items = Evaluate<T>(filter.Source, itemResolver);
+
+        var compiled = filter.Predicate.Compile();
+        if (compiled is not Func<T, bool> func)
+        {
+            throw new InvalidOperationException(
+                $"Filter predicate type '{compiled.GetType()}' is not compatible with Func<{typeof(T).Name}, bool>.");
+        }
+
+        return items.Where(func).ToList();
+    }
+
+    private List<T> EvaluateTraverseLink<T>(
+        TraverseLinkExpression traverse,
+        Func<string, IReadOnlyList<object>> itemResolver) where T : class
+    {
+        var sourceDescriptorName = ResolveSourceDescriptorName(traverse.Source);
+
+        if (!_descriptorIndex.TryGetValue(sourceDescriptorName, out var sourceDescriptor))
+        {
+            var availableTypes = string.Join(", ", _descriptorIndex.Keys.Select(k => $"'{k}'"));
+            throw new InvalidOperationException(
+                $"Object type '{sourceDescriptorName}' not found in ontology graph. Available types: {availableTypes}");
+        }
+
+        var link = sourceDescriptor.Links.FirstOrDefault(l => l.Name == traverse.LinkName);
+        if (link is null)
+        {
+            var availableLinks = string.Join(", ", sourceDescriptor.Links.Select(l => $"'{l.Name}'"));
+            throw new InvalidOperationException(
+                $"Link '{traverse.LinkName}' not found on object type '{sourceDescriptorName}'. Available links: {availableLinks}");
+        }
+
+        var targetItems = itemResolver(link.TargetTypeName);
+        return targetItems.OfType<T>().ToList();
+    }
+
+    private List<T> EvaluateInterfaceNarrow<T>(
+        InterfaceNarrowExpression narrow,
+        Func<string, IReadOnlyList<object>> itemResolver) where T : class
+    {
+        // Recurse with object to avoid premature type casting
+        var items = Evaluate<object>(narrow.Source, itemResolver);
+
+        return items
+            .Where(item => typeof(T).IsAssignableFrom(item.GetType()))
+            .Cast<T>()
+            .ToList();
+    }
+
+    /// <summary>
+    /// Walks the source expression to find the originating descriptor name.
+    /// Unlike <see cref="ObjectSetExpression.RootObjectTypeName"/> (which on
+    /// <see cref="TraverseLinkExpression"/> returns the target type name),
+    /// this walks the source subtree.
+    /// </summary>
+    private static string ResolveSourceDescriptorName(ObjectSetExpression expression) =>
+        expression switch
+        {
+            RootExpression root => root.ObjectTypeName,
+            FilterExpression filter => ResolveSourceDescriptorName(filter.Source),
+            IncludeExpression include => ResolveSourceDescriptorName(include.Source),
+            TraverseLinkExpression traverse => ResolveSourceDescriptorName(traverse.Source),
+            InterfaceNarrowExpression narrow => ResolveSourceDescriptorName(narrow.Source),
+            RawFilterExpression raw => ResolveSourceDescriptorName(raw.Source),
+            _ => throw new NotSupportedException(
+                $"Cannot resolve source descriptor from {expression.GetType().Name}"),
+        };
+}

--- a/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
@@ -62,6 +62,7 @@ public sealed class InMemoryExpressionEvaluator
             RootExpression root => EvaluateRoot<T>(root, itemResolver),
             FilterExpression filter => EvaluateFilter<T>(filter, itemResolver),
             IncludeExpression include => Evaluate<T>(include.Source, itemResolver),
+            TraverseLinkExpression traverse => EvaluateTraverseLink<T>(traverse, itemResolver),
             _ => throw new NotSupportedException(
                 $"Expression type '{expression.GetType().Name}' is not supported by InMemoryExpressionEvaluator.")
         };
@@ -90,4 +91,42 @@ public sealed class InMemoryExpressionEvaluator
         throw new InvalidOperationException(
             $"Filter predicate type '{compiled.GetType().Name}' is not compatible with Func<{typeof(T).Name}, bool>.");
     }
+
+    private List<T> EvaluateTraverseLink<T>(
+        TraverseLinkExpression traverse,
+        Func<string, IReadOnlyList<object>> itemResolver) where T : class
+    {
+        var sourceDescriptorName = ResolveSourceDescriptorName(traverse.Source);
+
+        if (!_descriptorIndex.TryGetValue(sourceDescriptorName, out var sourceDescriptor))
+        {
+            var available = string.Join(", ", _descriptorIndex.Keys);
+            throw new InvalidOperationException(
+                $"Object type '{sourceDescriptorName}' not found in ontology graph. Available types: {available}");
+        }
+
+        var link = sourceDescriptor.Links.FirstOrDefault(l => l.Name == traverse.LinkName);
+        if (link is null)
+        {
+            var available = string.Join(", ", sourceDescriptor.Links.Select(l => l.Name));
+            throw new InvalidOperationException(
+                $"Link '{traverse.LinkName}' not found on object type '{sourceDescriptorName}'. Available links: {available}");
+        }
+
+        var targetItems = itemResolver(link.TargetTypeName);
+        return targetItems.Cast<T>().ToList();
+    }
+
+    private static string ResolveSourceDescriptorName(ObjectSetExpression expression) =>
+        expression switch
+        {
+            RootExpression root => root.ObjectTypeName,
+            FilterExpression filter => ResolveSourceDescriptorName(filter.Source),
+            IncludeExpression include => ResolveSourceDescriptorName(include.Source),
+            TraverseLinkExpression traverse => ResolveSourceDescriptorName(traverse.Source),
+            InterfaceNarrowExpression narrow => ResolveSourceDescriptorName(narrow.Source),
+            RawFilterExpression raw => ResolveSourceDescriptorName(raw.Source),
+            _ => throw new NotSupportedException(
+                $"Cannot resolve source descriptor from {expression.GetType().Name}"),
+        };
 }

--- a/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
@@ -63,6 +63,7 @@ public sealed class InMemoryExpressionEvaluator
             FilterExpression filter => EvaluateFilter<T>(filter, itemResolver),
             IncludeExpression include => Evaluate<T>(include.Source, itemResolver),
             TraverseLinkExpression traverse => EvaluateTraverseLink<T>(traverse, itemResolver),
+            InterfaceNarrowExpression narrow => EvaluateInterfaceNarrow<T>(narrow, itemResolver),
             _ => throw new NotSupportedException(
                 $"Expression type '{expression.GetType().Name}' is not supported by InMemoryExpressionEvaluator.")
         };
@@ -115,6 +116,17 @@ public sealed class InMemoryExpressionEvaluator
 
         var targetItems = itemResolver(link.TargetTypeName);
         return targetItems.Cast<T>().ToList();
+    }
+
+    private List<T> EvaluateInterfaceNarrow<T>(
+        InterfaceNarrowExpression narrow,
+        Func<string, IReadOnlyList<object>> itemResolver) where T : class
+    {
+        var sourceItems = Evaluate<object>(narrow.Source, itemResolver);
+        return sourceItems
+            .Where(item => typeof(T).IsAssignableFrom(item.GetType()))
+            .Cast<T>()
+            .ToList();
     }
 
     private static string ResolveSourceDescriptorName(ObjectSetExpression expression) =>

--- a/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
@@ -64,6 +64,12 @@ public sealed class InMemoryExpressionEvaluator
             IncludeExpression include => Evaluate<T>(include.Source, itemResolver),
             TraverseLinkExpression traverse => EvaluateTraverseLink<T>(traverse, itemResolver),
             InterfaceNarrowExpression narrow => EvaluateInterfaceNarrow<T>(narrow, itemResolver),
+            RawFilterExpression => throw new NotSupportedException(
+                "RawFilterExpression evaluation is not supported by InMemoryExpressionEvaluator. " +
+                "Use ObjectSet<T>.Where() with typed predicates instead of raw filter strings."),
+            SimilarityExpression => throw new NotSupportedException(
+                "SimilarityExpression evaluation is not supported by InMemoryExpressionEvaluator. " +
+                "Similarity scoring is provider-specific."),
             _ => throw new NotSupportedException(
                 $"Expression type '{expression.GetType().Name}' is not supported by InMemoryExpressionEvaluator.")
         };

--- a/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
@@ -31,6 +31,7 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
     private readonly ConcurrentDictionary<string, List<string>> _searchableContent = new();
     private readonly ConcurrentDictionary<string, List<float[]>> _embeddings = new();
     private readonly IEmbeddingProvider? _embeddingProvider;
+    private readonly InMemoryExpressionEvaluator? _evaluator;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="InMemoryObjectSetProvider"/> class.
@@ -49,6 +50,37 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
     /// </param>
     public InMemoryObjectSetProvider(IEmbeddingProvider? embeddingProvider)
     {
+        _embeddingProvider = embeddingProvider;
+    }
+
+    /// <summary>
+    /// Initializes a new graph-aware instance of the <see cref="InMemoryObjectSetProvider"/> class.
+    /// Delegates expression evaluation to <see cref="InMemoryExpressionEvaluator"/>, gaining
+    /// TraverseLinkExpression and InterfaceNarrowExpression support.
+    /// </summary>
+    /// <param name="graph">
+    /// The frozen ontology graph used for link traversal and interface narrowing.
+    /// </param>
+    public InMemoryObjectSetProvider(OntologyGraph graph)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+        _evaluator = new InMemoryExpressionEvaluator(graph);
+    }
+
+    /// <summary>
+    /// Initializes a new graph-aware instance with an optional embedding provider.
+    /// </summary>
+    /// <param name="graph">
+    /// The frozen ontology graph used for link traversal and interface narrowing.
+    /// </param>
+    /// <param name="embeddingProvider">
+    /// When provided, <see cref="ExecuteSimilarityAsync{T}"/> will use real cosine similarity
+    /// against stored embeddings instead of keyword scoring.
+    /// </param>
+    public InMemoryObjectSetProvider(OntologyGraph graph, IEmbeddingProvider? embeddingProvider)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+        _evaluator = new InMemoryExpressionEvaluator(graph);
         _embeddingProvider = embeddingProvider;
     }
 
@@ -130,9 +162,12 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         where T : class
     {
         ArgumentNullException.ThrowIfNull(expression);
-        var items = GetSeededItems<T>(expression.RootObjectTypeName);
-        var filtered = ApplyExpression(items, expression);
-        var result = new ObjectSetResult<T>(filtered, filtered.Count, ObjectSetInclusion.Properties);
+
+        var items = _evaluator is not null
+            ? _evaluator.Evaluate<T>(expression, GetSeededItems)
+            : ApplyExpressionLegacy(GetSeededItems<T>(expression.RootObjectTypeName), expression);
+
+        var result = new ObjectSetResult<T>(items, items.Count, ObjectSetInclusion.Properties);
         return Task.FromResult(result);
     }
 
@@ -142,10 +177,12 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         [EnumeratorCancellation] CancellationToken ct = default) where T : class
     {
         ArgumentNullException.ThrowIfNull(expression);
-        var items = GetSeededItems<T>(expression.RootObjectTypeName);
-        var filtered = ApplyExpression(items, expression);
 
-        foreach (var item in filtered)
+        var items = _evaluator is not null
+            ? _evaluator.Evaluate<T>(expression, GetSeededItems)
+            : ApplyExpressionLegacy(GetSeededItems<T>(expression.RootObjectTypeName), expression);
+
+        foreach (var item in items)
         {
             ct.ThrowIfCancellationRequested();
             yield return item;
@@ -175,7 +212,9 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         }
 
         // Apply Source expression (filters, includes, etc.)
-        items = ApplyExpression(items, expression.Source);
+        items = _evaluator is not null
+            ? _evaluator.Evaluate<T>(expression.Source, GetSeededItems)
+            : ApplyExpressionLegacy(items, expression.Source);
 
         // When an embedding provider is available and non-placeholder embeddings exist, use cosine similarity
         if (_embeddingProvider is not null
@@ -279,6 +318,15 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         return map;
     }
 
+    /// <summary>
+    /// Item resolver delegate for <see cref="InMemoryExpressionEvaluator"/>.
+    /// Returns raw (untyped) items from the internal partition by descriptor name.
+    /// </summary>
+    private IReadOnlyList<object> GetSeededItems(string descriptorName)
+    {
+        return _items.TryGetValue(descriptorName, out var items) ? items : [];
+    }
+
     private List<T> GetSeededItems<T>(string partitionKey) where T : class
     {
         if (!_items.TryGetValue(partitionKey, out var items))
@@ -299,12 +347,12 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         return content;
     }
 
-    private static List<T> ApplyExpression<T>(List<T> items, ObjectSetExpression expression) where T : class
+    private static List<T> ApplyExpressionLegacy<T>(List<T> items, ObjectSetExpression expression) where T : class
     {
         if (expression is FilterExpression filter)
         {
             // Recursively apply the source expression first
-            var filtered = ApplyExpression(items, filter.Source);
+            var filtered = ApplyExpressionLegacy(items, filter.Source);
 
             var compiled = filter.Predicate.Compile();
             if (compiled is not Func<T, bool> func)
@@ -318,7 +366,7 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
 
         if (expression is IncludeExpression include)
         {
-            return ApplyExpression(items, include.Source);
+            return ApplyExpressionLegacy(items, include.Source);
         }
 
         // RootExpression or other — return all items (base case)

--- a/src/Strategos.Ontology/OntologyGraph.cs
+++ b/src/Strategos.Ontology/OntologyGraph.cs
@@ -103,7 +103,7 @@ public sealed class OntologyGraph
                 }
 
                 visited.Add(targetKey);
-                results.Add(new LinkTraversalResult(targetType, link.Name, currentDepth + 1));
+                results.Add(new LinkTraversalResult(targetType, link.Name, currentDepth + 1, link.Description));
                 queue.Enqueue((targetType, currentDepth + 1));
             }
         }

--- a/src/Strategos.Ontology/OntologyGraphBuilder.cs
+++ b/src/Strategos.Ontology/OntologyGraphBuilder.cs
@@ -164,7 +164,8 @@ public sealed class OntologyGraphBuilder
                 TargetDomain: descriptor.TargetDomain,
                 TargetObjectType: targetObjectType,
                 Cardinality: descriptor.Cardinality,
-                EdgeProperties: descriptor.EdgeProperties));
+                EdgeProperties: descriptor.EdgeProperties,
+                Description: descriptor.Description));
         }
 
         return resolved;

--- a/src/Strategos.Ontology/ResolvedCrossDomainLink.cs
+++ b/src/Strategos.Ontology/ResolvedCrossDomainLink.cs
@@ -9,4 +9,5 @@ public sealed record ResolvedCrossDomainLink(
     string TargetDomain,
     ObjectTypeDescriptor TargetObjectType,
     LinkCardinality Cardinality,
-    IReadOnlyList<PropertyDescriptor> EdgeProperties);
+    IReadOnlyList<PropertyDescriptor> EdgeProperties,
+    string? Description = null);


### PR DESCRIPTION
## Summary

- **Link descriptions:** Add `Description` property to `LinkDescriptor`, `CrossDomainLinkDescriptor`, `ResolvedCrossDomainLink`, and `LinkTraversalResult` with corresponding builder methods (`ILinkBuilder.Description()`, `ICrossDomainLinkBuilder.Description()`). Surfaced in `OntologyExploreTool` output for agent consumption.
- **`InMemoryExpressionEvaluator`:** New public, graph-aware class that evaluates `ObjectSetExpression` trees against items from any source via a `Func<string, IReadOnlyList<object>>` delegate. Handles `RootExpression`, `FilterExpression`, `IncludeExpression`, `TraverseLinkExpression` (schema-level), and `InterfaceNarrowExpression` (CLR-level). Thread-safe after construction.
- **`InMemoryObjectSetProvider` refactor:** New graph-aware constructors delegate to the evaluator for `ExecuteAsync`, `StreamAsync`, and `ExecuteSimilarityAsync` source filtering. Legacy parameterless constructor path preserved with full backward compatibility.

**Motivation:** Enables external consumers (Valkyrie Agent-First Engine, test harnesses) to evaluate ontology expressions against in-memory data without reimplementing the expression tree walker. See `docs/designs/2026-04-12-agent-first-engine-support.md`.

## Test plan

- [x] 32 new tests across 8 test files (evaluator: 16, provider: 6, link descriptions: 10)
- [x] Full suite: 575 ontology + 53 MCP tests, 0 failures
- [x] Backward compatibility: parameterless constructor tests verify legacy behavior unchanged
- [x] Thread safety: concurrent evaluation test with 10 parallel calls
- [x] Error handling: unknown links, unknown descriptors, raw filter rejection, similarity rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)