### PR TITLE
build(deps): dependency refresh (2026-04-18)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,10 @@ The library bridges agent frameworks and workflow engines by treating each agent
 - **Code Quality**: StyleCop Analyzers, .NET Analyzers
 - **Documentation**: VitePress (Node.js-based static site)
 
+## Build Requirements
+
+- **.NET SDK**: **10.0.202 or newer** (pinned in `global.json` with `rollForward: latestFeature`). Required because Roslyn 5.3 source generators produce `CS9057` under the .NET 10.0.1xx SDKs, which ship the C# compiler at 5.0.0.0. SDK 10.0.202 ships compiler 5.3.0, satisfying the analyzer floor. CI enforces this via `actions/setup-dotnet@v4` with `dotnet-version: '10.0.x'` (respects `global.json`).
+
 ## Key Dependencies
 
 - **Microsoft.Extensions.AI** - AI abstractions for LLM integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Dependency refresh (2026-04-18)** — All centrally-managed packages in `src/Directory.Packages.props` bumped to latest stable. Behavior-preserving; test count (3430) and Verify snapshots unchanged.
+  - `Microsoft.Extensions.Caching.Memory` 10.0.0 → 10.0.6
+  - `Microsoft.Extensions.DependencyInjection` 10.0.0 → 10.0.6
+  - `Microsoft.Extensions.DependencyInjection.Abstractions` 10.0.0 → 10.0.6
+  - `Microsoft.Extensions.Http` 10.0.0 → 10.0.6
+  - `Microsoft.Extensions.Logging.Abstractions` 10.0.0 → 10.0.6
+  - `Microsoft.Extensions.Options` 10.0.0 → 10.0.6
+  - `Microsoft.Extensions.TimeProvider.Testing` 10.0.0 → 10.5.0 (10.0.x patch lineage skipped by the package; testing-only surface)
+  - `Microsoft.Extensions.AI` 10.0.1 → 10.5.0 (version-locked with `.Abstractions`)
+  - `Microsoft.Extensions.AI.Abstractions` 10.0.1 → 10.5.0
+  - `Npgsql` 9.0.3 → 10.0.2 (pre-bump trigger scan clean: no date/time columns, no `NpgsqlCidr`, no `BeginText*Async`, no `DataTypeName`+`NpgsqlDbType` combined setters)
+  - `Pgvector` 0.3.0 → 0.3.2
+  - `MemoryPack` 1.21.3 → 1.21.4
+  - `BitFaster.Caching` 2.5.2 → 2.5.4
+  - `CommunityToolkit.HighPerformance` 8.4.0 → 8.4.2
+  - `TUnit` 1.2.11 → 1.37.0 (336 mechanical `.HasCount(...)` → `.Count().IsEqualTo(...)` rewrites; 4 `.IsEqualTo(true/false)` → `.IsTrue()/.IsFalse()` rewrites)
+  - `Microsoft.CodeAnalysis.CSharp` 4.14.0 → 5.3.0 (Roslyn 5)
+  - `Microsoft.CodeAnalysis.Analyzers` 4.14.0 → 5.3.0 (Roslyn 5)
+
+### Breaking
+
+- **.NET SDK floor raised to 10.0.202** — Required by Roslyn 5.3 source generators (`CS9057` against the compiler 5.0.0.0 shipped by .NET 10.0.1xx SDKs). Enforced via `global.json` with `rollForward: latestFeature`. See `AGENTS.md` → Build Requirements.
+
 ## [1.1.1] - 2026-01-19
 
 ### Added

--- a/docs/plans/2026-04-18-dep-refresh.md
+++ b/docs/plans/2026-04-18-dep-refresh.md
@@ -1,0 +1,187 @@
+# Dependency Refresh — Implementation Plan
+
+**Feature:** `refactor-dep-refresh`
+**Type:** refactor (overhaul)
+**Date:** 2026-04-18
+**Brief source:** workflow state `refactor-dep-refresh.brief`
+
+## Overview
+
+Bump all centrally-managed dependencies in `src/Directory.Packages.props` to latest stable (2026-04-18). Behavior-preserving. One commit per bump, sequential validation.
+
+Characterization fence (regression proof):
+
+- `dotnet build /p:TreatWarningsAsErrors=true` must remain green.
+- Full TUnit suite must pass via `-- --treenode-filter "/*/*/*/Name"`.
+- Source generator Verify snapshots must remain unchanged (both `Strategos.Generators.Tests` and `Strategos.Ontology.Generators.Tests`).
+
+All tasks are **sequential** — each bump depends on the prior being validated. Parallelization is intentionally off: a later bump failing after a mid-stream regression would need git archaeology to isolate.
+
+## Version targets
+
+| Package | From | To |
+|---|---|---|
+| Microsoft.Extensions.Caching.Memory | 10.0.0 | 10.0.6 |
+| Microsoft.Extensions.DependencyInjection(.Abstractions) | 10.0.0 | 10.0.6 |
+| Microsoft.Extensions.Http | 10.0.0 | 10.0.6 |
+| Microsoft.Extensions.Logging.Abstractions | 10.0.0 | 10.0.6 |
+| Microsoft.Extensions.Options | 10.0.0 | 10.0.6 |
+| Microsoft.Extensions.TimeProvider.Testing | 10.0.0 | 10.0.6 |
+| MemoryPack | 1.21.3 | 1.21.4 |
+| Pgvector | 0.3.0 | 0.3.2 |
+| BitFaster.Caching | 2.5.2 | 2.5.4 |
+| CommunityToolkit.HighPerformance | 8.4.0 | 8.4.2 |
+| Microsoft.Extensions.AI(.Abstractions) | 10.0.1 | 10.5.0 |
+| Npgsql | 9.0.3 | 10.0.2 |
+| TUnit | 1.2.11 | 1.37.0 |
+| Microsoft.CodeAnalysis.CSharp | 4.14.0 | 5.3.0 |
+| Microsoft.CodeAnalysis.Analyzers | 4.14.0 | 5.3.0 |
+
+Held at current: NSubstitute 5.3.0 (6.0 RC skipped), MinVer 6.0.0, Lvlup.Build 1.4.0, Verify.SourceGenerators 2.5.0, BenchmarkDotNet 0.15.8.
+
+## Tasks
+
+### Task 1: Baseline characterization
+
+**Phase:** RED (capture baseline only)
+
+1. [RED] Establish current-state evidence:
+   - Run `dotnet build src/strategos.sln /p:TreatWarningsAsErrors=true` — record result.
+   - Run `dotnet test src/strategos.sln -- --treenode-filter "/*/*/*/Name"` — record pass count.
+   - Confirm Verify snapshots exist and are current in `Strategos.Generators.Tests` and `Strategos.Ontology.Generators.Tests`. Run those two test projects specifically — any mismatched snapshots must be resolved before proceeding.
+2. [GREEN] n/a (no code change).
+3. [REFACTOR] n/a.
+
+**File touched:** none (reports only).
+**Dependencies:** None.
+**Parallelizable:** No (blocks everything).
+**Exit criterion:** All three gates green; pass counts recorded in the task output for later regression comparison.
+
+---
+
+### Task 2: Patch bumps (bundle)
+
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] No new tests — characterization from Task 1 is the fence.
+2. [GREEN] Edit `src/Directory.Packages.props`:
+   - `Microsoft.Extensions.*` (6 entries): 10.0.0 → 10.0.6
+   - `MemoryPack`: 1.21.3 → 1.21.4
+   - `Pgvector`: 0.3.0 → 0.3.2
+   - `BitFaster.Caching`: 2.5.2 → 2.5.4
+   - `CommunityToolkit.HighPerformance`: 8.4.0 → 8.4.2
+3. [REFACTOR] Run gates (build + full test suite). Commit as `build(deps): patch bumps — Microsoft.Extensions.*, MemoryPack, Pgvector, BitFaster, CommunityToolkit`.
+
+**File touched:** `src/Directory.Packages.props`.
+**Dependencies:** Task 1.
+**Parallelizable:** No.
+**Exit criterion:** Build + full test suite green; no Verify snapshot drift.
+
+---
+
+### Task 3: Microsoft.Extensions.AI 10.0.1 → 10.5.0
+
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] No new tests.
+2. [GREEN] Edit `src/Directory.Packages.props`:
+   - `Microsoft.Extensions.AI`: 10.0.1 → 10.5.0
+   - `Microsoft.Extensions.AI.Abstractions`: 10.0.1 → 10.5.0 (must stay version-locked)
+3. [REFACTOR] Gates. Commit as `build(deps): Microsoft.Extensions.AI 10.0.1 → 10.5.0`.
+
+**File touched:** `src/Directory.Packages.props`.
+**Dependencies:** Task 2.
+**Parallelizable:** No.
+**Exit criterion:** Build + test suite green; `Strategos.Agents.Tests` passes without code changes (consumer references `IChatClient`-shaped types only).
+
+---
+
+### Task 4: Npgsql 9.0.3 → 10.0.2
+
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Inspect `src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs` and `PgVectorServiceCollectionExtensions.cs`. Confirm no use of:
+   - `date` / `time` columns (would trigger DateOnly/TimeOnly default mapping change).
+   - `cidr` type (NpgsqlCidr removed in favour of `IPNetwork`).
+   - `BeginTextImportAsync` / `BeginTextExportAsync` COPY APIs.
+   - `NpgsqlParameter` where both `DataTypeName` and `NpgsqlDbType` are set together.
+   Run `Strategos.Ontology.Npgsql.Tests` with current version to capture baseline.
+2. [GREEN] Edit `src/Directory.Packages.props`: `Npgsql` 9.0.3 → 10.0.2. Resolve any compile errors surfaced.
+3. [REFACTOR] Gates. Commit as `build(deps): Npgsql 9.0.3 → 10.0.2`.
+
+**File touched:** `src/Directory.Packages.props` + (contingent) `src/Strategos.Ontology.Npgsql/*.cs`.
+**Dependencies:** Task 3.
+**Parallelizable:** No.
+**Exit criterion:** Build + all tests green; `Strategos.Ontology.Npgsql.Tests` passes; no ontology integration behavior change.
+
+---
+
+### Task 5: TUnit 1.2.11 → 1.37.0
+
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Confirm current invocation syntax works (`-- --treenode-filter "/*/*/*/Name"`) — already the repo convention per `memory/feedback_tunit_test_invocation.md`.
+2. [GREEN] Edit `src/Directory.Packages.props`: `TUnit` 1.2.11 → 1.37.0. If any analyzer diagnostics surface on `[Test]` / `Assert.That` / `[Arguments]`, apply the mechanical fixes (rename, hook-lifecycle adjustments); do NOT refactor test structure beyond what the analyzer requires.
+3. [REFACTOR] Gates. Commit as `build(deps): TUnit 1.2.11 → 1.37.0`.
+
+**File touched:** `src/Directory.Packages.props` + (contingent) test files surfaced by analyzers.
+**Dependencies:** Task 4.
+**Parallelizable:** No.
+**Exit criterion:** All 12 test projects pass with the recorded invocation syntax. Pass count matches or exceeds Task 1 baseline.
+
+---
+
+### Task 6: Microsoft.CodeAnalysis.CSharp 4.14.0 → 5.3.0
+
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Verify baseline: run `Strategos.Generators.Tests` and `Strategos.Ontology.Generators.Tests` — confirm all Verify snapshots current.
+2. [GREEN] Edit `src/Directory.Packages.props`:
+   - `Microsoft.CodeAnalysis.CSharp`: 4.14.0 → 5.3.0
+   - `Microsoft.CodeAnalysis.Analyzers`: 4.14.0 → 5.3.0
+   Resolve any compile warnings in `Strategos.Generators` / `Strategos.Ontology.Generators` (netstandard2.0 targets, `IsRoslynComponent=true`).
+3. [REFACTOR] Run both generator test projects. Verify snapshots MUST match exactly (behavioral invariance). Commit as `build(deps): Microsoft.CodeAnalysis.CSharp 4.14.0 → 5.3.0 (Roslyn 5)`.
+
+**File touched:** `src/Directory.Packages.props` + (contingent) `src/Strategos.Generators/**/*.cs`, `src/Strategos.Ontology.Generators/**/*.cs`.
+**Dependencies:** Task 5.
+**Parallelizable:** No.
+**Exit criterion:** Both generator test projects pass with zero snapshot drift. Full-solution build + test green.
+
+---
+
+### Task 7: CHANGELOG + AGENTS.md update
+
+**Phase:** GREEN (docs only)
+
+1. [GREEN]
+   - Append to `CHANGELOG.md`: a `## Unreleased` subsection (or next version header if one exists) with a `Changed` entry summarizing the dep bumps.
+   - If Task 6 introduced a consumer SDK floor (e.g., Roslyn 5 requires .NET 10 SDK in consumer builds), add a note to `AGENTS.md` under the build requirements section. If no floor change, document this decision in the task output and skip the AGENTS.md edit.
+2. [REFACTOR] Commit as `docs: record dependency refresh in CHANGELOG`.
+
+**File touched:** `CHANGELOG.md`, optionally `AGENTS.md`.
+**Dependencies:** Task 6.
+**Parallelizable:** No.
+**Exit criterion:** Docs reflect the bumps; no further gates required.
+
+## Parallelization summary
+
+All tasks sequential. Total: 7 tasks. Each bump is a single commit behind a full validation pass, so the history tells a clear bisect story if anything regresses downstream.
+
+## Risk matrix
+
+| Task | Risk | Mitigation |
+|---|---|---|
+| 1 | Baseline reveals pre-existing failure | Abort workflow; fix baseline first |
+| 2 | Patch bump breaks downstream | Extremely unlikely; one commit per patch lineage |
+| 3 | MEAI 10.5 changes `IChatClient` shape | Read IL diff; shim if needed; escape hatch = revert to 10.0.6 held at that version floor |
+| 4 | Npgsql 10 type-mapping default flips behavior | RED step scans source for triggers; fallback = `LegacyPostgresTypeResolverFactory` |
+| 5 | TUnit analyzers fail ~35 minor jump | Apply mechanical fixes only; if API break detected, stage via 1.10/1.20/1.30 intermediate bumps |
+| 6 | Roslyn 5 changes generator output | Verify snapshots catch drift; resolve case-by-case |
+| 7 | Missed CHANGELOG entry | Trivial to amend |
+
+## Out of scope (per brief)
+
+- ModelContextProtocol SDK adoption → separate `/exarchos:ideate`.
+- MEAI 10.5 feature adoption in `Strategos.Agents` → future refactor.
+- NSubstitute 6.0 RC → wait for stable.
+- Npgsql 10 `DateOnly` migration in ontology types → N/A (no date/time columns).

--- a/global.json
+++ b/global.json
@@ -1,4 +1,8 @@
 {
+  "sdk": {
+    "version": "10.0.202",
+    "rollForward": "latestFeature"
+  },
   "msbuild-sdks": {},
   "test": {
     "runner": "Microsoft.Testing.Platform"

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -13,8 +13,8 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.AI" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.AI" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.5.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
     <PackageVersion Include="MinVer" Version="6.0.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -24,7 +24,7 @@
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
     <!-- PostgreSQL / pgvector -->
-    <PackageVersion Include="Npgsql" Version="9.0.3" />
+    <PackageVersion Include="Npgsql" Version="10.0.2" />
     <PackageVersion Include="Pgvector" Version="0.3.2" />
     <!-- Benchmark packages -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,13 +6,13 @@
     <!-- Build tooling -->
     <PackageVersion Include="Lvlup.Build" Version="1.4.0" />
 
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.5.0" />
     <PackageVersion Include="Microsoft.Extensions.AI" Version="10.0.1" />
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.0.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
@@ -25,12 +25,12 @@
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
     <!-- PostgreSQL / pgvector -->
     <PackageVersion Include="Npgsql" Version="9.0.3" />
-    <PackageVersion Include="Pgvector" Version="0.3.0" />
+    <PackageVersion Include="Pgvector" Version="0.3.2" />
     <!-- Benchmark packages -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
-    <PackageVersion Include="MemoryPack" Version="1.21.3" />
-    <PackageVersion Include="BitFaster.Caching" Version="2.5.2" />
-    <PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.4.0" />
+    <PackageVersion Include="MemoryPack" Version="1.21.4" />
+    <PackageVersion Include="BitFaster.Caching" Version="2.5.4" />
+    <PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.4.2" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <!-- Analyzers provided by Lvlup.Build -->
-    <PackageVersion Include="TUnit" Version="1.2.11" />
+    <PackageVersion Include="TUnit" Version="1.37.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
     <!-- PostgreSQL / pgvector -->

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -15,8 +15,8 @@
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.5.0" />
     <PackageVersion Include="Microsoft.Extensions.AI" Version="10.5.0" />
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <!-- Analyzers provided by Lvlup.Build -->

--- a/src/Strategos.Agents.Tests/Abstractions/IContextAssemblerTests.cs
+++ b/src/Strategos.Agents.Tests/Abstractions/IContextAssemblerTests.cs
@@ -35,7 +35,7 @@ public class IContextAssemblerTests
 
         // Verify method parameters
         var parameters = assembleMethod!.GetParameters();
-        await Assert.That(parameters).HasCount(3);
+        await Assert.That(parameters).Count().IsEqualTo(3);
         await Assert.That(parameters[0].Name).IsEqualTo("state");
         await Assert.That(parameters[1].Name).IsEqualTo("stepContext");
         await Assert.That(parameters[1].ParameterType).IsEqualTo(typeof(StepContext));

--- a/src/Strategos.Agents.Tests/Models/AssembledContextBuilderTests.cs
+++ b/src/Strategos.Agents.Tests/Models/AssembledContextBuilderTests.cs
@@ -30,7 +30,7 @@ public class AssembledContextBuilderTests
         var context = builder.Build();
 
         // Assert
-        await Assert.That(context.Segments).HasCount(1);
+        await Assert.That(context.Segments).Count().IsEqualTo(1);
         await Assert.That(context.Segments[0]).IsTypeOf<StateContextSegment>();
 
         var segment = (StateContextSegment)context.Segments[0];
@@ -61,12 +61,12 @@ public class AssembledContextBuilderTests
         var context = builder.Build();
 
         // Assert
-        await Assert.That(context.Segments).HasCount(1);
+        await Assert.That(context.Segments).Count().IsEqualTo(1);
         await Assert.That(context.Segments[0]).IsTypeOf<RetrievalContextSegment>();
 
         var segment = (RetrievalContextSegment)context.Segments[0];
         await Assert.That(segment.CollectionName).IsEqualTo("knowledge-base");
-        await Assert.That(segment.Results).HasCount(2);
+        await Assert.That(segment.Results).Count().IsEqualTo(2);
     }
 
     // =============================================================================
@@ -88,7 +88,7 @@ public class AssembledContextBuilderTests
         var context = builder.Build();
 
         // Assert
-        await Assert.That(context.Segments).HasCount(1);
+        await Assert.That(context.Segments).Count().IsEqualTo(1);
         await Assert.That(context.Segments[0]).IsTypeOf<LiteralContextSegment>();
 
         var segment = (LiteralContextSegment)context.Segments[0];
@@ -121,7 +121,7 @@ public class AssembledContextBuilderTests
         var context = builder.Build();
 
         // Assert
-        await Assert.That(context.Segments).HasCount(4);
+        await Assert.That(context.Segments).Count().IsEqualTo(4);
         await Assert.That(context.Segments[0]).IsTypeOf<LiteralContextSegment>();
         await Assert.That(context.Segments[1]).IsTypeOf<StateContextSegment>();
         await Assert.That(context.Segments[2]).IsTypeOf<RetrievalContextSegment>();
@@ -184,8 +184,8 @@ public class AssembledContextBuilderTests
         var context2 = builder.Build();
 
         // Assert
-        await Assert.That(context1.Segments).HasCount(1);
-        await Assert.That(context2.Segments).HasCount(1);
+        await Assert.That(context1.Segments).Count().IsEqualTo(1);
+        await Assert.That(context2.Segments).Count().IsEqualTo(1);
         await Assert.That(context1.ToPromptString()).IsEqualTo(context2.ToPromptString());
     }
 }

--- a/src/Strategos.Agents.Tests/Models/AssembledContextTests.cs
+++ b/src/Strategos.Agents.Tests/Models/AssembledContextTests.cs
@@ -26,7 +26,7 @@ public class AssembledContextTests
         var context = AssembledContext.Empty;
 
         // Assert
-        await Assert.That(context.Segments).HasCount(0);
+        await Assert.That(context.Segments).Count().IsEqualTo(0);
     }
 
     /// <summary>
@@ -63,7 +63,7 @@ public class AssembledContextTests
         var context = new AssembledContext(segments);
 
         // Assert
-        await Assert.That(context.Segments).HasCount(2);
+        await Assert.That(context.Segments).Count().IsEqualTo(2);
         await Assert.That(context.Segments[0]).IsTypeOf<LiteralContextSegment>();
         await Assert.That(context.Segments[1]).IsTypeOf<StateContextSegment>();
     }

--- a/src/Strategos.Agents.Tests/Models/WorkflowAgentContextTests.cs
+++ b/src/Strategos.Agents.Tests/Models/WorkflowAgentContextTests.cs
@@ -48,8 +48,8 @@ public class WorkflowAgentContextTests
         context.Messages.Add(new ChatMessage(ChatRole.User, "Hello"));
 
         // Assert
-        await Assert.That(context.Messages).HasCount(1);
-        await Assert.That(messages).HasCount(1); // Original list also updated
+        await Assert.That(context.Messages).Count().IsEqualTo(1);
+        await Assert.That(messages).Count().IsEqualTo(1); // Original list also updated
     }
 
     /// <summary>

--- a/src/Strategos.Generators.Tests/Emitters/Saga/HandlerContextTests.cs
+++ b/src/Strategos.Generators.Tests/Emitters/Saga/HandlerContextTests.cs
@@ -107,7 +107,7 @@ public class HandlerContextTests
 
         // Assert
         await Assert.That(context.LoopsAtStep).IsNotNull();
-        await Assert.That(context.LoopsAtStep).HasCount(1);
+        await Assert.That(context.LoopsAtStep).Count().IsEqualTo(1);
     }
 
     /// <summary>

--- a/src/Strategos.Generators.Tests/EventSourcedEmitterIntegrationTests.cs
+++ b/src/Strategos.Generators.Tests/EventSourcedEmitterIntegrationTests.cs
@@ -316,7 +316,7 @@ public class EventSourcedEmitterIntegrationTests
         var result = GeneratorTestHelper.RunGenerator(source);
         var diagnostics = result.Diagnostics;
 
-        await Assert.That(diagnostics).HasCount().GreaterThanOrEqualTo(1);
+        await Assert.That(diagnostics).Count().IsGreaterThanOrEqualTo(1);
         await Assert.That(diagnostics.Any(d => d.Id == "AGWF016")).IsTrue();
     }
 

--- a/src/Strategos.Generators.Tests/GeneratorIntegrationTests.cs
+++ b/src/Strategos.Generators.Tests/GeneratorIntegrationTests.cs
@@ -28,7 +28,7 @@ public class GeneratorIntegrationTests
         var result = GeneratorTestHelper.RunGenerator(SourceTexts.ClassWithWorkflowAttribute);
 
         // Assert
-        await Assert.That(result.GeneratedTrees).HasCount().GreaterThanOrEqualTo(1);
+        await Assert.That(result.GeneratedTrees).Count().IsGreaterThanOrEqualTo(1);
     }
 
     /// <summary>
@@ -82,7 +82,7 @@ public class GeneratorIntegrationTests
         var result = GeneratorTestHelper.RunGenerator(SourceTexts.StructWithWorkflowAttribute);
 
         // Assert
-        await Assert.That(result.GeneratedTrees).HasCount().GreaterThanOrEqualTo(1);
+        await Assert.That(result.GeneratedTrees).Count().IsGreaterThanOrEqualTo(1);
     }
 
     /// <summary>
@@ -255,7 +255,7 @@ public class GeneratorIntegrationTests
         var result = GeneratorTestHelper.RunGenerator(SourceTexts.VersionedWorkflowV2);
 
         // Assert
-        await Assert.That(result.GeneratedTrees).HasCount().GreaterThanOrEqualTo(1);
+        await Assert.That(result.GeneratedTrees).Count().IsGreaterThanOrEqualTo(1);
     }
 
     /// <summary>
@@ -394,7 +394,7 @@ public class GeneratorIntegrationTests
         var result = GeneratorTestHelper.RunGenerator(SourceTexts.LinearWorkflow);
 
         // Assert - Phase, Commands, Events, Transitions, Saga, Handlers, Extensions, Diagram = 8 files
-        await Assert.That(result.GeneratedTrees).HasCount().EqualTo(8);
+        await Assert.That(result.GeneratedTrees).Count().IsEqualTo(8);
     }
 
     // =============================================================================
@@ -411,7 +411,7 @@ public class GeneratorIntegrationTests
         var result = GeneratorTestHelper.RunGenerator(SourceTexts.WorkflowWithFork);
 
         // Assert - Phase, Commands, Events, Transitions, Saga, Handlers, Extensions, Diagram = 8 files
-        await Assert.That(result.GeneratedTrees).HasCount().EqualTo(8);
+        await Assert.That(result.GeneratedTrees).Count().IsEqualTo(8);
     }
 
     /// <summary>
@@ -603,7 +603,7 @@ public class GeneratorIntegrationTests
         var result = GeneratorTestHelper.RunGenerator(SourceTexts.WorkflowWithOnFailure);
 
         // Assert
-        await Assert.That(result.GeneratedTrees).HasCount().GreaterThanOrEqualTo(1);
+        await Assert.That(result.GeneratedTrees).Count().IsGreaterThanOrEqualTo(1);
     }
 
     /// <summary>
@@ -731,7 +731,7 @@ public class GeneratorIntegrationTests
         var result = GeneratorTestHelper.RunGenerator(SourceTexts.WorkflowWithInstanceNames);
 
         // Assert - Should generate 8 files
-        await Assert.That(result.GeneratedTrees).HasCount().EqualTo(8);
+        await Assert.That(result.GeneratedTrees).Count().IsEqualTo(8);
     }
 
     /// <summary>

--- a/src/Strategos.Generators.Tests/Helpers/ApprovalExtractorTests.cs
+++ b/src/Strategos.Generators.Tests/Helpers/ApprovalExtractorTests.cs
@@ -58,7 +58,7 @@ public class CompleteStep : IWorkflowStep<TestState> { }
         var result = ApprovalExtractor.Extract(context);
 
         // Assert
-        await Assert.That(result).HasCount().EqualTo(0);
+        await Assert.That(result).Count().IsEqualTo(0);
     }
 
     /// <summary>
@@ -94,7 +94,7 @@ public class ManagerApprover { }
         var result = ApprovalExtractor.Extract(context);
 
         // Assert
-        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result).Count().IsEqualTo(1);
     }
 
     /// <summary>
@@ -132,7 +132,7 @@ public class DirectorApprover { }
         var result = ApprovalExtractor.Extract(context);
 
         // Assert
-        await Assert.That(result).HasCount().EqualTo(2);
+        await Assert.That(result).Count().IsEqualTo(2);
     }
 
     // =============================================================================
@@ -372,10 +372,10 @@ public class ManagerApprover { }
         var result = ApprovalExtractor.Extract(context);
 
         // Assert
-        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result).Count().IsEqualTo(1);
         await Assert.That(result[0].HasRejection).IsTrue();
         await Assert.That(result[0].RejectionSteps).IsNotNull();
-        await Assert.That(result[0].RejectionSteps!).HasCount().EqualTo(1);
+        await Assert.That(result[0].RejectionSteps!).Count().IsEqualTo(1);
         await Assert.That(result[0].RejectionSteps![0].StepName).IsEqualTo("LogRejectionStep");
     }
 
@@ -415,7 +415,7 @@ public class ManagerApprover { }
         var result = ApprovalExtractor.Extract(context);
 
         // Assert
-        await Assert.That(result[0].RejectionSteps!).HasCount().EqualTo(2);
+        await Assert.That(result[0].RejectionSteps!).Count().IsEqualTo(2);
         await Assert.That(result[0].RejectionSteps![0].StepName).IsEqualTo("LogRejectionStep");
         await Assert.That(result[0].RejectionSteps![1].StepName).IsEqualTo("NotifyRequesterStep");
     }
@@ -532,10 +532,10 @@ public class ManagerApprover { }
         var result = ApprovalExtractor.Extract(context);
 
         // Assert
-        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result).Count().IsEqualTo(1);
         await Assert.That(result[0].HasEscalation).IsTrue();
         await Assert.That(result[0].EscalationSteps).IsNotNull();
-        await Assert.That(result[0].EscalationSteps!).HasCount().EqualTo(1);
+        await Assert.That(result[0].EscalationSteps!).Count().IsEqualTo(1);
         await Assert.That(result[0].EscalationSteps![0].StepName).IsEqualTo("NotifyEscalationStep");
     }
 
@@ -572,10 +572,10 @@ public class DirectorApprover { }
         var result = ApprovalExtractor.Extract(context);
 
         // Assert
-        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result).Count().IsEqualTo(1);
         await Assert.That(result[0].HasEscalation).IsTrue();
         await Assert.That(result[0].NestedEscalationApprovals).IsNotNull();
-        await Assert.That(result[0].NestedEscalationApprovals!).HasCount().EqualTo(1);
+        await Assert.That(result[0].NestedEscalationApprovals!).Count().IsEqualTo(1);
         await Assert.That(result[0].NestedEscalationApprovals![0].ApproverTypeName).IsEqualTo("DirectorApprover");
     }
 
@@ -661,17 +661,17 @@ public class DirectorApprover { }
         var result = ApprovalExtractor.Extract(context);
 
         // Assert
-        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result).Count().IsEqualTo(1);
 
         // Verify escalation
         await Assert.That(result[0].HasEscalation).IsTrue();
-        await Assert.That(result[0].EscalationSteps!).HasCount().EqualTo(1);
-        await Assert.That(result[0].NestedEscalationApprovals!).HasCount().EqualTo(1);
+        await Assert.That(result[0].EscalationSteps!).Count().IsEqualTo(1);
+        await Assert.That(result[0].NestedEscalationApprovals!).Count().IsEqualTo(1);
         await Assert.That(result[0].IsEscalationTerminal).IsFalse();
 
         // Verify rejection
         await Assert.That(result[0].HasRejection).IsTrue();
-        await Assert.That(result[0].RejectionSteps!).HasCount().EqualTo(1);
+        await Assert.That(result[0].RejectionSteps!).Count().IsEqualTo(1);
         await Assert.That(result[0].IsRejectionTerminal).IsTrue();
     }
 
@@ -713,10 +713,10 @@ public class DirectorApprover { }
         var result = ApprovalExtractor.Extract(context);
 
         // Assert
-        await Assert.That(result[0].EscalationSteps!).HasCount().EqualTo(2);
+        await Assert.That(result[0].EscalationSteps!).Count().IsEqualTo(2);
         await Assert.That(result[0].EscalationSteps![0].StepName).IsEqualTo("NotifyEscalationStep");
         await Assert.That(result[0].EscalationSteps![1].StepName).IsEqualTo("PrepareEscalationStep");
-        await Assert.That(result[0].NestedEscalationApprovals!).HasCount().EqualTo(1);
+        await Assert.That(result[0].NestedEscalationApprovals!).Count().IsEqualTo(1);
         await Assert.That(result[0].NestedEscalationApprovals![0].ApprovalPointName).IsEqualTo("Director");
     }
 
@@ -775,17 +775,17 @@ public class ManagerApprover { }
         var result = ApprovalExtractor.Extract(context);
 
         // Assert
-        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result).Count().IsEqualTo(1);
         await Assert.That(result[0].ApprovalPointName).IsEqualTo("Manager");
 
         // Verify rejection steps
         await Assert.That(result[0].HasRejection).IsTrue();
-        await Assert.That(result[0].RejectionSteps!).HasCount().EqualTo(1);
+        await Assert.That(result[0].RejectionSteps!).Count().IsEqualTo(1);
         await Assert.That(result[0].RejectionSteps![0].StepName).IsEqualTo("TerminateStep");
 
         // Verify escalation steps
         await Assert.That(result[0].HasEscalation).IsTrue();
-        await Assert.That(result[0].EscalationSteps!).HasCount().EqualTo(1);
+        await Assert.That(result[0].EscalationSteps!).Count().IsEqualTo(1);
         await Assert.That(result[0].EscalationSteps![0].StepName).IsEqualTo("AutoFailStep");
     }
 }

--- a/src/Strategos.Generators.Tests/Helpers/ContextModelExtractorTests.cs
+++ b/src/Strategos.Generators.Tests/Helpers/ContextModelExtractorTests.cs
@@ -43,7 +43,7 @@ public class ContextModelExtractorTests
         var stepContexts = ContextModelExtractor.Extract(context);
 
         // Assert
-        await Assert.That(stepContexts).HasCount(0);
+        await Assert.That(stepContexts).Count().IsEqualTo(0);
     }
 
     /// <summary>
@@ -71,10 +71,10 @@ public class ContextModelExtractorTests
         var stepContexts = ContextModelExtractor.Extract(context);
 
         // Assert
-        await Assert.That(stepContexts).HasCount(1);
+        await Assert.That(stepContexts).Count().IsEqualTo(1);
         var (stepName, contextModel) = stepContexts.First();
         await Assert.That(stepName).IsEqualTo("ValidateStep");
-        await Assert.That(contextModel.Sources).HasCount(1);
+        await Assert.That(contextModel.Sources).Count().IsEqualTo(1);
         await Assert.That(contextModel.Sources[0]).IsTypeOf<LiteralContextSourceModel>();
         var literal = (LiteralContextSourceModel)contextModel.Sources[0];
         await Assert.That(literal.Value).IsEqualTo("You are a helpful assistant.");
@@ -109,9 +109,9 @@ public class ContextModelExtractorTests
         var stepContexts = ContextModelExtractor.Extract(context);
 
         // Assert
-        await Assert.That(stepContexts).HasCount(1);
+        await Assert.That(stepContexts).Count().IsEqualTo(1);
         var (stepName, contextModel) = stepContexts.First();
-        await Assert.That(contextModel.Sources).HasCount(1);
+        await Assert.That(contextModel.Sources).Count().IsEqualTo(1);
         await Assert.That(contextModel.Sources[0]).IsTypeOf<StateContextSourceModel>();
         var stateSource = (StateContextSourceModel)contextModel.Sources[0];
         await Assert.That(stateSource.PropertyPath).IsEqualTo("CustomerName");
@@ -143,7 +143,7 @@ public class ContextModelExtractorTests
         var stepContexts = ContextModelExtractor.Extract(context);
 
         // Assert
-        await Assert.That(stepContexts).HasCount(1);
+        await Assert.That(stepContexts).Count().IsEqualTo(1);
         var (_, contextModel) = stepContexts.First();
         var stateSource = (StateContextSourceModel)contextModel.Sources[0];
         await Assert.That(stateSource.PropertyPath).IsEqualTo("Order.Summary");
@@ -179,9 +179,9 @@ public class ContextModelExtractorTests
         var stepContexts = ContextModelExtractor.Extract(context);
 
         // Assert
-        await Assert.That(stepContexts).HasCount(1);
+        await Assert.That(stepContexts).Count().IsEqualTo(1);
         var (_, contextModel) = stepContexts.First();
-        await Assert.That(contextModel.Sources).HasCount(1);
+        await Assert.That(contextModel.Sources).Count().IsEqualTo(1);
         await Assert.That(contextModel.Sources[0]).IsTypeOf<RetrievalContextSourceModel>();
         var retrieval = (RetrievalContextSourceModel)contextModel.Sources[0];
         await Assert.That(retrieval.CollectionTypeName).IsEqualTo("ProductCatalog");
@@ -216,10 +216,10 @@ public class ContextModelExtractorTests
         var stepContexts = ContextModelExtractor.Extract(context);
 
         // Assert
-        await Assert.That(stepContexts).HasCount(1);
+        await Assert.That(stepContexts).Count().IsEqualTo(1);
         var (_, contextModel) = stepContexts.First();
         var retrieval = (RetrievalContextSourceModel)contextModel.Sources[0];
-        await Assert.That(retrieval.Filters).HasCount(1);
+        await Assert.That(retrieval.Filters).Count().IsEqualTo(1);
         await Assert.That(retrieval.Filters[0].Key).IsEqualTo("category");
         await Assert.That(retrieval.Filters[0].IsStatic).IsTrue();
     }
@@ -250,7 +250,7 @@ public class ContextModelExtractorTests
         var stepContexts = ContextModelExtractor.Extract(context);
 
         // Assert
-        await Assert.That(stepContexts).HasCount(1);
+        await Assert.That(stepContexts).Count().IsEqualTo(1);
         var (_, contextModel) = stepContexts.First();
         var retrieval = (RetrievalContextSourceModel)contextModel.Sources[0];
         await Assert.That(retrieval.QueryExpression).IsNotNull();

--- a/src/Strategos.Generators.Tests/Helpers/FailureHandlerExtractorTests.cs
+++ b/src/Strategos.Generators.Tests/Helpers/FailureHandlerExtractorTests.cs
@@ -57,7 +57,7 @@ public class CompleteStep : IWorkflowStep<TestState> { }
         var result = FailureHandlerExtractor.Extract(context);
 
         // Assert
-        await Assert.That(result).HasCount().EqualTo(0);
+        await Assert.That(result).Count().IsEqualTo(0);
     }
 
     /// <summary>
@@ -91,7 +91,7 @@ public class LogFailure : IWorkflowStep<TestState> { }
         var result = FailureHandlerExtractor.Extract(context);
 
         // Assert
-        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result).Count().IsEqualTo(1);
         await Assert.That(result[0].Scope).IsEqualTo(FailureHandlerScope.Workflow);
     }
 
@@ -130,7 +130,7 @@ public class NotifyAdmin : IWorkflowStep<TestState> { }
         var result = FailureHandlerExtractor.Extract(context);
 
         // Assert
-        await Assert.That(result[0].StepNames).HasCount().EqualTo(2);
+        await Assert.That(result[0].StepNames).Count().IsEqualTo(2);
         await Assert.That(result[0].StepNames[0]).IsEqualTo("LogFailure");
         await Assert.That(result[0].StepNames[1]).IsEqualTo("NotifyAdmin");
     }

--- a/src/Strategos.Generators.Tests/Models/ApprovalModelTests.cs
+++ b/src/Strategos.Generators.Tests/Models/ApprovalModelTests.cs
@@ -160,7 +160,7 @@ public class ApprovalModelTests
             escalationSteps: escalationSteps);
 
         // Assert
-        await Assert.That(model.EscalationSteps).HasCount().EqualTo(1);
+        await Assert.That(model.EscalationSteps).Count().IsEqualTo(1);
         await Assert.That(model.EscalationSteps![0].StepName).IsEqualTo("NotifyAdmin");
     }
 
@@ -184,7 +184,7 @@ public class ApprovalModelTests
             rejectionSteps: rejectionSteps);
 
         // Assert
-        await Assert.That(model.RejectionSteps).HasCount().EqualTo(1);
+        await Assert.That(model.RejectionSteps).Count().IsEqualTo(1);
         await Assert.That(model.RejectionSteps![0].StepName).IsEqualTo("LogRejection");
     }
 
@@ -210,7 +210,7 @@ public class ApprovalModelTests
             nestedEscalationApprovals: nestedApprovals);
 
         // Assert
-        await Assert.That(model.NestedEscalationApprovals).HasCount().EqualTo(1);
+        await Assert.That(model.NestedEscalationApprovals).Count().IsEqualTo(1);
         await Assert.That(model.NestedEscalationApprovals![0].ApprovalPointName).IsEqualTo("DirectorReview");
     }
 

--- a/src/Strategos.Generators.Tests/Models/BranchModelTests.cs
+++ b/src/Strategos.Generators.Tests/Models/BranchModelTests.cs
@@ -34,7 +34,7 @@ public class BranchModelTests
         // Assert
         await Assert.That(model.CaseValueLiteral).IsEqualTo("OrderStatus.Approved");
         await Assert.That(model.BranchPathPrefix).IsEqualTo("Approved");
-        await Assert.That(model.StepNames).HasCount().EqualTo(2);
+        await Assert.That(model.StepNames).Count().IsEqualTo(2);
         await Assert.That(model.IsTerminal).IsFalse();
     }
 
@@ -232,7 +232,7 @@ public class BranchModelTests
         await Assert.That(model.DiscriminatorPropertyPath).IsEqualTo("Status");
         await Assert.That(model.DiscriminatorTypeName).IsEqualTo("OrderStatus");
         await Assert.That(model.IsEnumDiscriminator).IsTrue();
-        await Assert.That(model.Cases).HasCount().EqualTo(2);
+        await Assert.That(model.Cases).Count().IsEqualTo(2);
         await Assert.That(model.RejoinStepName).IsEqualTo("Complete");
     }
 

--- a/src/Strategos.Generators.Tests/Models/StateModelTests.cs
+++ b/src/Strategos.Generators.Tests/Models/StateModelTests.cs
@@ -103,7 +103,7 @@ public class StateModelTests
         // Assert
         await Assert.That(model.TypeName).IsEqualTo("OrderState");
         await Assert.That(model.Namespace).IsEqualTo("TestNamespace");
-        await Assert.That(model.Properties).HasCount().EqualTo(1);
+        await Assert.That(model.Properties).Count().IsEqualTo(1);
     }
 
     /// <summary>
@@ -137,7 +137,7 @@ public class StateModelTests
         var model = new StateModel("OrderState", "TestNamespace", properties);
 
         // Assert
-        await Assert.That(model.Properties).HasCount().EqualTo(3);
+        await Assert.That(model.Properties).Count().IsEqualTo(3);
         await Assert.That(model.Properties[0].Name).IsEqualTo("Status");
         await Assert.That(model.Properties[1].Kind).IsEqualTo(StatePropertyKind.Append);
         await Assert.That(model.Properties[2].Kind).IsEqualTo(StatePropertyKind.Merge);

--- a/src/Strategos.Generators.Tests/Models/StepModelContextTests.cs
+++ b/src/Strategos.Generators.Tests/Models/StepModelContextTests.cs
@@ -39,7 +39,7 @@ public class StepModelContextTests
 
         // Assert
         await Assert.That(model.Context).IsNotNull();
-        await Assert.That(model.Context!.Sources).HasCount(1);
+        await Assert.That(model.Context!.Sources).Count().IsEqualTo(1);
     }
 
     /// <summary>
@@ -74,7 +74,7 @@ public class StepModelContextTests
         var context = new ContextModel(sources);
 
         // Assert
-        await Assert.That(context.Sources).HasCount(2);
+        await Assert.That(context.Sources).Count().IsEqualTo(2);
         await Assert.That(context.Sources[0]).IsTypeOf<LiteralContextSourceModel>();
         await Assert.That(context.Sources[1]).IsTypeOf<StateContextSourceModel>();
     }

--- a/src/Strategos.Generators.Tests/Models/WorkflowModelTests.cs
+++ b/src/Strategos.Generators.Tests/Models/WorkflowModelTests.cs
@@ -467,7 +467,7 @@ public class WorkflowModelTests
         await Assert.That(model.Branches).IsNotNull();
         await Assert.That(model.Branches!.Count).IsEqualTo(1);
         await Assert.That(model.Branches[0].BranchId).IsEqualTo("ProcessOrder-Status");
-        await Assert.That(model.Branches[0].Cases).HasCount().EqualTo(2);
+        await Assert.That(model.Branches[0].Cases).Count().IsEqualTo(2);
     }
 
     /// <summary>

--- a/src/Strategos.Generators.Tests/StateReducerGeneratorIntegrationTests.cs
+++ b/src/Strategos.Generators.Tests/StateReducerGeneratorIntegrationTests.cs
@@ -28,7 +28,7 @@ public class StateReducerGeneratorIntegrationTests
         var result = GeneratorTestHelper.RunStateReducerGenerator(SourceTexts.StateWithStandardProperties);
 
         // Assert
-        await Assert.That(result.GeneratedTrees).HasCount().GreaterThanOrEqualTo(1);
+        await Assert.That(result.GeneratedTrees).Count().IsGreaterThanOrEqualTo(1);
     }
 
     /// <summary>
@@ -54,7 +54,7 @@ public class StateReducerGeneratorIntegrationTests
         var result = GeneratorTestHelper.RunStateReducerGenerator(SourceTexts.StructWithWorkflowState);
 
         // Assert
-        await Assert.That(result.GeneratedTrees).HasCount().GreaterThanOrEqualTo(1);
+        await Assert.That(result.GeneratedTrees).Count().IsGreaterThanOrEqualTo(1);
     }
 
     /// <summary>

--- a/src/Strategos.Infrastructure.Tests/ArtifactStores/FileSystemArtifactStoreTests.cs
+++ b/src/Strategos.Infrastructure.Tests/ArtifactStores/FileSystemArtifactStoreTests.cs
@@ -429,7 +429,7 @@ public sealed class FileSystemArtifactStoreTests : IAsyncDisposable
 
         // Assert - All URIs should be unique
         var uniqueUris = uris.Distinct().ToList();
-        await Assert.That(uniqueUris).HasCount(concurrentCount);
+        await Assert.That(uniqueUris).Count().IsEqualTo(concurrentCount);
     }
 
     /// <summary>
@@ -507,7 +507,7 @@ public sealed class FileSystemArtifactStoreTests : IAsyncDisposable
 
         // Assert
         await Assert.That(retrieved.Name).IsEqualTo("root");
-        await Assert.That(retrieved.Tags).HasCount(3);
+        await Assert.That(retrieved.Tags).Count().IsEqualTo(3);
         await Assert.That(retrieved.Tags).Contains("tag2");
         await Assert.That(retrieved.Nested).IsNotNull();
         await Assert.That(retrieved.Nested!.Value).IsEqualTo(42);

--- a/src/Strategos.Infrastructure.Tests/ArtifactStores/InMemoryArtifactStoreTests.cs
+++ b/src/Strategos.Infrastructure.Tests/ArtifactStores/InMemoryArtifactStoreTests.cs
@@ -380,7 +380,7 @@ public sealed class InMemoryArtifactStoreTests
         // Assert
         await Assert.That(result.Id).IsEqualTo(42);
         await Assert.That(result.Name).IsEqualTo("Test Artifact");
-        await Assert.That(result.Tags).HasCount(3);
+        await Assert.That(result.Tags).Count().IsEqualTo(3);
         await Assert.That(result.Metadata).ContainsKey("key1");
         await Assert.That(result.Nested).IsNotNull();
         await Assert.That(result.Nested!.Level).IsEqualTo(1);

--- a/src/Strategos.Infrastructure.Tests/Ledgers/TaskLedgerHashingTests.cs
+++ b/src/Strategos.Infrastructure.Tests/Ledgers/TaskLedgerHashingTests.cs
@@ -134,7 +134,7 @@ public sealed class TaskLedgerHashingTests
 
         // Assert - All hashes should be identical
         var firstHash = hashes[0];
-        await Assert.That(hashes).HasCount().EqualTo(10);
+        await Assert.That(hashes).Count().IsEqualTo(10);
         foreach (var hash in hashes)
         {
             await Assert.That(hash).IsEqualTo(firstHash);
@@ -166,7 +166,7 @@ public sealed class TaskLedgerHashingTests
         // Assert - Hash should be computed and valid
         await Assert.That(ledger.ContentHash).IsNotNull();
         await Assert.That(ledger.ContentHash.Length).IsEqualTo(64); // SHA-256 produces 64 hex characters
-        await Assert.That(ledger.Tasks).HasCount().EqualTo(1000);
+        await Assert.That(ledger.Tasks).Count().IsEqualTo(1000);
         await Assert.That(ledger.VerifyIntegrity()).IsTrue();
     }
 

--- a/src/Strategos.Infrastructure.Tests/LoopDetection/LoopDetectorSemanticAllocationTests.cs
+++ b/src/Strategos.Infrastructure.Tests/LoopDetection/LoopDetectorSemanticAllocationTests.cs
@@ -183,7 +183,7 @@ public sealed class LoopDetectorSemanticAllocationTests
         await detector.DetectAsync(ledger).ConfigureAwait(false);
 
         // Assert
-        await Assert.That(capturedOutputs).HasCount(5);
+        await Assert.That(capturedOutputs).Count().IsEqualTo(5);
         await Assert.That(capturedOutputs).Contains("Output A");
         await Assert.That(capturedOutputs).Contains("Output B");
         await Assert.That(capturedOutputs).Contains("Output C");
@@ -221,7 +221,7 @@ public sealed class LoopDetectorSemanticAllocationTests
         await detector.DetectAsync(ledger).ConfigureAwait(false);
 
         // Assert
-        await Assert.That(capturedOutputs).HasCount(5);
+        await Assert.That(capturedOutputs).Count().IsEqualTo(5);
         // Verify null values are preserved
         var nullCount = capturedOutputs.Count(o => o is null);
         await Assert.That(nullCount).IsEqualTo(3);

--- a/src/Strategos.Ontology.MCP.Tests/OntologyActionToolResilienceTests.cs
+++ b/src/Strategos.Ontology.MCP.Tests/OntologyActionToolResilienceTests.cs
@@ -94,7 +94,7 @@ public class OntologyActionToolResilienceTests
             filter: "Symbol == 'AAPL'");
 
         // Assert - should still return error result (not throw)
-        await Assert.That(result.Results).HasCount().EqualTo(1);
+        await Assert.That(result.Results).Count().IsEqualTo(1);
         await Assert.That(result.Results[0].IsSuccess).IsFalse();
         await Assert.That(result.Results[0].Error).Contains("Test exception");
 

--- a/src/Strategos.Ontology.MCP.Tests/OntologyActionToolTests.cs
+++ b/src/Strategos.Ontology.MCP.Tests/OntologyActionToolTests.cs
@@ -41,7 +41,7 @@ public class OntologyActionToolTests
             objectId: "p1");
 
         // Assert
-        await Assert.That(result.Results).HasCount().EqualTo(1);
+        await Assert.That(result.Results).Count().IsEqualTo(1);
         await Assert.That(result.Results[0].IsSuccess).IsTrue();
 
         // Verify dispatcher was called with the correct context
@@ -84,7 +84,7 @@ public class OntologyActionToolTests
             filter: "Symbol == 'AAPL'");
 
         // Assert — should dispatch to each matched object
-        await Assert.That(result.Results).HasCount().EqualTo(2);
+        await Assert.That(result.Results).Count().IsEqualTo(2);
         await _actionDispatcher.Received(2).DispatchAsync(
             Arg.Any<ActionContext>(),
             Arg.Any<object>(),
@@ -145,7 +145,7 @@ public class OntologyActionToolTests
             objectId: "p1");
 
         // Assert
-        await Assert.That(result.Results).HasCount().EqualTo(1);
+        await Assert.That(result.Results).Count().IsEqualTo(1);
         await Assert.That(result.Results[0].IsSuccess).IsFalse();
         await Assert.That(result.Results[0].Error).Contains("nonexistent_action");
     }
@@ -162,7 +162,7 @@ public class OntologyActionToolTests
             objectId: "p1");
 
         // Assert
-        await Assert.That(result.Results).HasCount().EqualTo(1);
+        await Assert.That(result.Results).Count().IsEqualTo(1);
         await Assert.That(result.Results[0].IsSuccess).IsFalse();
         await Assert.That(result.Results[0].Error).Contains("NonExistentType");
     }

--- a/src/Strategos.Ontology.MCP.Tests/OntologyExploreToolTests.cs
+++ b/src/Strategos.Ontology.MCP.Tests/OntologyExploreToolTests.cs
@@ -22,7 +22,7 @@ public class OntologyExploreToolTests
 
         // Assert
         await Assert.That(result.Scope).IsEqualTo("domains");
-        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items).Count().IsEqualTo(1);
 
         var domain = result.Items[0];
         await Assert.That(domain.ContainsKey("domainName")).IsTrue();
@@ -52,7 +52,7 @@ public class OntologyExploreToolTests
 
         // Assert
         await Assert.That(result.Scope).IsEqualTo("actions");
-        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items).Count().IsEqualTo(1);
         await Assert.That(result.Items[0]["name"]?.ToString()).IsEqualTo("execute_trade");
         await Assert.That(result.Items[0]["description"]?.ToString()).IsEqualTo("Execute a trade on the position");
     }
@@ -65,7 +65,7 @@ public class OntologyExploreToolTests
 
         // Assert
         await Assert.That(result.Scope).IsEqualTo("links");
-        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items).Count().IsEqualTo(1);
         await Assert.That(result.Items[0]["name"]?.ToString()).IsEqualTo("Orders");
         await Assert.That(result.Items[0]["targetTypeName"]?.ToString()).IsEqualTo("TestOrder");
     }
@@ -78,7 +78,7 @@ public class OntologyExploreToolTests
 
         // Assert
         await Assert.That(result.Scope).IsEqualTo("events");
-        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items).Count().IsEqualTo(1);
         await Assert.That(result.Items[0]["description"]?.ToString()).IsEqualTo("Trade was executed");
     }
 
@@ -112,13 +112,13 @@ public class OntologyExploreToolTests
 
         // Assert — should return only types with vector properties
         await Assert.That(result.Scope).IsEqualTo("vectorProperties");
-        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items).Count().IsEqualTo(1);
         await Assert.That(result.Items[0]["name"]?.ToString()).IsEqualTo("TestDocument");
         await Assert.That(result.Items[0]["domain"]?.ToString()).IsEqualTo("content");
 
         var vectorProps = result.Items[0]["vectorProperties"] as IReadOnlyList<Dictionary<string, object?>>;
         await Assert.That(vectorProps).IsNotNull();
-        await Assert.That(vectorProps!).HasCount().EqualTo(1);
+        await Assert.That(vectorProps!).Count().IsEqualTo(1);
         await Assert.That(vectorProps[0]["name"]?.ToString()).IsEqualTo("Embedding");
         await Assert.That(vectorProps[0]["dimensions"]).IsEqualTo(1536);
     }
@@ -130,7 +130,7 @@ public class OntologyExploreToolTests
         var result = _tool.Explore(scope: "links", domain: "trading", objectType: "TestPosition");
 
         // Assert
-        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items).Count().IsEqualTo(1);
         await Assert.That(result.Items[0].ContainsKey("description")).IsTrue();
         await Assert.That(result.Items[0]["description"]?.ToString())
             .IsEqualTo("Orders placed against this position");
@@ -169,7 +169,7 @@ public class OntologyExploreToolTests
         var docType = result.Items.First(i => i["name"]?.ToString() == "TestDocument");
         var imgType = result.Items.First(i => i["name"]?.ToString() == "TestImage");
 
-        await Assert.That(docType["isSemanticSearchable"]).IsEqualTo(true);
-        await Assert.That(imgType["isSemanticSearchable"]).IsEqualTo(false);
+        await Assert.That((bool)docType["isSemanticSearchable"]!).IsTrue();
+        await Assert.That((bool)imgType["isSemanticSearchable"]!).IsFalse();
     }
 }

--- a/src/Strategos.Ontology.MCP.Tests/OntologyQueryToolTests.cs
+++ b/src/Strategos.Ontology.MCP.Tests/OntologyQueryToolTests.cs
@@ -37,7 +37,7 @@ public class OntologyQueryToolTests
 
         // Assert
         await Assert.That(result.ObjectType).IsEqualTo("TestPosition");
-        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items).Count().IsEqualTo(1);
     }
 
     [Test]
@@ -58,7 +58,7 @@ public class OntologyQueryToolTests
         // Assert
         await Assert.That(result.ObjectType).IsEqualTo("TestPosition");
         await Assert.That(result.Filter).IsEqualTo("Symbol == 'AAPL'");
-        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items).Count().IsEqualTo(1);
     }
 
     [Test]
@@ -78,7 +78,7 @@ public class OntologyQueryToolTests
 
         // Assert
         await Assert.That(result.TraverseLink).IsEqualTo("Orders");
-        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items).Count().IsEqualTo(1);
     }
 
     [Test]
@@ -98,7 +98,7 @@ public class OntologyQueryToolTests
 
         // Assert
         await Assert.That(result.InterfaceName).IsEqualTo("Searchable");
-        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items).Count().IsEqualTo(1);
     }
 
     [Test]
@@ -118,7 +118,7 @@ public class OntologyQueryToolTests
 
         // Assert
         await Assert.That(result.Include).IsEqualTo("Full");
-        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items).Count().IsEqualTo(1);
     }
 
     [Test]
@@ -235,7 +235,7 @@ public class OntologyQueryToolTests
             domain: "trading");
 
         // Assert
-        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result).Count().IsEqualTo(1);
         await Assert.That(result[0].EventType).IsEqualTo("TradeExecuted");
     }
 
@@ -284,7 +284,7 @@ public class OntologyQueryToolTests
         // Assert
         await Assert.That(result).IsTypeOf<SemanticQueryResult>();
         var semanticResult = (SemanticQueryResult)result;
-        await Assert.That(semanticResult.Scores).HasCount().EqualTo(1);
+        await Assert.That(semanticResult.Scores).Count().IsEqualTo(1);
         await Assert.That(semanticResult.Scores[0]).IsEqualTo(0.92);
         await Assert.That(semanticResult.SemanticQuery).IsEqualTo("high-value tech stocks");
     }
@@ -333,7 +333,7 @@ public class OntologyQueryToolTests
         // Assert — without semanticQuery, should return plain QueryResult, not SemanticQueryResult
         await Assert.That(result).IsTypeOf<QueryResult>();
         await Assert.That(result.ObjectType).IsEqualTo("TestPosition");
-        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items).Count().IsEqualTo(1);
     }
 
     [Test]

--- a/src/Strategos.Ontology.MCP.Tests/OntologyStubGeneratorTests.cs
+++ b/src/Strategos.Ontology.MCP.Tests/OntologyStubGeneratorTests.cs
@@ -21,7 +21,7 @@ public class OntologyStubGeneratorTests
         var stubs = _generator.Generate();
 
         // Assert — should produce stubs for each object type
-        await Assert.That(stubs).HasCount().EqualTo(2); // TestPosition, TestOrder
+        await Assert.That(stubs).Count().IsEqualTo(2); // TestPosition, TestOrder
         await Assert.That(stubs[0]).Contains("class ");
         await Assert.That(stubs[0]).Contains("\"\"\"");
     }

--- a/src/Strategos.Ontology.MCP.Tests/OntologyToolDiscoveryTests.cs
+++ b/src/Strategos.Ontology.MCP.Tests/OntologyToolDiscoveryTests.cs
@@ -16,7 +16,7 @@ public class OntologyToolDiscoveryTests
         var tools = discovery.Discover();
 
         // Assert — should return exactly 3 tools
-        await Assert.That(tools).HasCount().EqualTo(3);
+        await Assert.That(tools).Count().IsEqualTo(3);
     }
 
     [Test]
@@ -64,7 +64,7 @@ public class OntologyToolDiscoveryTests
         var actionTool = tools.First(t => t.Name == "ontology_action");
 
         // Assert — should have constraint summaries for the constrained action
-        await Assert.That(actionTool.ConstraintSummaries).HasCount().GreaterThanOrEqualTo(1);
+        await Assert.That(actionTool.ConstraintSummaries).Count().IsGreaterThanOrEqualTo(1);
         await Assert.That(actionTool.ConstraintSummaries.Select(s => s.ActionName))
             .Contains("close_account");
     }
@@ -101,7 +101,7 @@ public class OntologyToolDiscoveryTests
             .First(s => s.ActionName == "close_account");
 
         // Assert — descriptions should be populated and non-empty
-        await Assert.That(summary.ConstraintDescriptions).HasCount().EqualTo(3);
+        await Assert.That(summary.ConstraintDescriptions).Count().IsEqualTo(3);
         await Assert.That(summary.ConstraintDescriptions.All(d => !string.IsNullOrWhiteSpace(d)))
             .IsTrue();
     }
@@ -118,7 +118,7 @@ public class OntologyToolDiscoveryTests
         var actionTool = tools.First(t => t.Name == "ontology_action");
 
         // Assert
-        await Assert.That(actionTool.ConstraintSummaries).HasCount().EqualTo(0);
+        await Assert.That(actionTool.ConstraintSummaries).Count().IsEqualTo(0);
     }
 
     [Test]
@@ -133,7 +133,7 @@ public class OntologyToolDiscoveryTests
         var exploreTool = tools.First(t => t.Name == "ontology_explore");
 
         // Assert — constraint summaries are only attached to ontology_action, not explore
-        await Assert.That(exploreTool.ConstraintSummaries).HasCount().EqualTo(0);
+        await Assert.That(exploreTool.ConstraintSummaries).Count().IsEqualTo(0);
     }
 
     [Test]

--- a/src/Strategos.Ontology.MCP.Tests/SemanticQueryResultTests.cs
+++ b/src/Strategos.Ontology.MCP.Tests/SemanticQueryResultTests.cs
@@ -22,8 +22,8 @@ public class SemanticQueryResultTests
         QueryResult queryResult = result;
         await Assert.That(queryResult).IsNotNull();
         await Assert.That(result.ObjectType).IsEqualTo("TestDocument");
-        await Assert.That(result.Items).HasCount().EqualTo(1);
-        await Assert.That(result.Scores).HasCount().EqualTo(1);
+        await Assert.That(result.Items).Count().IsEqualTo(1);
+        await Assert.That(result.Scores).Count().IsEqualTo(1);
         await Assert.That(result.Scores[0]).IsEqualTo(0.95);
         await Assert.That(result.SemanticQuery).IsEqualTo("find relevant documents");
         await Assert.That(result.TopK).IsEqualTo(5);

--- a/src/Strategos.Ontology.Npgsql.Tests/Integration/IngestionPipelineIntegrationTests.cs
+++ b/src/Strategos.Ontology.Npgsql.Tests/Integration/IngestionPipelineIntegrationTests.cs
@@ -157,7 +157,7 @@ public class IngestionPipelineIntegrationTests
 
         // Verify graph was built with our domain
         var graph = provider.GetRequiredService<OntologyGraph>();
-        await Assert.That(graph.Domains).HasCount().EqualTo(1);
+        await Assert.That(graph.Domains).Count().IsEqualTo(1);
 
         var domain = graph.Domains[0];
         await Assert.That(domain.DomainName).IsEqualTo("documents");

--- a/src/Strategos.Ontology.Npgsql.Tests/Internal/ExpressionTranslatorTests.cs
+++ b/src/Strategos.Ontology.Npgsql.Tests/Internal/ExpressionTranslatorTests.cs
@@ -13,7 +13,7 @@ public class ExpressionTranslatorTests
         var result = ExpressionTranslator.Translate(root);
 
         await Assert.That(result.WhereClause).IsNull();
-        await Assert.That(result.Parameters).HasCount().EqualTo(0);
+        await Assert.That(result.Parameters).Count().IsEqualTo(0);
     }
 
     [Test]
@@ -26,7 +26,7 @@ public class ExpressionTranslatorTests
         var result = ExpressionTranslator.Translate(filter);
 
         await Assert.That(result.WhereClause).IsEqualTo("data->>'Name' = @p0");
-        await Assert.That(result.Parameters).HasCount().EqualTo(1);
+        await Assert.That(result.Parameters).Count().IsEqualTo(1);
         await Assert.That(result.Parameters[0].Name).IsEqualTo("@p0");
         await Assert.That(result.Parameters[0].Value).IsEqualTo("foo");
     }
@@ -69,7 +69,7 @@ public class ExpressionTranslatorTests
         var result = ExpressionTranslator.Translate(filter2);
 
         await Assert.That(result.WhereClause).IsEqualTo("data->>'Name' = @p0 AND (data->>'Age')::numeric > @p1");
-        await Assert.That(result.Parameters).HasCount().EqualTo(2);
+        await Assert.That(result.Parameters).Count().IsEqualTo(2);
     }
 
     [Test]
@@ -82,7 +82,7 @@ public class ExpressionTranslatorTests
         var result = ExpressionTranslator.Translate(filter);
 
         await Assert.That(result.WhereClause).Contains("AND");
-        await Assert.That(result.Parameters).HasCount().EqualTo(2);
+        await Assert.That(result.Parameters).Count().IsEqualTo(2);
     }
 
     [Test]
@@ -95,7 +95,7 @@ public class ExpressionTranslatorTests
         var result = ExpressionTranslator.Translate(filter);
 
         await Assert.That(result.WhereClause).Contains("OR");
-        await Assert.That(result.Parameters).HasCount().EqualTo(2);
+        await Assert.That(result.Parameters).Count().IsEqualTo(2);
     }
 
     [Test]

--- a/src/Strategos.Ontology.Npgsql.Tests/PgVectorSimilarityTests.cs
+++ b/src/Strategos.Ontology.Npgsql.Tests/PgVectorSimilarityTests.cs
@@ -56,7 +56,7 @@ public class PgVectorSimilarityTests
             .Returns(Task.FromResult(new float[] { 0.1f, 0.2f, 0.3f }));
 
         var result = await embeddingProvider.EmbedAsync("search term");
-        await Assert.That(result).HasCount().EqualTo(3);
+        await Assert.That(result).Count().IsEqualTo(3);
         await embeddingProvider.Received(1).EmbedAsync("search term", Arg.Any<CancellationToken>());
     }
 

--- a/src/Strategos.Ontology.Tests/Builder/InterfacePropertyMappingTests.cs
+++ b/src/Strategos.Ontology.Tests/Builder/InterfacePropertyMappingTests.cs
@@ -105,8 +105,8 @@ public class InterfacePropertyMappingTests
 
         var graph = graphBuilder.Build();
 
-        await Assert.That(graph.ObjectTypes).HasCount().EqualTo(1);
-        await Assert.That(graph.ObjectTypes[0].ImplementedInterfaces).HasCount().EqualTo(1);
+        await Assert.That(graph.ObjectTypes).Count().IsEqualTo(1);
+        await Assert.That(graph.ObjectTypes[0].ImplementedInterfaces).Count().IsEqualTo(1);
     }
 
     [Test]
@@ -128,8 +128,8 @@ public class InterfacePropertyMappingTests
 
         var graph = graphBuilder.Build();
 
-        await Assert.That(graph.ObjectTypes).HasCount().EqualTo(1);
-        await Assert.That(graph.ObjectTypes[0].ImplementedInterfaces).HasCount().EqualTo(1);
+        await Assert.That(graph.ObjectTypes).Count().IsEqualTo(1);
+        await Assert.That(graph.ObjectTypes[0].ImplementedInterfaces).Count().IsEqualTo(1);
     }
 
     [Test]
@@ -146,7 +146,7 @@ public class InterfacePropertyMappingTests
 
         var descriptor = builder.Build();
 
-        await Assert.That(descriptor.InterfacePropertyMappings).HasCount().EqualTo(2);
+        await Assert.That(descriptor.InterfacePropertyMappings).Count().IsEqualTo(2);
         await Assert.That(descriptor.InterfacePropertyMappings[0].SourcePropertyName).IsEqualTo("Name");
         await Assert.That(descriptor.InterfacePropertyMappings[0].TargetPropertyName).IsEqualTo("DisplayName");
         await Assert.That(descriptor.InterfacePropertyMappings[0].InterfaceName).IsEqualTo("IMappableInterface");

--- a/src/Strategos.Ontology.Tests/Chunking/ChunkingTypesTests.cs
+++ b/src/Strategos.Ontology.Tests/Chunking/ChunkingTypesTests.cs
@@ -61,7 +61,7 @@ public class ChunkingTypesTests
 
         // Assert
         await Assert.That(result).IsNotNull();
-        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result).Count().IsEqualTo(1);
         await Assert.That(result[0].Content).IsEqualTo(text);
         await Assert.That(result[0].Index).IsEqualTo(0);
         await Assert.That(result[0].StartOffset).IsEqualTo(0);

--- a/src/Strategos.Ontology.Tests/Chunking/FixedSizeChunkerTests.cs
+++ b/src/Strategos.Ontology.Tests/Chunking/FixedSizeChunkerTests.cs
@@ -22,7 +22,7 @@ public class FixedSizeChunkerTests
 
         var result = _sut.Chunk(text, new ChunkOptions { MaxTokens = 512 });
 
-        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result).Count().IsEqualTo(1);
         await Assert.That(result[0].Content).IsEqualTo(text);
     }
 

--- a/src/Strategos.Ontology.Tests/Chunking/ParagraphChunkerTests.cs
+++ b/src/Strategos.Ontology.Tests/Chunking/ParagraphChunkerTests.cs
@@ -13,7 +13,7 @@ public class ParagraphChunkerTests
 
         var result = _sut.Chunk(text);
 
-        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result).Count().IsEqualTo(1);
         await Assert.That(result[0].Content).IsEqualTo(text);
     }
 

--- a/src/Strategos.Ontology.Tests/Chunking/SentenceBoundaryChunkerTests.cs
+++ b/src/Strategos.Ontology.Tests/Chunking/SentenceBoundaryChunkerTests.cs
@@ -13,7 +13,7 @@ public class SentenceBoundaryChunkerTests
 
         var result = _sut.Chunk(text);
 
-        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result).Count().IsEqualTo(1);
         await Assert.That(result[0].Content).IsEqualTo(text);
     }
 
@@ -60,7 +60,7 @@ public class SentenceBoundaryChunkerTests
         var result = _sut.Chunk(text);
 
         // With default MaxTokens=512, this short text should be a single chunk
-        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result).Count().IsEqualTo(1);
         await Assert.That(result[0].Content).IsEqualTo(text);
     }
 

--- a/src/Strategos.Ontology.Tests/Configuration/AddOntologyTests.cs
+++ b/src/Strategos.Ontology.Tests/Configuration/AddOntologyTests.cs
@@ -84,9 +84,9 @@ public class AddOntologyTests
         var provider = services.BuildServiceProvider();
         var graph = provider.GetRequiredService<OntologyGraph>();
 
-        await Assert.That(graph.Domains).HasCount().EqualTo(1);
+        await Assert.That(graph.Domains).Count().IsEqualTo(1);
         await Assert.That(graph.Domains[0].DomainName).IsEqualTo("test-domain");
-        await Assert.That(graph.ObjectTypes).HasCount().EqualTo(1);
+        await Assert.That(graph.ObjectTypes).Count().IsEqualTo(1);
     }
 
     [Test]
@@ -123,7 +123,7 @@ public class AddOntologyTests
         var provider = services.BuildServiceProvider();
         var graph = provider.GetRequiredService<OntologyGraph>();
 
-        await Assert.That(graph.Domains).HasCount().EqualTo(2);
+        await Assert.That(graph.Domains).Count().IsEqualTo(2);
     }
 
     [Test]

--- a/src/Strategos.Ontology.Tests/Descriptors/DerivationSourceDescriptorTests.cs
+++ b/src/Strategos.Ontology.Tests/Descriptors/DerivationSourceDescriptorTests.cs
@@ -7,7 +7,7 @@ public class DerivationSourceDescriptorTests
     [Test]
     public async Task DerivationSourceKind_HasExpectedValues()
     {
-        await Assert.That(Enum.GetValues<DerivationSourceKind>()).HasCount().EqualTo(2);
+        await Assert.That(Enum.GetValues<DerivationSourceKind>()).Count().IsEqualTo(2);
         await Assert.That(DerivationSourceKind.Local).IsEqualTo((DerivationSourceKind)0);
         await Assert.That(DerivationSourceKind.External).IsEqualTo((DerivationSourceKind)1);
     }

--- a/src/Strategos.Ontology.Tests/Descriptors/PreconditionPostconditionDescriptorTests.cs
+++ b/src/Strategos.Ontology.Tests/Descriptors/PreconditionPostconditionDescriptorTests.cs
@@ -7,7 +7,7 @@ public class PreconditionPostconditionDescriptorTests
     [Test]
     public async Task PreconditionKind_HasExpectedValues()
     {
-        await Assert.That(Enum.GetValues<PreconditionKind>()).HasCount().EqualTo(3);
+        await Assert.That(Enum.GetValues<PreconditionKind>()).Count().IsEqualTo(3);
         await Assert.That(PreconditionKind.PropertyPredicate).IsEqualTo((PreconditionKind)0);
         await Assert.That(PreconditionKind.LinkExists).IsEqualTo((PreconditionKind)1);
         await Assert.That(PreconditionKind.Custom).IsEqualTo((PreconditionKind)2);
@@ -16,7 +16,7 @@ public class PreconditionPostconditionDescriptorTests
     [Test]
     public async Task PostconditionKind_HasExpectedValues()
     {
-        await Assert.That(Enum.GetValues<PostconditionKind>()).HasCount().EqualTo(3);
+        await Assert.That(Enum.GetValues<PostconditionKind>()).Count().IsEqualTo(3);
         await Assert.That(PostconditionKind.ModifiesProperty).IsEqualTo((PostconditionKind)0);
         await Assert.That(PostconditionKind.CreatesLink).IsEqualTo((PostconditionKind)1);
         await Assert.That(PostconditionKind.EmitsEvent).IsEqualTo((PostconditionKind)2);

--- a/src/Strategos.Ontology.Tests/Descriptors/PropertyDescriptorTests.cs
+++ b/src/Strategos.Ontology.Tests/Descriptors/PropertyDescriptorTests.cs
@@ -22,7 +22,7 @@ public class PropertyDescriptorTests
         var descriptor = new PropertyDescriptor("Symbol", typeof(string));
 
         // Assert
-        await Assert.That(descriptor.IsRequired).IsEqualTo(false);
+        await Assert.That(descriptor.IsRequired).IsFalse();
     }
 
     [Test]
@@ -32,7 +32,7 @@ public class PropertyDescriptorTests
         var descriptor = new PropertyDescriptor("Symbol", typeof(string));
 
         // Assert
-        await Assert.That(descriptor.IsComputed).IsEqualTo(false);
+        await Assert.That(descriptor.IsComputed).IsFalse();
     }
 
     [Test]

--- a/src/Strategos.Ontology.Tests/Embeddings/IEmbeddingProviderTests.cs
+++ b/src/Strategos.Ontology.Tests/Embeddings/IEmbeddingProviderTests.cs
@@ -37,7 +37,7 @@ public class IEmbeddingProviderTests
 
         // Assert
         await Assert.That(result).IsNotNull();
-        await Assert.That(result).HasCount().EqualTo(128);
+        await Assert.That(result).Count().IsEqualTo(128);
         await Assert.That(result).IsTypeOf<float[]>();
     }
 
@@ -53,8 +53,8 @@ public class IEmbeddingProviderTests
 
         // Assert
         await Assert.That(result).IsNotNull();
-        await Assert.That(result).HasCount().EqualTo(3);
-        await Assert.That(result[0]).HasCount().EqualTo(64);
+        await Assert.That(result).Count().IsEqualTo(3);
+        await Assert.That(result[0]).Count().IsEqualTo(64);
     }
 
     [Test]

--- a/src/Strategos.Ontology.Tests/Events/EventProviderTests.cs
+++ b/src/Strategos.Ontology.Tests/Events/EventProviderTests.cs
@@ -29,7 +29,7 @@ public class EventProviderTests
         }
 
         // Assert
-        await Assert.That(events).HasCount().EqualTo(1);
+        await Assert.That(events).Count().IsEqualTo(1);
         await Assert.That(events[0].Domain).IsEqualTo("CRM");
     }
 

--- a/src/Strategos.Ontology.Tests/Events/EventQueryTests.cs
+++ b/src/Strategos.Ontology.Tests/Events/EventQueryTests.cs
@@ -61,6 +61,6 @@ public class EventQueryTests
 
         // Assert
         await Assert.That(query.EventTypes).IsNotNull();
-        await Assert.That(query.EventTypes!).HasCount().EqualTo(2);
+        await Assert.That(query.EventTypes!).Count().IsEqualTo(2);
     }
 }

--- a/src/Strategos.Ontology.Tests/Integration/OntologyIntegrationTests.cs
+++ b/src/Strategos.Ontology.Tests/Integration/OntologyIntegrationTests.cs
@@ -203,7 +203,7 @@ public class OntologyIntegrationTests
         var provider = services.BuildServiceProvider();
         var graph = provider.GetRequiredService<OntologyGraph>();
 
-        await Assert.That(graph.CrossDomainLinks).HasCount().EqualTo(1);
+        await Assert.That(graph.CrossDomainLinks).Count().IsEqualTo(1);
 
         var link = graph.CrossDomainLinks[0];
         await Assert.That(link.Name).IsEqualTo("PositionToArticle");
@@ -230,7 +230,7 @@ public class OntologyIntegrationTests
 
         var implementors = graph.GetImplementors("IHasSymbol");
 
-        await Assert.That(implementors).HasCount().EqualTo(2);
+        await Assert.That(implementors).Count().IsEqualTo(2);
 
         var names = implementors.Select(i => i.Name).OrderBy(n => n).ToList();
         await Assert.That(names[0]).IsEqualTo("Article");
@@ -263,12 +263,12 @@ public class OntologyIntegrationTests
         var result = await positionSet.ExecuteAsync();
 
         await Assert.That(result).IsNotNull();
-        await Assert.That(result.Items).HasCount().EqualTo(0);
+        await Assert.That(result.Items).Count().IsEqualTo(0);
 
         // Verify the graph has the Position type
         var positionType = graph.GetObjectType("trading", "Position");
         await Assert.That(positionType).IsNotNull();
-        await Assert.That(positionType!.Actions).HasCount().EqualTo(1);
+        await Assert.That(positionType!.Actions).Count().IsEqualTo(1);
         await Assert.That(positionType.Actions[0].Name).IsEqualTo("close-position");
     }
 

--- a/src/Strategos.Ontology.Tests/InverseLinkTests.cs
+++ b/src/Strategos.Ontology.Tests/InverseLinkTests.cs
@@ -164,7 +164,7 @@ public class InverseLinkTests
 
         var inverseLinks = query.GetInverseLinks("InvDepartment", "Employees");
 
-        await Assert.That(inverseLinks).HasCount().EqualTo(1);
+        await Assert.That(inverseLinks).Count().IsEqualTo(1);
         await Assert.That(inverseLinks[0].Name).IsEqualTo("Department");
     }
 
@@ -178,6 +178,6 @@ public class InverseLinkTests
 
         var inverseLinks = query.GetInverseLinks("InvDepartment", "NonExistentLink");
 
-        await Assert.That(inverseLinks).HasCount().EqualTo(0);
+        await Assert.That(inverseLinks).Count().IsEqualTo(0);
     }
 }

--- a/src/Strategos.Ontology.Tests/IsAHierarchyTests.cs
+++ b/src/Strategos.Ontology.Tests/IsAHierarchyTests.cs
@@ -196,7 +196,7 @@ public class IsAHierarchyTests
         var graph = graphBuilder.Build();
         var subtypes = graph.GetSubtypes("IsAFinancialTransaction");
 
-        await Assert.That(subtypes).HasCount().EqualTo(2);
+        await Assert.That(subtypes).Count().IsEqualTo(2);
         var names = subtypes.Select(s => s.Name).OrderBy(n => n).ToList();
         await Assert.That(names[0]).IsEqualTo("IsAPayment");
         await Assert.That(names[1]).IsEqualTo("IsARefund");
@@ -213,7 +213,7 @@ public class IsAHierarchyTests
         var types = query.GetObjectTypes(includeSubtypes: true);
 
         // Should return all 3 types
-        await Assert.That(types).HasCount().EqualTo(3);
+        await Assert.That(types).Count().IsEqualTo(3);
     }
 
     [Test]
@@ -227,7 +227,7 @@ public class IsAHierarchyTests
         var types = query.GetObjectTypes(includeSubtypes: false);
 
         // Should return all 3 types (no filtering without specific type filter)
-        await Assert.That(types).HasCount().EqualTo(3);
+        await Assert.That(types).Count().IsEqualTo(3);
     }
 
     [Test]

--- a/src/Strategos.Ontology.Tests/ObjectSets/IObjectSetProviderTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/IObjectSetProviderTests.cs
@@ -18,7 +18,7 @@ public class IObjectSetProviderTests
         var result = await provider.ExecuteAsync<string>(expression, CancellationToken.None);
 
         // Assert
-        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items).Count().IsEqualTo(1);
         await Assert.That(result.TotalCount).IsEqualTo(1);
     }
 
@@ -47,7 +47,7 @@ public class IObjectSetProviderTests
         }
 
         // Assert
-        await Assert.That(items).HasCount().EqualTo(2);
+        await Assert.That(items).Count().IsEqualTo(2);
     }
 
     [Test]
@@ -67,8 +67,8 @@ public class IObjectSetProviderTests
         var result = await provider.ExecuteSimilarityAsync<string>(similarity, CancellationToken.None);
 
         // Assert
-        await Assert.That(result.Items).HasCount().EqualTo(2);
-        await Assert.That(result.Scores).HasCount().EqualTo(2);
+        await Assert.That(result.Items).Count().IsEqualTo(2);
+        await Assert.That(result.Scores).Count().IsEqualTo(2);
         await Assert.That(result.TotalCount).IsEqualTo(2);
     }
 
@@ -89,7 +89,7 @@ public class IObjectSetProviderTests
         var result = await provider.ExecuteSimilarityAsync<string>(similarity, CancellationToken.None);
 
         // Assert
-        await Assert.That(result.Items).HasCount().EqualTo(0);
-        await Assert.That(result.Scores).HasCount().EqualTo(0);
+        await Assert.That(result.Items).Count().IsEqualTo(0);
+        await Assert.That(result.Scores).Count().IsEqualTo(0);
     }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/IObjectSetWriterTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/IObjectSetWriterTests.cs
@@ -54,7 +54,7 @@ public class IObjectSetWriterTests
         // Act & Assert — no exception thrown
         await writer.StoreAsync("test item");
 
-        await Assert.That(writer.StoredItems).HasCount().EqualTo(1);
+        await Assert.That(writer.StoredItems).Count().IsEqualTo(1);
         await Assert.That(writer.StoredItems[0]).IsEqualTo("test item");
     }
 
@@ -68,7 +68,7 @@ public class IObjectSetWriterTests
         // Act & Assert — no exception thrown
         await writer.StoreBatchAsync(items);
 
-        await Assert.That(writer.StoredItems).HasCount().EqualTo(3);
+        await Assert.That(writer.StoredItems).Count().IsEqualTo(3);
     }
 
     /// <summary>
@@ -142,7 +142,7 @@ public class IObjectSetWriterTests
         // Assert — query under "my_partition" finds the item
         var hit = await provider.ExecuteAsync<Foo>(
             new RootExpression(typeof(Foo), "my_partition"));
-        await Assert.That(hit.Items).HasCount().EqualTo(1);
+        await Assert.That(hit.Items).Count().IsEqualTo(1);
         await Assert.That(hit.Items[0].Name).IsEqualTo("alpha");
 
         // Assert — query under a different descriptor name returns nothing
@@ -169,7 +169,7 @@ public class IObjectSetWriterTests
         // Assert — both items found under "my_partition"
         var hit = await provider.ExecuteAsync<Foo>(
             new RootExpression(typeof(Foo), "my_partition"));
-        await Assert.That(hit.Items).HasCount().EqualTo(2);
+        await Assert.That(hit.Items).Count().IsEqualTo(2);
 
         // Assert — nothing leaked into "other"
         var miss = await provider.ExecuteAsync<Foo>(
@@ -201,13 +201,13 @@ public class IObjectSetWriterTests
         // Assert — default partition (typeof(Foo).Name == "Foo") sees only the default-stored item
         var defaultHit = await provider.ExecuteAsync<Foo>(
             new RootExpression(typeof(Foo), nameof(Foo)));
-        await Assert.That(defaultHit.Items).HasCount().EqualTo(1);
+        await Assert.That(defaultHit.Items).Count().IsEqualTo(1);
         await Assert.That(defaultHit.Items[0].Name).IsEqualTo("default");
 
         // Assert — "other_partition" still sees only the explicitly-seeded item
         var otherHit = await provider.ExecuteAsync<Foo>(
             new RootExpression(typeof(Foo), "other_partition"));
-        await Assert.That(otherHit.Items).HasCount().EqualTo(1);
+        await Assert.That(otherHit.Items).Count().IsEqualTo(1);
         await Assert.That(otherHit.Items[0].Name).IsEqualTo("seeded");
     }
 

--- a/src/Strategos.Ontology.Tests/ObjectSets/ISearchableTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/ISearchableTests.cs
@@ -26,7 +26,7 @@ public class ISearchableTests
         var embedding = searchable.Embedding;
 
         // Assert
-        await Assert.That(embedding).HasCount().EqualTo(3);
+        await Assert.That(embedding).Count().IsEqualTo(3);
         await Assert.That(embedding[0]).IsEqualTo(0.5f);
         await Assert.That(embedding[1]).IsEqualTo(0.3f);
         await Assert.That(embedding[2]).IsEqualTo(0.8f);

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryExpressionEvaluatorTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryExpressionEvaluatorTests.cs
@@ -95,7 +95,7 @@ public class InMemoryExpressionEvaluatorTests
 
         var result = evaluator.Evaluate<EvalSource>(expression, resolver);
 
-        await Assert.That(result).HasCount().EqualTo(2);
+        await Assert.That(result).Count().IsEqualTo(2);
         await Assert.That(result[0].Name).IsEqualTo("A");
         await Assert.That(result[1].Name).IsEqualTo("B");
     }
@@ -111,7 +111,7 @@ public class InMemoryExpressionEvaluatorTests
 
         var result = evaluator.Evaluate<EvalSource>(filter, resolver);
 
-        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result).Count().IsEqualTo(1);
         await Assert.That(result[0].Name).IsEqualTo("A");
     }
 
@@ -135,7 +135,7 @@ public class InMemoryExpressionEvaluatorTests
 
         var result = evaluator.Evaluate<EvalSource>(filter2, resolver);
 
-        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result).Count().IsEqualTo(1);
         await Assert.That(result[0].Name).IsEqualTo("A");
     }
 
@@ -149,7 +149,7 @@ public class InMemoryExpressionEvaluatorTests
 
         var result = evaluator.Evaluate<EvalSource>(include, resolver);
 
-        await Assert.That(result).HasCount().EqualTo(2);
+        await Assert.That(result).Count().IsEqualTo(2);
     }
 
     [Test]
@@ -161,7 +161,7 @@ public class InMemoryExpressionEvaluatorTests
 
         var result = evaluator.Evaluate<EvalSource>(root, emptyResolver);
 
-        await Assert.That(result).HasCount().EqualTo(0);
+        await Assert.That(result).Count().IsEqualTo(0);
     }
 
     // -----------------------------------------------------------------------
@@ -178,7 +178,7 @@ public class InMemoryExpressionEvaluatorTests
 
         var result = evaluator.Evaluate<EvalTarget>(traverse, resolver);
 
-        await Assert.That(result).HasCount().EqualTo(2);
+        await Assert.That(result).Count().IsEqualTo(2);
         await Assert.That(result[0].Label).IsEqualTo("X");
         await Assert.That(result[1].Label).IsEqualTo("Y");
     }
@@ -195,7 +195,7 @@ public class InMemoryExpressionEvaluatorTests
 
         var result = evaluator.Evaluate<EvalTarget>(filter, resolver);
 
-        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result).Count().IsEqualTo(1);
         await Assert.That(result[0].Label).IsEqualTo("X");
     }
 
@@ -230,7 +230,7 @@ public class InMemoryExpressionEvaluatorTests
 
         var result = evaluator.Evaluate<IEvalInterface>(narrow, resolver);
 
-        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result).Count().IsEqualTo(1);
         await Assert.That(result[0]).IsTypeOf<EvalSource>();
     }
 
@@ -251,7 +251,7 @@ public class InMemoryExpressionEvaluatorTests
 
         var result = evaluator.Evaluate<IEvalInterface>(narrow, resolver);
 
-        await Assert.That(result).HasCount().EqualTo(0);
+        await Assert.That(result).Count().IsEqualTo(0);
     }
 
     [Test]
@@ -270,7 +270,7 @@ public class InMemoryExpressionEvaluatorTests
         var result = evaluator.Evaluate<EvalTarget>(traverse, resolver);
 
         // All target items returned despite source filter — schema-level traversal
-        await Assert.That(result).HasCount().EqualTo(2);
+        await Assert.That(result).Count().IsEqualTo(2);
     }
 
     [Test]
@@ -338,7 +338,7 @@ public class InMemoryExpressionEvaluatorTests
 
         var result = evaluator.Evaluate<EvalSource>(root, resolver);
 
-        await Assert.That(result).HasCount().EqualTo(0);
+        await Assert.That(result).Count().IsEqualTo(0);
     }
 
     [Test]
@@ -356,7 +356,7 @@ public class InMemoryExpressionEvaluatorTests
 
         foreach (var result in results)
         {
-            await Assert.That(result).HasCount().EqualTo(2);
+            await Assert.That(result).Count().IsEqualTo(2);
         }
     }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryObjectSetProviderTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryObjectSetProviderTests.cs
@@ -20,7 +20,7 @@ public class InMemoryObjectSetProviderTests
         var result = await provider.ExecuteAsync<TestEntity>(expression);
 
         // Assert
-        await Assert.That(result.Items).HasCount().EqualTo(2);
+        await Assert.That(result.Items).Count().IsEqualTo(2);
         await Assert.That(result.TotalCount).IsEqualTo(2);
         await Assert.That(result.Inclusion).IsEqualTo(ObjectSetInclusion.Properties);
     }
@@ -58,7 +58,7 @@ public class InMemoryObjectSetProviderTests
         var result = await provider.ExecuteSimilarityAsync<TestEntity>(expression);
 
         // Assert — "Match" has 4/4 = 1.0 score, "NoMatch" has 0/4 = 0.0 score
-        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items).Count().IsEqualTo(1);
         await Assert.That(result.Items[0].Name).IsEqualTo("Match");
     }
 
@@ -79,7 +79,7 @@ public class InMemoryObjectSetProviderTests
         var result = await provider.ExecuteSimilarityAsync<TestEntity>(expression);
 
         // Assert
-        await Assert.That(result.Items).HasCount().EqualTo(2);
+        await Assert.That(result.Items).Count().IsEqualTo(2);
     }
 
     [Test]
@@ -93,7 +93,7 @@ public class InMemoryObjectSetProviderTests
         var result = await provider.ExecuteSimilarityAsync<TestEntity>(expression);
 
         // Assert
-        await Assert.That(result.Items).HasCount().EqualTo(0);
+        await Assert.That(result.Items).Count().IsEqualTo(0);
         await Assert.That(result.TotalCount).IsEqualTo(0);
     }
 
@@ -110,7 +110,7 @@ public class InMemoryObjectSetProviderTests
         var result = await provider.ExecuteSimilarityAsync<TestEntity>(expression);
 
         // Assert — all 3/3 terms should match case-insensitively
-        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items).Count().IsEqualTo(1);
         await Assert.That(result.Scores[0]).IsEqualTo(1.0);
     }
 
@@ -132,7 +132,7 @@ public class InMemoryObjectSetProviderTests
         }
 
         // Assert
-        await Assert.That(items).HasCount().EqualTo(2);
+        await Assert.That(items).Count().IsEqualTo(2);
     }
 
     [Test]
@@ -152,7 +152,7 @@ public class InMemoryObjectSetProviderTests
         var result = await provider.ExecuteAsync<TestEntity>(filter);
 
         // Assert
-        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items).Count().IsEqualTo(1);
         await Assert.That(result.Items[0].Name).IsEqualTo("Alice");
     }
 
@@ -189,8 +189,8 @@ public class InMemoryObjectSetProviderTests
         var otherResult = await provider.ExecuteAsync<OtherEntity>(otherExpression);
 
         // Assert
-        await Assert.That(entityResult.Items).HasCount().EqualTo(1);
-        await Assert.That(otherResult.Items).HasCount().EqualTo(1);
+        await Assert.That(entityResult.Items).Count().IsEqualTo(1);
+        await Assert.That(otherResult.Items).Count().IsEqualTo(1);
         await Assert.That(entityResult.Items[0].Name).IsEqualTo("Entity1");
         await Assert.That(otherResult.Items[0].Value).IsEqualTo(42);
     }
@@ -212,13 +212,13 @@ public class InMemoryObjectSetProviderTests
 
         // The item was seeded under "trading_documents" and must NOT be
         // visible from the "knowledge_documents" partition.
-        await Assert.That(wrongResult.Items).HasCount().EqualTo(0);
+        await Assert.That(wrongResult.Items).Count().IsEqualTo(0);
 
         // Querying the correct partition finds it.
         var rightPartition = new RootExpression(typeof(TestEntity), "trading_documents");
         var rightResult = await provider.ExecuteAsync<TestEntity>(rightPartition);
 
-        await Assert.That(rightResult.Items).HasCount().EqualTo(1);
+        await Assert.That(rightResult.Items).Count().IsEqualTo(1);
         await Assert.That(rightResult.Items[0].Name).IsEqualTo("TradingOnly");
     }
 
@@ -235,7 +235,7 @@ public class InMemoryObjectSetProviderTests
         var expression = new RootExpression(typeof(TestEntity), nameof(TestEntity));
         var result = await provider.ExecuteAsync<TestEntity>(expression);
 
-        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items).Count().IsEqualTo(1);
         await Assert.That(result.Items[0].Name).IsEqualTo("Default");
     }
 
@@ -261,7 +261,7 @@ public class InMemoryObjectSetProviderTests
         var result = await provider.ExecuteAsync<ProvTarget>(traverse);
 
         // Assert
-        await Assert.That(result.Items).HasCount().EqualTo(2);
+        await Assert.That(result.Items).Count().IsEqualTo(2);
         await Assert.That(result.Items[0].Label).IsEqualTo("T1");
         await Assert.That(result.Items[1].Label).IsEqualTo("T2");
     }
@@ -285,7 +285,7 @@ public class InMemoryObjectSetProviderTests
         var result = await provider.ExecuteAsync<IProvInterface>(narrow);
 
         // Assert — ProvSource implements IProvInterface
-        await Assert.That(result.Items).HasCount().EqualTo(2);
+        await Assert.That(result.Items).Count().IsEqualTo(2);
     }
 
     [Test]
@@ -304,7 +304,7 @@ public class InMemoryObjectSetProviderTests
         var result = await provider.ExecuteAsync<TestEntity>(filter);
 
         // Assert — backward compat: filter still works without graph
-        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items).Count().IsEqualTo(1);
         await Assert.That(result.Items[0].Name).IsEqualTo("Alice");
     }
 
@@ -332,7 +332,7 @@ public class InMemoryObjectSetProviderTests
         }
 
         // Assert
-        await Assert.That(items).HasCount().EqualTo(2);
+        await Assert.That(items).Count().IsEqualTo(2);
         await Assert.That(items[0].Label).IsEqualTo("T1");
     }
 
@@ -370,7 +370,7 @@ public class InMemoryObjectSetProviderTests
 
         // Beta must NOT be in results (filtered out by Value > 5)
         var betaItems = result.Items.Where(i => i.Name == "Beta").ToList();
-        await Assert.That(betaItems).HasCount().EqualTo(0);
+        await Assert.That(betaItems).Count().IsEqualTo(0);
     }
 
     [Test]
@@ -388,7 +388,7 @@ public class InMemoryObjectSetProviderTests
         var result = await provider.ExecuteSimilarityAsync<TestEntity>(similarity);
 
         // Assert — "Match" should score 1.0 (all 3 terms match), "NoMatch" 0.0
-        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items).Count().IsEqualTo(1);
         await Assert.That(result.Items[0].Name).IsEqualTo("Match");
     }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryObjectSetWriterTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryObjectSetWriterTests.cs
@@ -25,7 +25,7 @@ public class InMemoryObjectSetWriterTests
         var result = await provider.ExecuteAsync<SimpleEntity>(new RootExpression(typeof(SimpleEntity), nameof(SimpleEntity)));
 
         // Assert
-        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items).Count().IsEqualTo(1);
         await Assert.That(result.Items[0].Name).IsEqualTo("hello");
     }
 
@@ -43,7 +43,7 @@ public class InMemoryObjectSetWriterTests
         var result = await provider.ExecuteAsync<WriterTestEntity>(new RootExpression(typeof(WriterTestEntity), nameof(WriterTestEntity)));
 
         // Assert
-        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items).Count().IsEqualTo(1);
         await Assert.That(result.Items[0].Name).IsEqualTo("test");
         await Assert.That(result.Items[0].Embedding).IsEqualTo(embedding);
     }
@@ -66,7 +66,7 @@ public class InMemoryObjectSetWriterTests
         var result = await provider.ExecuteAsync<SimpleEntity>(new RootExpression(typeof(SimpleEntity), nameof(SimpleEntity)));
 
         // Assert
-        await Assert.That(result.Items).HasCount().EqualTo(3);
+        await Assert.That(result.Items).Count().IsEqualTo(3);
     }
 
     [Test]
@@ -134,7 +134,7 @@ public class InMemoryObjectSetWriterTests
         var result = await provider.ExecuteAsync<SimpleEntity>(new RootExpression(typeof(SimpleEntity), nameof(SimpleEntity)));
 
         // Assert
-        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items).Count().IsEqualTo(1);
         await Assert.That(result.Items[0].Name).IsEqualTo("seeded");
     }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetActionEventTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetActionEventTests.cs
@@ -35,7 +35,7 @@ public class ObjectSetActionEventTests
         var results = await set.ApplyAsync("DoSomething", new { Value = 1 });
 
         // Assert
-        await Assert.That(results).HasCount().EqualTo(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].IsSuccess).IsTrue();
     }
 
@@ -79,7 +79,7 @@ public class ObjectSetActionEventTests
         }
 
         // Assert
-        await Assert.That(events).HasCount().EqualTo(1);
+        await Assert.That(events).Count().IsEqualTo(1);
         await Assert.That(events[0].EventType).IsEqualTo("Created");
     }
 

--- a/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetMaterializationTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetMaterializationTests.cs
@@ -32,7 +32,7 @@ public class ObjectSetMaterializationTests
         var result = await set.ExecuteAsync();
 
         // Assert
-        await Assert.That(result.Items).HasCount().EqualTo(2);
+        await Assert.That(result.Items).Count().IsEqualTo(2);
         await _provider.Received(1).ExecuteAsync<string>(Arg.Any<ObjectSetExpression>(), Arg.Any<CancellationToken>());
     }
 
@@ -59,7 +59,7 @@ public class ObjectSetMaterializationTests
         }
 
         // Assert
-        await Assert.That(items).HasCount().EqualTo(2);
+        await Assert.That(items).Count().IsEqualTo(2);
         _provider.Received(1).StreamAsync<string>(Arg.Any<ObjectSetExpression>(), Arg.Any<CancellationToken>());
     }
 

--- a/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTypesTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTypesTests.cs
@@ -41,7 +41,7 @@ public class ObjectSetTypesTests
         var result = new ObjectSetResult<string>(items, 3, ObjectSetInclusion.Properties);
 
         // Assert
-        await Assert.That(result.Items).HasCount().EqualTo(3);
+        await Assert.That(result.Items).Count().IsEqualTo(3);
         await Assert.That(result.TotalCount).IsEqualTo(3);
         await Assert.That(result.Inclusion).IsEqualTo(ObjectSetInclusion.Properties);
     }
@@ -53,7 +53,7 @@ public class ObjectSetTypesTests
         var result = new ObjectSetResult<string>([], 0, ObjectSetInclusion.Properties);
 
         // Assert
-        await Assert.That(result.Items).HasCount().EqualTo(0);
+        await Assert.That(result.Items).Count().IsEqualTo(0);
         await Assert.That(result.TotalCount).IsEqualTo(0);
     }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/ScoredObjectSetResultTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/ScoredObjectSetResultTests.cs
@@ -12,8 +12,8 @@ public class ScoredObjectSetResultTests
             ["a", "b"], 2, ObjectSetInclusion.Properties, [0.9, 0.8]);
 
         // Assert
-        await Assert.That(result.Items).HasCount().EqualTo(2);
-        await Assert.That(result.Scores).HasCount().EqualTo(2);
+        await Assert.That(result.Items).Count().IsEqualTo(2);
+        await Assert.That(result.Scores).Count().IsEqualTo(2);
         await Assert.That(result.TotalCount).IsEqualTo(2);
         await Assert.That(result.Inclusion).IsEqualTo(ObjectSetInclusion.Properties);
     }
@@ -50,7 +50,7 @@ public class ScoredObjectSetResultTests
             [], 0, ObjectSetInclusion.Properties, []);
 
         // Assert
-        await Assert.That(result.Items).HasCount().EqualTo(0);
-        await Assert.That(result.Scores).HasCount().EqualTo(0);
+        await Assert.That(result.Items).Count().IsEqualTo(0);
+        await Assert.That(result.Scores).Count().IsEqualTo(0);
     }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/SimilarObjectSetTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/SimilarObjectSetTests.cs
@@ -37,7 +37,7 @@ public class SimilarObjectSetTests
         var result = await similarSet.ExecuteAsync();
 
         // Assert
-        await Assert.That(result.Items).HasCount().EqualTo(2);
+        await Assert.That(result.Items).Count().IsEqualTo(2);
         await Assert.That(result.Scores[0]).IsEqualTo(0.9);
         await Assert.That(result.Scores[1]).IsEqualTo(0.8);
     }

--- a/src/Strategos.Ontology.Tests/OntologyGraphBuilderInterfaceValidationTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphBuilderInterfaceValidationTests.cs
@@ -89,9 +89,9 @@ public class OntologyGraphBuilderInterfaceValidationTests
 
         var graph = graphBuilder.Build();
 
-        await Assert.That(graph.ObjectTypes).HasCount().EqualTo(1);
-        await Assert.That(graph.Interfaces).HasCount().EqualTo(1);
-        await Assert.That(graph.ObjectTypes[0].ImplementedInterfaces).HasCount().EqualTo(1);
+        await Assert.That(graph.ObjectTypes).Count().IsEqualTo(1);
+        await Assert.That(graph.Interfaces).Count().IsEqualTo(1);
+        await Assert.That(graph.ObjectTypes[0].ImplementedInterfaces).Count().IsEqualTo(1);
         await Assert.That(graph.ObjectTypes[0].ImplementedInterfaces[0].Name).IsEqualTo("IIdentifiable");
     }
 
@@ -117,7 +117,7 @@ public class OntologyGraphBuilderInterfaceValidationTests
         var graph = graphBuilder.Build();
 
         await Assert.That(graph.WorkflowChains).IsNotNull();
-        await Assert.That(graph.WorkflowChains).HasCount().EqualTo(0);
+        await Assert.That(graph.WorkflowChains).Count().IsEqualTo(0);
     }
 
     [Test]
@@ -131,6 +131,6 @@ public class OntologyGraphBuilderInterfaceValidationTests
         var graph = graphBuilder.Build();
 
         await Assert.That(graph).IsNotNull();
-        await Assert.That(graph.WorkflowChains).HasCount().EqualTo(0);
+        await Assert.That(graph.WorkflowChains).Count().IsEqualTo(0);
     }
 }

--- a/src/Strategos.Ontology.Tests/OntologyGraphBuilderTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphBuilderTests.cs
@@ -372,7 +372,7 @@ public class OntologyGraphBuilderTests
         graphBuilder.AddDomain<TestTradingOntology>();
 
         var graph = graphBuilder.Build();
-        await Assert.That(graph.Domains).HasCount().EqualTo(1);
+        await Assert.That(graph.Domains).Count().IsEqualTo(1);
         await Assert.That(graph.Domains[0].DomainName).IsEqualTo("trading");
     }
 
@@ -385,7 +385,7 @@ public class OntologyGraphBuilderTests
         graphBuilder.AddDomain<TestMarketDataOntology>();
 
         var graph = graphBuilder.Build();
-        await Assert.That(graph.Domains).HasCount().EqualTo(2);
+        await Assert.That(graph.Domains).Count().IsEqualTo(2);
     }
 
     [Test]
@@ -408,9 +408,9 @@ public class OntologyGraphBuilderTests
 
         var graph = graphBuilder.Build();
 
-        await Assert.That(graph.Domains[0].ObjectTypes).HasCount().EqualTo(1);
+        await Assert.That(graph.Domains[0].ObjectTypes).Count().IsEqualTo(1);
         await Assert.That(graph.Domains[0].ObjectTypes[0].Name).IsEqualTo("TestPosition");
-        await Assert.That(graph.ObjectTypes).HasCount().EqualTo(1);
+        await Assert.That(graph.ObjectTypes).Count().IsEqualTo(1);
         await Assert.That(graph.ObjectTypes[0].Name).IsEqualTo("TestPosition");
     }
 
@@ -454,8 +454,8 @@ public class OntologyGraphBuilderTests
 
         var graph = graphBuilder.Build();
 
-        await Assert.That(graph.Domains).HasCount().EqualTo(2);
-        await Assert.That(graph.ObjectTypes).HasCount().EqualTo(2);
+        await Assert.That(graph.Domains).Count().IsEqualTo(2);
+        await Assert.That(graph.ObjectTypes).Count().IsEqualTo(2);
         await Assert.That(graph.ObjectTypes.Count(ot => ot.Name == "shared_name")).IsEqualTo(2);
     }
 
@@ -475,7 +475,7 @@ public class OntologyGraphBuilderTests
         await Assert.That(graph.ObjectTypeNamesByType.ContainsKey(typeof(TrackCFoo))).IsTrue();
 
         var names = graph.ObjectTypeNamesByType[typeof(TrackCFoo)];
-        await Assert.That(names).HasCount().EqualTo(1);
+        await Assert.That(names).Count().IsEqualTo(1);
         await Assert.That(names[0]).IsEqualTo(nameof(TrackCFoo));
     }
 
@@ -490,7 +490,7 @@ public class OntologyGraphBuilderTests
         await Assert.That(graph.ObjectTypeNamesByType.ContainsKey(typeof(TrackCFoo))).IsTrue();
 
         var names = graph.ObjectTypeNamesByType[typeof(TrackCFoo)];
-        await Assert.That(names).HasCount().EqualTo(2);
+        await Assert.That(names).Count().IsEqualTo(2);
         await Assert.That(names[0]).IsEqualTo("a");
         await Assert.That(names[1]).IsEqualTo("b");
     }
@@ -506,7 +506,7 @@ public class OntologyGraphBuilderTests
         IReadOnlyList<string> names = graph.ObjectTypeNamesByType
             .GetValueOrDefault(typeof(TrackCBar), Array.Empty<string>());
 
-        await Assert.That(names).HasCount().EqualTo(0);
+        await Assert.That(names).Count().IsEqualTo(0);
     }
 
     // -----------------------------------------------------------------------
@@ -579,9 +579,9 @@ public class OntologyGraphBuilderTests
 
         var graph = graphBuilder.Build();
 
-        await Assert.That(graph.ObjectTypes).HasCount().EqualTo(2);
+        await Assert.That(graph.ObjectTypes).Count().IsEqualTo(2);
         await Assert.That(graph.ObjectTypeNamesByType[typeof(TrackCSemanticDocument)])
-            .HasCount().EqualTo(2);
+            .Count().IsEqualTo(2);
     }
 
     // -----------------------------------------------------------------------
@@ -641,7 +641,7 @@ public class OntologyGraphBuilderTests
         var graph = graphBuilder.Build();
 
         // Chain must NOT be silently first-wins bound — it must be skipped entirely.
-        await Assert.That(graph.WorkflowChains).HasCount().EqualTo(0);
+        await Assert.That(graph.WorkflowChains).Count().IsEqualTo(0);
 
         // A warning must name the workflow, the ambiguous type, and both domains.
         var ambiguityWarnings = graph.Warnings
@@ -666,11 +666,11 @@ public class OntologyGraphBuilderTests
 
         var graph = graphBuilder.Build();
 
-        await Assert.That(graph.WorkflowChains).HasCount().EqualTo(1);
+        await Assert.That(graph.WorkflowChains).Count().IsEqualTo(1);
         await Assert.That(graph.WorkflowChains[0].WorkflowName).IsEqualTo("unambiguous-workflow");
         await Assert.That(graph.WorkflowChains[0].ConsumedType.Name).IsEqualTo(nameof(AmbiguousFoo));
         await Assert.That(graph.WorkflowChains[0].ProducedType.Name).IsEqualTo(nameof(AmbiguousBar));
-        await Assert.That(graph.Warnings.Where(w => w.Contains("unambiguous-workflow"))).HasCount().EqualTo(0);
+        await Assert.That(graph.Warnings.Where(w => w.Contains("unambiguous-workflow"))).Count().IsEqualTo(0);
     }
 
     [Test]
@@ -687,7 +687,7 @@ public class OntologyGraphBuilderTests
 
         var graph = graphBuilder.Build();
 
-        await Assert.That(graph.WorkflowChains).HasCount().EqualTo(0);
+        await Assert.That(graph.WorkflowChains).Count().IsEqualTo(0);
         var unknownWarnings = graph.Warnings
             .Where(w => w.Contains("unknown-consumed-workflow") && w.Contains("unknown") && w.Contains("TrackCBar"))
             .ToList();
@@ -707,7 +707,7 @@ public class OntologyGraphBuilderTests
 
         var graph = graphBuilder.Build();
 
-        await Assert.That(graph.CrossDomainLinks).HasCount().EqualTo(1);
+        await Assert.That(graph.CrossDomainLinks).Count().IsEqualTo(1);
         await Assert.That(graph.CrossDomainLinks[0].Description).IsEqualTo("Market data informs position pricing");
     }
 

--- a/src/Strategos.Ontology.Tests/OntologyGraphBuilderValidationTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphBuilderValidationTests.cs
@@ -67,7 +67,7 @@ public class OntologyGraphBuilderValidationTests
 
         var graph = graphBuilder.Build();
 
-        await Assert.That(graph.CrossDomainLinks).HasCount().EqualTo(1);
+        await Assert.That(graph.CrossDomainLinks).Count().IsEqualTo(1);
         await Assert.That(graph.CrossDomainLinks[0].Name).IsEqualTo("PositionToInstrument");
         await Assert.That(graph.CrossDomainLinks[0].SourceDomain).IsEqualTo("trading");
         await Assert.That(graph.CrossDomainLinks[0].TargetDomain).IsEqualTo("market-data");

--- a/src/Strategos.Ontology.Tests/OntologyGraphLookupTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphLookupTests.cs
@@ -58,7 +58,7 @@ public class OntologyGraphLookupTests
 
         var implementors = graph.GetImplementors("IIdentifiable");
 
-        await Assert.That(implementors).HasCount().EqualTo(1);
+        await Assert.That(implementors).Count().IsEqualTo(1);
         await Assert.That(implementors[0].Name).IsEqualTo("IdentifiablePosition");
     }
 
@@ -69,6 +69,6 @@ public class OntologyGraphLookupTests
 
         var implementors = graph.GetImplementors("INonExistent");
 
-        await Assert.That(implementors).HasCount().EqualTo(0);
+        await Assert.That(implementors).Count().IsEqualTo(0);
     }
 }

--- a/src/Strategos.Ontology.Tests/OntologyGraphTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphTests.cs
@@ -18,7 +18,7 @@ public class OntologyGraphTests
     {
         var graph = BuildGraphWithTwoDomains();
 
-        await Assert.That(graph.Domains).HasCount().EqualTo(2);
+        await Assert.That(graph.Domains).Count().IsEqualTo(2);
         await Assert.That(graph.Domains[0].DomainName).IsEqualTo("trading");
         await Assert.That(graph.Domains[1].DomainName).IsEqualTo("market-data");
     }
@@ -28,7 +28,7 @@ public class OntologyGraphTests
     {
         var graph = BuildGraphWithTwoDomains();
 
-        await Assert.That(graph.ObjectTypes).HasCount().EqualTo(2);
+        await Assert.That(graph.ObjectTypes).Count().IsEqualTo(2);
     }
 
     [Test]
@@ -39,7 +39,7 @@ public class OntologyGraphTests
 
         var graph = graphBuilder.Build();
 
-        await Assert.That(graph.Interfaces).HasCount().EqualTo(1);
+        await Assert.That(graph.Interfaces).Count().IsEqualTo(1);
         await Assert.That(graph.Interfaces[0].Name).IsEqualTo("IIdentifiable");
     }
 
@@ -48,7 +48,7 @@ public class OntologyGraphTests
     {
         var graph = BuildGraphWithTwoDomains();
 
-        await Assert.That(graph.CrossDomainLinks).HasCount().EqualTo(1);
+        await Assert.That(graph.CrossDomainLinks).Count().IsEqualTo(1);
         await Assert.That(graph.CrossDomainLinks[0].Name).IsEqualTo("PositionToInstrument");
     }
 

--- a/src/Strategos.Ontology.Tests/OntologyGraphTraversalTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphTraversalTests.cs
@@ -72,7 +72,7 @@ public class OntologyGraphTraversalTests
 
         var results = graph.TraverseLinks("trading", "TestPosition", maxDepth: 1);
 
-        await Assert.That(results).HasCount().EqualTo(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].ObjectType.Name).IsEqualTo("TestOrder");
         await Assert.That(results[0].LinkName).IsEqualTo("Orders");
         await Assert.That(results[0].Depth).IsEqualTo(1);
@@ -94,9 +94,9 @@ public class OntologyGraphTraversalTests
         var depth1 = results.Where(r => r.Depth == 1).ToList();
         var depth2 = results.Where(r => r.Depth == 2).ToList();
 
-        await Assert.That(depth1).HasCount().EqualTo(1);
+        await Assert.That(depth1).Count().IsEqualTo(1);
         await Assert.That(depth1[0].ObjectType.Name).IsEqualTo("TestPosition");
-        await Assert.That(depth2).HasCount().EqualTo(1);
+        await Assert.That(depth2).Count().IsEqualTo(1);
         await Assert.That(depth2[0].ObjectType.Name).IsEqualTo("TestOrder");
     }
 
@@ -110,7 +110,7 @@ public class OntologyGraphTraversalTests
         var results = graph.TraverseLinks("trading", "TestAccount", maxDepth: 1);
 
         // Should only include depth 1 (TestPosition), not depth 2 (TestOrder)
-        await Assert.That(results).HasCount().EqualTo(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].ObjectType.Name).IsEqualTo("TestPosition");
     }
 
@@ -148,7 +148,7 @@ public class OntologyGraphTraversalTests
 
         var result = graph.FindWorkflowChains("OrderExecution");
 
-        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result).Count().IsEqualTo(1);
         await Assert.That(result[0].WorkflowName).IsEqualTo("OrderExecution");
         await Assert.That(result[0].ConsumedType.Name).IsEqualTo("Order");
         await Assert.That(result[0].ProducedType.Name).IsEqualTo("Position");
@@ -163,7 +163,7 @@ public class OntologyGraphTraversalTests
 
         var results = graph.TraverseLinks("trading", "TestPosition", maxDepth: 1);
 
-        await Assert.That(results).HasCount().EqualTo(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].LinkName).IsEqualTo("Orders");
         await Assert.That(results[0].Description).IsEqualTo("Orders placed against this position");
     }
@@ -177,7 +177,7 @@ public class OntologyGraphTraversalTests
 
         var result = graph.FindWorkflowChains("NonExistent");
 
-        await Assert.That(result).HasCount().EqualTo(0);
+        await Assert.That(result).Count().IsEqualTo(0);
     }
 }
 

--- a/src/Strategos.Ontology.Tests/Query/OntologyQueryFluentSimilarityTests.cs
+++ b/src/Strategos.Ontology.Tests/Query/OntologyQueryFluentSimilarityTests.cs
@@ -190,7 +190,7 @@ public class OntologyQueryFluentSimilarityTests
 
         // Assert — only items seeded under trading_documents are returned.
         var tradingContent = tradingResults.Items.Select(d => d.Content).ToList();
-        await Assert.That(tradingResults.Items).HasCount().EqualTo(2);
+        await Assert.That(tradingResults.Items).Count().IsEqualTo(2);
         await Assert.That(tradingContent).Contains("market data for AAPL");
         await Assert.That(tradingContent).Contains("bond yields");
         await Assert.That(tradingContent).DoesNotContain("how authentication works");
@@ -208,7 +208,7 @@ public class OntologyQueryFluentSimilarityTests
 
         // Assert — only items seeded under knowledge_documents are returned.
         var knowledgeContent = knowledgeResults.Items.Select(d => d.Content).ToList();
-        await Assert.That(knowledgeResults.Items).HasCount().EqualTo(2);
+        await Assert.That(knowledgeResults.Items).Count().IsEqualTo(2);
         await Assert.That(knowledgeContent).Contains("how authentication works");
         await Assert.That(knowledgeContent).Contains("kubernetes pod lifecycle");
         await Assert.That(knowledgeContent).DoesNotContain("market data for AAPL");
@@ -217,7 +217,7 @@ public class OntologyQueryFluentSimilarityTests
         // Assert — the public reverse-index API surfaces both registrations
         // in registration order (Track D3).
         var allNames = query.GetObjectTypeNames<SemanticDocument>();
-        await Assert.That(allNames).HasCount().EqualTo(2);
+        await Assert.That(allNames).Count().IsEqualTo(2);
         await Assert.That(allNames).Contains("trading_documents");
         await Assert.That(allNames).Contains("knowledge_documents");
     }
@@ -255,12 +255,12 @@ public class OntologyQueryFluentSimilarityTests
             .GetObjectSet<SemanticDocument>("knowledge_documents")
             .ExecuteAsync();
 
-        await Assert.That(tradingResult.Items).HasCount().EqualTo(2);
+        await Assert.That(tradingResult.Items).Count().IsEqualTo(2);
         await Assert.That(tradingResult.Items.Select(d => d.Id)).Contains("t-1");
         await Assert.That(tradingResult.Items.Select(d => d.Id)).Contains("t-2");
         await Assert.That(tradingResult.Items.Select(d => d.Id)).DoesNotContain("k-1");
 
-        await Assert.That(knowledgeResult.Items).HasCount().EqualTo(1);
+        await Assert.That(knowledgeResult.Items).Count().IsEqualTo(1);
         await Assert.That(knowledgeResult.Items.Select(d => d.Id)).Contains("k-1");
     }
 
@@ -317,9 +317,9 @@ public class OntologyQueryFluentSimilarityTests
             .GetObjectSet<SemanticDocument>("knowledge_documents")
             .ExecuteAsync();
 
-        await Assert.That(tradingResult.Items).HasCount().EqualTo(2);
+        await Assert.That(tradingResult.Items).Count().IsEqualTo(2);
         await Assert.That(tradingResult.Items.Select(d => d.Content)).Contains("AAPL spot price");
         await Assert.That(tradingResult.Items.Select(d => d.Content)).Contains("bond yield curve");
-        await Assert.That(knowledgeResult.Items).HasCount().EqualTo(0);
+        await Assert.That(knowledgeResult.Items).Count().IsEqualTo(0);
     }
 }

--- a/src/Strategos.Ontology.Tests/Query/OntologyQueryTests.cs
+++ b/src/Strategos.Ontology.Tests/Query/OntologyQueryTests.cs
@@ -995,7 +995,7 @@ public class OntologyQueryServiceGetObjectTypeNamesTests
         var names = query.GetObjectTypeNames<D3Foo>();
 
         await Assert.That(names).IsNotNull();
-        await Assert.That(names).HasCount().EqualTo(1);
+        await Assert.That(names).Count().IsEqualTo(1);
         await Assert.That(names[0]).IsEqualTo(nameof(D3Foo));
     }
 
@@ -1009,7 +1009,7 @@ public class OntologyQueryServiceGetObjectTypeNamesTests
 
         var names = query.GetObjectTypeNames<D3Foo>();
 
-        await Assert.That(names).HasCount().EqualTo(2);
+        await Assert.That(names).Count().IsEqualTo(2);
         await Assert.That(names[0]).IsEqualTo("a");
         await Assert.That(names[1]).IsEqualTo("b");
     }
@@ -1025,7 +1025,7 @@ public class OntologyQueryServiceGetObjectTypeNamesTests
         var names = query.GetObjectTypeNames<D3Bar>();
 
         await Assert.That(names).IsNotNull();
-        await Assert.That(names).HasCount().EqualTo(0);
+        await Assert.That(names).Count().IsEqualTo(0);
     }
 }
 

--- a/src/Strategos.Ontology.Tests/ResolvedTypesTests.cs
+++ b/src/Strategos.Ontology.Tests/ResolvedTypesTests.cs
@@ -50,7 +50,7 @@ public class ResolvedTypesTests
 
         await Assert.That(link.SourceObjectType).IsEqualTo(sourceType);
         await Assert.That(link.TargetObjectType).IsEqualTo(targetType);
-        await Assert.That(link.EdgeProperties).HasCount().EqualTo(1);
+        await Assert.That(link.EdgeProperties).Count().IsEqualTo(1);
         await Assert.That(link.EdgeProperties[0].Name).IsEqualTo("Weight");
     }
 

--- a/src/Strategos.Ontology.Tests/Telemetry/TelemetryTests.cs
+++ b/src/Strategos.Ontology.Tests/Telemetry/TelemetryTests.cs
@@ -26,8 +26,8 @@ public class TelemetryTests
         await Assert.That(context.Domain).IsEqualTo("CRM");
         await Assert.That(context.ObjectType).IsEqualTo("Deal");
         await Assert.That(context.ActionName).IsEqualTo("Close");
-        await Assert.That(context.TraversedLinks).HasCount().EqualTo(1);
-        await Assert.That(context.ProducedEvents).HasCount().EqualTo(1);
+        await Assert.That(context.TraversedLinks).Count().IsEqualTo(1);
+        await Assert.That(context.ProducedEvents).Count().IsEqualTo(1);
         await Assert.That(context.QueryDepth).IsEqualTo(2);
         await Assert.That(context.InclusionLevel).IsEqualTo(ObjectSetInclusion.Full);
     }
@@ -41,7 +41,7 @@ public class TelemetryTests
             ObjectType: "Contact");
 
         // Assert
-        await Assert.That(context.TraversedLinks).HasCount().EqualTo(0);
+        await Assert.That(context.TraversedLinks).Count().IsEqualTo(0);
     }
 
     [Test]
@@ -53,7 +53,7 @@ public class TelemetryTests
             ObjectType: "Contact");
 
         // Assert
-        await Assert.That(context.ProducedEvents).HasCount().EqualTo(0);
+        await Assert.That(context.ProducedEvents).Count().IsEqualTo(0);
     }
 
     [Test]

--- a/src/Strategos.Tests/Builders/ApprovalBuilderTests.cs
+++ b/src/Strategos.Tests/Builders/ApprovalBuilderTests.cs
@@ -234,7 +234,7 @@ public class ApprovalBuilderTests
         var definition = builder.Build();
 
         // Assert
-        await Assert.That(definition.Configuration.Options).HasCount().EqualTo(1);
+        await Assert.That(definition.Configuration.Options).Count().IsEqualTo(1);
         await Assert.That(definition.Configuration.Options[0].OptionId).IsEqualTo("approve");
         await Assert.That(definition.Configuration.Options[0].Label).IsEqualTo("Approve");
         await Assert.That(definition.Configuration.Options[0].Description).IsEqualTo("Approve the request");
@@ -256,7 +256,7 @@ public class ApprovalBuilderTests
         var definition = builder.Build();
 
         // Assert
-        await Assert.That(definition.Configuration.Options).HasCount().EqualTo(2);
+        await Assert.That(definition.Configuration.Options).Count().IsEqualTo(2);
     }
 
     /// <summary>
@@ -534,7 +534,7 @@ public class ApprovalBuilderTests
         await Assert.That(definition.ApproverType).IsEqualTo(typeof(TestApprover));
         await Assert.That(definition.Configuration.StaticContext).IsEqualTo("Review request");
         await Assert.That(definition.Configuration.Timeout).IsEqualTo(TimeSpan.FromHours(4));
-        await Assert.That(definition.Configuration.Options).HasCount().EqualTo(2);
+        await Assert.That(definition.Configuration.Options).Count().IsEqualTo(2);
         await Assert.That(definition.Configuration.StaticMetadata.ContainsKey("category")).IsTrue();
         await Assert.That(definition.EscalationHandler).IsNotNull();
         await Assert.That(definition.RejectionHandler).IsNotNull();

--- a/src/Strategos.Tests/Builders/ApprovalEscalationBuilderTests.cs
+++ b/src/Strategos.Tests/Builders/ApprovalEscalationBuilderTests.cs
@@ -69,7 +69,7 @@ public class ApprovalEscalationBuilderTests
         builder.Then<NotifyAdminStep>();
 
         // Assert
-        await Assert.That(builder.Steps).HasCount().EqualTo(1);
+        await Assert.That(builder.Steps).Count().IsEqualTo(1);
         await Assert.That(builder.Steps[0].StepType).IsEqualTo(typeof(NotifyAdminStep));
     }
 
@@ -89,7 +89,7 @@ public class ApprovalEscalationBuilderTests
 
         // Assert
         await Assert.That(result).IsNotNull();
-        await Assert.That(builder.Steps).HasCount().EqualTo(2);
+        await Assert.That(builder.Steps).Count().IsEqualTo(2);
     }
 
     /// <summary>
@@ -146,7 +146,7 @@ public class ApprovalEscalationBuilderTests
             approval.WithContext("Escalated for supervisor review"));
 
         // Assert
-        await Assert.That(builder.NestedApprovals).HasCount().EqualTo(1);
+        await Assert.That(builder.NestedApprovals).Count().IsEqualTo(1);
         await Assert.That(builder.NestedApprovals[0].ApproverType).IsEqualTo(typeof(SupervisorApprover));
     }
 
@@ -167,7 +167,7 @@ public class ApprovalEscalationBuilderTests
                 approval.WithContext("For manager"));
 
         // Assert
-        await Assert.That(builder.NestedApprovals).HasCount().EqualTo(2);
+        await Assert.That(builder.NestedApprovals).Count().IsEqualTo(2);
     }
 
     /// <summary>
@@ -253,7 +253,7 @@ public class ApprovalEscalationBuilderTests
         var definition = builder.Build();
 
         // Assert
-        await Assert.That(definition.Steps).HasCount().EqualTo(1);
+        await Assert.That(definition.Steps).Count().IsEqualTo(1);
     }
 
     /// <summary>
@@ -271,7 +271,7 @@ public class ApprovalEscalationBuilderTests
         var definition = builder.Build();
 
         // Assert
-        await Assert.That(definition.NestedApprovals).HasCount().EqualTo(1);
+        await Assert.That(definition.NestedApprovals).Count().IsEqualTo(1);
     }
 
     /// <summary>

--- a/src/Strategos.Tests/Builders/ApprovalRejectionBuilderTests.cs
+++ b/src/Strategos.Tests/Builders/ApprovalRejectionBuilderTests.cs
@@ -54,7 +54,7 @@ public class ApprovalRejectionBuilderTests
         builder.Then<NotifyAdminStep>();
 
         // Assert
-        await Assert.That(builder.Steps).HasCount().EqualTo(1);
+        await Assert.That(builder.Steps).Count().IsEqualTo(1);
         await Assert.That(builder.Steps[0].StepType).IsEqualTo(typeof(NotifyAdminStep));
     }
 
@@ -75,7 +75,7 @@ public class ApprovalRejectionBuilderTests
 
         // Assert
         await Assert.That(result).IsNotNull();
-        await Assert.That(builder.Steps).HasCount().EqualTo(3);
+        await Assert.That(builder.Steps).Count().IsEqualTo(3);
     }
 
     /// <summary>
@@ -148,7 +148,7 @@ public class ApprovalRejectionBuilderTests
 
         // Assert
         await Assert.That(builder.IsTerminal).IsTrue();
-        await Assert.That(builder.Steps).HasCount().EqualTo(2);
+        await Assert.That(builder.Steps).Count().IsEqualTo(2);
     }
 
     // =============================================================================
@@ -186,7 +186,7 @@ public class ApprovalRejectionBuilderTests
         var definition = builder.Build();
 
         // Assert
-        await Assert.That(definition.Steps).HasCount().EqualTo(1);
+        await Assert.That(definition.Steps).Count().IsEqualTo(1);
     }
 
     /// <summary>

--- a/src/Strategos.Tests/Builders/BranchBuilderTests.cs
+++ b/src/Strategos.Tests/Builders/BranchBuilderTests.cs
@@ -70,7 +70,7 @@ public class BranchBuilderTests
 
         // Assert
         var branchPath = workflow.BranchPoints[0].Paths[0];
-        await Assert.That(branchPath.Steps).HasCount().EqualTo(1);
+        await Assert.That(branchPath.Steps).Count().IsEqualTo(1);
         await Assert.That(branchPath.Steps[0].StepType).IsEqualTo(typeof(AutoProcessStep));
     }
 
@@ -95,7 +95,7 @@ public class BranchBuilderTests
 
         // Assert
         var branchPath = workflow.BranchPoints[0].Paths[0];
-        await Assert.That(branchPath.Steps).HasCount().EqualTo(2);
+        await Assert.That(branchPath.Steps).Count().IsEqualTo(2);
     }
 
     /// <summary>

--- a/src/Strategos.Tests/Builders/FailureBuilderTests.cs
+++ b/src/Strategos.Tests/Builders/FailureBuilderTests.cs
@@ -54,7 +54,7 @@ public class FailureBuilderTests
         builder.Then<LogFailureStep>();
 
         // Assert
-        await Assert.That(builder.Steps).HasCount().EqualTo(1);
+        await Assert.That(builder.Steps).Count().IsEqualTo(1);
         await Assert.That(builder.Steps[0].StepType).IsEqualTo(typeof(LogFailureStep));
     }
 
@@ -74,7 +74,7 @@ public class FailureBuilderTests
 
         // Assert
         await Assert.That(result).IsNotNull();
-        await Assert.That(builder.Steps).HasCount().EqualTo(2);
+        await Assert.That(builder.Steps).Count().IsEqualTo(2);
     }
 
     /// <summary>
@@ -147,7 +147,7 @@ public class FailureBuilderTests
 
         // Assert
         await Assert.That(builder.IsTerminal).IsTrue();
-        await Assert.That(builder.Steps).HasCount().EqualTo(2);
+        await Assert.That(builder.Steps).Count().IsEqualTo(2);
     }
 
     // =============================================================================

--- a/src/Strategos.Tests/Builders/LoopBuilderForkTests.cs
+++ b/src/Strategos.Tests/Builders/LoopBuilderForkTests.cs
@@ -174,9 +174,9 @@ public class LoopBuilderForkTests
             .Finally<TestFinalStep>();
 
         // Assert
-        await Assert.That(workflow.ForkPoints).HasCount().EqualTo(1);
-        await Assert.That(workflow.ForkPoints[0].Paths[0].Steps).HasCount().EqualTo(2);
-        await Assert.That(workflow.ForkPoints[0].Paths[1].Steps).HasCount().EqualTo(1);
+        await Assert.That(workflow.ForkPoints).Count().IsEqualTo(1);
+        await Assert.That(workflow.ForkPoints[0].Paths[0].Steps).Count().IsEqualTo(2);
+        await Assert.That(workflow.ForkPoints[0].Paths[1].Steps).Count().IsEqualTo(1);
     }
 
     // =============================================================================
@@ -237,11 +237,11 @@ public class LoopBuilderForkTests
             .Finally<TestFinalStep>();
 
         // Assert
-        await Assert.That(workflow.Loops).HasCount().EqualTo(1);
+        await Assert.That(workflow.Loops).Count().IsEqualTo(1);
         var bodySteps = workflow.Loops[0].BodySteps;
 
         // Should have: PreForkStep, ParallelStep1, ParallelStep2, JoinStep, PostJoinStep
-        await Assert.That(bodySteps).HasCount().EqualTo(5);
+        await Assert.That(bodySteps).Count().IsEqualTo(5);
         await Assert.That(bodySteps.Last().StepType).IsEqualTo(typeof(PostJoinStep));
     }
 
@@ -271,8 +271,8 @@ public class LoopBuilderForkTests
 
         // Assert
         await Assert.That(workflow.ForkPoints).IsNotNull();
-        await Assert.That(workflow.ForkPoints).HasCount().EqualTo(1);
-        await Assert.That(workflow.ForkPoints[0].Paths).HasCount().EqualTo(2);
+        await Assert.That(workflow.ForkPoints).Count().IsEqualTo(1);
+        await Assert.That(workflow.ForkPoints[0].Paths).Count().IsEqualTo(2);
     }
 
     /// <summary>
@@ -384,7 +384,7 @@ public class LoopBuilderForkTests
             .Finally<TestFinalStep>();
 
         // Assert
-        await Assert.That(workflow.Loops[0].BodySteps).HasCount().EqualTo(4);
+        await Assert.That(workflow.Loops[0].BodySteps).Count().IsEqualTo(4);
         await Assert.That(workflow.Loops[0].BodySteps[0].StepType).IsEqualTo(typeof(PreForkStep));
     }
 
@@ -413,7 +413,7 @@ public class LoopBuilderForkTests
             .Finally<TestFinalStep>();
 
         // Assert
-        await Assert.That(workflow.ForkPoints).HasCount().EqualTo(2);
+        await Assert.That(workflow.ForkPoints).Count().IsEqualTo(2);
     }
 
     /// <summary>
@@ -442,7 +442,7 @@ public class LoopBuilderForkTests
             .Finally<TestFinalStep>();
 
         // Assert
-        await Assert.That(workflow.ForkPoints).HasCount().EqualTo(2);
+        await Assert.That(workflow.ForkPoints).Count().IsEqualTo(2);
     }
 
     // =============================================================================

--- a/src/Strategos.Tests/Builders/LoopBuilderTests.cs
+++ b/src/Strategos.Tests/Builders/LoopBuilderTests.cs
@@ -69,8 +69,8 @@ public class LoopBuilderTests
             .Finally<CompleteStep>();
 
         // Assert
-        await Assert.That(workflow.Loops).HasCount().EqualTo(1);
-        await Assert.That(workflow.Loops[0].BodySteps).HasCount().EqualTo(1);
+        await Assert.That(workflow.Loops).Count().IsEqualTo(1);
+        await Assert.That(workflow.Loops[0].BodySteps).Count().IsEqualTo(1);
         await Assert.That(workflow.Loops[0].BodySteps[0].StepType).IsEqualTo(typeof(CritiqueStep));
     }
 
@@ -94,7 +94,7 @@ public class LoopBuilderTests
             .Finally<CompleteStep>();
 
         // Assert
-        await Assert.That(workflow.Loops[0].BodySteps).HasCount().EqualTo(2);
+        await Assert.That(workflow.Loops[0].BodySteps).Count().IsEqualTo(2);
     }
 
     /// <summary>

--- a/src/Strategos.Tests/Builders/WorkflowBuilderAwaitApprovalTests.cs
+++ b/src/Strategos.Tests/Builders/WorkflowBuilderAwaitApprovalTests.cs
@@ -74,7 +74,7 @@ public class WorkflowBuilderAwaitApprovalTests
             .Finally<CompleteStep>();
 
         // Assert
-        await Assert.That(workflow.ApprovalPoints).HasCount().EqualTo(1);
+        await Assert.That(workflow.ApprovalPoints).Count().IsEqualTo(1);
     }
 
     /// <summary>
@@ -167,7 +167,7 @@ public class WorkflowBuilderAwaitApprovalTests
             .Finally<CompleteStep>();
 
         // Assert
-        await Assert.That(workflow.ApprovalPoints).HasCount().EqualTo(2);
+        await Assert.That(workflow.ApprovalPoints).Count().IsEqualTo(2);
     }
 
     /// <summary>
@@ -255,7 +255,7 @@ public class WorkflowBuilderAwaitApprovalTests
             .Finally<CompleteStep>();
 
         // Assert
-        await Assert.That(workflow.ApprovalPoints[0].Configuration.Options).HasCount().EqualTo(2);
+        await Assert.That(workflow.ApprovalPoints[0].Configuration.Options).Count().IsEqualTo(2);
         await Assert.That(workflow.ApprovalPoints[0].Configuration.Options[0].OptionId).IsEqualTo("approve");
         await Assert.That(workflow.ApprovalPoints[0].Configuration.Options[1].OptionId).IsEqualTo("reject");
     }
@@ -299,7 +299,7 @@ public class WorkflowBuilderAwaitApprovalTests
 
         // Assert
         await Assert.That(workflow.ApprovalPoints[0].RejectionHandler).IsNotNull();
-        await Assert.That(workflow.ApprovalPoints[0].RejectionHandler!.Steps).HasCount().EqualTo(1);
+        await Assert.That(workflow.ApprovalPoints[0].RejectionHandler!.Steps).Count().IsEqualTo(1);
     }
 
     // =============================================================================
@@ -322,7 +322,7 @@ public class WorkflowBuilderAwaitApprovalTests
             .Finally<CompleteStep>();
 
         // Assert
-        await Assert.That(workflow.Steps).HasCount().EqualTo(3);
+        await Assert.That(workflow.Steps).Count().IsEqualTo(3);
         await Assert.That(workflow.Steps[1].StepType).IsEqualTo(typeof(ProcessStep));
     }
 
@@ -348,6 +348,6 @@ public class WorkflowBuilderAwaitApprovalTests
             .Finally<CompleteStep>();
 
         // Assert
-        await Assert.That(workflow.BranchPoints).HasCount().EqualTo(1);
+        await Assert.That(workflow.BranchPoints).Count().IsEqualTo(1);
     }
 }

--- a/src/Strategos.Tests/Builders/WorkflowBuilderLambdaStepTests.cs
+++ b/src/Strategos.Tests/Builders/WorkflowBuilderLambdaStepTests.cs
@@ -66,7 +66,7 @@ public class WorkflowBuilderLambdaStepTests
             .Finally<CompleteStep>();
 
         // Assert - 3 steps: Validate, ProcessData (lambda), Complete
-        await Assert.That(workflow.Steps).HasCount().EqualTo(3);
+        await Assert.That(workflow.Steps).Count().IsEqualTo(3);
     }
 
     /// <summary>
@@ -186,7 +186,7 @@ public class WorkflowBuilderLambdaStepTests
             .Finally<CompleteStep>();
 
         // Assert - 4 steps: Validate, Step1, Step2, Complete
-        await Assert.That(workflow.Steps).HasCount().EqualTo(4);
+        await Assert.That(workflow.Steps).Count().IsEqualTo(4);
         await Assert.That(workflow.Steps[1].StepName).IsEqualTo("Step1");
         await Assert.That(workflow.Steps[2].StepName).IsEqualTo("Step2");
     }
@@ -210,7 +210,7 @@ public class WorkflowBuilderLambdaStepTests
             .Finally<CompleteStep>();
 
         // Assert - 5 steps: Validate, Process, CustomLogic, Process, Complete
-        await Assert.That(workflow.Steps).HasCount().EqualTo(5);
+        await Assert.That(workflow.Steps).Count().IsEqualTo(5);
         await Assert.That(workflow.Steps[0].IsLambdaStep).IsFalse();
         await Assert.That(workflow.Steps[2].IsLambdaStep).IsTrue();
         await Assert.That(workflow.Steps[2].StepName).IsEqualTo("CustomLogic");

--- a/src/Strategos.Tests/Builders/WorkflowBuilderOnFailureTests.cs
+++ b/src/Strategos.Tests/Builders/WorkflowBuilderOnFailureTests.cs
@@ -108,7 +108,7 @@ public class WorkflowBuilderOnFailureTests
             .Finally<CompleteStep>();
 
         // Assert
-        await Assert.That(workflow.FailureHandlers).HasCount().EqualTo(1);
+        await Assert.That(workflow.FailureHandlers).Count().IsEqualTo(1);
     }
 
     /// <summary>
@@ -145,7 +145,7 @@ public class WorkflowBuilderOnFailureTests
             .Finally<CompleteStep>();
 
         // Assert
-        await Assert.That(workflow.FailureHandlers[0].Steps).HasCount().EqualTo(2);
+        await Assert.That(workflow.FailureHandlers[0].Steps).Count().IsEqualTo(2);
         await Assert.That(workflow.FailureHandlers[0].Steps[0].StepType).IsEqualTo(typeof(LogFailureStep));
         await Assert.That(workflow.FailureHandlers[0].Steps[1].StepType).IsEqualTo(typeof(NotifyAdminStep));
     }
@@ -198,7 +198,7 @@ public class WorkflowBuilderOnFailureTests
             .Finally<CompleteStep>();
 
         // Assert - 3 steps: Validate, LogFailure, Complete
-        await Assert.That(workflow.Steps).HasCount().EqualTo(3);
+        await Assert.That(workflow.Steps).Count().IsEqualTo(3);
     }
 
     // =============================================================================
@@ -220,8 +220,8 @@ public class WorkflowBuilderOnFailureTests
             .Finally<CompleteStep>();
 
         // Assert
-        await Assert.That(workflow.Steps).HasCount().EqualTo(4);
-        await Assert.That(workflow.FailureHandlers).HasCount().EqualTo(1);
+        await Assert.That(workflow.Steps).Count().IsEqualTo(4);
+        await Assert.That(workflow.FailureHandlers).Count().IsEqualTo(1);
     }
 
     /// <summary>
@@ -243,6 +243,6 @@ public class WorkflowBuilderOnFailureTests
             .Finally<CompleteStep>();
 
         // Assert
-        await Assert.That(workflow.FailureHandlers).HasCount().EqualTo(1);
+        await Assert.That(workflow.FailureHandlers).Count().IsEqualTo(1);
     }
 }

--- a/src/Strategos.Tests/Builders/WorkflowBuilderTests.cs
+++ b/src/Strategos.Tests/Builders/WorkflowBuilderTests.cs
@@ -217,7 +217,7 @@ public class WorkflowBuilderTests
             .Finally<CompleteStep>();
 
         // Assert - 3 steps: Validate, Process, Complete
-        await Assert.That(workflow.Steps).HasCount().EqualTo(3);
+        await Assert.That(workflow.Steps).Count().IsEqualTo(3);
     }
 
     /// <summary>
@@ -234,7 +234,7 @@ public class WorkflowBuilderTests
             .Finally<CompleteStep>();
 
         // Assert - 2 transitions: Validate->Process, Process->Complete
-        await Assert.That(workflow.Transitions).HasCount().EqualTo(2);
+        await Assert.That(workflow.Transitions).Count().IsEqualTo(2);
     }
 
     /// <summary>
@@ -352,7 +352,7 @@ public class WorkflowBuilderTests
             .Finally<CompleteStep>();
 
         // Assert
-        await Assert.That(workflow.BranchPoints).HasCount().EqualTo(1);
+        await Assert.That(workflow.BranchPoints).Count().IsEqualTo(1);
     }
 
     /// <summary>
@@ -375,7 +375,7 @@ public class WorkflowBuilderTests
             .Finally<CompleteStep>();
 
         // Assert
-        await Assert.That(workflow.BranchPoints[0].Paths).HasCount().EqualTo(2);
+        await Assert.That(workflow.BranchPoints[0].Paths).Count().IsEqualTo(2);
     }
 
     /// <summary>
@@ -397,7 +397,7 @@ public class WorkflowBuilderTests
 
         // Assert
         var branchPath = workflow.BranchPoints[0].Paths[0];
-        await Assert.That(branchPath.Steps).HasCount().EqualTo(1);
+        await Assert.That(branchPath.Steps).Count().IsEqualTo(1);
         await Assert.That(branchPath.Steps[0].StepType).IsEqualTo(typeof(AutoProcessStep));
     }
 
@@ -421,7 +421,7 @@ public class WorkflowBuilderTests
             .Finally<CompleteStep>();
 
         // Assert - 4 steps: Validate, AutoProcess, ManualProcess, Complete
-        await Assert.That(workflow.Steps).HasCount().EqualTo(4);
+        await Assert.That(workflow.Steps).Count().IsEqualTo(4);
     }
 
     /// <summary>
@@ -444,7 +444,7 @@ public class WorkflowBuilderTests
 
         // Assert - Branch should rejoin at NotifyStep
         // Steps: Validate, AutoProcess, Notify, Complete
-        await Assert.That(workflow.Steps).HasCount().EqualTo(4);
+        await Assert.That(workflow.Steps).Count().IsEqualTo(4);
     }
 
     /// <summary>

--- a/src/Strategos.Tests/Configuration/BudgetOptionsTests.cs
+++ b/src/Strategos.Tests/Configuration/BudgetOptionsTests.cs
@@ -40,7 +40,7 @@ public sealed class BudgetOptionsTests
         var results = options.Validate(context).ToList();
 
         // Assert
-        await Assert.That(results).HasCount(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].MemberNames).Contains(nameof(BudgetOptions.StepsPerComplexityUnit));
     }
 
@@ -55,7 +55,7 @@ public sealed class BudgetOptionsTests
         var results = options.Validate(context).ToList();
 
         // Assert
-        await Assert.That(results).HasCount(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].ErrorMessage).Contains("StepsPerComplexityUnit");
     }
 
@@ -70,7 +70,7 @@ public sealed class BudgetOptionsTests
         var results = options.Validate(context).ToList();
 
         // Assert
-        await Assert.That(results).HasCount(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].MemberNames).Contains(nameof(BudgetOptions.AverageTokensPerStep));
     }
 
@@ -85,7 +85,7 @@ public sealed class BudgetOptionsTests
         var results = options.Validate(context).ToList();
 
         // Assert
-        await Assert.That(results).HasCount(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].ErrorMessage).Contains("AverageTokensPerStep");
     }
 
@@ -103,7 +103,7 @@ public sealed class BudgetOptionsTests
         var results = options.Validate(context).ToList();
 
         // Assert
-        await Assert.That(results).HasCount(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].MemberNames).Contains(nameof(BudgetOptions.ExecutionRatio));
     }
 
@@ -135,7 +135,7 @@ public sealed class BudgetOptionsTests
         var results = options.Validate(context).ToList();
 
         // Assert
-        await Assert.That(results).HasCount(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].MemberNames).Contains(nameof(BudgetOptions.ToolCallRatio));
     }
 
@@ -170,7 +170,7 @@ public sealed class BudgetOptionsTests
         var results = options.Validate(context).ToList();
 
         // Assert
-        await Assert.That(results).HasCount(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].MemberNames).Contains(nameof(BudgetOptions.RetryMargin));
     }
 
@@ -202,7 +202,7 @@ public sealed class BudgetOptionsTests
         var results = options.Validate(context).ToList();
 
         // Assert
-        await Assert.That(results).HasCount(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].MemberNames).Contains(nameof(BudgetOptions.DefaultStepBudget));
     }
 
@@ -217,7 +217,7 @@ public sealed class BudgetOptionsTests
         var results = options.Validate(context).ToList();
 
         // Assert
-        await Assert.That(results).HasCount(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].MemberNames).Contains(nameof(BudgetOptions.DefaultTokenBudget));
     }
 
@@ -232,7 +232,7 @@ public sealed class BudgetOptionsTests
         var results = options.Validate(context).ToList();
 
         // Assert
-        await Assert.That(results).HasCount(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].MemberNames).Contains(nameof(BudgetOptions.DefaultWallTimeSeconds));
     }
 
@@ -253,7 +253,7 @@ public sealed class BudgetOptionsTests
         var results = options.Validate(context).ToList();
 
         // Assert
-        await Assert.That(results).HasCount(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].ErrorMessage).Contains("increasing order");
     }
 
@@ -274,7 +274,7 @@ public sealed class BudgetOptionsTests
         var results = options.Validate(context).ToList();
 
         // Assert
-        await Assert.That(results).HasCount(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].MemberNames).Contains(nameof(BudgetOptions.AbundantMultiplier));
     }
 
@@ -295,7 +295,7 @@ public sealed class BudgetOptionsTests
         var results = options.Validate(context).ToList();
 
         // Assert
-        await Assert.That(results).HasCount(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].MemberNames).Contains(nameof(BudgetOptions.ScarceMultiplier));
     }
 

--- a/src/Strategos.Tests/Configuration/LoopDetectionOptionsTests.cs
+++ b/src/Strategos.Tests/Configuration/LoopDetectionOptionsTests.cs
@@ -40,7 +40,7 @@ public sealed class LoopDetectionOptionsTests
         var results = options.Validate(context).ToList();
 
         // Assert
-        await Assert.That(results).HasCount(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].MemberNames).Contains(nameof(LoopDetectionOptions.WindowSize));
     }
 
@@ -55,7 +55,7 @@ public sealed class LoopDetectionOptionsTests
         var results = options.Validate(context).ToList();
 
         // Assert
-        await Assert.That(results).HasCount(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].ErrorMessage).Contains("WindowSize");
     }
 
@@ -70,7 +70,7 @@ public sealed class LoopDetectionOptionsTests
         var results = options.Validate(context).ToList();
 
         // Assert
-        await Assert.That(results).HasCount(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].ErrorMessage).Contains("exceed 20");
     }
 
@@ -106,7 +106,7 @@ public sealed class LoopDetectionOptionsTests
         var results = options.Validate(context).ToList();
 
         // Assert
-        await Assert.That(results).HasCount(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].MemberNames).Contains(nameof(LoopDetectionOptions.SimilarityThreshold));
     }
 
@@ -139,7 +139,7 @@ public sealed class LoopDetectionOptionsTests
         var results = options.Validate(context).ToList();
 
         // Assert
-        await Assert.That(results).HasCount(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].MemberNames).Contains(nameof(LoopDetectionOptions.MaxResets));
     }
 
@@ -154,7 +154,7 @@ public sealed class LoopDetectionOptionsTests
         var results = options.Validate(context).ToList();
 
         // Assert
-        await Assert.That(results).HasCount(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].ErrorMessage).Contains("MaxResets");
     }
 
@@ -169,7 +169,7 @@ public sealed class LoopDetectionOptionsTests
         var results = options.Validate(context).ToList();
 
         // Assert
-        await Assert.That(results).HasCount(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].MemberNames).Contains(nameof(LoopDetectionOptions.MaxSpecialistRetries));
     }
 
@@ -184,7 +184,7 @@ public sealed class LoopDetectionOptionsTests
         var results = options.Validate(context).ToList();
 
         // Assert
-        await Assert.That(results).HasCount(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].ErrorMessage).Contains("MaxSpecialistRetries");
     }
 
@@ -203,7 +203,7 @@ public sealed class LoopDetectionOptionsTests
         var results = options.Validate(context).ToList();
 
         // Assert
-        await Assert.That(results).HasCount(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].MemberNames).Contains(nameof(LoopDetectionOptions.RecoveryThreshold));
     }
 
@@ -242,7 +242,7 @@ public sealed class LoopDetectionOptionsTests
         var results = options.Validate(context).ToList();
 
         // Assert
-        await Assert.That(results).HasCount(1);
+        await Assert.That(results).Count().IsEqualTo(1);
         await Assert.That(results[0].ErrorMessage).Contains("sum to 1.0");
     }
 

--- a/src/Strategos.Tests/Definitions/FailureHandlerDefinitionTests.cs
+++ b/src/Strategos.Tests/Definitions/FailureHandlerDefinitionTests.cs
@@ -210,7 +210,7 @@ public class FailureHandlerDefinitionTests
             isTerminal: true);
 
         // Assert
-        await Assert.That(definition.Steps).HasCount().EqualTo(2);
+        await Assert.That(definition.Steps).Count().IsEqualTo(2);
         await Assert.That(definition.Steps[0].StepType).IsEqualTo(typeof(LogFailureStep));
         await Assert.That(definition.Steps[1].StepType).IsEqualTo(typeof(NotifyAdminStep));
     }

--- a/src/Strategos.Tests/Definitions/ForkPathDefinitionTests.cs
+++ b/src/Strategos.Tests/Definitions/ForkPathDefinitionTests.cs
@@ -154,7 +154,7 @@ public class ForkPathDefinitionTests
         var definition = ForkPathDefinition.Create(pathIndex: 0, steps: steps);
 
         // Assert
-        await Assert.That(definition.Steps).HasCount().EqualTo(2);
+        await Assert.That(definition.Steps).Count().IsEqualTo(2);
         await Assert.That(definition.Steps[0].StepType).IsEqualTo(typeof(ProcessStep));
         await Assert.That(definition.Steps[1].StepType).IsEqualTo(typeof(CompleteStep));
     }

--- a/src/Strategos.Tests/Definitions/ForkPathStatusTests.cs
+++ b/src/Strategos.Tests/Definitions/ForkPathStatusTests.cs
@@ -83,6 +83,6 @@ public class ForkPathStatusTests
         var values = Enum.GetValues<ForkPathStatus>();
 
         // Assert
-        await Assert.That(values).HasCount().EqualTo(5);
+        await Assert.That(values).Count().IsEqualTo(5);
     }
 }

--- a/src/Strategos.Tests/Definitions/ForkPointDefinitionTests.cs
+++ b/src/Strategos.Tests/Definitions/ForkPointDefinitionTests.cs
@@ -227,7 +227,7 @@ public class ForkPointDefinitionTests
             joinStepId: "join-step");
 
         // Assert
-        await Assert.That(definition.Paths).HasCount().EqualTo(3);
+        await Assert.That(definition.Paths).Count().IsEqualTo(3);
         await Assert.That(definition.Paths[0].PathIndex).IsEqualTo(0);
         await Assert.That(definition.Paths[1].PathIndex).IsEqualTo(1);
         await Assert.That(definition.Paths[2].PathIndex).IsEqualTo(2);

--- a/src/Strategos.Tests/Definitions/WorkflowDefinitionTests.cs
+++ b/src/Strategos.Tests/Definitions/WorkflowDefinitionTests.cs
@@ -92,7 +92,7 @@ public class WorkflowDefinitionTests
         await Assert.That(original.Steps).IsEmpty();
 
         // Assert - Updated has the step
-        await Assert.That(updated.Steps).HasCount().EqualTo(1);
+        await Assert.That(updated.Steps).Count().IsEqualTo(1);
         await Assert.That(updated.Steps[0]).IsEqualTo(step);
     }
 
@@ -115,7 +115,7 @@ public class WorkflowDefinitionTests
             .WithStep(step3);
 
         // Assert
-        await Assert.That(result.Steps).HasCount().EqualTo(3);
+        await Assert.That(result.Steps).Count().IsEqualTo(3);
         await Assert.That(result.Steps[0]).IsEqualTo(step1);
         await Assert.That(result.Steps[1]).IsEqualTo(step2);
         await Assert.That(result.Steps[2]).IsEqualTo(step3);
@@ -265,7 +265,7 @@ public class WorkflowDefinitionTests
         var updated = definition.WithLoop(loop);
 
         // Assert
-        await Assert.That(updated.Loops).HasCount().EqualTo(1);
+        await Assert.That(updated.Loops).Count().IsEqualTo(1);
         await Assert.That(updated.Loops[0].LoopName).IsEqualTo("Refinement");
     }
 
@@ -285,7 +285,7 @@ public class WorkflowDefinitionTests
 
         // Assert
         await Assert.That(original.Loops).IsEmpty();
-        await Assert.That(updated.Loops).HasCount().EqualTo(1);
+        await Assert.That(updated.Loops).Count().IsEqualTo(1);
     }
 
     /// <summary>
@@ -306,7 +306,7 @@ public class WorkflowDefinitionTests
             .WithLoop(loop2);
 
         // Assert
-        await Assert.That(updated.Loops).HasCount().EqualTo(2);
+        await Assert.That(updated.Loops).Count().IsEqualTo(2);
         await Assert.That(updated.Loops[0].LoopName).IsEqualTo("Refinement");
         await Assert.That(updated.Loops[1].LoopName).IsEqualTo("Validation");
     }
@@ -344,7 +344,7 @@ public class WorkflowDefinitionTests
         var updated = definition.WithLoops(loops);
 
         // Assert
-        await Assert.That(updated.Loops).HasCount().EqualTo(2);
+        await Assert.That(updated.Loops).Count().IsEqualTo(2);
     }
 
     /// <summary>

--- a/src/Strategos.Tests/Orchestration/Ledgers/LedgerTypesTests.cs
+++ b/src/Strategos.Tests/Orchestration/Ledgers/LedgerTypesTests.cs
@@ -142,7 +142,7 @@ public sealed class LedgerTypesTests
         await Assert.That(entry.Signal).IsEqualTo(signal);
         await Assert.That(entry.ExecutorState).IsEqualTo(ExecutorState.Signaling);
         await Assert.That(entry.Output).IsEqualTo("Task completed successfully");
-        await Assert.That(entry.Artifacts).HasCount(2);
+        await Assert.That(entry.Artifacts).Count().IsEqualTo(2);
     }
 
     /// <summary>
@@ -394,7 +394,7 @@ public sealed class LedgerTypesTests
         // Assert
         await Assert.That(successData.Result).IsEqualTo("Completed successfully");
         await Assert.That(successData.Confidence).IsEqualTo(0.95);
-        await Assert.That(successData.Artifacts).HasCount(2);
+        await Assert.That(successData.Artifacts).Count().IsEqualTo(2);
         await Assert.That(successData.Artifacts).Contains("file1.txt");
     }
 

--- a/src/Strategos.Tests/Selection/AgentSelectionFeaturesTests.cs
+++ b/src/Strategos.Tests/Selection/AgentSelectionFeaturesTests.cs
@@ -133,7 +133,7 @@ public class AgentSelectionFeaturesTests
         };
 
         // Assert
-        await Assert.That(selection.Features!.MatchedKeywords).HasCount(3);
+        await Assert.That(selection.Features!.MatchedKeywords).Count().IsEqualTo(3);
         await Assert.That(selection.Features.MatchedKeywords).Contains("search");
     }
 

--- a/src/Strategos.Tests/Selection/TaskFeaturesTests.cs
+++ b/src/Strategos.Tests/Selection/TaskFeaturesTests.cs
@@ -233,7 +233,7 @@ public class TaskFeaturesTests
         var features = new TaskFeatures { MatchedKeywords = keywords };
 
         // Assert
-        await Assert.That(features.MatchedKeywords).HasCount(3);
+        await Assert.That(features.MatchedKeywords).Count().IsEqualTo(3);
         await Assert.That(features.MatchedKeywords).Contains("code");
         await Assert.That(features.MatchedKeywords).Contains("implement");
     }


### PR DESCRIPTION
## Summary

Behavior-preserving bump of all centrally-managed dependencies in `src/Directory.Packages.props` to latest stable (2026-04-18). 7 commits, one per bump; pass count **3430/0/0** held across every commit.

## What changed

| Package | From | To |
|---|---|---|
| Microsoft.Extensions.* (6 packages) | 10.0.0 | 10.0.6 |
| Microsoft.Extensions.TimeProvider.Testing | 10.0.0 | 10.5.0 (10.0.6 never published) |
| Microsoft.Extensions.AI / .Abstractions | 10.0.1 | 10.5.0 (version-locked pair) |
| Npgsql | 9.0.3 | 10.0.2 |
| TUnit | 1.2.11 | 1.37.0 |
| Microsoft.CodeAnalysis.CSharp / .Analyzers | 4.14.0 | 5.3.0 |
| MemoryPack | 1.21.3 | 1.21.4 |
| Pgvector | 0.3.0 | 0.3.2 |
| BitFaster.Caching | 2.5.2 | 2.5.4 |
| CommunityToolkit.HighPerformance | 8.4.0 | 8.4.2 |

Held at current: NSubstitute (5.3.0, 6.0 is RC), MinVer, Lvlup.Build, Verify.SourceGenerators, BenchmarkDotNet.

## Breaking: raises .NET SDK floor

The Roslyn 5.3 bump requires C# compiler ≥ 5.3.0, which .NET SDK 10.0.1xx does not ship (analyzer load fails with CS9057). `global.json` is pinned to SDK **10.0.202** with `rollForward: latestFeature`. CI via `actions/setup-dotnet@v4 dotnet-version: '10.0.x'` respects `global.json` and picks up the pin automatically. Local contributors need a .NET 10 SDK in the `10.0.2xx` feature band or later. See `AGENTS.md` → Build Requirements.

## Mechanical test-code rewrites (TUnit 1.37)

TUnit's analyzer surfaced two deprecations:
- **336 sites** — `.HasCount(X)` / `.HasCount().EqualTo(X)` / `.HasCount().GreaterThanOrEqualTo(X)` rewritten to `.Count().IsEqualTo(X)` / `.Count().IsGreaterThanOrEqualTo(X)` across 86 test files.
- **4 sites** — `.IsEqualTo(true/false)` rewritten to `.IsTrue()/.IsFalse()` (2 sites required a `(bool)x!` cast on dictionary-indexed subjects).

All rewrites are semantically equivalent and reviewed.

## Out of scope (tracked separately)

- **MCP SDK adoption** — not currently a dependency. Producer-side (Strategos.Ontology.MCP exposes MCP-shaped tool descriptors without the official SDK) and consumer-side opportunities remain untouched.
- **Microsoft.Extensions.AI 10.5 feature adoption in Strategos.Agents** — tracked in #45 (structured output, `UseFunctionInvocation`, `AIFunctionFactory`, MCP-client-as-tools, `ChatClientBuilder` middleware).
- **Npgsql 10 DateOnly/TimeOnly migration** — N/A (no date/time columns in ontology schema; only `timestamptz`).
- **NSubstitute 6.0 RC** — wait for stable.

## Test plan

- [x] `dotnet build src/strategos.sln /p:TreatWarningsAsErrors=true` — green after every bump
- [x] `dotnet test src/strategos.sln` — **3430 passed / 0 failed / 0 skipped** at baseline and after every commit (regression fence)
- [x] `dotnet test src/Strategos.Generators.Tests` — **1162/0/0** post-Roslyn-5.3
- [x] `dotnet test src/Strategos.Ontology.Generators.Tests` — **69/0/0** post-Roslyn-5.3
- [x] Generator Verify snapshots unchanged under Roslyn 5.3 (no `.received.*` produced — behavior-preservation proven)
- [x] Two-stage review APPROVED (0 HIGH / 0 MEDIUM / 0 LOW)

## Plan

`docs/plans/2026-04-18-dep-refresh.md` (included in this PR) — sequential 7-task execution with per-task gate validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)