### PR TITLE
feat(ontology): OntologyGraph.Version hash (closes #44)

### DIFF
--- a/src/Strategos.Ontology.Tests/OntologyGraphVersionTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphVersionTests.cs
@@ -1,11 +1,63 @@
 using System.Text.RegularExpressions;
 using Strategos.Ontology.Builder;
+using Strategos.Ontology.Descriptors;
 
 namespace Strategos.Ontology.Tests;
 
 public class OntologyGraphVersionTests
 {
     private static readonly Regex LowercaseHex64 = new("^[0-9a-f]{64}$", RegexOptions.Compiled);
+
+    // ------------------------------------------------------------------
+    // Helpers — construct OntologyGraph instances directly via the
+    // internal constructor so tests can isolate single structural deltas
+    // without going through the full DSL pipeline.
+    // ------------------------------------------------------------------
+
+    private static OntologyGraph Graph(
+        IReadOnlyList<DomainDescriptor>? domains = null,
+        IReadOnlyList<ObjectTypeDescriptor>? objectTypes = null,
+        IReadOnlyList<InterfaceDescriptor>? interfaces = null,
+        IReadOnlyList<ResolvedCrossDomainLink>? crossDomainLinks = null,
+        IReadOnlyList<WorkflowChain>? workflowChains = null,
+        IReadOnlyList<string>? warnings = null)
+    {
+        return new OntologyGraph(
+            domains ?? [],
+            objectTypes ?? [],
+            interfaces ?? [],
+            crossDomainLinks ?? [],
+            workflowChains ?? [],
+            objectTypeNamesByType: null,
+            warnings: warnings);
+    }
+
+    private static DomainDescriptor Domain(string name, params ObjectTypeDescriptor[] objectTypes) =>
+        new(name) { ObjectTypes = objectTypes };
+
+    private static ObjectTypeDescriptor ObjectType(
+        string name,
+        string domain,
+        Type? clrType = null,
+        PropertyDescriptor[]? properties = null,
+        ActionDescriptor[]? actions = null,
+        LinkDescriptor[]? links = null,
+        EventDescriptor[]? events = null,
+        InterfaceDescriptor[]? implementedInterfaces = null,
+        LifecycleDescriptor? lifecycle = null,
+        string? parentTypeName = null)
+    {
+        return new ObjectTypeDescriptor(name, clrType ?? typeof(object), domain)
+        {
+            Properties = properties ?? [],
+            Actions = actions ?? [],
+            Links = links ?? [],
+            Events = events ?? [],
+            ImplementedInterfaces = implementedInterfaces ?? [],
+            Lifecycle = lifecycle,
+            ParentTypeName = parentTypeName,
+        };
+    }
 
     [Test]
     public async Task Version_OnEmptyGraph_ReturnsLowercaseSha256Hex()
@@ -35,5 +87,131 @@ public class OntologyGraphVersionTests
         var graphB = new OntologyGraphBuilder().Build();
 
         await Assert.That(graphA.Version).IsEqualTo(graphB.Version);
+    }
+
+    // ------------------------------------------------------------------
+    // A2: hasher must be sensitive to ObjectType structural changes.
+    // ------------------------------------------------------------------
+
+    [Test]
+    public async Task Version_AddingObjectType_ChangesHash()
+    {
+        var graphA = Graph(domains: [Domain("d")]);
+
+        var t = ObjectType("T", "d");
+        var graphB = Graph(domains: [Domain("d", t)], objectTypes: [t]);
+
+        await Assert.That(graphA.Version).IsNotEqualTo(graphB.Version);
+    }
+
+    [Test]
+    public async Task Version_AddingProperty_ChangesHash()
+    {
+        var tA = ObjectType("T", "d");
+        var graphA = Graph(domains: [Domain("d", tA)], objectTypes: [tA]);
+
+        var tB = ObjectType("T", "d", properties:
+        [
+            new PropertyDescriptor("X", typeof(string)),
+        ]);
+        var graphB = Graph(domains: [Domain("d", tB)], objectTypes: [tB]);
+
+        await Assert.That(graphA.Version).IsNotEqualTo(graphB.Version);
+    }
+
+    [Test]
+    public async Task Version_RenamingAction_ChangesHash()
+    {
+        var tA = ObjectType("T", "d", actions:
+        [
+            new ActionDescriptor("DoIt", "desc"),
+        ]);
+        var graphA = Graph(domains: [Domain("d", tA)], objectTypes: [tA]);
+
+        var tB = ObjectType("T", "d", actions:
+        [
+            new ActionDescriptor("DoItRenamed", "desc"),
+        ]);
+        var graphB = Graph(domains: [Domain("d", tB)], objectTypes: [tB]);
+
+        await Assert.That(graphA.Version).IsNotEqualTo(graphB.Version);
+    }
+
+    [Test]
+    public async Task Version_AddingLink_ChangesHash()
+    {
+        var tA = ObjectType("T", "d");
+        var graphA = Graph(domains: [Domain("d", tA)], objectTypes: [tA]);
+
+        var tB = ObjectType("T", "d", links:
+        [
+            new LinkDescriptor("ToOther", "Other", LinkCardinality.OneToMany),
+        ]);
+        var graphB = Graph(domains: [Domain("d", tB)], objectTypes: [tB]);
+
+        await Assert.That(graphA.Version).IsNotEqualTo(graphB.Version);
+    }
+
+    [Test]
+    public async Task Version_AddingEvent_ChangesHash()
+    {
+        var tA = ObjectType("T", "d");
+        var graphA = Graph(domains: [Domain("d", tA)], objectTypes: [tA]);
+
+        var tB = ObjectType("T", "d", events:
+        [
+            new EventDescriptor(typeof(int), "evt"),
+        ]);
+        var graphB = Graph(domains: [Domain("d", tB)], objectTypes: [tB]);
+
+        await Assert.That(graphA.Version).IsNotEqualTo(graphB.Version);
+    }
+
+    [Test]
+    public async Task Version_LifecycleStateAddition_ChangesHash()
+    {
+        var lcA = new LifecycleDescriptor
+        {
+            PropertyName = "Status",
+            StateEnumTypeName = "S",
+            States =
+            [
+                new LifecycleStateDescriptor { Name = "Open", IsInitial = true },
+            ],
+            Transitions = [],
+        };
+        var lcB = new LifecycleDescriptor
+        {
+            PropertyName = "Status",
+            StateEnumTypeName = "S",
+            States =
+            [
+                new LifecycleStateDescriptor { Name = "Open", IsInitial = true },
+                new LifecycleStateDescriptor { Name = "Closed", IsTerminal = true },
+            ],
+            Transitions = [],
+        };
+
+        var tA = ObjectType("T", "d", lifecycle: lcA);
+        var tB = ObjectType("T", "d", lifecycle: lcB);
+
+        var graphA = Graph(domains: [Domain("d", tA)], objectTypes: [tA]);
+        var graphB = Graph(domains: [Domain("d", tB)], objectTypes: [tB]);
+
+        await Assert.That(graphA.Version).IsNotEqualTo(graphB.Version);
+    }
+
+    [Test]
+    public async Task Version_ImplementedInterface_ChangesHash()
+    {
+        var iface = new InterfaceDescriptor("ISearchable", typeof(IDisposable));
+
+        var tA = ObjectType("T", "d");
+        var tB = ObjectType("T", "d", implementedInterfaces: [iface]);
+
+        var graphA = Graph(domains: [Domain("d", tA)], objectTypes: [tA]);
+        var graphB = Graph(domains: [Domain("d", tB)], objectTypes: [tB], interfaces: [iface]);
+
+        await Assert.That(graphA.Version).IsNotEqualTo(graphB.Version);
     }
 }

--- a/src/Strategos.Ontology.Tests/OntologyGraphVersionTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphVersionTests.cs
@@ -273,4 +273,64 @@ public class OntologyGraphVersionTests
 
         await Assert.That(graphA.Version).IsNotEqualTo(graphB.Version);
     }
+
+    // ------------------------------------------------------------------
+    // A4: hasher must be INSENSITIVE to free-form Description text and
+    // to OntologyGraph.Warnings — design §4.1. Documentation churn must
+    // not bust caches that exist for structural invalidation.
+    // ------------------------------------------------------------------
+
+    [Test]
+    public async Task Version_ChangingActionDescription_DoesNotChangeHash()
+    {
+        var tA = ObjectType("T", "d", actions:
+        [
+            new ActionDescriptor("DoIt", "Original description"),
+        ]);
+        var tB = ObjectType("T", "d", actions:
+        [
+            new ActionDescriptor("DoIt", "Completely different prose"),
+        ]);
+
+        var graphA = Graph(domains: [Domain("d", tA)], objectTypes: [tA]);
+        var graphB = Graph(domains: [Domain("d", tB)], objectTypes: [tB]);
+
+        await Assert.That(graphA.Version).IsEqualTo(graphB.Version);
+    }
+
+    [Test]
+    public async Task Version_ChangingLinkDescription_DoesNotChangeHash()
+    {
+        var tA = ObjectType("T", "d", links:
+        [
+            new LinkDescriptor("ToOther", "Other", LinkCardinality.OneToMany)
+            {
+                Description = "Original",
+            },
+        ]);
+        var tB = ObjectType("T", "d", links:
+        [
+            new LinkDescriptor("ToOther", "Other", LinkCardinality.OneToMany)
+            {
+                Description = "Different",
+            },
+        ]);
+
+        var graphA = Graph(domains: [Domain("d", tA)], objectTypes: [tA]);
+        var graphB = Graph(domains: [Domain("d", tB)], objectTypes: [tB]);
+
+        await Assert.That(graphA.Version).IsEqualTo(graphB.Version);
+    }
+
+    [Test]
+    public async Task Version_DifferingWarnings_DoesNotChangeHash()
+    {
+        // Graphs with identical structural shape but different Warnings lists.
+        // Warnings are advisory diagnostic output; they must not influence the
+        // structural cache key.
+        var graphA = Graph(domains: [Domain("d")], warnings: []);
+        var graphB = Graph(domains: [Domain("d")], warnings: ["orphan interface"]);
+
+        await Assert.That(graphA.Version).IsEqualTo(graphB.Version);
+    }
 }

--- a/src/Strategos.Ontology.Tests/OntologyGraphVersionTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphVersionTests.cs
@@ -333,4 +333,72 @@ public class OntologyGraphVersionTests
 
         await Assert.That(graphA.Version).IsEqualTo(graphB.Version);
     }
+
+    // ------------------------------------------------------------------
+    // A5: reference fixture pins a known hash so any future drift in
+    // OntologyGraphHasher serialization shape (field order, framing,
+    // included fields) becomes a visible failure in CI.
+    // ------------------------------------------------------------------
+
+    // Pinned hash for the reference fixture. If this changes, the
+    // OntologyGraphHasher serialization shape has drifted — review the diff
+    // before updating.
+    private const string ReferenceFixtureVersion =
+        "9b3e82f07bd553bf5c71ccd222cc9f814082f677a1572c629d927e06d12698ca";
+
+    [Test]
+    public async Task Version_ReferenceFixture_MatchesPinnedConstant()
+    {
+        var graph = BuildReferenceFixture();
+
+        await Assert.That(graph.Version).IsEqualTo(ReferenceFixtureVersion);
+    }
+
+    private static OntologyGraph BuildReferenceFixture()
+    {
+        // Two domains, one ObjectType with a property + an action + a link,
+        // one cross-domain link, one workflow chain. Small enough that the
+        // pinned constant is easy to recompute by hand if needed; large
+        // enough to exercise every section of the hasher.
+        var orderType = new ObjectTypeDescriptor("Order", typeof(int), "trading")
+        {
+            Properties =
+            [
+                new PropertyDescriptor("Id", typeof(string), IsRequired: true),
+            ],
+            Actions =
+            [
+                new ActionDescriptor("Submit", "submit the order"),
+            ],
+            Links =
+            [
+                new LinkDescriptor("ForInstrument", "Instrument", LinkCardinality.OneToOne),
+            ],
+        };
+        var instrumentType = new ObjectTypeDescriptor("Instrument", typeof(string), "market-data");
+
+        var domains = new[]
+        {
+            new DomainDescriptor("trading") { ObjectTypes = [orderType] },
+            new DomainDescriptor("market-data") { ObjectTypes = [instrumentType] },
+        };
+
+        var xdl = new ResolvedCrossDomainLink(
+            "OrderToInstrument",
+            "trading",
+            orderType,
+            "market-data",
+            instrumentType,
+            LinkCardinality.OneToOne,
+            []);
+
+        var chain = new WorkflowChain("OrderFlow", orderType, instrumentType);
+
+        return new OntologyGraph(
+            domains,
+            [orderType, instrumentType],
+            interfaces: [],
+            crossDomainLinks: [xdl],
+            workflowChains: [chain]);
+    }
 }

--- a/src/Strategos.Ontology.Tests/OntologyGraphVersionTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphVersionTests.cs
@@ -1,6 +1,7 @@
 using System.Text.RegularExpressions;
 using Strategos.Ontology.Builder;
 using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Internal;
 
 namespace Strategos.Ontology.Tests;
 
@@ -596,6 +597,91 @@ public class OntologyGraphVersionTests
         var graph = BuildReferenceFixture();
 
         await Assert.That(graph.Version).IsEqualTo(ReferenceFixtureVersion);
+    }
+
+    // ------------------------------------------------------------------
+    // Permutation invariance — pins the canonicalization-via-sort guarantee
+    // across all four contribution surfaces: domain order, ObjectType order
+    // within a domain, CrossDomainLink order, and WorkflowChain order.
+    //
+    // CodeRabbit PR #49 nit: ensures shuffled registration order produces
+    // the same hash, which depends on the tie-breaker chain in
+    // OntologyGraphHasher being a *total* order over structural fields.
+    // Without complete tie-breakers, two equivalent collections can sort
+    // differently when their primary keys collide.
+    // ------------------------------------------------------------------
+
+    [Test]
+    public async Task Version_ShuffledRegistrationOrder_DoesNotChangeHash()
+    {
+        var graphA = BuildPermutationFixture(shuffled: false);
+        var graphB = BuildPermutationFixture(shuffled: true);
+
+        await Assert.That(graphA.Version).IsEqualTo(graphB.Version);
+    }
+
+    private static OntologyGraph BuildPermutationFixture(bool shuffled)
+    {
+        // Two domains, each with two object types. Two cross-domain links share
+        // the same SourceDomain (forcing the tie-breaker on TargetDomain /
+        // TargetObjectType / Cardinality to be exercised). Two workflow chains
+        // share the same WorkflowName (forcing the tie-breaker on
+        // ConsumedType.ClrType.FullName / ProducedType.ClrType.FullName).
+        var alphaA = new ObjectTypeDescriptor("Alpha", typeof(int), "domA");
+        var betaA = new ObjectTypeDescriptor("Beta", typeof(long), "domA");
+        var gammaB = new ObjectTypeDescriptor("Gamma", typeof(string), "domB");
+        var deltaB = new ObjectTypeDescriptor("Delta", typeof(double), "domB");
+
+        var domA = new DomainDescriptor("domA")
+        {
+            ObjectTypes = shuffled ? [betaA, alphaA] : [alphaA, betaA],
+        };
+        var domB = new DomainDescriptor("domB")
+        {
+            ObjectTypes = shuffled ? [deltaB, gammaB] : [gammaB, deltaB],
+        };
+
+        // Two CDLs sharing SourceDomain = "domA" and SourceObjectType = alphaA.
+        // Their primary key (SourceDomain, SourceObjectType.Name, Name) DIFFERS
+        // by Name, but we deliberately also vary TargetDomain/TargetObjectType
+        // so the tie-breaker chain is the only thing that fully orders them
+        // when consumers register the same logical link with permutations.
+        var xdl1 = new ResolvedCrossDomainLink(
+            "linkOne", "domA", alphaA, "domB", gammaB, LinkCardinality.OneToOne, []);
+        var xdl2 = new ResolvedCrossDomainLink(
+            "linkTwo", "domA", alphaA, "domB", deltaB, LinkCardinality.OneToMany, []);
+
+        // Two workflow chains sharing WorkflowName = "Pipeline". Without the
+        // tie-breaker on ConsumedType / ProducedType, swapping their order
+        // would not be canonicalized.
+        var wf1 = new WorkflowChain("Pipeline", alphaA, gammaB);
+        var wf2 = new WorkflowChain("Pipeline", betaA, deltaB);
+
+        var domains = shuffled ? new[] { domB, domA } : new[] { domA, domB };
+        var objectTypes = shuffled
+            ? new[] { deltaB, gammaB, betaA, alphaA }
+            : new[] { alphaA, betaA, gammaB, deltaB };
+        var crossDomainLinks = shuffled ? new[] { xdl2, xdl1 } : new[] { xdl1, xdl2 };
+        var workflowChains = shuffled ? new[] { wf2, wf1 } : new[] { wf1, wf2 };
+
+        return new OntologyGraph(
+            domains,
+            objectTypes,
+            interfaces: [],
+            crossDomainLinks: crossDomainLinks,
+            workflowChains: workflowChains);
+    }
+
+    // ------------------------------------------------------------------
+    // ComputeVersion null-graph guard — defensive guard at the entry point.
+    // CodeRabbit PR #49 nit: ArgumentNullException.ThrowIfNull(graph).
+    // ------------------------------------------------------------------
+
+    [Test]
+    public async Task ComputeVersion_NullGraph_Throws()
+    {
+        await Assert.That(() => OntologyGraphHasher.ComputeVersion(null!))
+            .Throws<ArgumentNullException>();
     }
 
     private static OntologyGraph BuildReferenceFixture()

--- a/src/Strategos.Ontology.Tests/OntologyGraphVersionTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphVersionTests.cs
@@ -214,4 +214,63 @@ public class OntologyGraphVersionTests
 
         await Assert.That(graphA.Version).IsNotEqualTo(graphB.Version);
     }
+
+    // ------------------------------------------------------------------
+    // A3: hasher must be sensitive to graph-level Interfaces,
+    // CrossDomainLinks, and WorkflowChains.
+    // ------------------------------------------------------------------
+
+    [Test]
+    public async Task Version_AddingInterface_ChangesHash()
+    {
+        var graphA = Graph(domains: [Domain("d")]);
+
+        var iface = new InterfaceDescriptor("ISearchable", typeof(IDisposable));
+        var graphB = Graph(domains: [Domain("d")], interfaces: [iface]);
+
+        await Assert.That(graphA.Version).IsNotEqualTo(graphB.Version);
+    }
+
+    [Test]
+    public async Task Version_AddingCrossDomainLink_ChangesHash()
+    {
+        var src = ObjectType("Src", "a");
+        var tgt = ObjectType("Tgt", "b");
+        var graphA = Graph(
+            domains: [Domain("a", src), Domain("b", tgt)],
+            objectTypes: [src, tgt]);
+
+        var xdl = new ResolvedCrossDomainLink(
+            "Link",
+            "a",
+            src,
+            "b",
+            tgt,
+            LinkCardinality.OneToMany,
+            []);
+        var graphB = Graph(
+            domains: [Domain("a", src), Domain("b", tgt)],
+            objectTypes: [src, tgt],
+            crossDomainLinks: [xdl]);
+
+        await Assert.That(graphA.Version).IsNotEqualTo(graphB.Version);
+    }
+
+    [Test]
+    public async Task Version_AddingWorkflowChain_ChangesHash()
+    {
+        var consumed = ObjectType("In", "d", clrType: typeof(int));
+        var produced = ObjectType("Out", "d", clrType: typeof(string));
+        var graphA = Graph(
+            domains: [Domain("d", consumed, produced)],
+            objectTypes: [consumed, produced]);
+
+        var chain = new WorkflowChain("WF", consumed, produced);
+        var graphB = Graph(
+            domains: [Domain("d", consumed, produced)],
+            objectTypes: [consumed, produced],
+            workflowChains: [chain]);
+
+        await Assert.That(graphA.Version).IsNotEqualTo(graphB.Version);
+    }
 }

--- a/src/Strategos.Ontology.Tests/OntologyGraphVersionTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphVersionTests.cs
@@ -216,6 +216,219 @@ public class OntologyGraphVersionTests
     }
 
     // ------------------------------------------------------------------
+    // MEDIUM-4: hasher must be sensitive to additional structural fields
+    // (KeyProperty, ObjectKind, action dispatch routing, interface action
+    // declarations, interface mappings) — design §4.1.
+    // ------------------------------------------------------------------
+
+    [Test]
+    public async Task Version_RenamingKeyProperty_ChangesHash()
+    {
+        // Renaming the key property is a primary-key / dispatch-routing change
+        // that must bust schema caches, even though property shape is unchanged.
+        var tA = new ObjectTypeDescriptor("T", typeof(object), "d")
+        {
+            KeyProperty = new PropertyDescriptor("Id", typeof(string)),
+            Properties = [new PropertyDescriptor("Id", typeof(string))],
+        };
+        var tB = new ObjectTypeDescriptor("T", typeof(object), "d")
+        {
+            KeyProperty = new PropertyDescriptor("Key", typeof(string)),
+            Properties = [new PropertyDescriptor("Key", typeof(string))],
+        };
+
+        var graphA = Graph(domains: [Domain("d", tA)], objectTypes: [tA]);
+        var graphB = Graph(domains: [Domain("d", tB)], objectTypes: [tB]);
+
+        await Assert.That(graphA.Version).IsNotEqualTo(graphB.Version);
+    }
+
+    [Test]
+    public async Task Version_ChangingObjectKind_ChangesHash()
+    {
+        // ObjectKind (Entity vs Process) is a semantic shape designation that
+        // changes how consumers reason about the type.
+        var tA = new ObjectTypeDescriptor("T", typeof(object), "d") { Kind = ObjectKind.Entity };
+        var tB = new ObjectTypeDescriptor("T", typeof(object), "d") { Kind = ObjectKind.Process };
+
+        var graphA = Graph(domains: [Domain("d", tA)], objectTypes: [tA]);
+        var graphB = Graph(domains: [Domain("d", tB)], objectTypes: [tB]);
+
+        await Assert.That(graphA.Version).IsNotEqualTo(graphB.Version);
+    }
+
+    [Test]
+    public async Task Version_RebindingActionWorkflow_ChangesHash()
+    {
+        // Rebinding an action's BoundWorkflowName changes dispatch routing
+        // even though the action's surface (Name/Accepts/Returns) is identical.
+        var tA = ObjectType("T", "d", actions:
+        [
+            new ActionDescriptor("DoIt", "desc")
+            {
+                BindingType = ActionBindingType.Workflow,
+                BoundWorkflowName = "WorkflowA",
+            },
+        ]);
+        var tB = ObjectType("T", "d", actions:
+        [
+            new ActionDescriptor("DoIt", "desc")
+            {
+                BindingType = ActionBindingType.Workflow,
+                BoundWorkflowName = "WorkflowB",
+            },
+        ]);
+
+        var graphA = Graph(domains: [Domain("d", tA)], objectTypes: [tA]);
+        var graphB = Graph(domains: [Domain("d", tB)], objectTypes: [tB]);
+
+        await Assert.That(graphA.Version).IsNotEqualTo(graphB.Version);
+    }
+
+    [Test]
+    public async Task Version_RebindingActionTool_ChangesHash()
+    {
+        // Rebinding BoundToolName / BoundToolMethod is also dispatch routing.
+        var tA = ObjectType("T", "d", actions:
+        [
+            new ActionDescriptor("DoIt", "desc")
+            {
+                BindingType = ActionBindingType.Tool,
+                BoundToolName = "ToolA",
+                BoundToolMethod = "Method1",
+            },
+        ]);
+        var tB = ObjectType("T", "d", actions:
+        [
+            new ActionDescriptor("DoIt", "desc")
+            {
+                BindingType = ActionBindingType.Tool,
+                BoundToolName = "ToolB",
+                BoundToolMethod = "Method1",
+            },
+        ]);
+
+        var graphA = Graph(domains: [Domain("d", tA)], objectTypes: [tA]);
+        var graphB = Graph(domains: [Domain("d", tB)], objectTypes: [tB]);
+
+        await Assert.That(graphA.Version).IsNotEqualTo(graphB.Version);
+    }
+
+    [Test]
+    public async Task Version_AddingInterfaceAction_ChangesHash()
+    {
+        // Interface actions are part of the schema agents reason about; adding
+        // one must bust caches that exist for structural invalidation.
+        var ifaceA = new InterfaceDescriptor("ISearchable", typeof(IDisposable));
+        var ifaceB = new InterfaceDescriptor("ISearchable", typeof(IDisposable))
+        {
+            Actions =
+            [
+                new InterfaceActionDescriptor { Name = "Search" },
+            ],
+        };
+
+        var graphA = Graph(domains: [Domain("d")], interfaces: [ifaceA]);
+        var graphB = Graph(domains: [Domain("d")], interfaces: [ifaceB]);
+
+        await Assert.That(graphA.Version).IsNotEqualTo(graphB.Version);
+    }
+
+    [Test]
+    public async Task Version_ChangingInterfaceActionAcceptsType_ChangesHash()
+    {
+        // InterfaceActionDescriptor.AcceptsTypeName is part of the action's
+        // structural shape — changing it changes the contract.
+        var ifaceA = new InterfaceDescriptor("ISearchable", typeof(IDisposable))
+        {
+            Actions =
+            [
+                new InterfaceActionDescriptor { Name = "Search", AcceptsTypeName = "QueryA" },
+            ],
+        };
+        var ifaceB = new InterfaceDescriptor("ISearchable", typeof(IDisposable))
+        {
+            Actions =
+            [
+                new InterfaceActionDescriptor { Name = "Search", AcceptsTypeName = "QueryB" },
+            ],
+        };
+
+        var graphA = Graph(domains: [Domain("d")], interfaces: [ifaceA]);
+        var graphB = Graph(domains: [Domain("d")], interfaces: [ifaceB]);
+
+        await Assert.That(graphA.Version).IsNotEqualTo(graphB.Version);
+    }
+
+    [Test]
+    public async Task Version_ChangingInterfacePropertyMapping_ChangesHash()
+    {
+        // InterfacePropertyMappings are user-authored Via() bindings — rebinding
+        // an interface property to a different local property is a dispatch
+        // change, even though the type's local properties are unchanged.
+        var iface = new InterfaceDescriptor("ISearchable", typeof(IDisposable));
+        var tA = new ObjectTypeDescriptor("T", typeof(object), "d")
+        {
+            ImplementedInterfaces = [iface],
+            InterfacePropertyMappings =
+            [
+                new InterfacePropertyMapping("LocalA", "InterfaceProp", "ISearchable"),
+            ],
+        };
+        var tB = new ObjectTypeDescriptor("T", typeof(object), "d")
+        {
+            ImplementedInterfaces = [iface],
+            InterfacePropertyMappings =
+            [
+                new InterfacePropertyMapping("LocalB", "InterfaceProp", "ISearchable"),
+            ],
+        };
+
+        var graphA = Graph(domains: [Domain("d", tA)], objectTypes: [tA], interfaces: [iface]);
+        var graphB = Graph(domains: [Domain("d", tB)], objectTypes: [tB], interfaces: [iface]);
+
+        await Assert.That(graphA.Version).IsNotEqualTo(graphB.Version);
+    }
+
+    [Test]
+    public async Task Version_ChangingInterfaceActionMapping_ChangesHash()
+    {
+        // InterfaceActionMappings record which concrete action implements each
+        // interface action. Source-of-truth user input; rebinding changes
+        // dispatch.
+        var iface = new InterfaceDescriptor("ISearchable", typeof(IDisposable));
+        var tA = new ObjectTypeDescriptor("T", typeof(object), "d")
+        {
+            ImplementedInterfaces = [iface],
+            InterfaceActionMappings =
+            [
+                new InterfaceActionMapping
+                {
+                    InterfaceActionName = "Search",
+                    ConcreteActionName = "SearchAlpha",
+                },
+            ],
+        };
+        var tB = new ObjectTypeDescriptor("T", typeof(object), "d")
+        {
+            ImplementedInterfaces = [iface],
+            InterfaceActionMappings =
+            [
+                new InterfaceActionMapping
+                {
+                    InterfaceActionName = "Search",
+                    ConcreteActionName = "SearchBeta",
+                },
+            ],
+        };
+
+        var graphA = Graph(domains: [Domain("d", tA)], objectTypes: [tA], interfaces: [iface]);
+        var graphB = Graph(domains: [Domain("d", tB)], objectTypes: [tB], interfaces: [iface]);
+
+        await Assert.That(graphA.Version).IsNotEqualTo(graphB.Version);
+    }
+
+    // ------------------------------------------------------------------
     // A3: hasher must be sensitive to graph-level Interfaces,
     // CrossDomainLinks, and WorkflowChains.
     // ------------------------------------------------------------------
@@ -323,6 +536,32 @@ public class OntologyGraphVersionTests
     }
 
     [Test]
+    public async Task Version_ChangingInterfaceActionDescription_DoesNotChangeHash()
+    {
+        // InterfaceActionDescriptor.Description is free-form documentation,
+        // matching the broader exclusion of Description fields from the hash.
+        var ifaceA = new InterfaceDescriptor("ISearchable", typeof(IDisposable))
+        {
+            Actions =
+            [
+                new InterfaceActionDescriptor { Name = "Search", Description = "Original prose" },
+            ],
+        };
+        var ifaceB = new InterfaceDescriptor("ISearchable", typeof(IDisposable))
+        {
+            Actions =
+            [
+                new InterfaceActionDescriptor { Name = "Search", Description = "Different prose" },
+            ],
+        };
+
+        var graphA = Graph(domains: [Domain("d")], interfaces: [ifaceA]);
+        var graphB = Graph(domains: [Domain("d")], interfaces: [ifaceB]);
+
+        await Assert.That(graphA.Version).IsEqualTo(graphB.Version);
+    }
+
+    [Test]
     public async Task Version_DifferingWarnings_DoesNotChangeHash()
     {
         // Graphs with identical structural shape but different Warnings lists.
@@ -343,8 +582,13 @@ public class OntologyGraphVersionTests
     // Pinned hash for the reference fixture. If this changes, the
     // OntologyGraphHasher serialization shape has drifted — review the diff
     // before updating.
+    //
+    // Regeneration: when intentionally adding a field to the hash, run this test
+    // once with the old constant, capture the new hash from the assertion failure
+    // message, and replace the constant. Confirm the diff matches the intended
+    // hasher change before committing.
     private const string ReferenceFixtureVersion =
-        "9b3e82f07bd553bf5c71ccd222cc9f814082f677a1572c629d927e06d12698ca";
+        "2095a57833d35ce0ee1dba1def232c79ab4b960631f2508955936c2b485e26d6";
 
     [Test]
     public async Task Version_ReferenceFixture_MatchesPinnedConstant()

--- a/src/Strategos.Ontology.Tests/OntologyGraphVersionTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphVersionTests.cs
@@ -1,0 +1,39 @@
+using System.Text.RegularExpressions;
+using Strategos.Ontology.Builder;
+
+namespace Strategos.Ontology.Tests;
+
+public class OntologyGraphVersionTests
+{
+    private static readonly Regex LowercaseHex64 = new("^[0-9a-f]{64}$", RegexOptions.Compiled);
+
+    [Test]
+    public async Task Version_OnEmptyGraph_ReturnsLowercaseSha256Hex()
+    {
+        var graph = new OntologyGraphBuilder().Build();
+
+        await Assert.That(graph.Version).IsNotNull();
+        await Assert.That(graph.Version.Length).IsEqualTo(64);
+        await Assert.That(LowercaseHex64.IsMatch(graph.Version)).IsTrue();
+    }
+
+    [Test]
+    public async Task Version_OnEmptyGraph_DoesNotIncludeSha256Prefix()
+    {
+        // Wire-format note: the "sha256:" prefix is added at the MCP _meta-emission
+        // boundary (Track B's ResponseMeta factory), NOT on the property itself.
+        // OntologyGraph.Version is bare hex.
+        var graph = new OntologyGraphBuilder().Build();
+
+        await Assert.That(graph.Version.StartsWith("sha256:")).IsFalse();
+    }
+
+    [Test]
+    public async Task Version_BuiltTwice_ReturnsSameHash()
+    {
+        var graphA = new OntologyGraphBuilder().Build();
+        var graphB = new OntologyGraphBuilder().Build();
+
+        await Assert.That(graphA.Version).IsEqualTo(graphB.Version);
+    }
+}

--- a/src/Strategos.Ontology/Internal/OntologyGraphHasher.cs
+++ b/src/Strategos.Ontology/Internal/OntologyGraphHasher.cs
@@ -15,13 +15,37 @@ internal static class OntologyGraphHasher
 {
     public static string ComputeVersion(OntologyGraph graph)
     {
-        // Excluded from the hash by design (see design 2026-04-19-mcp-surface-conformance.md §4.1):
+        // What is hashed (per design 2026-04-19-mcp-surface-conformance.md §4.1):
+        //   - Domain names (sorted).
+        //   - For each ObjectType (sorted by domain, name): Name, DomainName,
+        //     ParentTypeName, Kind (ObjectKind enum), KeyProperty name,
+        //     Properties (Name/Kind/PropertyType/IsRequired/VectorDimensions),
+        //     Actions (Name/AcceptsType/ReturnsType/BindingType/BoundWorkflowName/
+        //     BoundToolName/BoundToolMethod/Preconditions/Postconditions),
+        //     Links (Name/TargetTypeName/Cardinality/EdgeProperties),
+        //     Events (EventType/Severity/MaterializedLinks/UpdatedProperties),
+        //     Lifecycle (PropertyName/StateEnumTypeName/States/Transitions),
+        //     ImplementedInterfaces (Name only — full interface definition lives
+        //     in the graph-level Interfaces section), InterfacePropertyMappings
+        //     (Source/Target/InterfaceName), InterfaceActionMappings
+        //     (InterfaceActionName/ConcreteActionName).
+        //   - For each Interface (sorted by name): Name, Properties, Actions
+        //     (Name/AcceptsTypeName/ReturnsTypeName).
+        //   - CrossDomainLinks (Source/Target/Cardinality/EdgeProperties).
+        //   - WorkflowChains (Name/Consumed/Produced).
+        //
+        // What is deliberately NOT hashed (rationale):
         //   - Free-form Description text on actions, links, properties, lifecycle
-        //     states/transitions, events, and cross-domain links — documentation
-        //     churn must NOT bust structural caches that exist to invalidate when
-        //     the schema agents reason about actually changes shape.
+        //     states/transitions, events, cross-domain links, and interface actions —
+        //     documentation churn must NOT bust structural caches that exist to
+        //     invalidate when the schema agents reason about actually changes shape.
         //   - OntologyGraph.Warnings — advisory, non-structural.
-        //   - OntologyGraph.ObjectTypeNamesByType — derived index, not source.
+        //   - OntologyGraph.ObjectTypeNamesByType — derived index from ObjectTypes;
+        //     mutating it without mutating the underlying ObjectTypes is impossible.
+        //   - PropertyDescriptor.IsComputed / DerivedFrom / TransitiveDerivedFrom —
+        //     captured implicitly via PropertyKind (Computed) and the derivation
+        //     chain is reconstructable from Properties.
+        //   - ExternalLinkExtensionPoints.MatchedLinkNames — derived during build.
         // ActionPrecondition.Description IS included because it is the precondition's
         // identity / sort key, distinct from per-action free-form documentation prose.
         using var ms = new MemoryStream();
@@ -71,6 +95,14 @@ internal static class OntologyGraphHasher
         WriteString(writer, ot.Name);
         WriteString(writer, ot.ParentTypeName ?? string.Empty);
 
+        // Kind is structural: an Entity-vs-Process designation changes how
+        // consumers reason about the type, even with identical shape.
+        writer.Write((byte)ot.Kind);
+
+        // Key property name (or empty if absent). Renaming the key property
+        // is a dispatch-routing change, not a documentation change.
+        WriteString(writer, ot.KeyProperty?.Name ?? string.Empty);
+
         writer.Write("|PROPS|");
         foreach (var p in ot.Properties.OrderBy(p => p.Name, StringComparer.Ordinal))
         {
@@ -107,6 +139,33 @@ internal static class OntologyGraphHasher
             WriteString(writer, i.Name);
         }
 
+        // InterfacePropertyMappings record how a type's local properties satisfy
+        // each declared interface (Via() bindings). They are user-authored, not
+        // derived from other fields — rebinding interface property X from local
+        // property A to local property B is a structural change to dispatch.
+        writer.Write("|IPM|");
+        foreach (var m in ot.InterfacePropertyMappings
+                              .OrderBy(m => m.InterfaceName, StringComparer.Ordinal)
+                              .ThenBy(m => m.TargetPropertyName, StringComparer.Ordinal)
+                              .ThenBy(m => m.SourcePropertyName, StringComparer.Ordinal))
+        {
+            WriteString(writer, m.InterfaceName);
+            WriteString(writer, m.TargetPropertyName);
+            WriteString(writer, m.SourcePropertyName);
+        }
+
+        // InterfaceActionMappings record how a type's concrete actions satisfy
+        // each declared interface action. Source-of-truth user input; rebinding
+        // changes which concrete action the interface call routes to.
+        writer.Write("|IAM|");
+        foreach (var m in ot.InterfaceActionMappings
+                              .OrderBy(m => m.InterfaceActionName, StringComparer.Ordinal)
+                              .ThenBy(m => m.ConcreteActionName, StringComparer.Ordinal))
+        {
+            WriteString(writer, m.InterfaceActionName);
+            WriteString(writer, m.ConcreteActionName);
+        }
+
         writer.Write("|END_OT");
     }
 
@@ -130,6 +189,13 @@ internal static class OntologyGraphHasher
         WriteString(writer, a.AcceptsType?.FullName ?? string.Empty);
         WriteString(writer, a.ReturnsType?.FullName ?? string.Empty);
         WriteString(writer, a.BindingType.ToString());
+
+        // Action dispatch routing: rebinding from one workflow/tool to another
+        // is a structural behavior change for cache invalidation, even if the
+        // surface shape (Name/Accepts/Returns) is unchanged.
+        WriteString(writer, a.BoundWorkflowName ?? string.Empty);
+        WriteString(writer, a.BoundToolName ?? string.Empty);
+        WriteString(writer, a.BoundToolMethod ?? string.Empty);
 
         writer.Write("|PRE|");
         foreach (var pc in a.Preconditions.OrderBy(x => x.Description, StringComparer.Ordinal))
@@ -228,6 +294,17 @@ internal static class OntologyGraphHasher
                 WriteString(writer, p.Name);
                 WriteString(writer, p.Kind.ToString());
                 WriteString(writer, p.PropertyType.FullName ?? string.Empty);
+            }
+
+            // Interfaces can declare actions (InterfaceActionDescriptor); these
+            // are part of the schema agents reason about and must influence the
+            // hash. Free-form Description on each action is excluded.
+            writer.Write("|IACTIONS|");
+            foreach (var a in i.Actions.OrderBy(a => a.Name, StringComparer.Ordinal))
+            {
+                WriteString(writer, a.Name);
+                WriteString(writer, a.AcceptsTypeName ?? string.Empty);
+                WriteString(writer, a.ReturnsTypeName ?? string.Empty);
             }
         }
 

--- a/src/Strategos.Ontology/Internal/OntologyGraphHasher.cs
+++ b/src/Strategos.Ontology/Internal/OntologyGraphHasher.cs
@@ -29,6 +29,9 @@ internal static class OntologyGraphHasher
         {
             WriteStableHeader(writer, graph);
             WriteObjectTypes(writer, graph);
+            WriteInterfaces(writer, graph);
+            WriteCrossDomainLinks(writer, graph);
+            WriteWorkflowChains(writer, graph);
         }
 
         var hash = SHA256.HashData(ms.ToArray());
@@ -210,6 +213,65 @@ internal static class OntologyGraphHasher
             WriteString(writer, t.TriggerActionName ?? string.Empty);
             WriteString(writer, t.TriggerEventTypeName ?? string.Empty);
         }
+    }
+
+    private static void WriteInterfaces(BinaryWriter writer, OntologyGraph graph)
+    {
+        writer.Write("INTERFACES|");
+        foreach (var i in graph.Interfaces.OrderBy(i => i.Name, StringComparer.Ordinal))
+        {
+            writer.Write("I|");
+            WriteString(writer, i.Name);
+            writer.Write("|PROPS|");
+            foreach (var p in i.Properties.OrderBy(p => p.Name, StringComparer.Ordinal))
+            {
+                WriteString(writer, p.Name);
+                WriteString(writer, p.Kind.ToString());
+                WriteString(writer, p.PropertyType.FullName ?? string.Empty);
+            }
+        }
+
+        writer.Write("|END_INTERFACES");
+    }
+
+    private static void WriteCrossDomainLinks(BinaryWriter writer, OntologyGraph graph)
+    {
+        writer.Write("XDL|");
+        foreach (var x in graph.CrossDomainLinks
+                              .OrderBy(x => x.SourceDomain, StringComparer.Ordinal)
+                              .ThenBy(x => x.SourceObjectType.Name, StringComparer.Ordinal)
+                              .ThenBy(x => x.Name, StringComparer.Ordinal))
+        {
+            writer.Write("X|");
+            WriteString(writer, x.SourceDomain);
+            WriteString(writer, x.SourceObjectType.Name);
+            WriteString(writer, x.Name);
+            WriteString(writer, x.TargetDomain);
+            WriteString(writer, x.TargetObjectType.Name);
+            WriteString(writer, x.Cardinality.ToString());
+            writer.Write("|EDGE|");
+            foreach (var ep in x.EdgeProperties.OrderBy(p => p.Name, StringComparer.Ordinal))
+            {
+                WriteString(writer, ep.Name);
+                WriteString(writer, ep.Kind.ToString());
+            }
+        }
+
+        writer.Write("|END_XDL");
+    }
+
+    private static void WriteWorkflowChains(BinaryWriter writer, OntologyGraph graph)
+    {
+        writer.Write("WF|");
+        foreach (var w in graph.WorkflowChains.OrderBy(w => w.WorkflowName, StringComparer.Ordinal))
+        {
+            writer.Write("W|");
+            WriteString(writer, w.WorkflowName);
+            WriteString(writer, w.ConsumedType.ClrType.FullName ?? string.Empty);
+            WriteString(writer, w.ProducedType.ClrType.FullName ?? string.Empty);
+        }
+
+        writer.Write("|END_WF");
     }
 
     private static void WriteString(BinaryWriter writer, string s)

--- a/src/Strategos.Ontology/Internal/OntologyGraphHasher.cs
+++ b/src/Strategos.Ontology/Internal/OntologyGraphHasher.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
+using Strategos.Ontology.Descriptors;
 
 namespace Strategos.Ontology.Internal;
 
@@ -14,10 +15,20 @@ internal static class OntologyGraphHasher
 {
     public static string ComputeVersion(OntologyGraph graph)
     {
+        // Excluded from the hash by design (see design 2026-04-19-mcp-surface-conformance.md §4.1):
+        //   - Free-form Description text on actions, links, properties, lifecycle
+        //     states/transitions, events, and cross-domain links — documentation
+        //     churn must NOT bust structural caches that exist to invalidate when
+        //     the schema agents reason about actually changes shape.
+        //   - OntologyGraph.Warnings — advisory, non-structural.
+        //   - OntologyGraph.ObjectTypeNamesByType — derived index, not source.
+        // ActionPrecondition.Description IS included because it is the precondition's
+        // identity / sort key, distinct from per-action free-form documentation prose.
         using var ms = new MemoryStream();
         using (var writer = new BinaryWriter(ms, Encoding.UTF8, leaveOpen: true))
         {
             WriteStableHeader(writer, graph);
+            WriteObjectTypes(writer, graph);
         }
 
         var hash = SHA256.HashData(ms.ToArray());
@@ -34,6 +45,171 @@ internal static class OntologyGraphHasher
         }
 
         writer.Write("|END_DOMAINS");
+    }
+
+    private static void WriteObjectTypes(BinaryWriter writer, OntologyGraph graph)
+    {
+        writer.Write("OBJECT_TYPES|");
+        var sorted = graph.ObjectTypes
+            .OrderBy(ot => ot.DomainName, StringComparer.Ordinal)
+            .ThenBy(ot => ot.Name, StringComparer.Ordinal);
+        foreach (var ot in sorted)
+        {
+            WriteObjectType(writer, ot);
+        }
+
+        writer.Write("|END_OBJECT_TYPES");
+    }
+
+    private static void WriteObjectType(BinaryWriter writer, ObjectTypeDescriptor ot)
+    {
+        writer.Write("OT|");
+        WriteString(writer, ot.DomainName);
+        WriteString(writer, ot.Name);
+        WriteString(writer, ot.ParentTypeName ?? string.Empty);
+
+        writer.Write("|PROPS|");
+        foreach (var p in ot.Properties.OrderBy(p => p.Name, StringComparer.Ordinal))
+        {
+            WriteProperty(writer, p);
+        }
+
+        writer.Write("|ACTIONS|");
+        foreach (var a in ot.Actions.OrderBy(a => a.Name, StringComparer.Ordinal))
+        {
+            WriteAction(writer, a);
+        }
+
+        writer.Write("|LINKS|");
+        foreach (var l in ot.Links.OrderBy(l => l.Name, StringComparer.Ordinal))
+        {
+            WriteLink(writer, l);
+        }
+
+        writer.Write("|EVENTS|");
+        foreach (var e in ot.Events.OrderBy(e => e.EventType.FullName ?? string.Empty, StringComparer.Ordinal))
+        {
+            WriteEvent(writer, e);
+        }
+
+        writer.Write("|LIFECYCLE|");
+        if (ot.Lifecycle is not null)
+        {
+            WriteLifecycle(writer, ot.Lifecycle);
+        }
+
+        writer.Write("|IFACES|");
+        foreach (var i in ot.ImplementedInterfaces.OrderBy(i => i.Name, StringComparer.Ordinal))
+        {
+            WriteString(writer, i.Name);
+        }
+
+        writer.Write("|END_OT");
+    }
+
+    private static void WriteProperty(BinaryWriter writer, PropertyDescriptor p)
+    {
+        writer.Write("P|");
+        WriteString(writer, p.Name);
+        WriteString(writer, p.Kind.ToString());
+        WriteString(writer, p.PropertyType.FullName ?? string.Empty);
+
+        // PropertyDescriptor exposes IsRequired (not IsNullable); record IsRequired
+        // for structural sensitivity per design §4.1.
+        writer.Write(p.IsRequired);
+        writer.Write(p.VectorDimensions ?? 0);
+    }
+
+    private static void WriteAction(BinaryWriter writer, ActionDescriptor a)
+    {
+        writer.Write("A|");
+        WriteString(writer, a.Name);
+        WriteString(writer, a.AcceptsType?.FullName ?? string.Empty);
+        WriteString(writer, a.ReturnsType?.FullName ?? string.Empty);
+        WriteString(writer, a.BindingType.ToString());
+
+        writer.Write("|PRE|");
+        foreach (var pc in a.Preconditions.OrderBy(x => x.Description, StringComparer.Ordinal))
+        {
+            WriteString(writer, pc.Description);
+            WriteString(writer, pc.Expression);
+            WriteString(writer, pc.Kind.ToString());
+            WriteString(writer, pc.LinkName ?? string.Empty);
+            WriteString(writer, pc.Strength.ToString());
+        }
+
+        writer.Write("|POST|");
+        foreach (var pc in a.Postconditions
+                              .OrderBy(x => x.Kind.ToString(), StringComparer.Ordinal)
+                              .ThenBy(x => x.PropertyName ?? string.Empty, StringComparer.Ordinal)
+                              .ThenBy(x => x.LinkName ?? string.Empty, StringComparer.Ordinal)
+                              .ThenBy(x => x.EventTypeName ?? string.Empty, StringComparer.Ordinal))
+        {
+            WriteString(writer, pc.Kind.ToString());
+            WriteString(writer, pc.PropertyName ?? string.Empty);
+            WriteString(writer, pc.LinkName ?? string.Empty);
+            WriteString(writer, pc.EventTypeName ?? string.Empty);
+        }
+    }
+
+    private static void WriteLink(BinaryWriter writer, LinkDescriptor l)
+    {
+        writer.Write("L|");
+        WriteString(writer, l.Name);
+        WriteString(writer, l.TargetTypeName);
+        WriteString(writer, l.Cardinality.ToString());
+        writer.Write("|EDGE|");
+        foreach (var ep in l.EdgeProperties.OrderBy(p => p.Name, StringComparer.Ordinal))
+        {
+            WriteString(writer, ep.Name);
+            WriteString(writer, ep.Kind.ToString());
+        }
+    }
+
+    private static void WriteEvent(BinaryWriter writer, EventDescriptor e)
+    {
+        writer.Write("E|");
+        WriteString(writer, e.EventType.FullName ?? string.Empty);
+        WriteString(writer, e.Severity.ToString());
+        writer.Write("|ML|");
+        foreach (var ml in e.MaterializedLinks.OrderBy(x => x, StringComparer.Ordinal))
+        {
+            WriteString(writer, ml);
+        }
+
+        writer.Write("|UP|");
+        foreach (var up in e.UpdatedProperties.OrderBy(x => x, StringComparer.Ordinal))
+        {
+            WriteString(writer, up);
+        }
+    }
+
+    private static void WriteLifecycle(BinaryWriter writer, LifecycleDescriptor lc)
+    {
+        writer.Write("LC|");
+        WriteString(writer, lc.PropertyName);
+        WriteString(writer, lc.StateEnumTypeName);
+
+        writer.Write("|STATES|");
+        foreach (var s in lc.States.OrderBy(s => s.Name, StringComparer.Ordinal))
+        {
+            WriteString(writer, s.Name);
+            writer.Write(s.IsInitial);
+            writer.Write(s.IsTerminal);
+        }
+
+        writer.Write("|TRANS|");
+        foreach (var t in lc.Transitions
+                              .OrderBy(t => t.FromState, StringComparer.Ordinal)
+                              .ThenBy(t => t.ToState, StringComparer.Ordinal)
+                              .ThenBy(t => t.TriggerActionName ?? string.Empty, StringComparer.Ordinal)
+                              .ThenBy(t => t.TriggerEventTypeName ?? string.Empty, StringComparer.Ordinal))
+        {
+            WriteString(writer, t.FromState);
+            WriteString(writer, t.ToState);
+            WriteString(writer, t.TriggerActionName ?? string.Empty);
+            WriteString(writer, t.TriggerEventTypeName ?? string.Empty);
+        }
     }
 
     private static void WriteString(BinaryWriter writer, string s)

--- a/src/Strategos.Ontology/Internal/OntologyGraphHasher.cs
+++ b/src/Strategos.Ontology/Internal/OntologyGraphHasher.cs
@@ -15,6 +15,8 @@ internal static class OntologyGraphHasher
 {
     public static string ComputeVersion(OntologyGraph graph)
     {
+        ArgumentNullException.ThrowIfNull(graph);
+
         // What is hashed (per design 2026-04-19-mcp-surface-conformance.md §4.1):
         //   - Domain names (sorted).
         //   - For each ObjectType (sorted by domain, name): Name, DomainName,
@@ -314,10 +316,18 @@ internal static class OntologyGraphHasher
     private static void WriteCrossDomainLinks(BinaryWriter writer, OntologyGraph graph)
     {
         writer.Write("XDL|");
+        // Tie-breaker chain covers every structurally-significant field of
+        // ResolvedCrossDomainLink so that two collections with the same logical
+        // content always sort identically regardless of registration order.
+        // CodeRabbit PR #49 Major: an incomplete sort key falls back to input
+        // order for ties, which is not a stable canonicalization across builders.
         foreach (var x in graph.CrossDomainLinks
                               .OrderBy(x => x.SourceDomain, StringComparer.Ordinal)
                               .ThenBy(x => x.SourceObjectType.Name, StringComparer.Ordinal)
-                              .ThenBy(x => x.Name, StringComparer.Ordinal))
+                              .ThenBy(x => x.Name, StringComparer.Ordinal)
+                              .ThenBy(x => x.TargetDomain, StringComparer.Ordinal)
+                              .ThenBy(x => x.TargetObjectType.Name, StringComparer.Ordinal)
+                              .ThenBy(x => x.Cardinality.ToString(), StringComparer.Ordinal))
         {
             writer.Write("X|");
             WriteString(writer, x.SourceDomain);
@@ -340,7 +350,15 @@ internal static class OntologyGraphHasher
     private static void WriteWorkflowChains(BinaryWriter writer, OntologyGraph graph)
     {
         writer.Write("WF|");
-        foreach (var w in graph.WorkflowChains.OrderBy(w => w.WorkflowName, StringComparer.Ordinal))
+        // Tie-breaker chain covers every structurally-significant field of
+        // WorkflowChain (WorkflowName / ConsumedType / ProducedType) so chains
+        // sharing a workflow name still sort deterministically. CodeRabbit
+        // PR #49 Major: WorkflowName uniqueness is not enforced by the
+        // descriptor, so the tie-breaker is required for canonicalization.
+        foreach (var w in graph.WorkflowChains
+                              .OrderBy(w => w.WorkflowName, StringComparer.Ordinal)
+                              .ThenBy(w => w.ConsumedType.ClrType.FullName ?? string.Empty, StringComparer.Ordinal)
+                              .ThenBy(w => w.ProducedType.ClrType.FullName ?? string.Empty, StringComparer.Ordinal))
         {
             writer.Write("W|");
             WriteString(writer, w.WorkflowName);

--- a/src/Strategos.Ontology/Internal/OntologyGraphHasher.cs
+++ b/src/Strategos.Ontology/Internal/OntologyGraphHasher.cs
@@ -1,0 +1,48 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Strategos.Ontology.Internal;
+
+/// <summary>
+/// Computes a deterministic SHA-256 hash over the structural fields of an
+/// <see cref="OntologyGraph"/>. The hash is exposed via <see cref="OntologyGraph.Version"/>
+/// and surfaced (with a "sha256:" prefix added at the wire-emission boundary)
+/// as the <c>_meta.ontologyVersion</c> field on MCP tool responses so consumers
+/// can invalidate cached schema views on mismatch.
+/// </summary>
+internal static class OntologyGraphHasher
+{
+    public static string ComputeVersion(OntologyGraph graph)
+    {
+        using var ms = new MemoryStream();
+        using (var writer = new BinaryWriter(ms, Encoding.UTF8, leaveOpen: true))
+        {
+            WriteStableHeader(writer, graph);
+        }
+
+        var hash = SHA256.HashData(ms.ToArray());
+        return Convert.ToHexStringLower(hash);
+    }
+
+    private static void WriteStableHeader(BinaryWriter writer, OntologyGraph graph)
+    {
+        writer.Write("DOMAINS|");
+        var domainNames = graph.Domains.Select(d => d.DomainName).OrderBy(n => n, StringComparer.Ordinal);
+        foreach (var name in domainNames)
+        {
+            WriteString(writer, name);
+        }
+
+        writer.Write("|END_DOMAINS");
+    }
+
+    private static void WriteString(BinaryWriter writer, string s)
+    {
+        // Length-prefixed UTF-8 framing prevents accidental cross-field
+        // collisions where adjacent fields could otherwise concatenate to the
+        // same byte sequence under different splits.
+        var bytes = Encoding.UTF8.GetBytes(s);
+        writer.Write(bytes.Length);
+        writer.Write(bytes);
+    }
+}

--- a/src/Strategos.Ontology/OntologyGraph.cs
+++ b/src/Strategos.Ontology/OntologyGraph.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Internal;
 
 namespace Strategos.Ontology;
 
@@ -15,6 +16,17 @@ public sealed class OntologyGraph
     public IReadOnlyList<ResolvedCrossDomainLink> CrossDomainLinks { get; }
     public IReadOnlyList<WorkflowChain> WorkflowChains { get; }
     public IReadOnlyList<string> Warnings { get; }
+
+    /// <summary>
+    /// SHA-256 of a stable serialization of the graph's structural fields,
+    /// rendered as a 64-character lowercase hex string (no algorithm prefix).
+    /// Identical DSL input produces an identical hash across processes and
+    /// machines. Surfaced in MCP responses as <c>_meta.ontologyVersion</c>
+    /// (with a <c>"sha256:"</c> prefix added at the wire boundary) so
+    /// consumers can invalidate cached schema views on mismatch.
+    /// See <c>docs/designs/2026-04-19-mcp-surface-conformance.md</c> §4.1.
+    /// </summary>
+    public string Version { get; }
 
     /// <summary>
     /// Reverse index from CLR type to the list of descriptor names it was registered
@@ -55,6 +67,8 @@ public sealed class OntologyGraph
         _objectTypeLookup = BuildObjectTypeLookup(objectTypes);
         _implementorsLookup = BuildImplementorsLookup(objectTypes);
         _workflowChainLookup = BuildWorkflowChainLookup(workflowChains);
+
+        Version = OntologyGraphHasher.ComputeVersion(this);
     }
 
     public ObjectTypeDescriptor? GetObjectType(string domain, string name) =>


### PR DESCRIPTION
## Summary

Track A of the MCP Surface Conformance plan (`docs/plans/2026-04-19-mcp-surface-conformance.md`). Adds `OntologyGraph.Version` — a deterministic SHA-256 over the graph's structural fields — so MCP responses can advertise a schema version and consumers (Exarchos, Basileus) can invalidate cached schema views on mismatch.

- New: `OntologyGraph.Version` returns a 64-char lowercase hex string. Bare hex with NO `"sha256:"` prefix; the prefix is added at the wire-emission boundary by Track B's `ResponseMeta` factory.
- New: `Strategos.Ontology.Internal.OntologyGraphHasher` walks `Domains`, `ObjectTypes` (Properties, Actions with Pre/Postconditions, Links with EdgeProperties, Events, Lifecycle, ImplementedInterfaces), `Interfaces`, `CrossDomainLinks`, and `WorkflowChains` in stable sort order with length-prefixed UTF-8 framing.
- 17 new tests in `OntologyGraphVersionTests.cs` covering: A1 shape/determinism (3), A2 ObjectType structural sensitivity (7), A3 graph-level structural sensitivity (3), A4 insensitivity to free-form `Description` and `Warnings` (3), A5 pinned reference-fixture hash (1).

## What's hashed (per design §4.1)

`Domains` (names) · `ObjectTypes` (full structure) · `Interfaces` (with their properties) · `CrossDomainLinks` (full descriptor) · `WorkflowChains` (workflow + Consumed/Produced ClrType.FullName).

## What's NOT hashed (deliberately, per design §4.1)

- Free-form `Description` text on actions, links — documentation churn must not bust structural caches that exist for schema-shape invalidation.
- `OntologyGraph.Warnings` — advisory diagnostic output, non-structural.
- `OntologyGraph.ObjectTypeNamesByType` — derived index, not source.

The `ActionPrecondition.Description` *is* included because in the existing model it doubles as the precondition's identity / sort key (distinct from per-action prose).

## Wire-format note

`OntologyGraph.Version` is bare 64-char hex. The `"sha256:"` prefix is added at the MCP `_meta` emission boundary by Track B's `ResponseMeta` factory (separate worktree, separate PR). This separation lets future hash-algorithm migrations affect only the wire boundary, not the property contract.

## Closes

Closes #44.

## Test plan

- [x] All A1–A5 tests pass: `dotnet test --project src/Strategos.Ontology.Tests/Strategos.Ontology.Tests.csproj -- --treenode-filter "/*/*/OntologyGraphVersionTests/*"` (17/17)
- [x] Full `Strategos.Ontology.Tests` suite green (592/592)
- [x] `Strategos.Ontology.MCP.Tests` did not regress (53/53)
- [x] Full solution build clean (0 warnings, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)