### PR TITLE
feat(ontology): 2.5.0 polyglot descriptors + IOntologySource + AONT037 (PR-A)

### DIFF
--- a/docs/designs/2026-05-10-ontology-2-5-0-polyglot-ingestion.md
+++ b/docs/designs/2026-05-10-ontology-2-5-0-polyglot-ingestion.md
@@ -26,7 +26,7 @@ The Strategos-side surface is therefore three concrete things: (1) the descripto
 
 - Polyglot descriptor schema on `ObjectTypeDescriptor`, `LinkDescriptor`, `PropertyDescriptor` (#48)
 - `AONT037` source-generator diagnostic for `ClrType != null OR SymbolKey != null` invariant (#48)
-- `IOntologySource` interface + `OntologyDelta` event vocabulary + `AddSource<T>()` DI extension (#37)
+- `IOntologySource` interface + `OntologyDelta` event vocabulary + `AddSource<T>()` instance-method factory on `OntologyOptions` (constructs via `new T()`; AOT-safe; no DI activation) (#37)
 - Runtime `IOntologyBuilder.ObjectTypeFromDescriptor` / `ApplyDelta` (#37)
 - `DescriptorSource` enum (`HandAuthored | Ingested`) field-level provenance on descriptors (#37)
 - `AONT201` through `AONT208` graph-freeze diagnostics (#43, expanded from #43's original 6 codes per ADR §9.3)
@@ -121,7 +121,7 @@ public enum DescriptorSource { HandAuthored, Ingested }
 - `LinkDescriptor.TargetTypeName` already exists (PR #59); `LinkDescriptor.TargetSymbolKey` is added as a parallel optional field.
 - `PropertyDescriptor` reference-property fields accept `string? SymbolKey` alongside existing `Type? ReferenceType`.
 - Existing `DomainOntology` subclasses across `Strategos.Ontology.Tests`, `Strategos.Ontology.MCP.Tests`, and the trading sample compile and run unchanged with `LanguageId = "dotnet"` default.
-- 666 existing tests in `Strategos.Ontology.Tests` continue to pass; 121 in `Strategos.Ontology.MCP.Tests` continue to pass.
+- All existing tests in `Strategos.Ontology.Tests` and `Strategos.Ontology.MCP.Tests` continue to pass.
 
 ### DR-2: AONT037 source-generator diagnostic
 
@@ -137,7 +137,7 @@ public enum DescriptorSource { HandAuthored, Ingested }
 
 ### DR-3: `IOntologySource` extension point
 
-**Statement:** `Strategos.Ontology.IOntologySource` is a new public interface enabling ontology graph contributions from sources beyond hand-authored `DomainOntology.Define()`. Registered via DI: `options.AddSource<MartenOntologySource>()`.
+**Statement:** `Strategos.Ontology.IOntologySource` is a new public interface enabling ontology graph contributions from sources beyond hand-authored `DomainOntology.Define()`. Registered through the `OntologyOptions.AddSource<T>()` instance-method factory, which constructs the source via `new T()` (no DI activation) so the same registration path is AOT-safe and DI-free; callers requiring constructor injection should instantiate the source themselves and register via the descriptor overload.
 
 **Shape:**
 
@@ -161,7 +161,7 @@ public interface IOntologySource
 
 **Acceptance criteria:**
 - `IOntologySource` defined in `Strategos.Ontology` namespace, public.
-- `OntologyOptions.AddSource<T>()` extension method registers `T : IOntologySource` as transient.
+- `OntologyOptions.AddSource<T>()` is an instance-method factory on `OntologyOptions` that constructs `T : IOntologySource, new()` via `new T()` (no DI activation; AOT-safe). Callers needing constructor injection should instantiate the source themselves and register the instance.
 - `OntologyGraphBuilder.Build()` drains all registered sources' `LoadAsync` before returning the graph.
 - A `TestOntologySource` test fixture exists in `Strategos.Ontology.Tests.TestInfrastructure`.
 - An integration test exercises two sources contributing to the same `ObjectType` with non-overlapping fields; both contributions appear in the composed graph with correct `DescriptorSource`.

--- a/docs/designs/2026-05-10-ontology-2-5-0-polyglot-ingestion.md
+++ b/docs/designs/2026-05-10-ontology-2-5-0-polyglot-ingestion.md
@@ -58,7 +58,7 @@ PR-A is shippable in isolation: it unblocks basileus to start implementing `Mart
 
 The polyglot descriptor schema is a field-level evolution of the existing `ObjectTypeDescriptor` record — `ClrType` becomes nullable, joined by `SymbolKey`, `SymbolFqn`, and `LanguageId`. The lattice rule from basileus ADR §9.2 governs which origin wins per field:
 
-```
+```text
 ObjectTypeDescriptor (polyglot)
   ├── ClrType:      Type?       — hand-main wins; null iff descriptor is purely-ingested
   ├── SymbolKey:    string?     — ingested wins (SCIP moniker is mechanical truth)
@@ -157,11 +157,11 @@ public interface IOntologySource
 }
 ```
 
-`OntologyGraphBuilder` drains `LoadAsync` from each registered source at construction. `SubscribeAsync` is a v2.5.0 surface — Strategos ships the consumer but does not wire live invalidation in this slice; consumers may complete the async enumerable immediately. Live invalidation lands when basileus exercises the surface.
+`OntologyGraphBuilder.Build()` drains `LoadAsync` from each registered source as part of graph composition — before validation runs but after the hand-authored `DomainOntology.Define()` pass has populated the per-domain builders, so ingested deltas can reference hand descriptors that already exist. `SubscribeAsync` is a v2.5.0 surface — Strategos ships the consumer but does not wire live invalidation in this slice; consumers may complete the async enumerable immediately. Live invalidation lands when basileus exercises the surface.
 
 **Acceptance criteria:**
 - `IOntologySource` defined in `Strategos.Ontology` namespace, public.
-- `OntologyBuilderOptions.AddSource<T>()` extension method registers `T : IOntologySource` as transient.
+- `OntologyOptions.AddSource<T>()` extension method registers `T : IOntologySource` as transient.
 - `OntologyGraphBuilder.Build()` drains all registered sources' `LoadAsync` before returning the graph.
 - A `TestOntologySource` test fixture exists in `Strategos.Ontology.Tests.TestInfrastructure`.
 - An integration test exercises two sources contributing to the same `ObjectType` with non-overlapping fields; both contributions appear in the composed graph with correct `DescriptorSource`.

--- a/docs/designs/2026-05-10-ontology-2-5-0-polyglot-ingestion.md
+++ b/docs/designs/2026-05-10-ontology-2-5-0-polyglot-ingestion.md
@@ -1,0 +1,391 @@
+# Design: Strategos 2.5.0 — Polyglot Descriptors + IOntologySource + Drift Diagnostics
+
+**Date:** 2026-05-10
+**Status:** Draft (ideate output)
+**Workflow:** `ontology-2-5-0-polyglot-ingestion` (feature, ideate phase)
+**Scope:** Strategos-only carve-out of the cross-repo ingestion design
+**Parent ADR:** `../../../basileus/docs/adrs/ontological-data-fabric.md` §8.2 (Strategos additions), §9 (merge semantics), §15.7 (polyglot descriptor contract)
+**Prior design (cross-repo):** `docs/reference/2026-04-19-ingest-ontology-from-source.md`
+**Prior design (already-shipped 2.5.0):** `docs/designs/2026-05-08-ontology-2-5-0-dispatch-validation.md`
+**Closes:** strategos#37, strategos#48, strategos#43
+**Milestone:** Ontology 2.5.0 — Coordination Floor
+
+---
+
+## 1. Context and thesis
+
+PR #59 (slices B+C) shipped the dispatch + validation halves of v2.5.0 on 2026-05-09. Three issues remain on the milestone before the Coordination Floor is closed: #37 (`IOntologySource` + provenance), #48 (polyglot descriptor schema), #43 (AONT200-series drift diagnostics). This document specifies them as a single coherent slice — they share a graph-merge surface, a descriptor-shape evolution, and a test fixture matrix.
+
+The load-bearing constraint shaping every decision: **`Actions`, `Events`, `Lifecycle`, `InterfaceActionMappings`, `ExternalLinkExtensionPoints` are hand-authored only** (basileus ADR §9.2). The mechanical ingester is forbidden to contribute to these fields. AONT205 enforces this at graph-merge time. This invariant guarantees that the polyglot work does not need to thread `SymbolKey?` through the merged 2.5.0 dispatch and validation surfaces — those paths only operate on descriptors that carry hand-authored actions, which by invariant carry a non-null `ClrType`.
+
+The Strategos-side surface is therefore three concrete things: (1) the descriptor schema becomes polyglot-capable, (2) ingestion arrives via a new extension point with field-level provenance, and (3) drift between hand-authored intent and ingested mechanical schema surfaces as named diagnostics at merge time.
+
+## 2. Scope and non-goals
+
+### In scope (Strategos 2.5.0)
+
+- Polyglot descriptor schema on `ObjectTypeDescriptor`, `LinkDescriptor`, `PropertyDescriptor` (#48)
+- `AONT037` source-generator diagnostic for `ClrType != null OR SymbolKey != null` invariant (#48)
+- `IOntologySource` interface + `OntologyDelta` event vocabulary + `AddSource<T>()` DI extension (#37)
+- Runtime `IOntologyBuilder.ObjectTypeFromDescriptor` / `ApplyDelta` (#37)
+- `DescriptorSource` enum (`HandAuthored | Ingested`) field-level provenance on descriptors (#37)
+- `AONT201` through `AONT208` graph-freeze diagnostics (#43, expanded from #43's original 6 codes per ADR §9.3)
+- `AONT041` retarget from `ClrType`-keyed to `(DomainName, Name)`-keyed link-participant check
+- `OntologyValidateTool.FindObjectType` retarget to descriptor-name resolution (PR #59 deferred follow-up)
+
+### Out of scope
+
+- `MartenOntologySource` implementation (basileus owns; consumes `IOntologySource`)
+- `RoslynSourceAnalyzer`, `TypescriptLanguageFrontend`, SCIP wiring (basileus §7)
+- Marten event-stream replay, ingestion service orchestration (basileus §8.3–§8.13)
+- `ChunkContentHashCache`, embedding pipeline (basileus §8.5–§8.6)
+- Branch-hand stream and four-input fold (`MergeFour`) — Strategos 2.5.0 ships the two-input fold (`MergeTwo`: hand + ingested); four-input arrives with branch-stream support in a later release
+- Coverage gate / `IOntologyCoverageProvider` extensions (Strategos.Ontology.Query already has this; no work)
+- `Strategos.Contracts` TypeSpec emit for the new types (separate concern, tracked alongside `2026-04-18-typespec-contracts-pipeline.md`)
+- Multi-registered CLR types in structural links (#32) — explicitly deferred awaiting concrete use case
+- README + VitePress documentation updates (#23) — synthesizes after this slice merges
+
+### Cadence
+
+Two PRs, sequenced:
+
+- **PR-A: Schema + ingest** — DR-1, DR-2, DR-3, DR-4, DR-5, DR-6, DR-9, DR-10
+- **PR-B: Drift diagnostics** — DR-7, DR-8
+
+PR-A is shippable in isolation: it unblocks basileus to start implementing `MartenOntologySource` against a stable contract. PR-B follows once PR-A merges, since AONT201–AONT208 require descriptors with mixed provenance to test against.
+
+## 3. Architecture overview
+
+The polyglot descriptor schema is a field-level evolution of the existing `ObjectTypeDescriptor` record — `ClrType` becomes nullable, joined by `SymbolKey`, `SymbolFqn`, and `LanguageId`. The lattice rule from basileus ADR §9.2 governs which origin wins per field:
+
+```
+ObjectTypeDescriptor (polyglot)
+  ├── ClrType:      Type?       — hand-main wins; null iff descriptor is purely-ingested
+  ├── SymbolKey:    string?     — ingested wins (SCIP moniker is mechanical truth)
+  ├── SymbolFqn:    string?     — ingested wins
+  ├── LanguageId:   string      — hand-main wins; default "dotnet" for hand-authored
+  ├── Source:       DescriptorSource  — record-level provenance: HandAuthored | Ingested
+  ├── Properties:   Set<PropertyDescriptor>  — per-name union; each carries Source
+  ├── Links:        Set<LinkDescriptor>      — per-name union; each carries Source
+  ├── Actions:      ImmutableArray<ActionDescriptor>  — HAND-ONLY (AONT205)
+  ├── Events:       ImmutableArray<EventDescriptor>   — HAND-ONLY (AONT205)
+  └── Lifecycle:    LifecycleDescriptor?     — HAND-ONLY (AONT205)
+
+OntologyBuilder pipeline:
+  IOntologySource.LoadAsync     →  OntologyDelta[]
+                                       ↓
+                                 IOntologyBuilder.ApplyDelta
+                                       ↓
+                                 Two-input fold (MergeTwo, ADR §9.1)
+                                       ↓
+                                 Graph-freeze with AONT200-series checks
+                                       ↓
+                                 OntologyGraph (consumed by PR #59 surfaces)
+```
+
+Runtime paths shipped in PR #59 (`IActionDispatcher.*`, `EstimateBlastRadius`, `DetectPatternViolations`, `GetActionConstraintReport`) key descriptors by `(DomainName, Name)` and observe `descriptor.Actions` for dispatch decisions. Because `Actions` is hand-only, those paths only see descriptors with `ClrType != null` — no polyglot composition cost at runtime.
+
+## 4. Design requirements
+
+### DR-1: Polyglot descriptor schema
+
+**Statement:** `ObjectTypeDescriptor`, `LinkDescriptor`, and `PropertyDescriptor` accept polyglot identity. `ClrType` becomes nullable. `SymbolKey`, `SymbolFqn`, and `LanguageId` are added with documented semantics per basileus ADR §8.2.5.
+
+**Shape:**
+
+```csharp
+public sealed record ObjectTypeDescriptor
+{
+    public required string Name { get; init; }
+    public required string DomainName { get; init; }
+
+    public Type? ClrType { get; init; }
+    public string? SymbolKey { get; init; }
+    public string? SymbolFqn { get; init; }
+    public string LanguageId { get; init; } = "dotnet";
+
+    public DescriptorSource Source { get; init; } = DescriptorSource.HandAuthored;
+    public string? SourceId { get; init; }
+    public DateTimeOffset? IngestedAt { get; init; }
+
+    // ... existing properties unchanged
+}
+
+public enum DescriptorSource { HandAuthored, Ingested }
+```
+
+`LinkDescriptor.TargetType`/`ParentType` and any `PropertyDescriptor` `Type` references receive the same treatment: optional CLR-type, optional symbol-key, exclusive.
+
+**Acceptance criteria:**
+- `ObjectTypeDescriptor.ClrType` is nullable; default constructor of new field set throws `InvalidOperationException` if `ClrType` and `SymbolKey` are both null at construction.
+- `LinkDescriptor.TargetTypeName` already exists (PR #59); `LinkDescriptor.TargetSymbolKey` is added as a parallel optional field.
+- `PropertyDescriptor` reference-property fields accept `string? SymbolKey` alongside existing `Type? ReferenceType`.
+- Existing `DomainOntology` subclasses across `Strategos.Ontology.Tests`, `Strategos.Ontology.MCP.Tests`, and the trading sample compile and run unchanged with `LanguageId = "dotnet"` default.
+- 666 existing tests in `Strategos.Ontology.Tests` continue to pass; 121 in `Strategos.Ontology.MCP.Tests` continue to pass.
+
+### DR-2: AONT037 source-generator diagnostic
+
+**Statement:** A new source-generator diagnostic fires when a hand-authored `DomainOntology.Define()` produces an `ObjectTypeDescriptor` with both `ClrType == null` and `SymbolKey == null`. Severity Error.
+
+**Trigger:** `OntologyDefinitionAnalyzer` walks `Define()` method bodies; for each `obj.ObjectType<T>()` or `obj.ObjectType(name, ...)` call, verify the resulting descriptor satisfies the invariant. The hand-authored DSL always carries `T` (so `ClrType` is implied non-null) — AONT037 catches the case where the descriptor-by-name overload is used without supplying a `SymbolKey`.
+
+**Acceptance criteria:**
+- Diagnostic registered in `OntologyDefinitionAnalyzer` with identifier `AONT037`, severity Error.
+- Positive test: `Define()` calling `obj.ObjectType("Foo", domainName: "Trading")` without `SymbolKey` produces AONT037 with a fix-suggestion message naming both options.
+- Negative test: `Define()` calling `obj.ObjectType<TradeOrder>()` does not produce AONT037.
+- Diagnostic documentation in `docs/reference/ontology-diagnostics.md` (or equivalent) updated.
+
+### DR-3: `IOntologySource` extension point
+
+**Statement:** `Strategos.Ontology.IOntologySource` is a new public interface enabling ontology graph contributions from sources beyond hand-authored `DomainOntology.Define()`. Registered via DI: `options.AddSource<MartenOntologySource>()`.
+
+**Shape:**
+
+```csharp
+namespace Strategos.Ontology;
+
+public interface IOntologySource
+{
+    /// <summary>Stable identifier; tags provenance and conflict diagnostics.</summary>
+    string SourceId { get; }
+
+    /// <summary>Replays the source's full state as a stream of deltas. Called once at startup.</summary>
+    IAsyncEnumerable<OntologyDelta> LoadAsync(CancellationToken ct);
+
+    /// <summary>Subscribes to incremental updates. Empty for static sources.</summary>
+    IAsyncEnumerable<OntologyDelta> SubscribeAsync(CancellationToken ct);
+}
+```
+
+`OntologyGraphBuilder` drains `LoadAsync` from each registered source at construction. `SubscribeAsync` is a v2.5.0 surface — Strategos ships the consumer but does not wire live invalidation in this slice; consumers may complete the async enumerable immediately. Live invalidation lands when basileus exercises the surface.
+
+**Acceptance criteria:**
+- `IOntologySource` defined in `Strategos.Ontology` namespace, public.
+- `OntologyBuilderOptions.AddSource<T>()` extension method registers `T : IOntologySource` as transient.
+- `OntologyGraphBuilder.Build()` drains all registered sources' `LoadAsync` before returning the graph.
+- A `TestOntologySource` test fixture exists in `Strategos.Ontology.Tests.TestInfrastructure`.
+- An integration test exercises two sources contributing to the same `ObjectType` with non-overlapping fields; both contributions appear in the composed graph with correct `DescriptorSource`.
+
+### DR-4: `OntologyDelta` event vocabulary
+
+**Statement:** `OntologyDelta` is a sealed abstract record with eight concrete variants covering object-type, property, and link granularity. Per basileus ADR §8.2.2.
+
+**Variants:**
+
+```csharp
+public abstract record OntologyDelta
+{
+    public required string SourceId { get; init; }
+    public required DateTimeOffset Timestamp { get; init; }
+
+    public sealed record AddObjectType(ObjectTypeDescriptor Descriptor) : OntologyDelta;
+    public sealed record UpdateObjectType(ObjectTypeDescriptor Descriptor) : OntologyDelta;
+    public sealed record RemoveObjectType(string DomainName, string TypeName) : OntologyDelta;
+    public sealed record AddProperty(string DomainName, string TypeName, PropertyDescriptor Descriptor) : OntologyDelta;
+    public sealed record RenameProperty(string DomainName, string TypeName, string FromName, string ToName) : OntologyDelta;
+    public sealed record RemoveProperty(string DomainName, string TypeName, string PropertyName) : OntologyDelta;
+    public sealed record AddLink(string DomainName, string SourceTypeName, LinkDescriptor Descriptor) : OntologyDelta;
+    public sealed record RemoveLink(string DomainName, string SourceTypeName, string LinkName) : OntologyDelta;
+}
+```
+
+Mechanical ingester is forbidden from constructing `Add`/`Update` deltas whose descriptors contain `Actions`, `Events`, or `Lifecycle` — this is the AONT205 invariant. Validation occurs at delta-apply time, not at delta-construction time.
+
+**Acceptance criteria:**
+- All eight variants defined as sealed records under `OntologyDelta`.
+- `Strategos.Ontology.Tests.OntologyDeltaTests` exercises each variant's construction + round-trip equality.
+- `RenameProperty` is a single delta, not `RemoveProperty + AddProperty` — preserves rename identity through the matcher.
+
+### DR-5: Runtime `IOntologyBuilder` API
+
+**Statement:** `IOntologyBuilder` exposes two new methods enabling delta application without the expression-tree DSL.
+
+**Shape:**
+
+```csharp
+public interface IOntologyBuilder
+{
+    // ... existing expression-tree DSL methods unchanged
+
+    /// <summary>Adds an ObjectType from a fully-specified descriptor. Bypasses the expression-tree DSL.</summary>
+    void ObjectTypeFromDescriptor(ObjectTypeDescriptor descriptor);
+
+    /// <summary>Applies an OntologyDelta against the current builder state.</summary>
+    void ApplyDelta(OntologyDelta delta);
+}
+```
+
+The DSL path remains the supported entry point for `DomainOntology.Define()` subclasses. `ObjectTypeFromDescriptor` is the mechanism `IOntologySource` contributions reach the graph — necessary because ingested types may only be known by `SymbolKey`, with no loaded CLR type.
+
+**Acceptance criteria:**
+- Both methods are non-virtual on the public interface; existing implementations get them via default interface methods where backward compat matters.
+- `ApplyDelta` dispatches by delta variant; unknown variants throw `NotSupportedException`.
+- Each delta variant has a positive test exercising the apply path.
+- Adding an ObjectType with `Source = Ingested` and a non-empty `Actions` array throws `OntologyCompositionException` with message naming AONT205.
+
+### DR-6: Field-level provenance metadata
+
+**Statement:** Each descriptor type carries a `DescriptorSource Source { get; init; }` property. `PropertyDescriptor` and `LinkDescriptor` carry per-field provenance, not per-parent — a single `ObjectTypeDescriptor` can have hand-authored `Properties` and ingested-added `Properties`, each tagged separately.
+
+**Merge semantics (two-input fold, MergeTwo):**
+
+```csharp
+ObjectTypeDescriptor MergeTwo(ObjectTypeDescriptor hand, ObjectTypeDescriptor ingested)
+{
+    return new ObjectTypeDescriptor
+    {
+        Name = hand.Name,                          // mismatch is AONT006
+        DomainName = hand.DomainName,
+        ClrType = hand.ClrType ?? ingested.ClrType,        // hand wins, fallback to ingested
+        SymbolKey = ingested.SymbolKey ?? hand.SymbolKey,  // ingested wins (SCIP authoritative)
+        SymbolFqn = ingested.SymbolFqn ?? hand.SymbolFqn,
+        LanguageId = hand.LanguageId,
+        Source = DescriptorSource.HandAuthored,             // record-level: hand wins on composition
+        Properties = MergeProperties(hand.Properties, ingested.Properties),
+        Links = MergeLinks(hand.Links, ingested.Links),
+        Actions = hand.Actions,                             // INTENT — hand only
+        Events = hand.Events,                               // INTENT — hand only
+        Lifecycle = hand.Lifecycle,                         // INTENT — hand only
+    };
+}
+```
+
+Per-property merge: hand wins on conflict, ingested-only properties added with `Source = Ingested`. Same for links.
+
+**Acceptance criteria:**
+- `DescriptorSource` enum present; default value `HandAuthored`.
+- `PropertyDescriptor.Source` and `LinkDescriptor.Source` properties exist, default `HandAuthored`.
+- `MergeTwo` implementation in `OntologyGraphBuilder` follows the lattice rule from basileus ADR §9.1.
+- Test matrix: hand-only, ingested-only, hand-overrides-ingested, ingested-adds-to-hand, conflict-resolves-to-hand, identity-fields-from-ingested.
+- Field-level provenance accessible via `ObjectTypeDescriptor.GetPropertyProvenance(name)` helper.
+
+### DR-7: AONT200-series graph-freeze diagnostics
+
+**Statement:** Eight new diagnostics fire at `OntologyGraphBuilder.Build()` based on observable conditions in the composed graph. Per basileus ADR §9.3.
+
+**Catalog:**
+
+| ID | Trigger | Severity |
+|---|---|---|
+| AONT201 | Hand-declared property does not exist on ingested descriptor | Error |
+| AONT202 | Hand-declared property type mismatches ingested | Warning |
+| AONT203 | Ingested-only property missing from hand `Define()` when `[DomainEntity(Strict = true)]` | Warning |
+| AONT204 | Ingested type not referenced by any hand-authored `Define()` | Info |
+| AONT205 | Mechanical ingester contributed to intent-only field (`Actions`/`Events`/`Lifecycle`) | Error |
+| AONT206 | Hand-declared property also ingested mechanically — opt-in cleanup hint | Info (off by default) |
+| AONT207 | Branch-hand vs main-hand property conflict — **deferred** (requires four-input fold) | — |
+| AONT208 | `LanguageId` disagreement between origins | Error |
+
+AONT207 is named here for vocabulary alignment with basileus ADR but is not implemented in this slice (four-input fold is out of scope per §2). The diagnostic registration is present; the trigger is unreachable until branch-hand stream support lands.
+
+**Acceptance criteria:**
+- All eight diagnostics registered in `OntologyDefinitionAnalyzer` and `OntologyGraphBuilder` per applicability (compile-time vs graph-freeze).
+- AONT201–AONT206, AONT208 each have positive and negative tests; AONT207 has a registration test only with a `[Skip("requires four-input fold")]` placeholder.
+- AONT201's exception/diagnostic message names the offending property + suggests `Pass-6b rename matcher may have missed this` when context allows.
+- AONT203 fires only when the `[DomainEntity(Strict = true)]` opt-in is set.
+- AONT206 is gated by MSBuild property `OntologyEnableHygieneHints` (default false).
+
+### DR-8: AONT041 retarget
+
+**Statement:** `AONT041 MultiRegisteredTypeInLink` currently keys its multi-registration check by `ClrType`. With polyglot descriptors, this produces false negatives when a multi-registered type is participated in a link via `SymbolKey`-only descriptor. Retarget to `(DomainName, Name)` keying.
+
+**Acceptance criteria:**
+- AONT041 lookup uses descriptor-name + domain-name composite key.
+- Regression test: hand-authored multi-registration of `TradeOrder` as `"orders"` + `"open_orders"` participating in a link still trips AONT041 (existing behavior preserved).
+- New test: ingested descriptor with `SymbolKey="scip-typescript ./mod#User"` registered twice (e.g., once per workspace) participating in a hand-authored link trips AONT041.
+- `OntologyValidateTool.FindObjectType` retargets to descriptor-name resolution (closes PR #59 deferred follow-up: "domain-agnostic; cross-domain name collisions could silently resolve").
+
+### DR-9: Test fixture infrastructure
+
+**Statement:** `Strategos.Ontology.Tests` gains a `TestOntologySource` for fast synthetic deltas and one Roslyn-based integration test verifying real `SymbolKey.ToString()` round-trip.
+
+**Test infrastructure:**
+
+```csharp
+namespace Strategos.Ontology.Tests.TestInfrastructure;
+
+public sealed class TestOntologySource : IOntologySource
+{
+    public required string SourceId { get; init; }
+    public required ImmutableArray<OntologyDelta> Deltas { get; init; }
+
+    public async IAsyncEnumerable<OntologyDelta> LoadAsync([EnumeratorCancellation] CancellationToken ct)
+    {
+        foreach (var delta in Deltas) { ct.ThrowIfCancellationRequested(); yield return delta; }
+    }
+
+    public async IAsyncEnumerable<OntologyDelta> SubscribeAsync([EnumeratorCancellation] CancellationToken ct)
+    {
+        await Task.Yield(); yield break;
+    }
+}
+```
+
+**Integration test:** One new test using `Microsoft.CodeAnalysis.CSharp` to compile a small `.cs` snippet, extract an `INamedTypeSymbol`, serialize via `SymbolKey.Create(symbol).ToString()`, and validate that an `ObjectTypeDescriptor` built from that `SymbolKey` round-trips through the runtime builder + graph-freeze without losing identity.
+
+**Acceptance criteria:**
+- `TestOntologySource` exists in test infrastructure; unit/merge/diagnostic tests use it.
+- `Strategos.Ontology.Tests.csproj` adds `Microsoft.CodeAnalysis.CSharp` as a test-only dependency (PrivateAssets="all").
+- One Roslyn integration test passes; it does not run when `SkipRoslynIntegrationTests` MSBuild property is set (CI escape hatch).
+- Test count delta: ~80 new tests across PR-A + PR-B (synthetic) + 1 Roslyn integration test.
+
+### DR-10: Error handling, failure modes, edge cases
+
+**Statement (mandatory per ideate skill):** The slice must specify behavior under three failure modes: (i) source raises during `LoadAsync`, (ii) delta application fails the AONT205 invariant, (iii) graph-freeze produces an error-severity diagnostic.
+
+**Failure mode 1 — Source raises during `LoadAsync`:**
+`OntologyGraphBuilder.Build()` propagates the exception with `SourceId` in the message. No partial graph is produced. Other sources do not run.
+
+**Failure mode 2 — Delta apply violates AONT205:**
+`IOntologyBuilder.ApplyDelta` throws `OntologyCompositionException` with diagnostic identifier `AONT205`, the offending field name, and `SourceId`. The builder is poisoned (no further deltas accepted on that builder instance); `Build()` will throw.
+
+**Failure mode 3 — Error-severity diagnostic during graph-freeze:**
+`OntologyGraphBuilder.Build()` aggregates all Error-severity diagnostics (AONT201, AONT205, AONT208) and throws `OntologyCompositionException` with all findings in `Diagnostics: ImmutableArray<OntologyDiagnostic>`. Warnings (AONT202, AONT203) and Info (AONT204, AONT206) are logged via `ILogger<OntologyGraphBuilder>` and surfaced on the returned graph as `OntologyGraph.NonFatalDiagnostics`.
+
+**Acceptance criteria:**
+- Test: `TestOntologySource` that yields-and-throws produces an exception whose message contains the `SourceId`.
+- Test: applying an ingested `Add` delta with `Actions.Count > 0` throws `OntologyCompositionException` with `Diagnostic.Id == "AONT205"`.
+- Test: a graph with one AONT201 + one AONT202 + one AONT204 throws on Build(); thrown exception's `Diagnostics` contains the AONT201 only; the AONT202 and AONT204 are accessible via the exception's `NonFatalDiagnostics` property for telemetry purposes.
+- Logging at `LogLevel.Warning` for AONT202/AONT203 with structured properties (`DiagnosticId`, `DomainName`, `TypeName`, `PropertyName`).
+
+## 5. Open questions
+
+1. **Should `PropertyDescriptor.Source` be on the descriptor itself or on a parallel `ObjectTypeDescriptor.PropertyProvenance: ImmutableDictionary<string, DescriptorSource>` map?** Recommendation: on the descriptor (simpler, no parallel-map drift risk). Open for review challenge.
+
+2. **`OntologyGraph.NonFatalDiagnostics` shape — `ImmutableArray<OntologyDiagnostic>` or richer?** Suggest matching `ConstraintViolationReport`'s shape from PR #59 for consistency.
+
+3. **How does `IOntologyVersionedCache` (`OntologyGraph.Version` from #44) compose with `SubscribeAsync` for live invalidation in v2.6.0?** Out of scope here but the design should not foreclose it. Current proposal: `OntologyGraphBuilder.RebuildAsync` consumes `SubscribeAsync` deltas and bumps the version hash; cache consumers invalidate via existing `_meta.ontologyVersion` envelope.
+
+## 6. Risks and trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| Field-level provenance on `PropertyDescriptor`/`LinkDescriptor` increases descriptor record size; many call sites construct these in tests | Default `Source = HandAuthored` preserves existing test ergonomics; `with { Source = Ingested }` is the explicit opt-in for new ingested paths |
+| AONT201 firing rate may be high when basileus first runs against an existing trading ontology that has drifted | Acceptable; AONT201 is the load-bearing diagnostic for the inversion thesis and is expected to fire on first integration — that is the value it delivers. Document in basileus rollout runbook |
+| Two-PR cadence (PR-A → PR-B) leaves a window where ingested types can be added to the graph but drift diagnostics are silent | PR-A explicitly logs `LogLevel.Information` events on every ingested-with-mismatch case so the diagnostic gap is observable. PR-B converts those to graph-freeze errors |
+| `Microsoft.CodeAnalysis.CSharp` test dependency adds ~5MB to test restore | Acceptable; gated behind PrivateAssets and the `SkipRoslynIntegrationTests` MSBuild property |
+
+## 7. Cross-references
+
+- **basileus ADR:** `../../../basileus/docs/adrs/ontological-data-fabric.md` — §8.2 (Strategos additions), §9 (merge semantics), §15.7 (polyglot descriptor contract in Strategos.Contracts)
+- **Prior cross-repo design:** `docs/reference/2026-04-19-ingest-ontology-from-source.md`
+- **Prior 2.5.0 dispatch+validation design:** `docs/designs/2026-05-08-ontology-2-5-0-dispatch-validation.md`
+- **PR #59 deferred follow-ups (this slice closes):** `OntologyValidateTool.FindObjectType` cross-domain resolution
+- **#31 multi-registration design:** `docs/designs/2026-04-08-ontology-descriptor-name-dispatch.md` (AONT041 origins)
+- **GitHub issues:** strategos#37, strategos#48, strategos#43
+- **Deferred to follow-up:** strategos#32 (multi-registered link participants, awaits use case), strategos#23 (docs)
+
+## 8. axiom:design dimensional summary
+
+This design was constrained by `axiom:design` DIM-1..DIM-8 during ideation. Notable applications:
+
+- **DIM-1 Topology:** Every shared resource has a single source-of-truth path. `OntologyGraphBuilder` is the single composition root for source merging. No silent fallbacks: missing `IOntologySource` is not an error; failing `IOntologySource.LoadAsync` is a startup error.
+- **DIM-2 Observability:** All diagnostics carry structured identifiers (AONT201–AONT208, AONT037). Non-fatal diagnostics surface via `ILogger` + `OntologyGraph.NonFatalDiagnostics`. No silent catches.
+- **DIM-3 Contracts:** Changes to PR #59's already-shipped surface (`IOntologyQuery.*`, `IActionDispatcher.*`) are zero. The descriptor schema evolution is opt-in via nullable fields with documented defaults; existing hand-authored ontologies compile unchanged.
+- **DIM-4 Test Fidelity:** `TestOntologySource` matches production source wiring (same `IOntologySource` interface); the one Roslyn integration test guards against `SymbolKey.ToString()` divergence between Strategos test fixtures and basileus production ingester.
+- **DIM-5 Hygiene:** Two-PR cadence avoids dead code in PR-A (no diagnostic-shape placeholders). AONT207 is named for vocabulary alignment but explicitly unreachable until four-input fold ships.
+- **DIM-6 Architecture:** Polyglot composition does not ripple through merged 2.5.0 surfaces; dispatch + validation paths remain descriptor-name-keyed. Single responsibility per module preserved.
+- **DIM-7 Resilience:** Graph-freeze is bounded by `MaxExpansionDegree` (existing from PR #59). `LoadAsync` exceptions are loud, not silent. No new caches in this slice.
+- **DIM-8 Prose:** Diagnostic messages name specific identifiers (property names, type names, source IDs), not generic categories.
+
+No paired invariants skill detected. Run `/axiom:scaffold-invariants` to create one.

--- a/docs/plans/2026-05-10-ontology-2-5-0-polyglot-ingestion.md
+++ b/docs/plans/2026-05-10-ontology-2-5-0-polyglot-ingestion.md
@@ -527,7 +527,7 @@ PR-B begins after PR-A merges to main.
 
 ## PR-B acceptance gate
 
-```
+```bash
 dotnet build strategos.sln  # 0 warnings, 0 errors
 dotnet test  # all test projects pass
 ```

--- a/docs/plans/2026-05-10-ontology-2-5-0-polyglot-ingestion.md
+++ b/docs/plans/2026-05-10-ontology-2-5-0-polyglot-ingestion.md
@@ -1,0 +1,575 @@
+# Implementation Plan: Strategos 2.5.0 — Polyglot Descriptors + IOntologySource + Drift Diagnostics
+
+**Date:** 2026-05-10
+**Design:** `docs/designs/2026-05-10-ontology-2-5-0-polyglot-ingestion.md`
+**Feature ID:** `ontology-2-5-0-polyglot-ingestion`
+**Closes:** strategos#37, strategos#48, strategos#43
+**Iron Law:** **NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST**
+
+## Cadence
+
+Two PRs, sequenced:
+
+- **PR-A** (Tasks 1–22): Schema + `IOntologySource` + provenance + AONT037 + test fixtures. Unblocks basileus.
+- **PR-B** (Tasks 23–32): AONT200-series drift diagnostics + AONT041 retarget + `OntologyValidateTool.FindObjectType` retarget.
+
+PR-B depends on PR-A being merged.
+
+## Traceability matrix (design → tasks)
+
+| DR | Title | Tasks |
+|---|---|---|
+| DR-1 | Polyglot descriptor schema | 1, 2, 3, 4 |
+| DR-2 | AONT037 source-generator diagnostic | 18, 19 |
+| DR-3 | `IOntologySource` extension point | 7, 12, 13 |
+| DR-4 | `OntologyDelta` event vocabulary | 8 |
+| DR-5 | Runtime `IOntologyBuilder` API | 9, 10, 11 |
+| DR-6 | Field-level provenance metadata | 5, 6, 14, 15, 16 |
+| DR-7 | AONT200-series graph-freeze diagnostics | 23, 24, 25, 26, 27, 28, 29, 30 |
+| DR-8 | AONT041 retarget + `FindObjectType` retarget | 31, 32 |
+| DR-9 | Test fixture infrastructure | 20, 21, 22 |
+| DR-10 | Error handling and failure modes | 5, 16, 17, 27 |
+
+## Conventions
+
+- Test naming: `Method_Scenario_Outcome` (e.g., `Build_IngestedDescriptorWithActions_ThrowsAONT205`).
+- Test framework: TUnit (Strategos convention). Invocation: `dotnet test src/Strategos.Ontology.Tests/Strategos.Ontology.Tests.csproj -- --treenode-filter "/*/*/*/<TestName>"`.
+- Each task: [RED] failing test → [GREEN] minimum code → [REFACTOR] if needed.
+- File paths absolute from repo root.
+
+---
+
+## PR-A: Schema + IOntologySource + Provenance + AONT037 + Test Fixtures
+
+### Task 1: `DescriptorSource` enum
+
+**Implements:** DR-6
+**Phase:** RED → GREEN
+
+1. [RED] Add test `DescriptorSource_DefaultValue_IsHandAuthored` to `src/Strategos.Ontology.Tests/Descriptors/DescriptorSourceTests.cs` asserting `default(DescriptorSource) == DescriptorSource.HandAuthored`.
+   - Expected failure: `DescriptorSource` does not exist.
+2. [GREEN] Create `src/Strategos.Ontology/Descriptors/DescriptorSource.cs` with enum: `HandAuthored = 0, Ingested = 1`.
+
+**Dependencies:** None
+**Parallelizable:** Yes
+**testingStrategy:** unit
+
+### Task 2: `ObjectTypeDescriptor` polyglot fields
+
+**Implements:** DR-1
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Add tests to `src/Strategos.Ontology.Tests/Descriptors/ObjectTypeDescriptorPolyglotTests.cs`:
+   - `Ctor_HandAuthoredDefault_LanguageIdIsDotnet` — descriptor built via existing positional ctor `(Name, ClrType, DomainName)` has `LanguageId == "dotnet"`.
+   - `Ctor_IngestedDescriptor_AcceptsNullClrTypeAndSymbolKey` — descriptor built with `SymbolKey != null, ClrType == null` compiles and round-trips.
+   - `Ctor_BothNull_ThrowsInvalidOperationException` — descriptor with `ClrType == null` and `SymbolKey == null` throws at construction with message naming the invariant.
+   - Expected failure: properties do not exist; positional ctor still requires `Type ClrType`.
+2. [GREEN] Refactor `src/Strategos.Ontology/Descriptors/ObjectTypeDescriptor.cs`:
+   - Change from positional record `(string Name, Type ClrType, string DomainName)` to property-init record with `Name`, `DomainName` required, `ClrType` optional, `SymbolKey`, `SymbolFqn`, `LanguageId` (default `"dotnet"`), `Source` (default `HandAuthored`), `SourceId`, `IngestedAt` optional.
+   - Preserve backward-compat constructor `(string name, Type clrType, string domainName)` that calls the new init form with `ClrType = clrType, LanguageId = "dotnet"`.
+   - Add invariant guard in the constructor body.
+3. [REFACTOR] Update any test/sample call sites that broke (expected: zero — positional ctor preserved).
+
+**Dependencies:** Task 1
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 3: `LinkDescriptor` polyglot fields
+
+**Implements:** DR-1
+**Phase:** RED → GREEN
+
+1. [RED] Add tests to `src/Strategos.Ontology.Tests/Descriptors/LinkDescriptorPolyglotTests.cs`:
+   - `Ctor_SymbolKeyTargetOnly_ParentTypeNullOk` — `LinkDescriptor` with `TargetSymbolKey != null` and `TargetType == null` constructs.
+   - `Source_DefaultValue_IsHandAuthored`.
+   - Expected failure: `TargetSymbolKey`, `Source` don't exist on `LinkDescriptor`.
+2. [GREEN] Update `src/Strategos.Ontology/Descriptors/LinkDescriptor.cs`:
+   - Add `string? TargetSymbolKey { get; init; }` parallel to existing `TargetTypeName`.
+   - Add `DescriptorSource Source { get; init; } = HandAuthored`.
+
+**Dependencies:** Task 1
+**Parallelizable:** Yes (with Task 4)
+**testingStrategy:** unit
+
+### Task 4: `PropertyDescriptor` polyglot + provenance fields
+
+**Implements:** DR-1, DR-6
+**Phase:** RED → GREEN
+
+1. [RED] Add tests to `src/Strategos.Ontology.Tests/Descriptors/PropertyDescriptorPolyglotTests.cs`:
+   - `Ctor_ReferenceTypeBySymbolKey_AcceptsNullClrType` — for reference-typed properties, `ReferenceSymbolKey != null` + `ReferenceType == null` constructs.
+   - `Source_DefaultValue_IsHandAuthored`.
+   - Expected failure: properties don't exist.
+2. [GREEN] Update `src/Strategos.Ontology/Descriptors/PropertyDescriptor.cs`:
+   - Add `string? ReferenceSymbolKey { get; init; }` parallel to existing `ReferenceType`.
+   - Add `DescriptorSource Source { get; init; } = HandAuthored`.
+
+**Dependencies:** Task 1
+**Parallelizable:** Yes (with Task 3)
+**testingStrategy:** unit
+
+### Task 5: `OntologyCompositionException` aggregates diagnostics
+
+**Implements:** DR-10
+**Phase:** RED → GREEN
+
+1. [RED] Add tests to `src/Strategos.Ontology.Tests/Exceptions/OntologyCompositionExceptionTests.cs`:
+   - `Ctor_WithDiagnostics_ExposesDiagnosticsProperty` — exception constructed with a list of `(DiagnosticId, Message, Severity)` exposes them via `Diagnostics: ImmutableArray<OntologyDiagnostic>`.
+   - `Ctor_MessageContainsFirstDiagnosticId` — default message lists the first diagnostic ID.
+2. [GREEN] Extend or create `src/Strategos.Ontology/Exceptions/OntologyCompositionException.cs` (check whether one exists; if so extend; if not create) with `Diagnostics` and `NonFatalDiagnostics` properties. Add `OntologyDiagnostic` record (`Id`, `Message`, `Severity`, `DomainName?`, `TypeName?`, `PropertyName?`).
+
+**Dependencies:** None
+**Parallelizable:** Yes
+**testingStrategy:** unit
+
+### Task 6: `OntologyDiagnostic` record + `DiagnosticSeverity` mirror
+
+**Implements:** DR-6, DR-10
+**Phase:** RED → GREEN
+
+1. [RED] Add test `OntologyDiagnostic_Construction_PreservesFields` to `src/Strategos.Ontology.Tests/Diagnostics/OntologyDiagnosticTests.cs` asserting field round-trip.
+2. [GREEN] Create `src/Strategos.Ontology/Diagnostics/OntologyDiagnostic.cs`. Mirror Roslyn's `DiagnosticSeverity` enum locally to avoid runtime-binding to `Microsoft.CodeAnalysis` from the runtime assembly.
+
+**Dependencies:** Task 5
+**Parallelizable:** Yes
+**testingStrategy:** unit
+
+### Task 7: `IOntologySource` interface
+
+**Implements:** DR-3
+**Phase:** RED → GREEN
+
+1. [RED] Add test `IOntologySource_ImplementedByTestSource_ExposesSourceId` to `src/Strategos.Ontology.Tests/Sources/IOntologySourceContractTests.cs`. Construct an inline test impl; assert `SourceId` returns the configured value.
+   - Expected failure: `IOntologySource` namespace does not exist.
+2. [GREEN] Create `src/Strategos.Ontology/Sources/IOntologySource.cs` with the interface (`SourceId`, `LoadAsync`, `SubscribeAsync`).
+
+**Dependencies:** None
+**Parallelizable:** Yes
+**testingStrategy:** unit
+
+### Task 8: `OntologyDelta` event vocabulary
+
+**Implements:** DR-4
+**Phase:** RED → GREEN
+
+1. [RED] Add tests to `src/Strategos.Ontology.Tests/Sources/OntologyDeltaTests.cs`:
+   - `AddObjectType_Construction_RoundTrips` (and one test per variant for: `UpdateObjectType`, `RemoveObjectType`, `AddProperty`, `RenameProperty`, `RemoveProperty`, `AddLink`, `RemoveLink`).
+   - `RenameProperty_IsSingleDelta_NotRemoveThenAdd` — assert via type assertion that a property-rename delta is `OntologyDelta.RenameProperty`, not a pair.
+   - Expected failure: `OntologyDelta` does not exist.
+2. [GREEN] Create `src/Strategos.Ontology/Sources/OntologyDelta.cs` with the eight sealed-record variants under the abstract base.
+
+**Dependencies:** Task 1, Task 7
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 9: `IOntologyBuilder.ObjectTypeFromDescriptor`
+
+**Implements:** DR-5
+**Phase:** RED → GREEN
+
+1. [RED] Add test `ObjectTypeFromDescriptor_IngestedDescriptor_AppearsInBuiltGraph` to `src/Strategos.Ontology.Tests/Builder/IOntologyBuilderDescriptorPathTests.cs`. Construct an `OntologyBuilder`, call `ObjectTypeFromDescriptor` with `Source = Ingested`, build, assert the descriptor is present with `Source == Ingested`.
+   - Expected failure: method doesn't exist.
+2. [GREEN] Add `ObjectTypeFromDescriptor(ObjectTypeDescriptor)` to `IOntologyBuilder` (`src/Strategos.Ontology/Builder/`). Implement on the concrete `OntologyBuilder` to register the descriptor in the builder's internal store.
+
+**Dependencies:** Task 2, Task 7
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 10: `IOntologyBuilder.ApplyDelta` — `AddObjectType` variant
+
+**Implements:** DR-5
+**Phase:** RED → GREEN
+
+1. [RED] Add test `ApplyDelta_AddObjectType_RegistersDescriptor` to `src/Strategos.Ontology.Tests/Builder/IOntologyBuilderApplyDeltaTests.cs`. Builder applies an `OntologyDelta.AddObjectType` delta; built graph contains the type.
+2. [GREEN] Implement `ApplyDelta(OntologyDelta)` on `OntologyBuilder` with the `AddObjectType` branch routing to `ObjectTypeFromDescriptor`.
+
+**Dependencies:** Task 8, Task 9
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 11: `IOntologyBuilder.ApplyDelta` — remaining seven variants
+
+**Implements:** DR-5
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Add a test per variant to `IOntologyBuilderApplyDeltaTests.cs`:
+   - `ApplyDelta_UpdateObjectType_OverwritesExisting`
+   - `ApplyDelta_RemoveObjectType_DropsType`
+   - `ApplyDelta_AddProperty_AppendsToParent`
+   - `ApplyDelta_RenameProperty_PreservesIdentity`
+   - `ApplyDelta_RemoveProperty_DropsByName`
+   - `ApplyDelta_AddLink_AppendsToSourceType`
+   - `ApplyDelta_RemoveLink_DropsByName`
+2. [GREEN] Implement each variant branch in `ApplyDelta`. Use a switch expression over the sealed-record hierarchy.
+3. [REFACTOR] Extract per-variant logic into private methods if the switch grows past ~50 lines.
+
+**Dependencies:** Task 10
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 12: `OntologyBuilderOptions.AddSource<T>` DI extension
+
+**Implements:** DR-3
+**Phase:** RED → GREEN
+
+1. [RED] Add test `AddSource_TestSource_RegistersAsTransient` to `src/Strategos.Ontology.Tests/Extensions/OntologyBuilderOptionsExtensionsTests.cs`. Configure DI via `services.AddOntology(opts => opts.AddSource<TestOntologySource>())`; resolve `IEnumerable<IOntologySource>`; assert one instance.
+   - Expected failure: `AddSource<T>` does not exist.
+2. [GREEN] Add extension method to `src/Strategos.Ontology/Extensions/OntologyBuilderOptionsExtensions.cs` (locate existing file under that name or `Strategos.Ontology/Configuration/`). Register `T : IOntologySource` as transient.
+
+**Dependencies:** Task 7, Task 20 (TestOntologySource)
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 13: `OntologyGraphBuilder.Build()` drains registered sources
+
+**Implements:** DR-3
+**Phase:** RED → GREEN
+
+1. [RED] Add test `Build_TwoSourcesContributingDifferentFields_BothAppearInGraph` to `src/Strategos.Ontology.Tests/OntologyGraphBuilderSourcesTests.cs`. Register two `TestOntologySource` instances; verify both contribute to the composed graph.
+   - Expected failure: builder doesn't drain sources.
+2. [GREEN] In `src/Strategos.Ontology/OntologyGraphBuilder.cs`, drain `IEnumerable<IOntologySource>` from DI; for each source, iterate `LoadAsync`, apply each delta via the existing builder. Run before composition.
+
+**Dependencies:** Task 11, Task 12, Task 20
+**Parallelizable:** No
+**testingStrategy:** integration
+
+### Task 14: `MergeTwo` lattice — identity fields
+
+**Implements:** DR-6
+**Phase:** RED → GREEN
+
+1. [RED] Add tests to `src/Strategos.Ontology.Tests/Merge/MergeTwoIdentityTests.cs`:
+   - `MergeTwo_ClrType_HandWinsOverIngested`.
+   - `MergeTwo_SymbolKey_IngestedWinsOverHand` — SCIP moniker is authoritative.
+   - `MergeTwo_LanguageId_HandWins`.
+   - Expected failure: `MergeTwo` doesn't exist or doesn't follow ADR §9.2 rules.
+2. [GREEN] Implement `MergeTwo(ObjectTypeDescriptor hand, ObjectTypeDescriptor ingested) → ObjectTypeDescriptor` in `OntologyGraphBuilder.cs` (or new `src/Strategos.Ontology/Merge/MergeTwo.cs`). Follow the lattice rule from design §4 DR-6.
+
+**Dependencies:** Task 2
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 15: `MergeTwo` lattice — property + link union
+
+**Implements:** DR-6
+**Phase:** RED → GREEN
+
+1. [RED] Add tests to `src/Strategos.Ontology.Tests/Merge/MergeTwoPropertyLinkTests.cs`:
+   - `MergeTwo_HandPropertyMissingFromIngested_BothPresent` — set union semantics.
+   - `MergeTwo_PropertyConflict_HandWins` — per-name conflict resolves to hand.
+   - `MergeTwo_IngestedOnlyProperty_TaggedIngested` — provenance preserved.
+   - Same three for `Links`.
+2. [GREEN] Implement `MergeProperties(hand, ingested)` and `MergeLinks(hand, ingested)` helpers. Tag conflict-loser side with the winner's Source.
+
+**Dependencies:** Task 14
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 16: AONT205 invariant check at delta-apply
+
+**Implements:** DR-6, DR-10
+**Phase:** RED → GREEN
+
+1. [RED] Add tests to `src/Strategos.Ontology.Tests/Builder/IOntologyBuilderInvariantTests.cs`:
+   - `ApplyDelta_AddIngestedDescriptorWithActions_ThrowsOntologyCompositionException` — exception's `Diagnostics` contains AONT205.
+   - `ApplyDelta_AddIngestedDescriptorWithLifecycle_ThrowsAONT205`.
+   - `ApplyDelta_AddIngestedDescriptorWithEvents_ThrowsAONT205`.
+   - Expected failure: invariant not enforced; descriptor passes through silently.
+2. [GREEN] In `ApplyDelta`'s `AddObjectType`/`UpdateObjectType` branches, when `descriptor.Source == Ingested`, validate `Actions.Count == 0 && Events.Count == 0 && Lifecycle == null`. On violation, throw `OntologyCompositionException` with AONT205 diagnostic naming the offending field.
+
+**Dependencies:** Task 5, Task 10
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 17: Source-error propagation with `SourceId` context
+
+**Implements:** DR-10
+**Phase:** RED → GREEN
+
+1. [RED] Add test `Build_SourceThrowsDuringLoadAsync_ExceptionMessageContainsSourceId` to `OntologyGraphBuilderSourcesTests.cs`. `TestOntologySource` that throws after yielding one delta; assert `Build()` throws with the source's `SourceId` in the message.
+2. [GREEN] Wrap each source's drain in try/catch in `OntologyGraphBuilder.Build()`; re-throw with `OntologyCompositionException` whose message includes `SourceId`.
+
+**Dependencies:** Task 13
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 18: AONT037 diagnostic registration
+
+**Implements:** DR-2
+**Phase:** RED → GREEN
+
+1. [RED] Add test `Diagnostic_AONT037_IsRegistered` to `src/Strategos.Ontology.Generators.Tests/Analyzers/AONT037RegistrationTests.cs` asserting `OntologyDiagnostics` exposes a `DiagnosticDescriptor` with ID `"AONT037"`, Title contains `"polyglot"`, severity Error.
+2. [GREEN] Add `AONT037 PolyglotInvariantViolated` to `OntologyDiagnosticIds.cs` and a matching `DiagnosticDescriptor` to `OntologyDiagnostics.cs`. Helper text: requires `ClrType` or `SymbolKey` non-null.
+3. [GREEN] If `docs/reference/ontology-diagnostics.md` (or equivalent) exists, append AONT037 entry with title, severity, trigger description, and fix guidance.
+
+**Dependencies:** None
+**Parallelizable:** Yes
+**testingStrategy:** unit
+
+### Task 19: AONT037 analyzer trigger
+
+**Implements:** DR-2
+**Phase:** RED → GREEN
+
+1. [RED] Add tests to `src/Strategos.Ontology.Generators.Tests/Analyzers/AONT037AnalyzerTests.cs`:
+   - `Analyze_DescriptorOverloadWithoutSymbolKey_FiresAONT037` — `obj.ObjectType("Foo", domainName: "Trading")` produces AONT037.
+   - `Analyze_GenericObjectTypeCall_DoesNotFireAONT037` — `obj.ObjectType<TradeOrder>()` is clean.
+2. [GREEN] In `OntologyDefinitionAnalyzer.cs`, register an action for `InvocationExpressionSyntax` matching `obj.ObjectType(name, …)` non-generic overload. If the call provides neither a `Type` argument nor a `symbolKey:` named argument, report AONT037.
+
+**Dependencies:** Task 18
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 20: `TestOntologySource` test fixture
+
+**Implements:** DR-9
+**Phase:** RED → GREEN
+
+1. [RED] Add test `TestOntologySource_LoadAsync_YieldsConfiguredDeltas` to `src/Strategos.Ontology.Tests/TestInfrastructure/TestOntologySourceTests.cs`. Construct with three deltas; verify enumeration order matches.
+2. [GREEN] Create `src/Strategos.Ontology.Tests/TestInfrastructure/TestOntologySource.cs` per design §4 DR-9 shape. `LoadAsync` yields configured deltas; `SubscribeAsync` completes immediately.
+
+**Dependencies:** Task 7, Task 8
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 21: Synthetic merge/diagnostic test matrix
+
+**Implements:** DR-9, DR-6
+**Phase:** RED → GREEN
+
+1. [RED] Add tests to `src/Strategos.Ontology.Tests/Merge/MergeMatrixTests.cs` using `TestOntologySource`:
+   - `Merge_HandOnly_GraphMatchesHand`
+   - `Merge_IngestedOnly_GraphMatchesIngested`
+   - `Merge_HandOverridesIngestedProperty_HandWins`
+   - `Merge_IngestedAddsLink_LinkAppearsWithIngestedProvenance`
+   - `Merge_IdentityFields_FollowLatticeRule` — parameterized over each identity field per lattice.
+2. [GREEN] Wire each test through `OntologyGraphBuilder` end-to-end. All assertions on graph-level shape; no internal-state inspection.
+
+**Dependencies:** Task 13, Task 15, Task 20
+**Parallelizable:** No
+**testingStrategy:** integration
+
+### Task 22: Roslyn SymbolKey round-trip integration test
+
+**Implements:** DR-9
+**Phase:** RED → GREEN
+
+1. [RED] Add test `RoslynSymbolKey_RoundTripThroughBuilder_PreservesIdentity` to `src/Strategos.Ontology.Tests/Integration/RoslynSymbolKeyIntegrationTests.cs`. Compile a small `.cs` source string via `CSharpCompilation.Create`, extract a named type's `INamedTypeSymbol`, serialize via `SymbolKey.Create(symbol).ToString()`, build an `ObjectTypeDescriptor` with that `SymbolKey`, push through `OntologyBuilder.ApplyDelta`, assert the built graph contains a descriptor whose `SymbolKey` equals the serialized form.
+   - Gate behind MSBuild property `SkipRoslynIntegrationTests` — skip if set.
+   - Expected failure: test infra (Microsoft.CodeAnalysis.CSharp) not in test deps.
+2. [GREEN] Add `Microsoft.CodeAnalysis.CSharp` (4.x) to `src/Strategos.Ontology.Tests/Strategos.Ontology.Tests.csproj` as `PrivateAssets="all"`. Implement the test.
+
+**Dependencies:** Task 13, Task 20
+**Parallelizable:** Yes (independent of Task 21)
+**testingStrategy:** integration
+
+---
+
+## PR-A acceptance gate
+
+Run before opening PR-A:
+
+```
+dotnet build strategos.sln  # 0 warnings, 0 errors
+dotnet test src/Strategos.Ontology.Tests/Strategos.Ontology.Tests.csproj
+dotnet test src/Strategos.Ontology.Generators.Tests/Strategos.Ontology.Generators.Tests.csproj
+dotnet test src/Strategos.Ontology.MCP.Tests/Strategos.Ontology.MCP.Tests.csproj
+```
+
+Existing test counts hold (666 + 75 + 121 from PR #59). New test count delta: ~50 (synthetic merge matrix + each delta variant + invariant checks + AONT037).
+
+---
+
+## PR-B: AONT200-series + AONT041 retarget
+
+PR-B begins after PR-A merges to main.
+
+### Task 23: AONT201 (hand property missing from ingested)
+
+**Implements:** DR-7
+**Phase:** RED → GREEN
+
+1. [RED] Add tests to `src/Strategos.Ontology.Tests/Diagnostics/AONT201Tests.cs`:
+   - `Build_HandDeclaresPropertyMissingFromIngested_AONT201Error` — `OntologyCompositionException` thrown; `Diagnostics[0].Id == "AONT201"`; message names the property.
+   - `Build_HandDeclaresPropertyPresentInIngested_NoAONT201`.
+2. [GREEN] In `OntologyGraphBuilder` graph-freeze phase (after merge, before return), iterate descriptors with mixed provenance (`hand.Properties ∩ ingested.Properties`); for each hand-side property not present in ingested by name, emit AONT201 error.
+
+**Dependencies:** PR-A merged
+**Parallelizable:** Yes (with 24, 25, 26, 28, 30)
+**testingStrategy:** unit
+
+### Task 24: AONT202 (property type mismatch hand vs ingested)
+
+**Implements:** DR-7
+**Phase:** RED → GREEN
+
+1. [RED] Add tests to `AONT202Tests.cs`:
+   - `Build_HandScalarVsIngestedReference_AONT202Warning` — `OntologyGraph.NonFatalDiagnostics` contains AONT202 warning.
+   - `Build_HandAndIngestedAgree_NoAONT202`.
+   - `Build_AONT202Fires_LoggerReceivesStructuredWarning` — verify `ILogger<OntologyGraphBuilder>` receives a `LogWarning` call with structured properties `{DiagnosticId, DomainName, TypeName, PropertyName}` (use TUnit-compatible logger fake or `Microsoft.Extensions.Logging.Testing.FakeLogger`).
+2. [GREEN] Graph-freeze comparator: hand property kind vs ingested property kind; mismatch emits AONT202 warning to `NonFatalDiagnostics` **and** to `ILogger<OntologyGraphBuilder>.LogWarning` with structured properties `{DiagnosticId = "AONT202", DomainName, TypeName, PropertyName}`.
+
+**Dependencies:** PR-A merged, Task 23 (shares graph-freeze plumbing)
+**Parallelizable:** Yes
+**testingStrategy:** unit
+
+### Task 25: AONT203 (ingested-only property missing under Strict)
+
+**Implements:** DR-7
+**Phase:** RED → GREEN
+
+1. [RED] Add tests to `AONT203Tests.cs`:
+   - `Build_StrictTypeMissingIngestedProperty_AONT203Warning`.
+   - `Build_NonStrictTypeMissingIngestedProperty_NoAONT203` — opt-in only.
+   - `Build_AONT203Fires_LoggerReceivesStructuredWarning` — verify structured `LogWarning` parallel to AONT202 (see Task 24).
+2. [GREEN] Add `DomainEntityAttribute(Strict = true)` recognition in graph-freeze; for `Strict = true` descriptors, ingested-side properties missing on hand emit AONT203 to `NonFatalDiagnostics` **and** to `ILogger<OntologyGraphBuilder>.LogWarning` with structured properties `{DiagnosticId = "AONT203", DomainName, TypeName, PropertyName}`.
+
+**Dependencies:** PR-A merged
+**Parallelizable:** Yes
+**testingStrategy:** unit
+
+### Task 26: AONT204 (ingested type not referenced by hand)
+
+**Implements:** DR-7
+**Phase:** RED → GREEN
+
+1. [RED] Add tests to `AONT204Tests.cs`:
+   - `Build_IngestedTypeNoHandReference_AONT204Info` — info-level diagnostic on `NonFatalDiagnostics`.
+   - `Build_IngestedTypeReferencedByHand_NoAONT204`.
+2. [GREEN] Graph-freeze emits AONT204 for descriptors with `Source = Ingested` that have no incoming reference from a hand-authored descriptor (via Links, ParentType, KeyProperty references).
+
+**Dependencies:** PR-A merged
+**Parallelizable:** Yes
+**testingStrategy:** unit
+
+### Task 27: AONT205 graph-freeze surface (already enforced at delta-apply)
+
+**Implements:** DR-7, DR-10
+**Phase:** RED → GREEN
+
+1. [RED] Add tests to `AONT205Tests.cs`:
+   - `Build_TwoSourcesAttemptIntentContributionPostMerge_AONT205Error` — a stress case where two sources race intent fields; merge detects and emits AONT205. (Defensive — delta-apply enforces at write time; graph-freeze is the safety net.)
+2. [GREEN] Add graph-freeze AONT205 check covering the post-merge state.
+
+**Dependencies:** PR-A merged
+**Parallelizable:** Yes
+**testingStrategy:** unit
+
+### Task 28: AONT206 (opt-in hygiene hint)
+
+**Implements:** DR-7
+**Phase:** RED → GREEN
+
+1. [RED] Add tests to `AONT206Tests.cs`:
+   - `Build_HandPropertyAlsoIngested_AONT206InfoWhenEnabled` — only fires when MSBuild prop `OntologyEnableHygieneHints=true`.
+   - `Build_HandPropertyAlsoIngested_NoAONT206ByDefault`.
+2. [GREEN] Wire opt-in flag into `OntologyGraphBuilderOptions`; gate AONT206 emission on it.
+
+**Dependencies:** PR-A merged
+**Parallelizable:** Yes
+**testingStrategy:** unit
+
+### Task 29: AONT207 registration-only with Skip
+
+**Implements:** DR-7
+**Phase:** RED → GREEN
+
+1. [RED] Add registration test `Diagnostic_AONT207_IsRegisteredButSkipped` to `AONT207RegistrationTests.cs` asserting AONT207 is registered in the diagnostic catalog with severity Warning. Mark a trigger test with `[Skip("requires four-input fold")]` for documentation.
+2. [GREEN] Register the diagnostic ID + descriptor only. No trigger logic.
+
+**Dependencies:** PR-A merged
+**Parallelizable:** Yes
+**testingStrategy:** unit
+
+### Task 30: AONT208 (LanguageId disagreement)
+
+**Implements:** DR-7
+**Phase:** RED → GREEN
+
+1. [RED] Add tests to `AONT208Tests.cs`:
+   - `Build_TwoSourcesDisagreeLanguageId_AONT208Error`.
+2. [GREEN] Graph-freeze checks `MergeTwo`'s output for `LanguageId` agreement when both inputs supply it; mismatch emits AONT208.
+
+**Dependencies:** PR-A merged
+**Parallelizable:** Yes
+**testingStrategy:** unit
+
+### Task 31: AONT041 retarget to descriptor-name keying
+
+**Implements:** DR-8
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Add tests to `src/Strategos.Ontology.Tests/OntologyGraphBuilderAONT041LinkTargetTests.cs` (existing file — append):
+   - `AONT041_SymbolKeyKeyedMultiRegistration_InLinkParticipant_Fires` — ingested descriptor with `SymbolKey != null` registered twice as link participant trips AONT041.
+   - `AONT041_ClrTypeMultiRegistrationInLink_StillFires` — existing behavior preserved.
+2. [GREEN] In `OntologyGraphBuilder.cs`, find the AONT041 check; change the multi-registration lookup from `descriptor.ClrType`-keyed to `(descriptor.DomainName, descriptor.Name)`-keyed. Update the link-participant scan accordingly.
+3. [REFACTOR] Extract the multi-registration lookup to a private helper `IsMultiRegistered(string domain, string name)`.
+
+**Dependencies:** PR-A merged
+**Parallelizable:** Yes
+**testingStrategy:** unit
+
+### Task 32: `OntologyValidateTool.FindObjectType` retarget
+
+**Implements:** DR-8
+**Phase:** RED → GREEN
+
+1. [RED] Add tests to `src/Strategos.Ontology.MCP.Tests/Tools/OntologyValidateToolFindObjectTypeTests.cs`:
+   - `FindObjectType_CrossDomainSameName_ResolvesByDomain` — two domains with a same-named type; lookup specifies domain + name; correct descriptor returned.
+   - `FindObjectType_AmbiguousByNameOnly_Throws` — bare-name lookup against ambiguous catalog throws with diagnostic naming both candidates.
+2. [GREEN] Update `FindObjectType` in `src/Strategos.Ontology.MCP/Tools/OntologyValidateTool.cs` to require `(domain, name)` or throw on ambiguity.
+
+**Dependencies:** PR-A merged
+**Parallelizable:** Yes
+**testingStrategy:** unit
+
+---
+
+## PR-B acceptance gate
+
+```
+dotnet build strategos.sln  # 0 warnings, 0 errors
+dotnet test  # all test projects pass
+```
+
+Test count delta from PR-B: ~30 new tests across diagnostics + retargets.
+
+---
+
+## Parallel groups
+
+**PR-A:**
+- **Sequential foundation:** Task 1 → Task 2 → Tasks 3, 4 (parallel) → Task 5
+- **Parallel after foundation:**
+  - Group α (sources): 7 → 8 → 20 → 21
+  - Group β (builder): 9 → 10 → 11 → 13 → 17
+  - Group γ (merge): 14 → 15 → 16
+  - Group δ (analyzer): 18 → 19
+  - Group ε (DI): 12 (after 7 + 20)
+  - Group ζ (integration test): 22 (after 13 + 20)
+- **Final:** Tasks 21, 22 (synthesis + Roslyn round-trip)
+
+**PR-B:** Tasks 23–32 are mostly parallel after PR-A merges. Group:
+- AONT201–AONT208 (Tasks 23–30) — parallel after Task 23 establishes graph-freeze plumbing
+- AONT041 retarget (Task 31) — parallel
+- FindObjectType retarget (Task 32) — parallel
+
+## Open follow-ups (documented in design §5, not in scope)
+
+- `OntologyGraph.NonFatalDiagnostics` shape — match `ConstraintViolationReport` from PR #59 for consistency (decided implicitly via Task 6's `OntologyDiagnostic`)
+- `IOntologyVersionedCache` composition with `SubscribeAsync` for live invalidation — v2.6.0
+- Branch-hand stream + four-input fold (`MergeFour`) — v2.6.0 (AONT207 unreachable until then)
+
+## Plan-review delta annotations (folded gaps)
+
+The following design-acceptance bullets are satisfied via in-task sub-steps rather than dedicated tasks:
+
+- **DR-2 doc update** — folded into Task 18 step 3.
+- **DR-6 `GetPropertyProvenance(name)` helper** — superseded by direct `PropertyDescriptor.Source` access (Task 4). The design's helper API is replaced by per-property `Source` field, eliminating a parallel-map drift risk. Functionally equivalent.
+- **DR-10 ILogger emission for AONT202/AONT203** — folded into Tasks 24 step 2 and Task 25 step 2 as explicit `ILogger<OntologyGraphBuilder>.LogWarning` calls with structured properties.
+
+## Estimated cost
+
+- PR-A: ~22 tasks × ~30 min average = ~11 hours. Net ~600 lines impl + ~1500 lines test.
+- PR-B: ~10 tasks × ~25 min average = ~4 hours. Net ~250 lines impl + ~800 lines test.
+- Total: ~15 hours focused work across both PRs.

--- a/docs/plans/2026-05-10-ontology-2-5-0-polyglot-ingestion.md
+++ b/docs/plans/2026-05-10-ontology-2-5-0-polyglot-ingestion.md
@@ -369,7 +369,7 @@ PR-B depends on PR-A being merged.
 
 Run before opening PR-A:
 
-```
+```bash
 dotnet build strategos.sln  # 0 warnings, 0 errors
 dotnet test src/Strategos.Ontology.Tests/Strategos.Ontology.Tests.csproj
 dotnet test src/Strategos.Ontology.Generators.Tests/Strategos.Ontology.Generators.Tests.csproj

--- a/src/Strategos.Ontology.Generators.Tests/Analyzers/AONT037AnalyzerTests.cs
+++ b/src/Strategos.Ontology.Generators.Tests/Analyzers/AONT037AnalyzerTests.cs
@@ -1,0 +1,108 @@
+using Strategos.Ontology.Generators.Diagnostics;
+
+namespace Strategos.Ontology.Generators.Tests.Analyzers;
+
+/// <summary>
+/// Task 19 — AONT037 analyzer trigger tests.
+/// </summary>
+/// <remarks>
+/// AONT037 fires when the non-generic descriptor-by-name overload
+/// <c>obj.ObjectType(name, …)</c> is invoked without providing either
+/// a <c>Type</c> argument (e.g. <c>typeof(T)</c>) or a <c>symbolKey:</c>
+/// named argument. The generic overload <c>obj.ObjectType&lt;T&gt;(…)</c>
+/// always carries a CLR type, so it must NOT fire.
+/// </remarks>
+public class AONT037AnalyzerTests
+{
+    [Test]
+    public async Task Analyze_DescriptorOverloadWithoutSymbolKey_FiresAONT037()
+    {
+        var source = @"
+using Strategos.Ontology;
+using Strategos.Ontology.Builder;
+
+public class TestDomain : DomainOntology
+{
+    public override string DomainName => ""trading"";
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.ObjectType(""Foo"", domainName: ""trading"");
+    }
+}";
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsWithIdAsync(
+            source, OntologyDiagnosticIds.PolyglotInvariantViolated);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Analyze_GenericObjectTypeCall_DoesNotFireAONT037()
+    {
+        var source = @"
+using Strategos.Ontology;
+using Strategos.Ontology.Builder;
+
+public class TradeOrder { public System.Guid Id { get; set; } }
+
+public class TestDomain : DomainOntology
+{
+    public override string DomainName => ""trading"";
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.ObjectType<TradeOrder>();
+    }
+}";
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsWithIdAsync(
+            source, OntologyDiagnosticIds.PolyglotInvariantViolated);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Analyze_DescriptorOverloadWithSymbolKeyNamedArg_DoesNotFireAONT037()
+    {
+        var source = @"
+using Strategos.Ontology;
+using Strategos.Ontology.Builder;
+
+public class TestDomain : DomainOntology
+{
+    public override string DomainName => ""trading"";
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.ObjectType(""Foo"", symbolKey: ""scip-typescript ./mod#User"", domainName: ""trading"");
+    }
+}";
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsWithIdAsync(
+            source, OntologyDiagnosticIds.PolyglotInvariantViolated);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Analyze_DescriptorOverloadWithTypeArgument_DoesNotFireAONT037()
+    {
+        var source = @"
+using Strategos.Ontology;
+using Strategos.Ontology.Builder;
+
+public class TradeOrder { public System.Guid Id { get; set; } }
+
+public class TestDomain : DomainOntology
+{
+    public override string DomainName => ""trading"";
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.ObjectType(""Foo"", typeof(TradeOrder), ""trading"");
+    }
+}";
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsWithIdAsync(
+            source, OntologyDiagnosticIds.PolyglotInvariantViolated);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+}

--- a/src/Strategos.Ontology.Generators.Tests/Analyzers/AONT037AnalyzerTests.cs
+++ b/src/Strategos.Ontology.Generators.Tests/Analyzers/AONT037AnalyzerTests.cs
@@ -105,4 +105,66 @@ public class TestDomain : DomainOntology
 
         await Assert.That(diagnostics.Length).IsEqualTo(0);
     }
+
+    [Test]
+    public async Task Analyze_DescriptorOverloadWithClrTypeNamedArg_DoesNotFireAONT037()
+    {
+        // Regression: a `clrType:` named argument satisfies the identity
+        // invariant regardless of the expression form (typeof, variable,
+        // factory call). Previously the matcher only recognised
+        // `typeof(...)` positional/named — a `clrType: someVariable`
+        // pattern false-fired AONT037.
+        var source = @"
+using System;
+using Strategos.Ontology;
+using Strategos.Ontology.Builder;
+
+public class TradeOrder { public System.Guid Id { get; set; } }
+
+public class TestDomain : DomainOntology
+{
+    public override string DomainName => ""trading"";
+    protected override void Define(IOntologyBuilder builder)
+    {
+        Type t = typeof(TradeOrder);
+        builder.ObjectType(""Foo"", clrType: t, domainName: ""trading"");
+    }
+}";
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsWithIdAsync(
+            source, OntologyDiagnosticIds.PolyglotInvariantViolated);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Analyze_ObjectTypeOnNonBuilderReceiver_DoesNotFireAONT037()
+    {
+        // Regression: AONT037 must only fire on IOntologyBuilder
+        // receivers. A `.ObjectType(...)` call on any other type is not
+        // a builder registration and must not false-fire.
+        var source = @"
+using Strategos.Ontology;
+using Strategos.Ontology.Builder;
+
+public class Bystander
+{
+    public void ObjectType(string name) { }
+}
+
+public class TestDomain : DomainOntology
+{
+    public override string DomainName => ""trading"";
+    protected override void Define(IOntologyBuilder builder)
+    {
+        var b = new Bystander();
+        b.ObjectType(""Foo"");
+    }
+}";
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsWithIdAsync(
+            source, OntologyDiagnosticIds.PolyglotInvariantViolated);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
 }

--- a/src/Strategos.Ontology.Generators.Tests/Analyzers/AONT037RegistrationTests.cs
+++ b/src/Strategos.Ontology.Generators.Tests/Analyzers/AONT037RegistrationTests.cs
@@ -1,0 +1,53 @@
+using Microsoft.CodeAnalysis;
+using Strategos.Ontology.Generators.Analyzers;
+using Strategos.Ontology.Generators.Diagnostics;
+
+namespace Strategos.Ontology.Generators.Tests.Analyzers;
+
+/// <summary>
+/// Task 18 — AONT037 PolyglotInvariantViolated diagnostic registration tests.
+/// </summary>
+/// <remarks>
+/// Verifies that the diagnostic id, descriptor metadata, and analyzer's
+/// <see cref="OntologyDefinitionAnalyzer.SupportedDiagnostics"/> array
+/// all expose AONT037 with severity Error and a helper message that
+/// names both the <c>ClrType</c> and <c>SymbolKey</c> escape hatches.
+/// </remarks>
+public class AONT037RegistrationTests
+{
+    [Test]
+    public async Task AONT037_DiagnosticId_IsPolyglotInvariantViolated()
+    {
+        await Assert.That(OntologyDiagnosticIds.PolyglotInvariantViolated).IsEqualTo("AONT037");
+    }
+
+    [Test]
+    public async Task AONT037_DescriptorRegistered_HasErrorSeverity()
+    {
+        var descriptor = OntologyDiagnostics.PolyglotInvariantViolated;
+
+        await Assert.That(descriptor.Id).IsEqualTo("AONT037");
+        await Assert.That(descriptor.DefaultSeverity).IsEqualTo(DiagnosticSeverity.Error);
+        await Assert.That(descriptor.IsEnabledByDefault).IsTrue();
+    }
+
+    [Test]
+    public async Task AONT037_HelperMessage_NamesClrTypeAndSymbolKey()
+    {
+        var descriptor = OntologyDiagnostics.PolyglotInvariantViolated;
+        var message = descriptor.MessageFormat.ToString();
+
+        await Assert.That(message).Contains("ClrType");
+        await Assert.That(message).Contains("SymbolKey");
+    }
+
+    [Test]
+    public async Task AONT037_RegisteredInAnalyzerSupportedDiagnostics()
+    {
+        var analyzer = new OntologyDefinitionAnalyzer();
+
+        var supported = analyzer.SupportedDiagnostics;
+
+        await Assert.That(supported.Any(d => d.Id == "AONT037")).IsTrue();
+    }
+}

--- a/src/Strategos.Ontology.Generators.Tests/Analyzers/AONT207RegistrationTests.cs
+++ b/src/Strategos.Ontology.Generators.Tests/Analyzers/AONT207RegistrationTests.cs
@@ -1,0 +1,39 @@
+using Microsoft.CodeAnalysis;
+
+using Strategos.Ontology.Generators.Diagnostics;
+
+namespace Strategos.Ontology.Generators.Tests.Analyzers;
+
+/// <summary>
+/// DR-7 (Task 29): AONT207 (branch-hand vs main-hand conflict) is
+/// registration-only in 2.5.0 — its trigger requires the four-input
+/// fold (branch-hand stream) which is deferred. This fixture asserts
+/// the diagnostic id and descriptor are present in the vocabulary so
+/// downstream consumers (and the basileus ADR alignment) can reference
+/// the identifier; the trigger test is preserved as a `[Skip]` marker
+/// for the v2.6.0 follow-up.
+/// </summary>
+public sealed class AONT207RegistrationTests
+{
+    [Test]
+    public async Task Diagnostic_AONT207_IsRegistered()
+    {
+        await Assert.That(OntologyDiagnosticIds.BranchHandConflict).IsEqualTo("AONT207");
+
+        var descriptor = OntologyDiagnostics.BranchHandConflict;
+        await Assert.That(descriptor.Id).IsEqualTo("AONT207");
+        await Assert.That(descriptor.DefaultSeverity).IsEqualTo(DiagnosticSeverity.Warning);
+        await Assert.That(descriptor.IsEnabledByDefault).IsTrue();
+    }
+
+    [Test]
+    [Skip("requires four-input fold")]
+    public async Task Build_BranchHandConflict_FiresAONT207()
+    {
+        // Placeholder for the trigger test exercised once branch-hand
+        // stream support lands and OntologyGraphBuilder gains a
+        // four-input fold over (main-hand, branch-hand, main-ingested,
+        // branch-ingested). Until then, AONT207 is vocabulary-only.
+        await Task.CompletedTask;
+    }
+}

--- a/src/Strategos.Ontology.Generators/Analyzers/OntologyDefinitionAnalyzer.cs
+++ b/src/Strategos.Ontology.Generators/Analyzers/OntologyDefinitionAnalyzer.cs
@@ -50,7 +50,8 @@ public sealed class OntologyDefinitionAnalyzer : DiagnosticAnalyzer
             OntologyDiagnostics.ExtensionPointEdgeMissing,
             OntologyDiagnostics.ExtensionPointNoLinks,
             OntologyDiagnostics.ExtensionPointMaxLinksExceeded,
-            OntologyDiagnostics.ReadOnlyConflictsWithMutation);
+            OntologyDiagnostics.ReadOnlyConflictsWithMutation,
+            OntologyDiagnostics.PolyglotInvariantViolated);
 
     public override void Initialize(AnalysisContext context)
     {

--- a/src/Strategos.Ontology.Generators/Analyzers/OntologyDefinitionAnalyzer.cs
+++ b/src/Strategos.Ontology.Generators/Analyzers/OntologyDefinitionAnalyzer.cs
@@ -99,8 +99,9 @@ public sealed class OntologyDefinitionAnalyzer : DiagnosticAnalyzer
     // or a `symbolKey:` named argument. Generic `ObjectType<T>()` is exempt
     // because the type argument supplies ClrType.
     //
-    // Matched purely-syntactically so the diagnostic fires even before the
-    // descriptor overload lands on IOntologyBuilder.
+    // Receiver-type filtered (must be IOntologyBuilder) so a stray
+    // `.ObjectType(...)` call on an unrelated receiver inside a Define()
+    // body doesn't false-fire AONT037.
     private static void ReportPolyglotInvariantViolations(
         SyntaxNodeAnalysisContext context, SyntaxNode body)
     {
@@ -123,15 +124,30 @@ public sealed class OntologyDefinitionAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
+            // Receiver must be an IOntologyBuilder (or the concrete
+            // OntologyBuilder). When the semantic model can't resolve the
+            // receiver type (e.g. heavily-broken source mid-edit), we err
+            // on the side of "skip" rather than false-fire — the user's
+            // editor will report the real error before AONT037 matters.
+            var receiverType = context.SemanticModel
+                .GetTypeInfo(memberAccess.Expression, context.CancellationToken).Type;
+            if (receiverType is null || !IsOntologyBuilderType(receiverType.Name))
+            {
+                continue;
+            }
+
             var args = invocation.ArgumentList.Arguments;
 
-            // Either form satisfies the invariant: a `symbolKey:` named arg,
-            // or any argument whose expression is a Type-valued expression
-            // (`typeof(...)`).
+            // Either form satisfies the invariant:
+            //  - a `symbolKey:` named argument,
+            //  - a `clrType:` named argument (Type-valued, regardless of
+            //    expression form — typeof, variable, factory call, etc.),
+            //  - any positional argument whose expression is `typeof(...)`.
             var hasSymbolKey = args.Any(a =>
                 a.NameColon?.Name.Identifier.Text == "symbolKey");
             var hasTypeArgument = args.Any(a =>
-                a.Expression is TypeOfExpressionSyntax);
+                a.NameColon?.Name.Identifier.Text == "clrType"
+                || a.Expression is TypeOfExpressionSyntax);
 
             if (hasSymbolKey || hasTypeArgument)
             {

--- a/src/Strategos.Ontology.Generators/Analyzers/OntologyDefinitionAnalyzer.cs
+++ b/src/Strategos.Ontology.Generators/Analyzers/OntologyDefinitionAnalyzer.cs
@@ -91,6 +91,69 @@ public sealed class OntologyDefinitionAnalyzer : DiagnosticAnalyzer
         var domainInfo = new DomainAnalysisInfo();
         CollectDomainInfo(body, context.SemanticModel, domainInfo);
         ReportDiagnostics(context, domainInfo);
+        ReportPolyglotInvariantViolations(context, body);
+    }
+
+    // AONT037: Polyglot identity invariant — descriptor-by-name overload
+    // (non-generic `ObjectType(name, …)`) must supply either a Type argument
+    // or a `symbolKey:` named argument. Generic `ObjectType<T>()` is exempt
+    // because the type argument supplies ClrType.
+    //
+    // Matched purely-syntactically so the diagnostic fires even before the
+    // descriptor overload lands on IOntologyBuilder.
+    private static void ReportPolyglotInvariantViolations(
+        SyntaxNodeAnalysisContext context, SyntaxNode body)
+    {
+        foreach (var invocation in body.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            // Member-access form `<receiver>.ObjectType(...)` only.
+            if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            {
+                continue;
+            }
+
+            // Generic overload uses GenericNameSyntax — exempt.
+            if (memberAccess.Name is not IdentifierNameSyntax identifier)
+            {
+                continue;
+            }
+
+            if (identifier.Identifier.Text != "ObjectType")
+            {
+                continue;
+            }
+
+            var args = invocation.ArgumentList.Arguments;
+
+            // Either form satisfies the invariant: a `symbolKey:` named arg,
+            // or any argument whose expression is a Type-valued expression
+            // (`typeof(...)`).
+            var hasSymbolKey = args.Any(a =>
+                a.NameColon?.Name.Identifier.Text == "symbolKey");
+            var hasTypeArgument = args.Any(a =>
+                a.Expression is TypeOfExpressionSyntax);
+
+            if (hasSymbolKey || hasTypeArgument)
+            {
+                continue;
+            }
+
+            // Use the first positional argument (typically the descriptor
+            // name literal) as the {0} placeholder when we can extract it;
+            // fall back to "<unknown>".
+            var descriptorName = "<unknown>";
+            if (args.Count > 0
+                && args[0].Expression is LiteralExpressionSyntax literal
+                && literal.IsKind(SyntaxKind.StringLiteralExpression))
+            {
+                descriptorName = literal.Token.ValueText;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                OntologyDiagnostics.PolyglotInvariantViolated,
+                invocation.GetLocation(),
+                descriptorName));
+        }
     }
 
     private static bool IsDomainOntologySubclass(INamedTypeSymbol? type)

--- a/src/Strategos.Ontology.Generators/Diagnostics/OntologyDiagnosticIds.cs
+++ b/src/Strategos.Ontology.Generators/Diagnostics/OntologyDiagnosticIds.cs
@@ -54,4 +54,14 @@ internal static class OntologyDiagnosticIds
 
     // Polyglot identity invariant (AONT037)
     public const string PolyglotInvariantViolated = "AONT037";
+
+    // Polyglot graph-freeze diagnostics (AONT201-208) — DR-7
+    public const string HandPropertyMissingFromIngested = "AONT201";
+    public const string HandPropertyTypeMismatch = "AONT202";
+    public const string IngestedPropertyMissingFromHandStrict = "AONT203";
+    public const string IngestedTypeNotReferencedByHand = "AONT204";
+    public const string IngestedContributesToIntentOnly = "AONT205";
+    public const string HandPropertyAlsoIngestedHygieneHint = "AONT206";
+    public const string BranchHandConflict = "AONT207";
+    public const string LanguageIdDisagreement = "AONT208";
 }

--- a/src/Strategos.Ontology.Generators/Diagnostics/OntologyDiagnosticIds.cs
+++ b/src/Strategos.Ontology.Generators/Diagnostics/OntologyDiagnosticIds.cs
@@ -51,4 +51,7 @@ internal static class OntologyDiagnosticIds
 
     // ReadOnly (AONT036)
     public const string ReadOnlyConflictsWithMutation = "AONT036";
+
+    // Polyglot identity invariant (AONT037)
+    public const string PolyglotInvariantViolated = "AONT037";
 }

--- a/src/Strategos.Ontology.Generators/Diagnostics/OntologyDiagnostics.cs
+++ b/src/Strategos.Ontology.Generators/Diagnostics/OntologyDiagnostics.cs
@@ -317,4 +317,70 @@ internal static class OntologyDiagnostics
         Category,
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    // --- Polyglot graph-freeze diagnostics (AONT201-208) — DR-7 ---
+
+    public static readonly DiagnosticDescriptor HandPropertyMissingFromIngested = new(
+        OntologyDiagnosticIds.HandPropertyMissingFromIngested,
+        "Hand-declared property missing from ingested descriptor",
+        "Hand-declared property '{0}' on '{1}.{2}' is missing from the ingested descriptor. Pass-6b rename matcher may have missed this — verify the property name on the ingested side.",
+        Category,
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor HandPropertyTypeMismatch = new(
+        OntologyDiagnosticIds.HandPropertyTypeMismatch,
+        "Hand-declared property type mismatches ingested",
+        "Property '{0}' on '{1}.{2}' has hand-declared type/kind that mismatches the ingested side (hand: {3}, ingested: {4})",
+        Category,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor IngestedPropertyMissingFromHandStrict = new(
+        OntologyDiagnosticIds.IngestedPropertyMissingFromHandStrict,
+        "Ingested-only property missing from hand Define() under Strict",
+        "Property '{0}' is present on the ingested descriptor of '{1}.{2}' but not declared in hand Define(); type is marked [DomainEntity(Strict = true)]",
+        Category,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor IngestedTypeNotReferencedByHand = new(
+        OntologyDiagnosticIds.IngestedTypeNotReferencedByHand,
+        "Ingested type not referenced by any hand-authored Define()",
+        "Ingested-only descriptor '{0}.{1}' is not referenced by any hand-authored type (no Links, ParentType, or KeyProperty references found)",
+        Category,
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor IngestedContributesToIntentOnly = new(
+        OntologyDiagnosticIds.IngestedContributesToIntentOnly,
+        "Mechanical ingester contributed to intent-only field",
+        "Ingested descriptor '{0}.{1}' contributes to intent-only field '{2}' — mechanical ingesters must leave Actions, Events, and Lifecycle empty",
+        Category,
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor HandPropertyAlsoIngestedHygieneHint = new(
+        OntologyDiagnosticIds.HandPropertyAlsoIngestedHygieneHint,
+        "Hand-declared property is also ingested mechanically (opt-in hygiene hint)",
+        "Property '{0}' on '{1}.{2}' is declared in hand Define() and also contributed by the ingested side — consider removing the redundant hand declaration",
+        Category,
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor BranchHandConflict = new(
+        OntologyDiagnosticIds.BranchHandConflict,
+        "Branch-hand vs main-hand property conflict (deferred)",
+        "Branch-hand and main-hand declarations conflict on '{0}.{1}'; requires four-input fold support (deferred)",
+        Category,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor LanguageIdDisagreement = new(
+        OntologyDiagnosticIds.LanguageIdDisagreement,
+        "LanguageId disagreement between origins",
+        "Descriptor '{0}.{1}' has LanguageId disagreement between hand ('{2}') and ingested ('{3}') contributions",
+        Category,
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }

--- a/src/Strategos.Ontology.Generators/Diagnostics/OntologyDiagnostics.cs
+++ b/src/Strategos.Ontology.Generators/Diagnostics/OntologyDiagnostics.cs
@@ -313,7 +313,7 @@ internal static class OntologyDiagnostics
     public static readonly DiagnosticDescriptor PolyglotInvariantViolated = new(
         OntologyDiagnosticIds.PolyglotInvariantViolated,
         "ObjectType descriptor violates DR-1 polyglot identity invariant",
-        "ObjectType descriptor '{0}' must supply ClrType (via generic obj.ObjectType<T>()) or SymbolKey (via symbolKey: named argument on the descriptor overload); neither was provided",
+        "ObjectType descriptor '{0}' must supply ClrType (via generic builder.Object<T>() or the clrType: named argument on the descriptor overload) or SymbolKey (via symbolKey: named argument on the descriptor overload); neither was provided",
         Category,
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);

--- a/src/Strategos.Ontology.Generators/Diagnostics/OntologyDiagnostics.cs
+++ b/src/Strategos.Ontology.Generators/Diagnostics/OntologyDiagnostics.cs
@@ -307,4 +307,14 @@ internal static class OntologyDiagnostics
         Category,
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    // --- Polyglot identity invariant (AONT037) ---
+
+    public static readonly DiagnosticDescriptor PolyglotInvariantViolated = new(
+        OntologyDiagnosticIds.PolyglotInvariantViolated,
+        "ObjectType descriptor violates DR-1 polyglot identity invariant",
+        "ObjectType descriptor '{0}' must supply ClrType (via generic obj.ObjectType<T>()) or SymbolKey (via symbolKey: named argument on the descriptor overload); neither was provided",
+        Category,
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }

--- a/src/Strategos.Ontology.MCP.Tests/Tools/OntologyValidateToolFindObjectTypeTests.cs
+++ b/src/Strategos.Ontology.MCP.Tests/Tools/OntologyValidateToolFindObjectTypeTests.cs
@@ -1,0 +1,139 @@
+using Microsoft.Extensions.DependencyInjection;
+
+using Strategos.Ontology;
+using Strategos.Ontology.Builder;
+using Strategos.Ontology.Configuration;
+using Strategos.Ontology.Query;
+
+namespace Strategos.Ontology.MCP.Tests.Tools;
+
+/// <summary>
+/// DR-8 Task 32: <see cref="OntologyQueryService.FindObjectType"/> — invoked
+/// transitively by <see cref="OntologyValidateTool"/>'s constraint-collection
+/// path — must require a <c>(domain, name)</c> pair and throw on bare-name
+/// ambiguity. This closes the PR #59 follow-up where a domain-agnostic
+/// fallback could silently resolve to a same-named type in a different
+/// domain.
+/// </summary>
+/// <remarks>
+/// The function under test is private to <c>OntologyQueryService</c>; tests
+/// drive it via the public <see cref="IOntologyQuery.GetActions(string)"/>
+/// entry point (bare name) and the domain-qualified
+/// <see cref="IOntologyQuery.GetActionConstraintReport(string, string, System.Collections.Generic.IReadOnlyDictionary{string, object?}?)"/>
+/// overload (which routes through <c>OntologyGraph.GetObjectType(domain, name)</c>
+/// directly — the unambiguous path).
+/// </remarks>
+public sealed class OntologyValidateToolFindObjectTypeTests
+{
+    private static ServiceProvider BuildCrossDomainProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddOntology(opts =>
+        {
+            opts.AddDomain<TradingOrderDomain>();
+            opts.AddDomain<FulfillmentOrderDomain>();
+        });
+        return services.BuildServiceProvider();
+    }
+
+    [Test]
+    public async Task FindObjectType_CrossDomainSameName_ResolvesByDomain()
+    {
+        // Two domains both register an "Order" descriptor. Domain-qualified
+        // lookup must return the descriptor from the requested domain, not
+        // silently fall through to a same-named descriptor in another domain.
+        await using var provider = BuildCrossDomainProvider();
+        var query = provider.GetRequiredService<IOntologyQuery>();
+
+        var tradingReports = query.GetActionConstraintReport(
+            "trading", "Order", knownProperties: null);
+        var fulfillmentReports = query.GetActionConstraintReport(
+            "fulfillment", "Order", knownProperties: null);
+
+        // Each domain registers a distinct action on its Order — the report
+        // shapes diverge, which is the ground-truth signal that resolution
+        // honored the (domain, name) tuple.
+        await Assert.That(tradingReports.Any(r => r.Action.Name == "submit_order")).IsTrue();
+        await Assert.That(fulfillmentReports.Any(r => r.Action.Name == "ship_order")).IsTrue();
+        await Assert.That(tradingReports.Any(r => r.Action.Name == "ship_order")).IsFalse();
+        await Assert.That(fulfillmentReports.Any(r => r.Action.Name == "submit_order")).IsFalse();
+    }
+
+    [Test]
+    public async Task FindObjectType_AmbiguousByNameOnly_Throws()
+    {
+        // Bare-name lookup against an ambiguous catalog (two "Order"s across
+        // domains) must throw rather than silently return the first match.
+        // The diagnostic must enumerate all matching (DomainName, Name)
+        // candidates so the operator can disambiguate.
+        await using var provider = BuildCrossDomainProvider();
+        var query = provider.GetRequiredService<IOntologyQuery>();
+
+        var exception = await Assert.That(() => query.GetActions("Order"))
+            .ThrowsException()
+            .WithExceptionType(typeof(InvalidOperationException));
+
+        await Assert.That(exception!.Message).Contains("Order");
+        await Assert.That(exception.Message).Contains("trading");
+        await Assert.That(exception.Message).Contains("fulfillment");
+    }
+
+    [Test]
+    public async Task FindObjectType_UnambiguousByNameOnly_ResolvesNormally()
+    {
+        // When only one domain registers a given simple name, the bare-name
+        // path must still return that descriptor — the throw-on-ambiguity
+        // rule only fires when there are 2+ candidates. This guards against
+        // breaking the many existing IOntologyQuery callers that pass bare
+        // names against single-domain graphs.
+        var services = new ServiceCollection();
+        services.AddOntology(opts => opts.AddDomain<TradingOrderDomain>());
+        await using var provider = services.BuildServiceProvider();
+        var query = provider.GetRequiredService<IOntologyQuery>();
+
+        var actions = query.GetActions("Order");
+
+        await Assert.That(actions.Any(a => a.Name == "submit_order")).IsTrue();
+    }
+}
+
+// Trading and Fulfillment each register an "Order" type with a distinct action
+// so cross-domain resolution can be detected by *which* action shows up in
+// the constraint report.
+public class TradingOrder
+{
+    public string Id { get; set; } = "";
+}
+
+public class FulfillmentOrder
+{
+    public string Id { get; set; } = "";
+}
+
+public class TradingOrderDomain : DomainOntology
+{
+    public override string DomainName => "trading";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TradingOrder>("Order", obj =>
+        {
+            obj.Key(o => o.Id);
+            obj.Action("submit_order");
+        });
+    }
+}
+
+public class FulfillmentOrderDomain : DomainOntology
+{
+    public override string DomainName => "fulfillment";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<FulfillmentOrder>("Order", obj =>
+        {
+            obj.Key(o => o.Id);
+            obj.Action("ship_order");
+        });
+    }
+}

--- a/src/Strategos.Ontology.Tests/Builder/IOntologyBuilderApplyDeltaTests.cs
+++ b/src/Strategos.Ontology.Tests/Builder/IOntologyBuilderApplyDeltaTests.cs
@@ -66,19 +66,23 @@ public class IOntologyBuilderApplyDeltaTests
         new(d) { SourceId = SourceId, Timestamp = Timestamp };
 
     [Test]
-    public async Task ApplyDelta_UpdateObjectType_OverwritesExisting()
+    public async Task ApplyDelta_UpdateObjectType_SameProvenance_OverwritesExisting()
     {
+        // Same-provenance Update replaces at the existing index — no
+        // duplicate entry created and no cross-provenance merge invoked.
         IOntologyBuilder builder = new OntologyBuilder("Trading");
 
         var original = new ObjectTypeDescriptor("Position", typeof(string), "Trading")
         {
-            Source = DescriptorSource.HandAuthored,
+            Source = DescriptorSource.Ingested,
+            SourceId = SourceId,
+            SymbolKey = "scip ./pos.ts#PositionV1",
         };
         var updated = new ObjectTypeDescriptor("Position", typeof(string), "Trading")
         {
             Source = DescriptorSource.Ingested,
             SourceId = SourceId,
-            SymbolKey = "scip ./pos.ts#Position",
+            SymbolKey = "scip ./pos.ts#PositionV2",
         };
 
         builder.ApplyDelta(AddDelta(original));
@@ -91,6 +95,41 @@ public class IOntologyBuilderApplyDeltaTests
         var built = ((OntologyBuilder)builder).ObjectTypes;
         await Assert.That(built.Count).IsEqualTo(1);
         await Assert.That(built[0].Source).IsEqualTo(DescriptorSource.Ingested);
+        await Assert.That(built[0].SymbolKey).IsEqualTo("scip ./pos.ts#PositionV2");
+    }
+
+    [Test]
+    public async Task ApplyDelta_UpdateObjectType_CrossProvenance_FoldsThroughMergeTwo()
+    {
+        // Cross-provenance Update follows the DR-6 lateral lattice: an
+        // ingested Update against a hand-authored existing descriptor
+        // folds through MergeTwo rather than silently overwriting hand
+        // intent. After merge: record-level Source = HandAuthored (hand
+        // wins on composition), but ingested-authoritative identity
+        // fields (SymbolKey) win per the lattice rule.
+        IOntologyBuilder builder = new OntologyBuilder("Trading");
+
+        var existing = new ObjectTypeDescriptor("Position", typeof(string), "Trading")
+        {
+            Source = DescriptorSource.HandAuthored,
+        };
+        var ingestedUpdate = new ObjectTypeDescriptor("Position", typeof(string), "Trading")
+        {
+            Source = DescriptorSource.Ingested,
+            SourceId = SourceId,
+            SymbolKey = "scip ./pos.ts#Position",
+        };
+
+        builder.ApplyDelta(AddDelta(existing));
+        builder.ApplyDelta(new OntologyDelta.UpdateObjectType(ingestedUpdate)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        });
+
+        var built = ((OntologyBuilder)builder).ObjectTypes;
+        await Assert.That(built.Count).IsEqualTo(1);
+        await Assert.That(built[0].Source).IsEqualTo(DescriptorSource.HandAuthored);
         await Assert.That(built[0].SymbolKey).IsEqualTo("scip ./pos.ts#Position");
     }
 

--- a/src/Strategos.Ontology.Tests/Builder/IOntologyBuilderApplyDeltaTests.cs
+++ b/src/Strategos.Ontology.Tests/Builder/IOntologyBuilderApplyDeltaTests.cs
@@ -59,4 +59,225 @@ public class IOntologyBuilderApplyDeltaTests
 
         await Assert.That(caught).IsNotNull();
     }
+
+    // ----- Task 11: remaining seven variants + unknown-variant fallthrough -----
+
+    private static OntologyDelta.AddObjectType AddDelta(ObjectTypeDescriptor d) =>
+        new(d) { SourceId = SourceId, Timestamp = Timestamp };
+
+    [Test]
+    public async Task ApplyDelta_UpdateObjectType_OverwritesExisting()
+    {
+        IOntologyBuilder builder = new OntologyBuilder("Trading");
+
+        var original = new ObjectTypeDescriptor("Position", typeof(string), "Trading")
+        {
+            Source = DescriptorSource.HandAuthored,
+        };
+        var updated = new ObjectTypeDescriptor("Position", typeof(string), "Trading")
+        {
+            Source = DescriptorSource.Ingested,
+            SourceId = SourceId,
+            SymbolKey = "scip ./pos.ts#Position",
+        };
+
+        builder.ApplyDelta(AddDelta(original));
+        builder.ApplyDelta(new OntologyDelta.UpdateObjectType(updated)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        });
+
+        var built = ((OntologyBuilder)builder).ObjectTypes;
+        await Assert.That(built.Count).IsEqualTo(1);
+        await Assert.That(built[0].Source).IsEqualTo(DescriptorSource.Ingested);
+        await Assert.That(built[0].SymbolKey).IsEqualTo("scip ./pos.ts#Position");
+    }
+
+    [Test]
+    public async Task ApplyDelta_RemoveObjectType_DropsType()
+    {
+        IOntologyBuilder builder = new OntologyBuilder("Trading");
+
+        var d = new ObjectTypeDescriptor("Position", typeof(string), "Trading");
+        builder.ApplyDelta(AddDelta(d));
+
+        builder.ApplyDelta(new OntologyDelta.RemoveObjectType("Trading", "Position")
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        });
+
+        await Assert.That(((OntologyBuilder)builder).ObjectTypes.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ApplyDelta_AddProperty_AppendsToParent()
+    {
+        IOntologyBuilder builder = new OntologyBuilder("Trading");
+
+        var parent = new ObjectTypeDescriptor("Position", typeof(string), "Trading")
+        {
+            Properties = new List<PropertyDescriptor>
+            {
+                new("Existing", typeof(int)),
+            },
+        };
+        builder.ApplyDelta(AddDelta(parent));
+
+        var newProp = new PropertyDescriptor("Symbol", typeof(string))
+        {
+            Source = DescriptorSource.Ingested,
+        };
+
+        builder.ApplyDelta(new OntologyDelta.AddProperty("Trading", "Position", newProp)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        });
+
+        var built = ((OntologyBuilder)builder).ObjectTypes;
+        await Assert.That(built.Count).IsEqualTo(1);
+        await Assert.That(built[0].Properties.Count).IsEqualTo(2);
+        await Assert.That(built[0].Properties.Any(p => p.Name == "Symbol")).IsTrue();
+        await Assert.That(built[0].Properties.Single(p => p.Name == "Symbol").Source)
+            .IsEqualTo(DescriptorSource.Ingested);
+    }
+
+    [Test]
+    public async Task ApplyDelta_RenameProperty_PreservesIdentity()
+    {
+        IOntologyBuilder builder = new OntologyBuilder("Trading");
+
+        var parent = new ObjectTypeDescriptor("Position", typeof(string), "Trading")
+        {
+            Properties = new List<PropertyDescriptor>
+            {
+                new("Sym", typeof(string)) { Source = DescriptorSource.Ingested },
+            },
+        };
+        builder.ApplyDelta(AddDelta(parent));
+
+        builder.ApplyDelta(new OntologyDelta.RenameProperty(
+            "Trading", "Position", "Sym", "Symbol")
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        });
+
+        var built = ((OntologyBuilder)builder).ObjectTypes[0];
+        await Assert.That(built.Properties.Count).IsEqualTo(1);
+        await Assert.That(built.Properties[0].Name).IsEqualTo("Symbol");
+        // Identity preserved: other fields including Source carry through
+        await Assert.That(built.Properties[0].Source).IsEqualTo(DescriptorSource.Ingested);
+        await Assert.That(built.Properties[0].PropertyType).IsEqualTo(typeof(string));
+    }
+
+    [Test]
+    public async Task ApplyDelta_RemoveProperty_DropsByName()
+    {
+        IOntologyBuilder builder = new OntologyBuilder("Trading");
+
+        var parent = new ObjectTypeDescriptor("Position", typeof(string), "Trading")
+        {
+            Properties = new List<PropertyDescriptor>
+            {
+                new("Keep", typeof(int)),
+                new("Drop", typeof(int)),
+            },
+        };
+        builder.ApplyDelta(AddDelta(parent));
+
+        builder.ApplyDelta(new OntologyDelta.RemoveProperty("Trading", "Position", "Drop")
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        });
+
+        var built = ((OntologyBuilder)builder).ObjectTypes[0];
+        await Assert.That(built.Properties.Count).IsEqualTo(1);
+        await Assert.That(built.Properties[0].Name).IsEqualTo("Keep");
+    }
+
+    [Test]
+    public async Task ApplyDelta_AddLink_AppendsToSourceType()
+    {
+        IOntologyBuilder builder = new OntologyBuilder("Trading");
+
+        var parent = new ObjectTypeDescriptor("Position", typeof(string), "Trading");
+        builder.ApplyDelta(AddDelta(parent));
+
+        var link = new LinkDescriptor("Orders", "Order", LinkCardinality.OneToMany)
+        {
+            Source = DescriptorSource.Ingested,
+        };
+
+        builder.ApplyDelta(new OntologyDelta.AddLink("Trading", "Position", link)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        });
+
+        var built = ((OntologyBuilder)builder).ObjectTypes[0];
+        await Assert.That(built.Links.Count).IsEqualTo(1);
+        await Assert.That(built.Links[0].Name).IsEqualTo("Orders");
+        await Assert.That(built.Links[0].Source).IsEqualTo(DescriptorSource.Ingested);
+    }
+
+    [Test]
+    public async Task ApplyDelta_RemoveLink_DropsByName()
+    {
+        IOntologyBuilder builder = new OntologyBuilder("Trading");
+
+        var parent = new ObjectTypeDescriptor("Position", typeof(string), "Trading")
+        {
+            Links = new List<LinkDescriptor>
+            {
+                new("Keep", "Other", LinkCardinality.OneToOne),
+                new("Drop", "Other", LinkCardinality.OneToOne),
+            },
+        };
+        builder.ApplyDelta(AddDelta(parent));
+
+        builder.ApplyDelta(new OntologyDelta.RemoveLink("Trading", "Position", "Drop")
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        });
+
+        var built = ((OntologyBuilder)builder).ObjectTypes[0];
+        await Assert.That(built.Links.Count).IsEqualTo(1);
+        await Assert.That(built.Links[0].Name).IsEqualTo("Keep");
+    }
+
+    [Test]
+    public async Task ApplyDelta_UnknownVariant_ThrowsNotSupportedException()
+    {
+        IOntologyBuilder builder = new OntologyBuilder("Trading");
+
+        NotSupportedException? caught = null;
+        try
+        {
+            builder.ApplyDelta(new UnknownVariantDelta
+            {
+                SourceId = SourceId,
+                Timestamp = Timestamp,
+            });
+        }
+        catch (NotSupportedException ex)
+        {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNotNull();
+        await Assert.That(caught!.Message).Contains("UnknownVariantDelta");
+    }
+
+    /// <summary>
+    /// Test-only derived record exercising the unknown-variant fallthrough.
+    /// The production sealed-record hierarchy is closed; this fixture lives
+    /// outside it precisely so the default switch arm is reachable from
+    /// test code per DR-5 AC2.
+    /// </summary>
+    private sealed record UnknownVariantDelta : OntologyDelta;
 }

--- a/src/Strategos.Ontology.Tests/Builder/IOntologyBuilderApplyDeltaTests.cs
+++ b/src/Strategos.Ontology.Tests/Builder/IOntologyBuilderApplyDeltaTests.cs
@@ -1,0 +1,62 @@
+using Strategos.Ontology;
+using Strategos.Ontology.Builder;
+using Strategos.Ontology.Descriptors;
+
+namespace Strategos.Ontology.Tests.Builder;
+
+/// <summary>
+/// DR-5 (Task 10 + Task 11): exercises the <c>IOntologyBuilder.ApplyDelta</c>
+/// switch across each <see cref="OntologyDelta"/> variant. Task 10 covers
+/// <see cref="OntologyDelta.AddObjectType"/>; Task 11 covers the remaining
+/// seven variants plus the unknown-variant fallthrough.
+/// </summary>
+public class IOntologyBuilderApplyDeltaTests
+{
+    private static readonly DateTimeOffset Timestamp =
+        new(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+
+    private const string SourceId = "marten-typescript";
+
+    [Test]
+    public async Task ApplyDelta_AddObjectType_RegistersDescriptor()
+    {
+        IOntologyBuilder builder = new OntologyBuilder("Trading");
+
+        var descriptor = new ObjectTypeDescriptor("Position", typeof(string), "Trading")
+        {
+            Source = DescriptorSource.Ingested,
+            SourceId = SourceId,
+        };
+
+        OntologyDelta delta = new OntologyDelta.AddObjectType(descriptor)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        };
+
+        builder.ApplyDelta(delta);
+
+        var built = ((OntologyBuilder)builder).ObjectTypes;
+        await Assert.That(built.Count).IsEqualTo(1);
+        await Assert.That(built[0].Name).IsEqualTo("Position");
+        await Assert.That(built[0].Source).IsEqualTo(DescriptorSource.Ingested);
+    }
+
+    [Test]
+    public async Task ApplyDelta_NullDelta_Throws()
+    {
+        IOntologyBuilder builder = new OntologyBuilder("Trading");
+
+        ArgumentNullException? caught = null;
+        try
+        {
+            builder.ApplyDelta(null!);
+        }
+        catch (ArgumentNullException ex)
+        {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNotNull();
+    }
+}

--- a/src/Strategos.Ontology.Tests/Builder/IOntologyBuilderDescriptorPathTests.cs
+++ b/src/Strategos.Ontology.Tests/Builder/IOntologyBuilderDescriptorPathTests.cs
@@ -1,0 +1,73 @@
+using Strategos.Ontology.Builder;
+using Strategos.Ontology.Descriptors;
+
+namespace Strategos.Ontology.Tests.Builder;
+
+/// <summary>
+/// DR-5 (Task 9): the <see cref="IOntologyBuilder.ObjectTypeFromDescriptor"/>
+/// path lets ingestion sources register a fully-specified
+/// <see cref="ObjectTypeDescriptor"/> without going through the
+/// expression-tree DSL — necessary because ingested types may only be
+/// known by <c>SymbolKey</c>, with no loaded CLR type.
+/// </summary>
+public class IOntologyBuilderDescriptorPathTests
+{
+    [Test]
+    public async Task ObjectTypeFromDescriptor_IngestedDescriptor_AppearsInBuiltGraph()
+    {
+        IOntologyBuilder builder = new OntologyBuilder("Identity");
+
+        var ingested = new ObjectTypeDescriptor
+        {
+            Name = "User",
+            DomainName = "Identity",
+            ClrType = null,
+            SymbolKey = "scip-typescript . ./src/user.ts#User",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = "marten-typescript",
+        };
+
+        builder.ObjectTypeFromDescriptor(ingested);
+
+        var built = ((OntologyBuilder)builder).ObjectTypes;
+        await Assert.That(built.Count).IsEqualTo(1);
+        await Assert.That(built[0].Name).IsEqualTo("User");
+        await Assert.That(built[0].Source).IsEqualTo(DescriptorSource.Ingested);
+        await Assert.That(built[0].SymbolKey).IsEqualTo("scip-typescript . ./src/user.ts#User");
+        await Assert.That(built[0].ClrType).IsNull();
+    }
+
+    [Test]
+    public async Task ObjectTypeFromDescriptor_HandAuthoredDescriptor_PreservesSourceHandAuthored()
+    {
+        IOntologyBuilder builder = new OntologyBuilder("Trading");
+
+        var descriptor = new ObjectTypeDescriptor("Position", typeof(string), "Trading");
+
+        builder.ObjectTypeFromDescriptor(descriptor);
+
+        var built = ((OntologyBuilder)builder).ObjectTypes;
+        await Assert.That(built.Count).IsEqualTo(1);
+        await Assert.That(built[0].Source).IsEqualTo(DescriptorSource.HandAuthored);
+        await Assert.That(built[0].ClrType).IsEqualTo(typeof(string));
+    }
+
+    [Test]
+    public async Task ObjectTypeFromDescriptor_NullDescriptor_Throws()
+    {
+        IOntologyBuilder builder = new OntologyBuilder("Trading");
+
+        ArgumentNullException? caught = null;
+        try
+        {
+            builder.ObjectTypeFromDescriptor(null!);
+        }
+        catch (ArgumentNullException ex)
+        {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNotNull();
+    }
+}

--- a/src/Strategos.Ontology.Tests/Builder/IOntologyBuilderInvariantTests.cs
+++ b/src/Strategos.Ontology.Tests/Builder/IOntologyBuilderInvariantTests.cs
@@ -1,0 +1,248 @@
+using System.Collections.Immutable;
+
+using Strategos.Ontology;
+using Strategos.Ontology.Builder;
+using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Events;
+using Strategos.Ontology.Actions;
+
+namespace Strategos.Ontology.Tests.Builder;
+
+/// <summary>
+/// DR-6 + DR-10 (Task 16): the AONT205 invariant fires at delta-apply
+/// time when a mechanical ingester contributes to one of the intent-only
+/// fields (<c>Actions</c>, <c>Events</c>, <c>Lifecycle</c>).
+/// <see cref="OntologyBuilder.ApplyDelta"/> aborts with an
+/// <see cref="OntologyCompositionException"/> whose
+/// <see cref="OntologyCompositionException.Diagnostics"/> contains
+/// the offending diagnostic, identifying the violated field. Hand-authored
+/// descriptors are unaffected.
+/// </summary>
+public class IOntologyBuilderInvariantTests
+{
+    private static readonly DateTimeOffset Timestamp =
+        new(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+
+    private const string SourceId = "marten-typescript";
+
+    [Test]
+    public async Task ApplyDelta_AddIngestedDescriptorWithActions_ThrowsOntologyCompositionException()
+    {
+        IOntologyBuilder builder = new OntologyBuilder("Trading");
+
+        var descriptor = new ObjectTypeDescriptor
+        {
+            Name = "Position",
+            DomainName = "Trading",
+            SymbolKey = "scip-typescript ./pos.ts#Position",
+            Source = DescriptorSource.Ingested,
+            SourceId = SourceId,
+            Actions = new List<ActionDescriptor>
+            {
+                new("Trade", "Trade action"),
+            },
+        };
+
+        var delta = new OntologyDelta.AddObjectType(descriptor)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        };
+
+        OntologyCompositionException? caught = null;
+        try
+        {
+            builder.ApplyDelta(delta);
+        }
+        catch (OntologyCompositionException ex)
+        {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNotNull();
+        await Assert.That(caught!.Diagnostics.Any(d => d.Id == "AONT205")).IsTrue();
+        // Offending field is identified — the diagnostic message or its
+        // structured fields must name the violated intent field.
+        var aont205 = caught.Diagnostics.First(d => d.Id == "AONT205");
+        await Assert.That(aont205.Message).Contains("Actions");
+    }
+
+    [Test]
+    public async Task ApplyDelta_AddIngestedDescriptorWithLifecycle_ThrowsAONT205()
+    {
+        IOntologyBuilder builder = new OntologyBuilder("Trading");
+
+        var descriptor = new ObjectTypeDescriptor
+        {
+            Name = "Position",
+            DomainName = "Trading",
+            SymbolKey = "scip-typescript ./pos.ts#Position",
+            Source = DescriptorSource.Ingested,
+            SourceId = SourceId,
+            Lifecycle = new LifecycleDescriptor
+            {
+                PropertyName = "State",
+                StateEnumTypeName = "PositionState",
+                States = new List<LifecycleStateDescriptor>
+                {
+                    new() { Name = "Open", IsInitial = true },
+                    new() { Name = "Closed", IsTerminal = true },
+                },
+                Transitions = new List<LifecycleTransitionDescriptor>(),
+            },
+        };
+
+        var delta = new OntologyDelta.AddObjectType(descriptor)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        };
+
+        OntologyCompositionException? caught = null;
+        try
+        {
+            builder.ApplyDelta(delta);
+        }
+        catch (OntologyCompositionException ex)
+        {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNotNull();
+        var aont205 = caught!.Diagnostics.FirstOrDefault(d => d.Id == "AONT205");
+        await Assert.That(aont205).IsNotNull();
+        await Assert.That(aont205!.Message).Contains("Lifecycle");
+    }
+
+    [Test]
+    public async Task ApplyDelta_AddIngestedDescriptorWithEvents_ThrowsAONT205()
+    {
+        IOntologyBuilder builder = new OntologyBuilder("Trading");
+
+        var descriptor = new ObjectTypeDescriptor
+        {
+            Name = "Position",
+            DomainName = "Trading",
+            SymbolKey = "scip-typescript ./pos.ts#Position",
+            Source = DescriptorSource.Ingested,
+            SourceId = SourceId,
+            Events = new List<EventDescriptor>
+            {
+                new(typeof(string), "Position opened"),
+            },
+        };
+
+        var delta = new OntologyDelta.AddObjectType(descriptor)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        };
+
+        OntologyCompositionException? caught = null;
+        try
+        {
+            builder.ApplyDelta(delta);
+        }
+        catch (OntologyCompositionException ex)
+        {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNotNull();
+        var aont205 = caught!.Diagnostics.FirstOrDefault(d => d.Id == "AONT205");
+        await Assert.That(aont205).IsNotNull();
+        await Assert.That(aont205!.Message).Contains("Events");
+    }
+
+    [Test]
+    public async Task ApplyDelta_AddHandAuthoredDescriptorWithActions_DoesNotThrow()
+    {
+        // Negative: hand-authored descriptors are the home of Actions/
+        // Events/Lifecycle. AONT205 must only fire when Source == Ingested.
+        IOntologyBuilder builder = new OntologyBuilder("Trading");
+
+        var descriptor = new ObjectTypeDescriptor("Position", typeof(string), "Trading")
+        {
+            Source = DescriptorSource.HandAuthored,
+            Actions = new List<ActionDescriptor>
+            {
+                new("Trade", "Trade action"),
+            },
+        };
+
+        var delta = new OntologyDelta.AddObjectType(descriptor)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        };
+
+        Exception? caught = null;
+        try
+        {
+            builder.ApplyDelta(delta);
+        }
+        catch (Exception ex)
+        {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNull();
+        await Assert.That(((OntologyBuilder)builder).ObjectTypes.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ApplyDelta_UpdateIngestedDescriptorWithActions_ThrowsAONT205()
+    {
+        // Covers the UpdateObjectType branch — same invariant must apply
+        // on update as on add. The builder is first seeded with a clean
+        // ingested descriptor; the update then introduces an Actions
+        // contribution, which must fail.
+        IOntologyBuilder builder = new OntologyBuilder("Trading");
+
+        var seed = new ObjectTypeDescriptor
+        {
+            Name = "Position",
+            DomainName = "Trading",
+            SymbolKey = "scip-typescript ./pos.ts#Position",
+            Source = DescriptorSource.Ingested,
+            SourceId = SourceId,
+        };
+        builder.ApplyDelta(new OntologyDelta.AddObjectType(seed)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        });
+
+        var updated = new ObjectTypeDescriptor
+        {
+            Name = "Position",
+            DomainName = "Trading",
+            SymbolKey = "scip-typescript ./pos.ts#Position",
+            Source = DescriptorSource.Ingested,
+            SourceId = SourceId,
+            Actions = new List<ActionDescriptor>
+            {
+                new("Trade", "Trade action"),
+            },
+        };
+
+        OntologyCompositionException? caught = null;
+        try
+        {
+            builder.ApplyDelta(new OntologyDelta.UpdateObjectType(updated)
+            {
+                SourceId = SourceId,
+                Timestamp = Timestamp,
+            });
+        }
+        catch (OntologyCompositionException ex)
+        {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNotNull();
+        var aont205 = caught!.Diagnostics.FirstOrDefault(d => d.Id == "AONT205");
+        await Assert.That(aont205).IsNotNull();
+        await Assert.That(aont205!.Message).Contains("Actions");
+    }
+}

--- a/src/Strategos.Ontology.Tests/Builder/IngestedOriginalsMirrorTests.cs
+++ b/src/Strategos.Ontology.Tests/Builder/IngestedOriginalsMirrorTests.cs
@@ -1,0 +1,284 @@
+using Strategos.Ontology;
+using Strategos.Ontology.Builder;
+using Strategos.Ontology.Descriptors;
+
+namespace Strategos.Ontology.Tests.Builder;
+
+/// <summary>
+/// DR-7: regression tests for the <c>_ingestedOriginals</c> snapshot the
+/// <see cref="OntologyBuilder"/> retains so AONT201–AONT208 graph-freeze
+/// diagnostics can diff hand-declared properties against the pre-merge
+/// ingested side after MergeTwo has run.
+/// </summary>
+/// <remarks>
+/// Three invariants under test:
+///   1. Property/link <see cref="OntologyDelta"/>s mutate the ingested
+///      snapshot when one exists for the same <c>(Domain, Name)</c> — the
+///      snapshot would otherwise read stale pre-delta state after an
+///      incremental stream.
+///   2. An incoming hand-authored <c>UpdateObjectType</c> against an
+///      existing ingested baseline preserves the ingested snapshot rather
+///      than clearing it (the merge fold needs that baseline downstream).
+///   3. <see cref="OntologyBuilder.IngestedOriginals"/> returns a
+///      defensive read-only wrapper that consumers cannot down-cast and
+///      mutate.
+/// </remarks>
+public class IngestedOriginalsMirrorTests
+{
+    private static readonly DateTimeOffset Timestamp =
+        new(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+
+    private const string SourceId = "marten-typescript";
+
+    private static OntologyDelta.AddObjectType IngestedAdd(
+        string typeName,
+        params PropertyDescriptor[] properties)
+    {
+        var descriptor = new ObjectTypeDescriptor
+        {
+            Name = typeName,
+            DomainName = "Trading",
+            SymbolKey = $"scip ./mod#{typeName}",
+            Source = DescriptorSource.Ingested,
+            SourceId = SourceId,
+            Properties = properties,
+        };
+        return new OntologyDelta.AddObjectType(descriptor)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        };
+    }
+
+    private static OntologyDelta.AddObjectType IngestedAddWithLinks(
+        string typeName,
+        params LinkDescriptor[] links)
+    {
+        var descriptor = new ObjectTypeDescriptor
+        {
+            Name = typeName,
+            DomainName = "Trading",
+            SymbolKey = $"scip ./mod#{typeName}",
+            Source = DescriptorSource.Ingested,
+            SourceId = SourceId,
+            Links = links,
+        };
+        return new OntologyDelta.AddObjectType(descriptor)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        };
+    }
+
+    [Test]
+    public async Task AddProperty_OnIngestedBaseline_MirrorsToSnapshot()
+    {
+        var builder = new OntologyBuilder("Trading");
+        IOntologyBuilder b = builder;
+
+        b.ApplyDelta(IngestedAdd("Position", new PropertyDescriptor("Existing", typeof(int))));
+
+        var added = new PropertyDescriptor("Symbol", typeof(string))
+        {
+            Source = DescriptorSource.Ingested,
+        };
+        b.ApplyDelta(new OntologyDelta.AddProperty("Trading", "Position", added)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        });
+
+        var snapshot = builder.IngestedOriginals[("Trading", "Position")];
+        await Assert.That(snapshot.Properties.Any(p => p.Name == "Symbol")).IsTrue();
+        await Assert.That(snapshot.Properties.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task RenameProperty_OnIngestedBaseline_MirrorsToSnapshot()
+    {
+        var builder = new OntologyBuilder("Trading");
+        IOntologyBuilder b = builder;
+
+        b.ApplyDelta(IngestedAdd("Position", new PropertyDescriptor("Sym", typeof(string))));
+
+        b.ApplyDelta(new OntologyDelta.RenameProperty("Trading", "Position", "Sym", "Symbol")
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        });
+
+        var snapshot = builder.IngestedOriginals[("Trading", "Position")];
+        await Assert.That(snapshot.Properties.Any(p => p.Name == "Symbol")).IsTrue();
+        await Assert.That(snapshot.Properties.Any(p => p.Name == "Sym")).IsFalse();
+    }
+
+    [Test]
+    public async Task RemoveProperty_OnIngestedBaseline_MirrorsToSnapshot()
+    {
+        var builder = new OntologyBuilder("Trading");
+        IOntologyBuilder b = builder;
+
+        b.ApplyDelta(IngestedAdd(
+            "Position",
+            new PropertyDescriptor("Keep", typeof(int)),
+            new PropertyDescriptor("Drop", typeof(int))));
+
+        b.ApplyDelta(new OntologyDelta.RemoveProperty("Trading", "Position", "Drop")
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        });
+
+        var snapshot = builder.IngestedOriginals[("Trading", "Position")];
+        await Assert.That(snapshot.Properties.Any(p => p.Name == "Drop")).IsFalse();
+        await Assert.That(snapshot.Properties.Any(p => p.Name == "Keep")).IsTrue();
+    }
+
+    [Test]
+    public async Task AddLink_OnIngestedBaseline_MirrorsToSnapshot()
+    {
+        var builder = new OntologyBuilder("Trading");
+        IOntologyBuilder b = builder;
+
+        b.ApplyDelta(IngestedAddWithLinks("Position"));
+
+        var link = new LinkDescriptor("Payments", "Payment", LinkCardinality.OneToMany);
+        b.ApplyDelta(new OntologyDelta.AddLink("Trading", "Position", link)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        });
+
+        var snapshot = builder.IngestedOriginals[("Trading", "Position")];
+        await Assert.That(snapshot.Links.Any(l => l.Name == "Payments")).IsTrue();
+    }
+
+    [Test]
+    public async Task RemoveLink_OnIngestedBaseline_MirrorsToSnapshot()
+    {
+        var builder = new OntologyBuilder("Trading");
+        IOntologyBuilder b = builder;
+
+        b.ApplyDelta(IngestedAddWithLinks(
+            "Position",
+            new LinkDescriptor("Payments", "Payment", LinkCardinality.OneToMany)));
+
+        b.ApplyDelta(new OntologyDelta.RemoveLink("Trading", "Position", "Payments")
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        });
+
+        var snapshot = builder.IngestedOriginals[("Trading", "Position")];
+        await Assert.That(snapshot.Links.Any(l => l.Name == "Payments")).IsFalse();
+    }
+
+    [Test]
+    public async Task PropertyDelta_OnHandOnlyKey_DoesNotCreateSnapshot()
+    {
+        // No ingested baseline → mirror must be a no-op, not a fabrication.
+        var builder = new OntologyBuilder("Trading");
+        IOntologyBuilder b = builder;
+
+        var handAdd = new ObjectTypeDescriptor("Position", typeof(string), "Trading")
+        {
+            Source = DescriptorSource.HandAuthored,
+        };
+        b.ApplyDelta(new OntologyDelta.AddObjectType(handAdd)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        });
+
+        b.ApplyDelta(new OntologyDelta.AddProperty(
+            "Trading",
+            "Position",
+            new PropertyDescriptor("Symbol", typeof(string)))
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        });
+
+        await Assert.That(builder.IngestedOriginals.ContainsKey(("Trading", "Position"))).IsFalse();
+    }
+
+    [Test]
+    public async Task UpdateObjectType_HandOverIngested_PreservesIngestedSnapshot()
+    {
+        // DR-7 cross-provenance fold: incoming hand update against
+        // existing ingested baseline must keep the snapshot so AONT201–
+        // AONT208 can still diff. Previously SyncIngestedOriginal ran
+        // before the merge decision and wiped the snapshot.
+        var builder = new OntologyBuilder("Trading");
+        IOntologyBuilder b = builder;
+
+        b.ApplyDelta(IngestedAdd(
+            "Position",
+            new PropertyDescriptor("Symbol", typeof(string)) { Source = DescriptorSource.Ingested }));
+
+        var handUpdate = new ObjectTypeDescriptor("Position", typeof(string), "Trading")
+        {
+            Source = DescriptorSource.HandAuthored,
+            Properties = new List<PropertyDescriptor>
+            {
+                new("Quantity", typeof(int)) { Source = DescriptorSource.HandAuthored },
+            },
+        };
+
+        b.ApplyDelta(new OntologyDelta.UpdateObjectType(handUpdate)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        });
+
+        await Assert.That(builder.IngestedOriginals.ContainsKey(("Trading", "Position"))).IsTrue();
+        var snapshot = builder.IngestedOriginals[("Trading", "Position")];
+        await Assert.That(snapshot.Source).IsEqualTo(DescriptorSource.Ingested);
+        await Assert.That(snapshot.Properties.Any(p => p.Name == "Symbol")).IsTrue();
+    }
+
+    [Test]
+    public async Task UpdateObjectType_HandReplacesHand_ClearsAnyStaleSnapshot()
+    {
+        var builder = new OntologyBuilder("Trading");
+        IOntologyBuilder b = builder;
+
+        var handAdd = new ObjectTypeDescriptor("Position", typeof(string), "Trading")
+        {
+            Source = DescriptorSource.HandAuthored,
+        };
+        b.ApplyDelta(new OntologyDelta.AddObjectType(handAdd)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        });
+
+        var handUpdate = new ObjectTypeDescriptor("Position", typeof(string), "Trading")
+        {
+            Source = DescriptorSource.HandAuthored,
+        };
+        b.ApplyDelta(new OntologyDelta.UpdateObjectType(handUpdate)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        });
+
+        await Assert.That(builder.IngestedOriginals.ContainsKey(("Trading", "Position"))).IsFalse();
+    }
+
+    [Test]
+    public async Task IngestedOriginals_ReturnsDefensiveReadOnlyWrapper()
+    {
+        // Consumers must not be able to down-cast the property's
+        // IReadOnlyDictionary to Dictionary and mutate it. Returning a
+        // fresh ReadOnlyDictionary each call prevents this.
+        var builder = new OntologyBuilder("Trading");
+        IOntologyBuilder b = builder;
+
+        b.ApplyDelta(IngestedAdd("Position"));
+
+        var snapshot = builder.IngestedOriginals;
+
+        await Assert.That(snapshot is Dictionary<(string, string), ObjectTypeDescriptor>).IsFalse();
+    }
+}

--- a/src/Strategos.Ontology.Tests/Descriptors/DescriptorSourceTests.cs
+++ b/src/Strategos.Ontology.Tests/Descriptors/DescriptorSourceTests.cs
@@ -1,0 +1,28 @@
+using Strategos.Ontology.Descriptors;
+
+namespace Strategos.Ontology.Tests.Descriptors;
+
+public class DescriptorSourceTests
+{
+    [Test]
+    public async Task DescriptorSource_DefaultValue_IsHandAuthored()
+    {
+        // Arrange & Act
+        var value = default(DescriptorSource);
+
+        // Assert
+        await Assert.That(value).IsEqualTo(DescriptorSource.HandAuthored);
+    }
+
+    [Test]
+    public async Task DescriptorSource_HandAuthored_HasValueZero()
+    {
+        await Assert.That((int)DescriptorSource.HandAuthored).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task DescriptorSource_Ingested_HasValueOne()
+    {
+        await Assert.That((int)DescriptorSource.Ingested).IsEqualTo(1);
+    }
+}

--- a/src/Strategos.Ontology.Tests/Descriptors/LinkDescriptorPolyglotTests.cs
+++ b/src/Strategos.Ontology.Tests/Descriptors/LinkDescriptorPolyglotTests.cs
@@ -1,0 +1,40 @@
+using Strategos.Ontology.Descriptors;
+
+namespace Strategos.Ontology.Tests.Descriptors;
+
+public class LinkDescriptorPolyglotTests
+{
+    [Test]
+    public async Task TargetSymbolKey_DefaultValue_IsNull()
+    {
+        var descriptor = new LinkDescriptor("Orders", "TradeOrder", LinkCardinality.OneToMany);
+
+        await Assert.That(descriptor.TargetSymbolKey).IsNull();
+    }
+
+    [Test]
+    public async Task Source_DefaultValue_IsHandAuthored()
+    {
+        var descriptor = new LinkDescriptor("Orders", "TradeOrder", LinkCardinality.OneToMany);
+
+        await Assert.That(descriptor.Source).IsEqualTo(DescriptorSource.HandAuthored);
+    }
+
+    [Test]
+    public async Task Ctor_SymbolKeyTargetOnly_TargetTypeNameStillPresent()
+    {
+        // A link descriptor with a SymbolKey target (ingestion path).
+        // TargetTypeName remains required (used by hand-authored paths and as
+        // a string-keyed display); TargetSymbolKey rides alongside for SCIP
+        // identity per DR-1.
+        var descriptor = new LinkDescriptor("Authors", "User", LinkCardinality.OneToMany)
+        {
+            TargetSymbolKey = "scip-typescript . ./src/user.ts#User",
+            Source = DescriptorSource.Ingested,
+        };
+
+        await Assert.That(descriptor.TargetTypeName).IsEqualTo("User");
+        await Assert.That(descriptor.TargetSymbolKey).IsEqualTo("scip-typescript . ./src/user.ts#User");
+        await Assert.That(descriptor.Source).IsEqualTo(DescriptorSource.Ingested);
+    }
+}

--- a/src/Strategos.Ontology.Tests/Descriptors/ObjectTypeDescriptorPolyglotTests.cs
+++ b/src/Strategos.Ontology.Tests/Descriptors/ObjectTypeDescriptorPolyglotTests.cs
@@ -1,0 +1,95 @@
+using Strategos.Ontology.Descriptors;
+
+namespace Strategos.Ontology.Tests.Descriptors;
+
+public class ObjectTypeDescriptorPolyglotTests
+{
+    [Test]
+    public async Task Ctor_HandAuthoredDefault_LanguageIdIsDotnet()
+    {
+        // Arrange & Act — positional ctor preserved for backward compat
+        var descriptor = new ObjectTypeDescriptor("Position", typeof(string), "Trading");
+
+        // Assert
+        await Assert.That(descriptor.LanguageId).IsEqualTo("dotnet");
+    }
+
+    [Test]
+    public async Task Ctor_HandAuthoredDefault_SourceIsHandAuthored()
+    {
+        var descriptor = new ObjectTypeDescriptor("Position", typeof(string), "Trading");
+
+        await Assert.That(descriptor.Source).IsEqualTo(DescriptorSource.HandAuthored);
+    }
+
+    [Test]
+    public async Task Ctor_HandAuthoredDefault_SymbolKeyAndFqnAreNull()
+    {
+        var descriptor = new ObjectTypeDescriptor("Position", typeof(string), "Trading");
+
+        await Assert.That(descriptor.SymbolKey).IsNull();
+        await Assert.That(descriptor.SymbolFqn).IsNull();
+        await Assert.That(descriptor.SourceId).IsNull();
+        await Assert.That(descriptor.IngestedAt).IsNull();
+    }
+
+    [Test]
+    public async Task Ctor_IngestedDescriptor_AcceptsNullClrTypeWithSymbolKey()
+    {
+        // Property-init form — ingested descriptor with no CLR type, only a SymbolKey
+        var descriptor = new ObjectTypeDescriptor
+        {
+            Name = "User",
+            DomainName = "Identity",
+            ClrType = null,
+            SymbolKey = "scip-typescript . ./src/user.ts#User",
+            SymbolFqn = "user.User",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = "marten-typescript",
+            IngestedAt = new DateTimeOffset(2026, 5, 10, 0, 0, 0, TimeSpan.Zero),
+        };
+
+        await Assert.That(descriptor.ClrType).IsNull();
+        await Assert.That(descriptor.SymbolKey).IsEqualTo("scip-typescript . ./src/user.ts#User");
+        await Assert.That(descriptor.SymbolFqn).IsEqualTo("user.User");
+        await Assert.That(descriptor.LanguageId).IsEqualTo("typescript");
+        await Assert.That(descriptor.Source).IsEqualTo(DescriptorSource.Ingested);
+        await Assert.That(descriptor.SourceId).IsEqualTo("marten-typescript");
+        await Assert.That(descriptor.IngestedAt).IsNotNull();
+    }
+
+    [Test]
+    public async Task Ctor_BothClrTypeAndSymbolKeyNull_ThrowsInvalidOperationException()
+    {
+        // Hand-authored polyglot escape: no CLR type and no SymbolKey violates DR-1
+        InvalidOperationException? caught = null;
+        try
+        {
+            _ = new ObjectTypeDescriptor
+            {
+                Name = "Orphan",
+                DomainName = "Trading",
+                ClrType = null,
+                SymbolKey = null,
+            };
+        }
+        catch (InvalidOperationException ex)
+        {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNotNull();
+        await Assert.That(caught!.Message).Contains("ClrType");
+        await Assert.That(caught.Message).Contains("SymbolKey");
+    }
+
+    [Test]
+    public async Task Ctor_PositionalForm_ProvidesClrType_DoesNotThrow()
+    {
+        // Backward-compat: positional ctor always carries a non-null ClrType
+        var descriptor = new ObjectTypeDescriptor("Position", typeof(string), "Trading");
+
+        await Assert.That(descriptor.ClrType).IsEqualTo(typeof(string));
+    }
+}

--- a/src/Strategos.Ontology.Tests/Descriptors/PropertyDescriptorPolyglotTests.cs
+++ b/src/Strategos.Ontology.Tests/Descriptors/PropertyDescriptorPolyglotTests.cs
@@ -1,0 +1,40 @@
+using Strategos.Ontology.Descriptors;
+
+namespace Strategos.Ontology.Tests.Descriptors;
+
+public class PropertyDescriptorPolyglotTests
+{
+    [Test]
+    public async Task ReferenceSymbolKey_DefaultValue_IsNull()
+    {
+        var descriptor = new PropertyDescriptor("OwnerId", typeof(Guid));
+
+        await Assert.That(descriptor.ReferenceSymbolKey).IsNull();
+    }
+
+    [Test]
+    public async Task Source_DefaultValue_IsHandAuthored()
+    {
+        var descriptor = new PropertyDescriptor("OwnerId", typeof(Guid));
+
+        await Assert.That(descriptor.Source).IsEqualTo(DescriptorSource.HandAuthored);
+    }
+
+    [Test]
+    public async Task Ctor_ReferenceTypeBySymbolKey_StoresSymbolKey()
+    {
+        // For reference-typed properties whose target type is identified
+        // by SCIP rather than CLR (ingestion path), ReferenceSymbolKey
+        // rides alongside PropertyType.
+        var descriptor = new PropertyDescriptor("Owner", typeof(object))
+        {
+            ReferenceSymbolKey = "scip-typescript . ./src/user.ts#User",
+            Source = DescriptorSource.Ingested,
+            Kind = PropertyKind.Reference,
+        };
+
+        await Assert.That(descriptor.ReferenceSymbolKey).IsEqualTo("scip-typescript . ./src/user.ts#User");
+        await Assert.That(descriptor.Source).IsEqualTo(DescriptorSource.Ingested);
+        await Assert.That(descriptor.Kind).IsEqualTo(PropertyKind.Reference);
+    }
+}

--- a/src/Strategos.Ontology.Tests/Diagnostics/AONT201Tests.cs
+++ b/src/Strategos.Ontology.Tests/Diagnostics/AONT201Tests.cs
@@ -1,0 +1,143 @@
+using System.Collections.Immutable;
+
+using Strategos.Ontology;
+using Strategos.Ontology.Builder;
+using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Tests.TestInfrastructure;
+
+namespace Strategos.Ontology.Tests.Diagnostics;
+
+/// <summary>
+/// DR-7 (Task 23): AONT201 fires at graph-freeze when a hand-authored
+/// descriptor declares a property whose name is absent from the
+/// corresponding ingested descriptor (after MergeTwo). The diagnostic
+/// is error-severity, surfaces in <see cref="OntologyCompositionException.Diagnostics"/>,
+/// and the message identifies the offending property and includes a
+/// hint about the Pass-6b rename matcher per DR-7 AC3.
+/// </summary>
+public class AONT201Tests
+{
+    private static readonly DateTimeOffset Timestamp =
+        new(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+
+    public sealed class HandPos
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Symbol { get; set; } = string.Empty;
+        public decimal Quantity { get; set; }
+    }
+
+    private sealed class HandPositionOntology : DomainOntology
+    {
+        public override string DomainName => "Trading";
+
+        protected override void Define(IOntologyBuilder builder)
+        {
+            builder.Object<HandPos>("Position", obj =>
+            {
+                obj.Key(p => p.Id);
+                obj.Property(p => p.Symbol);
+                obj.Property(p => p.Quantity);
+            });
+        }
+    }
+
+    [Test]
+    public async Task Build_HandDeclaresPropertyMissingFromIngested_AONT201Error()
+    {
+        // Ingested descriptor with the SAME name + domain but missing the
+        // hand-declared "Quantity" property; after MergeTwo the merged
+        // descriptor carries "Symbol" (ingested-present, will land in hand
+        // anyway) and "Quantity" (hand-only) — Quantity is hand-only and
+        // hence "missing on the ingested side": AONT201.
+        var ingested = new ObjectTypeDescriptor
+        {
+            Name = "Position",
+            DomainName = "Trading",
+            ClrType = null,
+            SymbolKey = "scip-typescript ./pos.ts#Position",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = "marten-typescript",
+            Properties = new List<PropertyDescriptor>
+            {
+                new("Symbol", typeof(string)) { Source = DescriptorSource.Ingested },
+            },
+        };
+
+        var source = new TestOntologySource
+        {
+            SourceId = "marten-typescript",
+            Deltas = ImmutableArray.Create<OntologyDelta>(
+                new OntologyDelta.AddObjectType(ingested)
+                {
+                    SourceId = "marten-typescript",
+                    Timestamp = Timestamp,
+                }),
+        };
+
+        var graphBuilder = new OntologyGraphBuilder()
+            .AddDomain<HandPositionOntology>()
+            .AddSources(new IOntologySource[] { source });
+
+        OntologyCompositionException? caught = null;
+        try
+        {
+            graphBuilder.Build();
+        }
+        catch (OntologyCompositionException ex)
+        {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNotNull();
+        var aont201 = caught!.Diagnostics.FirstOrDefault(d => d.Id == "AONT201");
+        await Assert.That(aont201).IsNotNull();
+        await Assert.That(aont201!.Message).Contains("Quantity");
+        // Hint about Pass-6b rename matcher (DR-7 AC3).
+        await Assert.That(aont201.Message).Contains("Pass-6b rename matcher");
+    }
+
+    [Test]
+    public async Task Build_HandDeclaresPropertyPresentInIngested_NoAONT201()
+    {
+        // Ingested side carries BOTH hand-declared properties — no
+        // AONT201 should fire.
+        var ingested = new ObjectTypeDescriptor
+        {
+            Name = "Position",
+            DomainName = "Trading",
+            ClrType = null,
+            SymbolKey = "scip-typescript ./pos.ts#Position",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = "marten-typescript",
+            Properties = new List<PropertyDescriptor>
+            {
+                new("Symbol", typeof(string)) { Source = DescriptorSource.Ingested },
+                new("Quantity", typeof(decimal)) { Source = DescriptorSource.Ingested },
+            },
+        };
+
+        var source = new TestOntologySource
+        {
+            SourceId = "marten-typescript",
+            Deltas = ImmutableArray.Create<OntologyDelta>(
+                new OntologyDelta.AddObjectType(ingested)
+                {
+                    SourceId = "marten-typescript",
+                    Timestamp = Timestamp,
+                }),
+        };
+
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<HandPositionOntology>()
+            .AddSources(new IOntologySource[] { source })
+            .Build();
+
+        // No AONT201 should appear in NonFatalDiagnostics either — the
+        // hand property is fully accounted for on the ingested side.
+        await Assert.That(graph.NonFatalDiagnostics.Any(d => d.Id == "AONT201"))
+            .IsFalse();
+    }
+}

--- a/src/Strategos.Ontology.Tests/Diagnostics/AONT202Tests.cs
+++ b/src/Strategos.Ontology.Tests/Diagnostics/AONT202Tests.cs
@@ -1,0 +1,248 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Strategos.Ontology;
+using Strategos.Ontology.Builder;
+using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Tests.TestInfrastructure;
+
+namespace Strategos.Ontology.Tests.Diagnostics;
+
+/// <summary>
+/// DR-7 (Task 24): AONT202 is a warning-severity graph-freeze
+/// diagnostic emitted when a hand-declared property's type/kind
+/// disagrees with the ingested side's contribution for the same
+/// property name. The warning is non-fatal — it surfaces on
+/// <see cref="OntologyGraph.NonFatalDiagnostics"/> and is also routed
+/// through the wired <see cref="ILogger{T}"/> with structured properties.
+/// </summary>
+public class AONT202Tests
+{
+    private static readonly DateTimeOffset Timestamp =
+        new(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+
+    public sealed class HandPos
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Symbol { get; set; } = string.Empty;
+    }
+
+    private sealed class HandPositionOntology : DomainOntology
+    {
+        public override string DomainName => "Trading";
+
+        protected override void Define(IOntologyBuilder builder)
+        {
+            builder.Object<HandPos>("Position", obj =>
+            {
+                obj.Key(p => p.Id);
+                // Hand declares Symbol as a Scalar string property.
+                obj.Property(p => p.Symbol);
+            });
+        }
+    }
+
+    [Test]
+    public async Task Build_HandScalarVsIngestedReference_AONT202Warning()
+    {
+        // Ingested side declares "Symbol" but as Reference-kinded, with a
+        // mismatched property type. The hand-merged descriptor still uses
+        // hand-side metadata, but AONT202 should fire as a warning so
+        // ingest authors notice the drift.
+        var ingested = new ObjectTypeDescriptor
+        {
+            Name = "Position",
+            DomainName = "Trading",
+            ClrType = null,
+            SymbolKey = "scip-typescript ./pos.ts#Position",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = "marten-typescript",
+            Properties = new List<PropertyDescriptor>
+            {
+                new("Symbol", typeof(Guid))
+                {
+                    Kind = PropertyKind.Reference,
+                    Source = DescriptorSource.Ingested,
+                },
+            },
+        };
+
+        var source = new TestOntologySource
+        {
+            SourceId = "marten-typescript",
+            Deltas = ImmutableArray.Create<OntologyDelta>(
+                new OntologyDelta.AddObjectType(ingested)
+                {
+                    SourceId = "marten-typescript",
+                    Timestamp = Timestamp,
+                }),
+        };
+
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<HandPositionOntology>()
+            .AddSources(new IOntologySource[] { source })
+            .Build();
+
+        var aont202 = graph.NonFatalDiagnostics.FirstOrDefault(d => d.Id == "AONT202");
+        await Assert.That(aont202).IsNotNull();
+        await Assert.That(aont202!.Severity).IsEqualTo(Strategos.Ontology.Diagnostics.OntologyDiagnosticSeverity.Warning);
+        await Assert.That(aont202.PropertyName).IsEqualTo("Symbol");
+        await Assert.That(aont202.DomainName).IsEqualTo("Trading");
+        await Assert.That(aont202.TypeName).IsEqualTo("Position");
+    }
+
+    [Test]
+    public async Task Build_HandAndIngestedAgree_NoAONT202()
+    {
+        // Both sides declare Symbol as a scalar string property — no
+        // mismatch, no AONT202.
+        var ingested = new ObjectTypeDescriptor
+        {
+            Name = "Position",
+            DomainName = "Trading",
+            ClrType = null,
+            SymbolKey = "scip-typescript ./pos.ts#Position",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = "marten-typescript",
+            Properties = new List<PropertyDescriptor>
+            {
+                new("Symbol", typeof(string))
+                {
+                    Kind = PropertyKind.Scalar,
+                    Source = DescriptorSource.Ingested,
+                },
+            },
+        };
+
+        var source = new TestOntologySource
+        {
+            SourceId = "marten-typescript",
+            Deltas = ImmutableArray.Create<OntologyDelta>(
+                new OntologyDelta.AddObjectType(ingested)
+                {
+                    SourceId = "marten-typescript",
+                    Timestamp = Timestamp,
+                }),
+        };
+
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<HandPositionOntology>()
+            .AddSources(new IOntologySource[] { source })
+            .Build();
+
+        await Assert.That(graph.NonFatalDiagnostics.Any(d => d.Id == "AONT202")).IsFalse();
+    }
+
+    [Test]
+    public async Task Build_AONT202Fires_LoggerReceivesStructuredWarning()
+    {
+        var ingested = new ObjectTypeDescriptor
+        {
+            Name = "Position",
+            DomainName = "Trading",
+            ClrType = null,
+            SymbolKey = "scip-typescript ./pos.ts#Position",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = "marten-typescript",
+            Properties = new List<PropertyDescriptor>
+            {
+                new("Symbol", typeof(Guid))
+                {
+                    Kind = PropertyKind.Reference,
+                    Source = DescriptorSource.Ingested,
+                },
+            },
+        };
+
+        var source = new TestOntologySource
+        {
+            SourceId = "marten-typescript",
+            Deltas = ImmutableArray.Create<OntologyDelta>(
+                new OntologyDelta.AddObjectType(ingested)
+                {
+                    SourceId = "marten-typescript",
+                    Timestamp = Timestamp,
+                }),
+        };
+
+        var logger = new FakeLogger<OntologyGraphBuilder>();
+
+        _ = new OntologyGraphBuilder()
+            .WithLogger(logger)
+            .AddDomain<HandPositionOntology>()
+            .AddSources(new IOntologySource[] { source })
+            .Build();
+
+        var warning = logger.Entries
+            .FirstOrDefault(e => e.Level == LogLevel.Warning
+                              && e.State.TryGetValue("DiagnosticId", out var id)
+                              && id as string == "AONT202");
+
+        await Assert.That(warning).IsNotNull();
+        await Assert.That(warning!.State.TryGetValue("DomainName", out var domainName)).IsTrue();
+        await Assert.That(domainName as string).IsEqualTo("Trading");
+        await Assert.That(warning.State.TryGetValue("TypeName", out var typeName)).IsTrue();
+        await Assert.That(typeName as string).IsEqualTo("Position");
+        await Assert.That(warning.State.TryGetValue("PropertyName", out var propertyName)).IsTrue();
+        await Assert.That(propertyName as string).IsEqualTo("Symbol");
+    }
+}
+
+/// <summary>
+/// Minimal in-test logger that captures structured state pairs so
+/// AONT2xx-tests can assert structured-property propagation without
+/// pulling in Microsoft.Extensions.Logging.Testing.
+/// </summary>
+internal sealed class FakeLogger<T> : ILogger<T>
+{
+    private readonly ConcurrentQueue<FakeLogEntry> _entries = new();
+
+    public IReadOnlyCollection<FakeLogEntry> Entries => _entries.ToArray();
+
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        var entry = new FakeLogEntry
+        {
+            Level = logLevel,
+            Message = formatter(state, exception),
+        };
+
+        if (state is IReadOnlyList<KeyValuePair<string, object?>> pairs)
+        {
+            foreach (var kvp in pairs)
+            {
+                entry.State[kvp.Key] = kvp.Value;
+            }
+        }
+
+        _entries.Enqueue(entry);
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+        public void Dispose() { }
+    }
+}
+
+internal sealed class FakeLogEntry
+{
+    public LogLevel Level { get; init; }
+    public string Message { get; init; } = string.Empty;
+    public Dictionary<string, object?> State { get; } = new();
+}

--- a/src/Strategos.Ontology.Tests/Diagnostics/AONT203Tests.cs
+++ b/src/Strategos.Ontology.Tests/Diagnostics/AONT203Tests.cs
@@ -1,0 +1,199 @@
+using System.Collections.Immutable;
+
+using Microsoft.Extensions.Logging;
+
+using Strategos.Ontology;
+using Strategos.Ontology.Builder;
+using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Tests.TestInfrastructure;
+
+namespace Strategos.Ontology.Tests.Diagnostics;
+
+/// <summary>
+/// DR-7 (Task 25): AONT203 is a warning-severity graph-freeze
+/// diagnostic emitted when an ingested-only property is missing from
+/// the hand-authored <c>Define()</c> declaration of a type opted in
+/// to strict mode via <c>[DomainEntity(Strict = true)]</c>. Strict is
+/// opt-in: types without the attribute (or with Strict = false) do
+/// not fire AONT203.
+/// </summary>
+public class AONT203Tests
+{
+    private static readonly DateTimeOffset Timestamp =
+        new(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+
+    [DomainEntity(Strict = true)]
+    public sealed class StrictPos
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Symbol { get; set; } = string.Empty;
+    }
+
+    public sealed class LooseQuote
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Symbol { get; set; } = string.Empty;
+    }
+
+    private sealed class StrictTradingOntology : DomainOntology
+    {
+        public override string DomainName => "Trading";
+
+        protected override void Define(IOntologyBuilder builder)
+        {
+            builder.Object<StrictPos>("Position", obj =>
+            {
+                obj.Key(p => p.Id);
+                obj.Property(p => p.Symbol);
+                // Quantity (ingested-only) is intentionally not declared
+                // here so AONT203 fires under Strict.
+            });
+        }
+    }
+
+    private sealed class LooseTradingOntology : DomainOntology
+    {
+        public override string DomainName => "Trading";
+
+        protected override void Define(IOntologyBuilder builder)
+        {
+            builder.Object<LooseQuote>("Quote", obj =>
+            {
+                obj.Key(p => p.Id);
+                obj.Property(p => p.Symbol);
+            });
+        }
+    }
+
+    [Test]
+    public async Task Build_StrictTypeMissingIngestedProperty_AONT203Warning()
+    {
+        var ingested = new ObjectTypeDescriptor
+        {
+            Name = "Position",
+            DomainName = "Trading",
+            ClrType = null,
+            SymbolKey = "scip-typescript ./pos.ts#Position",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = "marten-typescript",
+            Properties = new List<PropertyDescriptor>
+            {
+                new("Symbol", typeof(string)) { Source = DescriptorSource.Ingested },
+                new("Quantity", typeof(decimal)) { Source = DescriptorSource.Ingested },
+            },
+        };
+
+        var source = new TestOntologySource
+        {
+            SourceId = "marten-typescript",
+            Deltas = ImmutableArray.Create<OntologyDelta>(
+                new OntologyDelta.AddObjectType(ingested)
+                {
+                    SourceId = "marten-typescript",
+                    Timestamp = Timestamp,
+                }),
+        };
+
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<StrictTradingOntology>()
+            .AddSources(new IOntologySource[] { source })
+            .Build();
+
+        var aont203 = graph.NonFatalDiagnostics.FirstOrDefault(d => d.Id == "AONT203");
+        await Assert.That(aont203).IsNotNull();
+        await Assert.That(aont203!.PropertyName).IsEqualTo("Quantity");
+        await Assert.That(aont203.DomainName).IsEqualTo("Trading");
+        await Assert.That(aont203.TypeName).IsEqualTo("Position");
+    }
+
+    [Test]
+    public async Task Build_NonStrictTypeMissingIngestedProperty_NoAONT203()
+    {
+        // LooseQuote is not annotated with [DomainEntity(Strict=true)] —
+        // missing ingested-only properties should NOT fire AONT203.
+        var ingested = new ObjectTypeDescriptor
+        {
+            Name = "Quote",
+            DomainName = "Trading",
+            ClrType = null,
+            SymbolKey = "scip-typescript ./quote.ts#Quote",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = "marten-typescript",
+            Properties = new List<PropertyDescriptor>
+            {
+                new("Symbol", typeof(string)) { Source = DescriptorSource.Ingested },
+                new("Bid", typeof(decimal)) { Source = DescriptorSource.Ingested },
+            },
+        };
+
+        var source = new TestOntologySource
+        {
+            SourceId = "marten-typescript",
+            Deltas = ImmutableArray.Create<OntologyDelta>(
+                new OntologyDelta.AddObjectType(ingested)
+                {
+                    SourceId = "marten-typescript",
+                    Timestamp = Timestamp,
+                }),
+        };
+
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<LooseTradingOntology>()
+            .AddSources(new IOntologySource[] { source })
+            .Build();
+
+        await Assert.That(graph.NonFatalDiagnostics.Any(d => d.Id == "AONT203")).IsFalse();
+    }
+
+    [Test]
+    public async Task Build_AONT203Fires_LoggerReceivesStructuredWarning()
+    {
+        var ingested = new ObjectTypeDescriptor
+        {
+            Name = "Position",
+            DomainName = "Trading",
+            ClrType = null,
+            SymbolKey = "scip-typescript ./pos.ts#Position",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = "marten-typescript",
+            Properties = new List<PropertyDescriptor>
+            {
+                new("Symbol", typeof(string)) { Source = DescriptorSource.Ingested },
+                new("Quantity", typeof(decimal)) { Source = DescriptorSource.Ingested },
+            },
+        };
+
+        var source = new TestOntologySource
+        {
+            SourceId = "marten-typescript",
+            Deltas = ImmutableArray.Create<OntologyDelta>(
+                new OntologyDelta.AddObjectType(ingested)
+                {
+                    SourceId = "marten-typescript",
+                    Timestamp = Timestamp,
+                }),
+        };
+
+        var logger = new FakeLogger<OntologyGraphBuilder>();
+
+        _ = new OntologyGraphBuilder()
+            .WithLogger(logger)
+            .AddDomain<StrictTradingOntology>()
+            .AddSources(new IOntologySource[] { source })
+            .Build();
+
+        var warning = logger.Entries
+            .FirstOrDefault(e => e.Level == LogLevel.Warning
+                              && e.State.TryGetValue("DiagnosticId", out var id)
+                              && id as string == "AONT203");
+
+        await Assert.That(warning).IsNotNull();
+        await Assert.That(warning!.State.TryGetValue("TypeName", out var typeName)).IsTrue();
+        await Assert.That(typeName as string).IsEqualTo("Position");
+        await Assert.That(warning.State.TryGetValue("PropertyName", out var propertyName)).IsTrue();
+        await Assert.That(propertyName as string).IsEqualTo("Quantity");
+    }
+}

--- a/src/Strategos.Ontology.Tests/Diagnostics/AONT204Tests.cs
+++ b/src/Strategos.Ontology.Tests/Diagnostics/AONT204Tests.cs
@@ -1,0 +1,143 @@
+using System.Collections.Immutable;
+
+using Strategos.Ontology;
+using Strategos.Ontology.Builder;
+using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Tests.TestInfrastructure;
+
+namespace Strategos.Ontology.Tests.Diagnostics;
+
+/// <summary>
+/// DR-7 (Task 26): AONT204 is an info-severity graph-freeze diagnostic
+/// emitted when an ingested descriptor (one whose graph-level Source
+/// is <see cref="DescriptorSource.Ingested"/>) is not referenced by
+/// any hand-authored descriptor via Links, ParentTypeName, or
+/// KeyProperty references. Surfaces ingested noise that may indicate
+/// orphan ingestion.
+/// </summary>
+public class AONT204Tests
+{
+    private static readonly DateTimeOffset Timestamp =
+        new(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+
+    public sealed class HandPortfolio
+    {
+        public string Id { get; set; } = string.Empty;
+    }
+
+    // CLR shadow for the ingested-only "Order" target. Never registered
+    // as a hand-side Object<>; lives only so the HasMany<Order>(...) link
+    // writes a target name of "Order" into the hand descriptor.
+    public sealed class Order
+    {
+        public string Id { get; set; } = string.Empty;
+    }
+
+    private sealed class HandPortfolioOntology : DomainOntology
+    {
+        public override string DomainName => "Trading";
+
+        protected override void Define(IOntologyBuilder builder)
+        {
+            builder.Object<HandPortfolio>("Portfolio", obj =>
+            {
+                obj.Key(p => p.Id);
+            });
+        }
+    }
+
+    private sealed class HandPortfolioLinkingOrderOntology : DomainOntology
+    {
+        public override string DomainName => "Trading";
+
+        protected override void Define(IOntologyBuilder builder)
+        {
+            builder.Object<HandPortfolio>("Portfolio", obj =>
+            {
+                obj.Key(p => p.Id);
+                // Hand-side link references a target named "Order" — the
+                // descriptor of that name is contributed purely by the
+                // ingested source.
+                obj.HasMany<Order>("Orders");
+            });
+        }
+    }
+
+    [Test]
+    public async Task Build_IngestedTypeNoHandReference_AONT204Info()
+    {
+        // Ingestion contributes a brand-new descriptor "Order" that is
+        // not referenced by any hand-authored type — no Links pointing
+        // to it, no ParentTypeName, no KeyProperty references. AONT204
+        // info diagnostic should fire.
+        var orphanOrder = new ObjectTypeDescriptor
+        {
+            Name = "Order",
+            DomainName = "Trading",
+            ClrType = null,
+            SymbolKey = "scip-typescript ./ord.ts#Order",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = "marten-typescript",
+        };
+
+        var source = new TestOntologySource
+        {
+            SourceId = "marten-typescript",
+            Deltas = ImmutableArray.Create<OntologyDelta>(
+                new OntologyDelta.AddObjectType(orphanOrder)
+                {
+                    SourceId = "marten-typescript",
+                    Timestamp = Timestamp,
+                }),
+        };
+
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<HandPortfolioOntology>()
+            .AddSources(new IOntologySource[] { source })
+            .Build();
+
+        var aont204 = graph.NonFatalDiagnostics.FirstOrDefault(d => d.Id == "AONT204");
+        await Assert.That(aont204).IsNotNull();
+        await Assert.That(aont204!.Severity)
+            .IsEqualTo(Strategos.Ontology.Diagnostics.OntologyDiagnosticSeverity.Info);
+        await Assert.That(aont204.TypeName).IsEqualTo("Order");
+        await Assert.That(aont204.DomainName).IsEqualTo("Trading");
+    }
+
+    [Test]
+    public async Task Build_IngestedTypeReferencedByHand_NoAONT204()
+    {
+        // Hand-authored Portfolio carries a HasMany "Orders" link
+        // pointing at the ingested "Order" descriptor — AONT204 should
+        // not fire because the ingested type is referenced.
+        var referencedOrder = new ObjectTypeDescriptor
+        {
+            Name = "Order",
+            DomainName = "Trading",
+            ClrType = null,
+            SymbolKey = "scip-typescript ./ord.ts#Order",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = "marten-typescript",
+        };
+
+        var source = new TestOntologySource
+        {
+            SourceId = "marten-typescript",
+            Deltas = ImmutableArray.Create<OntologyDelta>(
+                new OntologyDelta.AddObjectType(referencedOrder)
+                {
+                    SourceId = "marten-typescript",
+                    Timestamp = Timestamp,
+                }),
+        };
+
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<HandPortfolioLinkingOrderOntology>()
+            .AddSources(new IOntologySource[] { source })
+            .Build();
+
+        await Assert.That(graph.NonFatalDiagnostics.Any(d => d.Id == "AONT204")).IsFalse();
+    }
+}

--- a/src/Strategos.Ontology.Tests/Diagnostics/AONT205Tests.cs
+++ b/src/Strategos.Ontology.Tests/Diagnostics/AONT205Tests.cs
@@ -1,0 +1,90 @@
+using System.Collections.Immutable;
+
+using Strategos.Ontology;
+using Strategos.Ontology.Builder;
+using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Tests.TestInfrastructure;
+
+namespace Strategos.Ontology.Tests.Diagnostics;
+
+/// <summary>
+/// DR-7 (Task 27): AONT205 also fires at graph-freeze as a defensive
+/// invariant check on the composed graph. Task 16 already fires the
+/// diagnostic at delta-apply; the freeze-time check guards the
+/// post-merge state for the "two ingested sources racing intent" stress
+/// case — if any descriptor survives to graph-freeze with
+/// Source = Ingested AND non-empty Actions/Events/Lifecycle, the build
+/// fails with AONT205 as an error.
+/// </summary>
+public class AONT205GraphFreezeTests
+{
+    private static readonly DateTimeOffset Timestamp =
+        new(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+
+    [Test]
+    public async Task Build_TwoSourcesAttemptIntentContributionPostMerge_AONT205Error()
+    {
+        // Synthesize the post-merge state directly: a purely ingested
+        // descriptor that — despite Task 16's delta-apply check — somehow
+        // reaches graph-freeze with intent fields populated. The
+        // graph-freeze check must catch this defensively. We bypass the
+        // delta path by hand-feeding the descriptor through a custom
+        // DomainOntology that uses ObjectTypeFromDescriptor directly.
+        var graphBuilder = new OntologyGraphBuilder()
+            .AddDomain<DefectiveIngestedIntentOntology>();
+
+        OntologyCompositionException? caught = null;
+        try
+        {
+            graphBuilder.Build();
+        }
+        catch (OntologyCompositionException ex)
+        {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNotNull();
+        var aont205 = caught!.Diagnostics.FirstOrDefault(d => d.Id == "AONT205");
+        await Assert.That(aont205).IsNotNull();
+        await Assert.That(aont205!.DomainName).IsEqualTo("Trading");
+        await Assert.That(aont205.TypeName).IsEqualTo("DefectivePosition");
+    }
+
+    /// <summary>
+    /// Custom DomainOntology that bypasses the delta-apply invariant by
+    /// calling <see cref="OntologyBuilder.ObjectTypeFromDescriptor"/>
+    /// directly with an Ingested-tagged descriptor that carries Actions.
+    /// Simulates a hypothetical bug where two sources race and the
+    /// defensive Task 16 check is not enough.
+    /// </summary>
+    private sealed class DefectiveIngestedIntentOntology : DomainOntology
+    {
+        public override string DomainName => "Trading";
+
+        protected override void Define(IOntologyBuilder builder)
+        {
+            var defect = new ObjectTypeDescriptor
+            {
+                Name = "DefectivePosition",
+                DomainName = "Trading",
+                ClrType = null,
+                SymbolKey = "scip-typescript ./defect.ts#DefectivePosition",
+                LanguageId = "typescript",
+                Source = DescriptorSource.Ingested,
+                SourceId = "marten-typescript-defect",
+                Actions = new List<ActionDescriptor>
+                {
+                    new("Trade", "Trade action emitted by a misbehaving ingester"),
+                },
+            };
+
+            // ObjectTypeFromDescriptor is exposed on the concrete builder
+            // type. Cast through the concrete type to bypass the
+            // delta-level AONT205 check that ApplyDelta enforces.
+            if (builder is OntologyBuilder concrete)
+            {
+                concrete.ObjectTypeFromDescriptor(defect);
+            }
+        }
+    }
+}

--- a/src/Strategos.Ontology.Tests/Diagnostics/AONT206Tests.cs
+++ b/src/Strategos.Ontology.Tests/Diagnostics/AONT206Tests.cs
@@ -1,0 +1,102 @@
+using System.Collections.Immutable;
+
+using Strategos.Ontology;
+using Strategos.Ontology.Builder;
+using Strategos.Ontology.Configuration;
+using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Tests.TestInfrastructure;
+
+namespace Strategos.Ontology.Tests.Diagnostics;
+
+/// <summary>
+/// DR-7 (Task 28): AONT206 is an opt-in info-severity hygiene hint
+/// flagged when a hand-declared property is ALSO contributed by the
+/// ingested side. Gated behind the MSBuild property
+/// <c>OntologyEnableHygieneHints</c> — wired through
+/// <see cref="OntologyOptions.EnableHygieneHints"/>. Off by default so
+/// existing graphs are not flooded with cosmetic hints.
+/// </summary>
+public class AONT206Tests
+{
+    private static readonly DateTimeOffset Timestamp =
+        new(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+
+    public sealed class HandPos
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Symbol { get; set; } = string.Empty;
+    }
+
+    private sealed class HandPositionOntology : DomainOntology
+    {
+        public override string DomainName => "Trading";
+
+        protected override void Define(IOntologyBuilder builder)
+        {
+            builder.Object<HandPos>("Position", obj =>
+            {
+                obj.Key(p => p.Id);
+                obj.Property(p => p.Symbol);
+            });
+        }
+    }
+
+    private static TestOntologySource BuildSourceWithOverlappingSymbol() =>
+        new()
+        {
+            SourceId = "marten-typescript",
+            Deltas = ImmutableArray.Create<OntologyDelta>(
+                new OntologyDelta.AddObjectType(
+                    new ObjectTypeDescriptor
+                    {
+                        Name = "Position",
+                        DomainName = "Trading",
+                        ClrType = null,
+                        SymbolKey = "scip-typescript ./pos.ts#Position",
+                        LanguageId = "typescript",
+                        Source = DescriptorSource.Ingested,
+                        SourceId = "marten-typescript",
+                        Properties = new List<PropertyDescriptor>
+                        {
+                            // Same property name as the hand declaration:
+                            // hygiene-hint territory.
+                            new("Symbol", typeof(string)) { Source = DescriptorSource.Ingested },
+                        },
+                    })
+                {
+                    SourceId = "marten-typescript",
+                    Timestamp = Timestamp,
+                }),
+        };
+
+    [Test]
+    public async Task Build_HandPropertyAlsoIngested_AONT206InfoWhenEnabled()
+    {
+        var options = new OntologyOptions { EnableHygieneHints = true };
+
+        var graph = new OntologyGraphBuilder()
+            .WithOptions(options)
+            .AddDomain<HandPositionOntology>()
+            .AddSources(new IOntologySource[] { BuildSourceWithOverlappingSymbol() })
+            .Build();
+
+        var aont206 = graph.NonFatalDiagnostics.FirstOrDefault(d => d.Id == "AONT206");
+        await Assert.That(aont206).IsNotNull();
+        await Assert.That(aont206!.Severity)
+            .IsEqualTo(Strategos.Ontology.Diagnostics.OntologyDiagnosticSeverity.Info);
+        await Assert.That(aont206.PropertyName).IsEqualTo("Symbol");
+    }
+
+    [Test]
+    public async Task Build_HandPropertyAlsoIngested_NoAONT206ByDefault()
+    {
+        // No WithOptions call — default EnableHygieneHints is false; the
+        // hint must not fire.
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<HandPositionOntology>()
+            .AddSources(new IOntologySource[] { BuildSourceWithOverlappingSymbol() })
+            .Build();
+
+        await Assert.That(graph.NonFatalDiagnostics.Any(d => d.Id == "AONT206")).IsFalse();
+    }
+}

--- a/src/Strategos.Ontology.Tests/Diagnostics/AONT208Tests.cs
+++ b/src/Strategos.Ontology.Tests/Diagnostics/AONT208Tests.cs
@@ -1,0 +1,100 @@
+using System.Collections.Immutable;
+
+using Strategos.Ontology;
+using Strategos.Ontology.Builder;
+using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Tests.TestInfrastructure;
+
+namespace Strategos.Ontology.Tests.Diagnostics;
+
+/// <summary>
+/// DR-7 (Task 30): AONT208 is an error-severity graph-freeze diagnostic
+/// emitted when MergeTwo's two inputs disagree on <c>LanguageId</c>
+/// where the hand side has opted into a non-default value (i.e. the
+/// hand-authored descriptor was explicitly set to a polyglot language).
+/// Hand descriptors that default to <c>"dotnet"</c> do not fire this
+/// diagnostic against ingested polyglot contributions — that is the
+/// expected polyglot composition path.
+/// </summary>
+public class AONT208Tests
+{
+    private static readonly DateTimeOffset Timestamp =
+        new(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>
+    /// Hand-side ontology that publishes a descriptor with an explicit
+    /// non-default LanguageId. The ingested source then contributes a
+    /// disagreeing LanguageId — AONT208 fires.
+    /// </summary>
+    private sealed class HandRustAuthoringOntology : DomainOntology
+    {
+        public override string DomainName => "Trading";
+
+        protected override void Define(IOntologyBuilder builder)
+        {
+            // Hand-feed a descriptor whose LanguageId is explicitly
+            // "rust" (the hand-author has opted into polyglot identity).
+            // The merge happens when an ingested AddObjectType arrives
+            // for the same (Domain, Name) with a different LanguageId.
+            if (builder is OntologyBuilder concrete)
+            {
+                concrete.ObjectTypeFromDescriptor(new ObjectTypeDescriptor
+                {
+                    Name = "Position",
+                    DomainName = "Trading",
+                    SymbolKey = "rust ./pos.rs::Position",
+                    LanguageId = "rust",
+                    Source = DescriptorSource.HandAuthored,
+                });
+            }
+        }
+    }
+
+    [Test]
+    public async Task Build_TwoSourcesDisagreeLanguageId_AONT208Error()
+    {
+        var ingested = new ObjectTypeDescriptor
+        {
+            Name = "Position",
+            DomainName = "Trading",
+            ClrType = null,
+            SymbolKey = "scip-typescript ./pos.ts#Position",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = "marten-typescript",
+        };
+
+        var source = new TestOntologySource
+        {
+            SourceId = "marten-typescript",
+            Deltas = ImmutableArray.Create<OntologyDelta>(
+                new OntologyDelta.AddObjectType(ingested)
+                {
+                    SourceId = "marten-typescript",
+                    Timestamp = Timestamp,
+                }),
+        };
+
+        var graphBuilder = new OntologyGraphBuilder()
+            .AddDomain<HandRustAuthoringOntology>()
+            .AddSources(new IOntologySource[] { source });
+
+        OntologyCompositionException? caught = null;
+        try
+        {
+            graphBuilder.Build();
+        }
+        catch (OntologyCompositionException ex)
+        {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNotNull();
+        var aont208 = caught!.Diagnostics.FirstOrDefault(d => d.Id == "AONT208");
+        await Assert.That(aont208).IsNotNull();
+        await Assert.That(aont208!.DomainName).IsEqualTo("Trading");
+        await Assert.That(aont208.TypeName).IsEqualTo("Position");
+        await Assert.That(aont208.Message).Contains("rust");
+        await Assert.That(aont208.Message).Contains("typescript");
+    }
+}

--- a/src/Strategos.Ontology.Tests/Diagnostics/MixedSeverityAggregationTests.cs
+++ b/src/Strategos.Ontology.Tests/Diagnostics/MixedSeverityAggregationTests.cs
@@ -1,0 +1,126 @@
+using System.Collections.Immutable;
+
+using Strategos.Ontology;
+using Strategos.Ontology.Builder;
+using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Tests.TestInfrastructure;
+
+namespace Strategos.Ontology.Tests.Diagnostics;
+
+/// <summary>
+/// DR-10 AC3 — pins the design's mixed-severity aggregation contract:
+/// when graph-freeze produces one Error (AONT201) + one Warning
+/// (AONT202) + one Info (AONT204), <see cref="OntologyGraphBuilder.Build"/>
+/// throws <see cref="OntologyCompositionException"/> with the Error in
+/// <see cref="OntologyCompositionException.Diagnostics"/> and the
+/// Warning + Info in <see cref="OntologyCompositionException.NonFatalDiagnostics"/>.
+/// PR-A's test suite could not exercise this because the AONT200-series
+/// triggers did not yet exist; PR-B closes that gap.
+/// </summary>
+public class MixedSeverityAggregationTests
+{
+    private static readonly DateTimeOffset Timestamp =
+        new(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+
+    public sealed class HandPos
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Symbol { get; set; } = string.Empty;
+        public decimal Quantity { get; set; }
+    }
+
+    private sealed class HandPositionOntology : DomainOntology
+    {
+        public override string DomainName => "Trading";
+
+        protected override void Define(IOntologyBuilder builder)
+        {
+            builder.Object<HandPos>("Position", obj =>
+            {
+                obj.Key(p => p.Id);
+                obj.Property(p => p.Symbol);
+                obj.Property(p => p.Quantity);
+            });
+        }
+    }
+
+    [Test]
+    public async Task Build_AONT201PlusAONT202PlusAONT204_ThrowsWithErrorOnlyInDiagnostics_NonFatalCarriesWarningsAndInfo()
+    {
+        // Position (ingested mirror): carries "Symbol" with a mismatched
+        // type/kind ⇒ AONT202 (warning), and is missing "Quantity"
+        // entirely ⇒ AONT201 (error). A separate ingested orphan type
+        // "OrphanOrder" with no hand references ⇒ AONT204 (info).
+        var positionMirror = new ObjectTypeDescriptor
+        {
+            Name = "Position",
+            DomainName = "Trading",
+            ClrType = null,
+            SymbolKey = "scip-typescript ./pos.ts#Position",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = "marten-typescript",
+            Properties = new List<PropertyDescriptor>
+            {
+                new("Symbol", typeof(Guid))
+                {
+                    Kind = PropertyKind.Reference,
+                    Source = DescriptorSource.Ingested,
+                },
+            },
+        };
+
+        var orphanOrder = new ObjectTypeDescriptor
+        {
+            Name = "OrphanOrder",
+            DomainName = "Trading",
+            ClrType = null,
+            SymbolKey = "scip-typescript ./ord.ts#OrphanOrder",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = "marten-typescript",
+        };
+
+        var source = new TestOntologySource
+        {
+            SourceId = "marten-typescript",
+            Deltas = ImmutableArray.Create<OntologyDelta>(
+                new OntologyDelta.AddObjectType(positionMirror)
+                {
+                    SourceId = "marten-typescript",
+                    Timestamp = Timestamp,
+                },
+                new OntologyDelta.AddObjectType(orphanOrder)
+                {
+                    SourceId = "marten-typescript",
+                    Timestamp = Timestamp,
+                }),
+        };
+
+        var graphBuilder = new OntologyGraphBuilder()
+            .AddDomain<HandPositionOntology>()
+            .AddSources(new IOntologySource[] { source });
+
+        OntologyCompositionException? caught = null;
+        try
+        {
+            graphBuilder.Build();
+        }
+        catch (OntologyCompositionException ex)
+        {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNotNull();
+
+        // Fatal: AONT201 only.
+        await Assert.That(caught!.Diagnostics.Any(d => d.Id == "AONT201")).IsTrue();
+        await Assert.That(caught.Diagnostics.Any(d => d.Id == "AONT202")).IsFalse();
+        await Assert.That(caught.Diagnostics.Any(d => d.Id == "AONT204")).IsFalse();
+
+        // Non-fatal: AONT202 + AONT204.
+        await Assert.That(caught.NonFatalDiagnostics.Any(d => d.Id == "AONT202")).IsTrue();
+        await Assert.That(caught.NonFatalDiagnostics.Any(d => d.Id == "AONT204")).IsTrue();
+        await Assert.That(caught.NonFatalDiagnostics.Any(d => d.Id == "AONT201")).IsFalse();
+    }
+}

--- a/src/Strategos.Ontology.Tests/Exceptions/OntologyCompositionExceptionTests.cs
+++ b/src/Strategos.Ontology.Tests/Exceptions/OntologyCompositionExceptionTests.cs
@@ -1,0 +1,90 @@
+using System.Collections.Immutable;
+
+using Strategos.Ontology;
+using Strategos.Ontology.Diagnostics;
+
+namespace Strategos.Ontology.Tests.Exceptions;
+
+public class OntologyCompositionExceptionTests
+{
+    [Test]
+    public async Task Ctor_LegacyMessageOnly_ExposesEmptyDiagnostics()
+    {
+        // Preserves backward compatibility with the pre-DR-10 single-message ctor.
+        var ex = new OntologyCompositionException("AONT040: duplicate type");
+
+        await Assert.That(ex.Message).IsEqualTo("AONT040: duplicate type");
+        await Assert.That(ex.Diagnostics).IsEmpty();
+        await Assert.That(ex.NonFatalDiagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Ctor_LegacyMessageAndInner_PreservesInner()
+    {
+        var inner = new InvalidOperationException("boom");
+        var ex = new OntologyCompositionException("AONT040: duplicate type", inner);
+
+        await Assert.That(ex.InnerException).IsEqualTo(inner);
+        await Assert.That(ex.Diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Ctor_WithDiagnostics_ExposesDiagnosticsProperty()
+    {
+        var diagnostics = ImmutableArray.Create(
+            new OntologyDiagnostic(
+                Id: "AONT201",
+                Message: "Hand-declared property 'Symbol' does not exist on ingested descriptor",
+                Severity: OntologyDiagnosticSeverity.Error,
+                DomainName: "Trading",
+                TypeName: "TradeOrder",
+                PropertyName: "Symbol"),
+            new OntologyDiagnostic(
+                Id: "AONT208",
+                Message: "LanguageId disagreement between origins",
+                Severity: OntologyDiagnosticSeverity.Error,
+                DomainName: "Trading",
+                TypeName: "TradeOrder",
+                PropertyName: null));
+
+        var ex = new OntologyCompositionException(diagnostics);
+
+        await Assert.That(ex.Diagnostics.Length).IsEqualTo(2);
+        await Assert.That(ex.Diagnostics[0].Id).IsEqualTo("AONT201");
+        await Assert.That(ex.Diagnostics[1].Id).IsEqualTo("AONT208");
+        await Assert.That(ex.NonFatalDiagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Ctor_WithDiagnosticsAndNonFatal_ExposesBoth()
+    {
+        var fatal = ImmutableArray.Create(
+            new OntologyDiagnostic("AONT201", "fatal 1", OntologyDiagnosticSeverity.Error, null, null, null));
+        var nonFatal = ImmutableArray.Create(
+            new OntologyDiagnostic("AONT202", "warn 1", OntologyDiagnosticSeverity.Warning, null, null, null),
+            new OntologyDiagnostic("AONT204", "info 1", OntologyDiagnosticSeverity.Info, null, null, null));
+
+        var ex = new OntologyCompositionException(fatal, nonFatal);
+
+        await Assert.That(ex.Diagnostics.Length).IsEqualTo(1);
+        await Assert.That(ex.NonFatalDiagnostics.Length).IsEqualTo(2);
+        await Assert.That(ex.NonFatalDiagnostics[0].Id).IsEqualTo("AONT202");
+    }
+
+    [Test]
+    public async Task Ctor_WithDiagnostics_MessageContainsFirstDiagnosticId()
+    {
+        var diagnostics = ImmutableArray.Create(
+            new OntologyDiagnostic(
+                "AONT205",
+                "Ingested descriptor contributes to Actions",
+                OntologyDiagnosticSeverity.Error,
+                "Trading",
+                "TradeOrder",
+                null));
+
+        var ex = new OntologyCompositionException(diagnostics);
+
+        await Assert.That(ex.Message).Contains("AONT205");
+    }
+}

--- a/src/Strategos.Ontology.Tests/Extensions/OntologyBuilderOptionsExtensionsTests.cs
+++ b/src/Strategos.Ontology.Tests/Extensions/OntologyBuilderOptionsExtensionsTests.cs
@@ -1,0 +1,122 @@
+using System.Collections.Immutable;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Strategos.Ontology;
+using Strategos.Ontology.Configuration;
+
+namespace Strategos.Ontology.Tests.Extensions;
+
+/// <summary>
+/// DR-3 (Task 12): DI extension <c>OntologyOptions.AddSource&lt;T&gt;()</c>
+/// registers an <see cref="IOntologySource"/> implementation as transient
+/// so the source-drain in <see cref="OntologyGraphBuilder"/> can resolve
+/// it from <see cref="IServiceProvider"/>. Resolution as
+/// <see cref="IEnumerable{T}"/> is the production wiring contract.
+/// </summary>
+public class OntologyBuilderOptionsExtensionsTests
+{
+    [Test]
+    public async Task AddSource_TestSource_RegistersAsTransient()
+    {
+        var services = new ServiceCollection();
+
+        services.AddOntology(opts =>
+        {
+            opts.AddSource<DiTestOntologySource>();
+        });
+
+        var provider = services.BuildServiceProvider();
+
+        var resolved = provider.GetServices<IOntologySource>().ToList();
+
+        await Assert.That(resolved).HasCount().EqualTo(1);
+        await Assert.That(resolved[0]).IsTypeOf<DiTestOntologySource>();
+    }
+
+    [Test]
+    public async Task AddSource_ResolvedTwice_YieldsDistinctInstances()
+    {
+        // Transient lifetime contract — each resolution is a fresh instance.
+        var services = new ServiceCollection();
+
+        services.AddOntology(opts =>
+        {
+            opts.AddSource<DiTestOntologySource>();
+        });
+
+        var provider = services.BuildServiceProvider();
+
+        var first = provider.GetServices<IOntologySource>().Single();
+        var second = provider.GetServices<IOntologySource>().Single();
+
+        await Assert.That(first).IsNotSameReferenceAs(second);
+    }
+
+    [Test]
+    public async Task AddSource_MultipleSources_AllRegistered()
+    {
+        // AddSource<T> must accumulate registrations — registering two
+        // distinct source types both surface in IEnumerable<IOntologySource>.
+        var services = new ServiceCollection();
+
+        services.AddOntology(opts =>
+        {
+            opts.AddSource<DiTestOntologySource>();
+            opts.AddSource<SecondDiTestOntologySource>();
+        });
+
+        var provider = services.BuildServiceProvider();
+        var resolved = provider.GetServices<IOntologySource>().ToList();
+
+        await Assert.That(resolved).HasCount().EqualTo(2);
+        await Assert.That(resolved.Any(s => s is DiTestOntologySource)).IsTrue();
+        await Assert.That(resolved.Any(s => s is SecondDiTestOntologySource)).IsTrue();
+    }
+
+    /// <summary>
+    /// Parameterless <see cref="IOntologySource"/> for DI activation. The
+    /// production <c>TestOntologySource</c> fixture uses <c>required</c>
+    /// init properties so it cannot be activated by the container without
+    /// a factory; this minimal variant exists solely for DI-resolution
+    /// coverage. Real ingester wiring will follow the same pattern by
+    /// supplying a parameterless ctor or a factory registration.
+    /// </summary>
+    private sealed class DiTestOntologySource : IOntologySource
+    {
+        public string SourceId => "di-test";
+
+        public async IAsyncEnumerable<OntologyDelta> LoadAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        {
+            await Task.Yield();
+            yield break;
+        }
+
+        public async IAsyncEnumerable<OntologyDelta> SubscribeAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        {
+            await Task.Yield();
+            yield break;
+        }
+    }
+
+    private sealed class SecondDiTestOntologySource : IOntologySource
+    {
+        public string SourceId => "di-test-second";
+
+        public async IAsyncEnumerable<OntologyDelta> LoadAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        {
+            await Task.Yield();
+            yield break;
+        }
+
+        public async IAsyncEnumerable<OntologyDelta> SubscribeAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        {
+            await Task.Yield();
+            yield break;
+        }
+    }
+}

--- a/src/Strategos.Ontology.Tests/Integration/RoslynSymbolKeyIntegrationTests.cs
+++ b/src/Strategos.Ontology.Tests/Integration/RoslynSymbolKeyIntegrationTests.cs
@@ -1,0 +1,168 @@
+using System.Collections.Immutable;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+using Strategos.Ontology;
+using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Tests.TestInfrastructure;
+
+using TUnit.Core;
+
+namespace Strategos.Ontology.Tests.Integration;
+
+/// <summary>
+/// DR-9 (Task 22): Roslyn round-trip integration test guarding against
+/// drift between Strategos test fixtures and the basileus production
+/// SCIP ingester. Compiles a small C# source string, extracts a named
+/// type symbol, serializes its identity into the descriptor
+/// <see cref="ObjectTypeDescriptor.SymbolKey"/>, and verifies the
+/// descriptor reaches the composed <see cref="OntologyGraph"/> with
+/// that identity preserved bit-for-bit.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Deviation from plan wording.</b> Task 22 in the plan suggests
+/// <c>SymbolKey.Create(symbol).ToString()</c> but
+/// <c>Microsoft.CodeAnalysis.SymbolKey</c> is internal to Roslyn —
+/// it is not callable from a test project that references the public
+/// <c>Microsoft.CodeAnalysis.CSharp</c> package. The plan explicitly
+/// authorizes the public-surface substitute
+/// <see cref="ISymbol.GetDocumentationCommentId"/>: it is stable,
+/// mechanically derived from the symbol, and is the cref / DocId form
+/// that downstream SCIP ingesters already canonicalize on. The
+/// identity round-trip we care about — "the string a Roslyn-driven
+/// ingester would put on a descriptor survives <see cref="OntologyBuilder.ApplyDelta"/>
+/// and graph-freeze unchanged" — is preserved unchanged with this
+/// substitution.
+/// </para>
+/// <para>
+/// The test is gated behind the MSBuild property
+/// <c>SkipRoslynIntegrationTests</c> via
+/// <see cref="SkipIfRoslynIntegrationDisabledAttribute"/>. Set
+/// <c>SkipRoslynIntegrationTests=true</c> at build time to short-
+/// circuit this fixture on environments where the Roslyn dependency
+/// is unwanted (e.g. minimal CI lanes).
+/// </para>
+/// </remarks>
+public class RoslynSymbolKeyIntegrationTests
+{
+    private const string TradeOrderSource = """
+        namespace Trading.Polyglot
+        {
+            public class TradeOrder
+            {
+                public string Id { get; set; } = "";
+                public decimal Amount { get; set; }
+            }
+        }
+        """;
+
+    [Test]
+    [SkipIfRoslynIntegrationDisabled]
+    public async Task RoslynSymbolKey_RoundTripThroughBuilder_PreservesIdentity()
+    {
+        // --- Arrange: compile a small C# snippet via Roslyn ---
+        var syntaxTree = CSharpSyntaxTree.ParseText(TradeOrderSource);
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "RoslynSymbolKeyRoundTrip",
+            syntaxTrees: new[] { syntaxTree },
+            references: new[]
+            {
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            },
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var symbol = compilation.GetTypeByMetadataName("Trading.Polyglot.TradeOrder");
+        await Assert.That(symbol).IsNotNull();
+
+        // SymbolKey is internal in Roslyn; the public, mechanically-
+        // derived alternative is GetDocumentationCommentId() (cref ID).
+        // See type-doc remarks above for the rationale.
+        var serializedSymbolKey = symbol!.GetDocumentationCommentId();
+        await Assert.That(serializedSymbolKey).IsNotNull();
+        await Assert.That(serializedSymbolKey!).IsNotEmpty();
+
+        // --- Act: build an ObjectTypeDescriptor that carries the
+        // serialized symbol identity, push it through the source-drain
+        // path so it lands via OntologyBuilder.ApplyDelta in
+        // OntologyGraphBuilder.Build(). ---
+        var descriptor = new ObjectTypeDescriptor
+        {
+            Name = "TradeOrder",
+            DomainName = "Trading",
+            ClrType = null,
+            SymbolKey = serializedSymbolKey,
+            SymbolFqn = "Trading.Polyglot.TradeOrder",
+            LanguageId = "dotnet",
+            Source = DescriptorSource.Ingested,
+            SourceId = "roslyn-roundtrip",
+        };
+
+        var timestamp = new DateTimeOffset(2026, 5, 14, 12, 0, 0, TimeSpan.Zero);
+        var source = new TestOntologySource
+        {
+            SourceId = "roslyn-roundtrip",
+            Deltas = ImmutableArray.Create<OntologyDelta>(
+                new OntologyDelta.AddObjectType(descriptor)
+                {
+                    SourceId = "roslyn-roundtrip",
+                    Timestamp = timestamp,
+                }),
+        };
+
+        var graph = new OntologyGraphBuilder()
+            .AddSources(new IOntologySource[] { source })
+            .Build();
+
+        // --- Assert: the descriptor reached the graph and its
+        // SymbolKey survived bit-for-bit. ---
+        var landed = graph.ObjectTypes.FirstOrDefault(
+            ot => ot.DomainName == "Trading" && ot.Name == "TradeOrder");
+
+        await Assert.That(landed).IsNotNull();
+        await Assert.That(landed!.SymbolKey).IsEqualTo(serializedSymbolKey);
+        await Assert.That(landed.ClrType).IsNull();
+        await Assert.That(landed.Source).IsEqualTo(DescriptorSource.Ingested);
+        await Assert.That(landed.SourceId).IsEqualTo("roslyn-roundtrip");
+    }
+}
+
+/// <summary>
+/// Conditional-skip attribute for the Roslyn integration fixture.
+/// Two activation paths:
+/// <list type="bullet">
+///   <item><description>
+///     <b>Build-time:</b> the MSBuild property
+///     <c>SkipRoslynIntegrationTests=true</c> defines the
+///     <c>SKIP_ROSLYN_INTEGRATION_TESTS</c> preprocessor symbol, which
+///     unconditionally short-circuits this attribute's
+///     <see cref="ShouldSkip"/> to <c>true</c>.
+///   </description></item>
+///   <item><description>
+///     <b>Run-time:</b> the identically-named environment variable
+///     (<c>SKIP_ROSLYN_INTEGRATION_TESTS=true|1</c>) skips the test
+///     without rebuilding — convenient for ad-hoc CI lanes.
+///   </description></item>
+/// </list>
+/// </summary>
+internal sealed class SkipIfRoslynIntegrationDisabledAttribute : SkipAttribute
+{
+    public SkipIfRoslynIntegrationDisabledAttribute()
+        : base("SkipRoslynIntegrationTests is set; skipping Roslyn integration fixture.")
+    {
+    }
+
+    public override Task<bool> ShouldSkip(TestRegisteredContext context)
+    {
+#if SKIP_ROSLYN_INTEGRATION_TESTS
+        return Task.FromResult(true);
+#else
+        var raw = Environment.GetEnvironmentVariable("SKIP_ROSLYN_INTEGRATION_TESTS");
+        var skip = !string.IsNullOrEmpty(raw)
+            && (raw.Equals("true", StringComparison.OrdinalIgnoreCase)
+                || raw == "1");
+        return Task.FromResult(skip);
+#endif
+    }
+}

--- a/src/Strategos.Ontology.Tests/Integration/RoslynSymbolKeyIntegrationTests.cs
+++ b/src/Strategos.Ontology.Tests/Integration/RoslynSymbolKeyIntegrationTests.cs
@@ -155,6 +155,9 @@ public class RoslynSymbolKeyIntegrationTests
 /// </summary>
 internal sealed class SkipIfRoslynIntegrationDisabledAttribute : SkipAttribute
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SkipIfRoslynIntegrationDisabledAttribute"/> class.
+    /// </summary>
     public SkipIfRoslynIntegrationDisabledAttribute()
         : base("SkipRoslynIntegrationTests is set; skipping Roslyn integration fixture.")
     {

--- a/src/Strategos.Ontology.Tests/Integration/RoslynSymbolKeyIntegrationTests.cs
+++ b/src/Strategos.Ontology.Tests/Integration/RoslynSymbolKeyIntegrationTests.cs
@@ -58,6 +58,13 @@ public class RoslynSymbolKeyIntegrationTests
         }
         """;
 
+    /// <summary>
+    /// Verifies that the Roslyn-derived symbol identity put on an
+    /// ingested <see cref="ObjectTypeDescriptor"/> survives the
+    /// <see cref="IOntologySource"/> drain, <see cref="OntologyBuilder.ApplyDelta"/>,
+    /// and graph-freeze unchanged. Guards against drift between Strategos
+    /// test fixtures and the basileus production SCIP ingester.
+    /// </summary>
     [Test]
     [SkipIfRoslynIntegrationDisabled]
     public async Task RoslynSymbolKey_RoundTripThroughBuilder_PreservesIdentity()

--- a/src/Strategos.Ontology.Tests/Merge/MergeMatrixTests.cs
+++ b/src/Strategos.Ontology.Tests/Merge/MergeMatrixTests.cs
@@ -164,6 +164,10 @@ public class MergeMatrixTests
         // Hand-only descriptor for HandPosition; ingestion contributes a
         // *new* link not declared by hand. The link must surface in the
         // composed graph tagged with Source = Ingested.
+        // The ingested mirror declares the hand-known "Symbol" property so
+        // DR-7 AONT201 (hand-declared property missing from ingested) does
+        // not fire — this fixture is exercising link-merge, not the
+        // property-completeness diagnostic.
         var ingestedShadow = new ObjectTypeDescriptor
         {
             Name = "HandPosition",
@@ -172,6 +176,10 @@ public class MergeMatrixTests
             LanguageId = "typescript",
             Source = DescriptorSource.Ingested,
             SourceId = IngestSourceId,
+            Properties = new List<PropertyDescriptor>
+            {
+                new("Symbol", typeof(string)) { Source = DescriptorSource.Ingested },
+            },
             Links = new List<LinkDescriptor>
             {
                 new("RelatedOrders", "Order", LinkCardinality.OneToMany)
@@ -218,6 +226,9 @@ public class MergeMatrixTests
         // ClrType: hand carries it; ingestion does not. Hand wins on the
         // happy path (and since ingestion can't carry CLR identity, the
         // outcome is "hand's CLR type survives").
+        // The ingested mirror declares the hand-known "Symbol" property so
+        // DR-7 AONT201 does not fire — this fixture is exercising identity
+        // field merge, not the property-completeness diagnostic.
         var ingestedShadow = new ObjectTypeDescriptor
         {
             Name = "HandPosition",
@@ -227,6 +238,10 @@ public class MergeMatrixTests
             LanguageId = "typescript",
             Source = DescriptorSource.Ingested,
             SourceId = IngestSourceId,
+            Properties = new List<PropertyDescriptor>
+            {
+                new("Symbol", typeof(string)) { Source = DescriptorSource.Ingested },
+            },
         };
 
         var source = new TestOntologySource
@@ -248,6 +263,9 @@ public class MergeMatrixTests
     public async Task Merge_IdentityFields_FollowLatticeRule_SymbolKey()
     {
         // SymbolKey: ingestion is SCIP-authoritative — ingested wins.
+        // The ingested mirror declares the hand-known "Symbol" property so
+        // DR-7 AONT201 does not fire — this fixture is exercising identity
+        // field merge, not the property-completeness diagnostic.
         var ingestedShadow = new ObjectTypeDescriptor
         {
             Name = "HandPosition",
@@ -256,6 +274,10 @@ public class MergeMatrixTests
             LanguageId = "typescript",
             Source = DescriptorSource.Ingested,
             SourceId = IngestSourceId,
+            Properties = new List<PropertyDescriptor>
+            {
+                new("Symbol", typeof(string)) { Source = DescriptorSource.Ingested },
+            },
         };
 
         var source = new TestOntologySource
@@ -278,6 +300,9 @@ public class MergeMatrixTests
     public async Task Merge_IdentityFields_FollowLatticeRule_SymbolFqn()
     {
         // SymbolFqn: ingested wins.
+        // The ingested mirror declares the hand-known "Symbol" property so
+        // DR-7 AONT201 does not fire — this fixture is exercising identity
+        // field merge, not the property-completeness diagnostic.
         var ingestedShadow = new ObjectTypeDescriptor
         {
             Name = "HandPosition",
@@ -287,6 +312,10 @@ public class MergeMatrixTests
             LanguageId = "typescript",
             Source = DescriptorSource.Ingested,
             SourceId = IngestSourceId,
+            Properties = new List<PropertyDescriptor>
+            {
+                new("Symbol", typeof(string)) { Source = DescriptorSource.Ingested },
+            },
         };
 
         var source = new TestOntologySource
@@ -310,6 +339,9 @@ public class MergeMatrixTests
         // LanguageId: hand wins, even when ingestion declares a different
         // language. (The hand path's CLR origin pins the descriptor's
         // primary language identity.)
+        // The ingested mirror declares the hand-known "Symbol" property so
+        // DR-7 AONT201 does not fire — this fixture is exercising identity
+        // field merge, not the property-completeness diagnostic.
         var ingestedShadow = new ObjectTypeDescriptor
         {
             Name = "HandPosition",
@@ -318,6 +350,10 @@ public class MergeMatrixTests
             LanguageId = "typescript",
             Source = DescriptorSource.Ingested,
             SourceId = IngestSourceId,
+            Properties = new List<PropertyDescriptor>
+            {
+                new("Symbol", typeof(string)) { Source = DescriptorSource.Ingested },
+            },
         };
 
         var source = new TestOntologySource

--- a/src/Strategos.Ontology.Tests/Merge/MergeMatrixTests.cs
+++ b/src/Strategos.Ontology.Tests/Merge/MergeMatrixTests.cs
@@ -1,0 +1,337 @@
+using System.Collections.Immutable;
+
+using Strategos.Ontology;
+using Strategos.Ontology.Builder;
+using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Tests.TestInfrastructure;
+
+namespace Strategos.Ontology.Tests.Merge;
+
+/// <summary>
+/// DR-6 + DR-9 (Task 21): end-to-end merge matrix verifying the
+/// hand-vs-ingested lattice composes through
+/// <see cref="OntologyGraphBuilder.Build"/> — not through direct
+/// <c>MergeTwo</c> calls. Every assertion is on graph-level shape;
+/// no internal-state inspection. Uses
+/// <see cref="TestOntologySource"/> as the ingestion fixture.
+/// </summary>
+public class MergeMatrixTests
+{
+    private const string DomainName = "Trading";
+
+    private const string IngestSourceId = "marten-typescript";
+
+    private static readonly DateTimeOffset Timestamp =
+        new(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>Hand-authored model for the matrix; lives at fixture scope.</summary>
+    public sealed class HandPosition
+    {
+        public Guid Id { get; set; }
+
+        public string Symbol { get; set; } = "";
+    }
+
+    /// <summary>Ingestion-only mirror — no hand-authored counterpart.</summary>
+    public sealed class IngestedOnlyType
+    {
+        public Guid Id { get; set; }
+    }
+
+    public sealed class TradingOntology : DomainOntology
+    {
+        public override string DomainName => MergeMatrixTests.DomainName;
+
+        protected override void Define(IOntologyBuilder builder)
+        {
+            builder.Object<HandPosition>(obj =>
+            {
+                obj.Key(p => p.Id);
+                obj.Property(p => p.Symbol).Required();
+            });
+        }
+    }
+
+    public sealed class EmptyTradingOntology : DomainOntology
+    {
+        public override string DomainName => MergeMatrixTests.DomainName;
+
+        protected override void Define(IOntologyBuilder builder)
+        {
+            // intentionally empty — domain registered, no hand types
+        }
+    }
+
+    private static OntologyDelta.AddObjectType IngestedAdd(ObjectTypeDescriptor d) =>
+        new(d) { SourceId = IngestSourceId, Timestamp = Timestamp };
+
+    [Test]
+    public async Task Merge_HandOnly_GraphMatchesHand()
+    {
+        // No ingestion source — the composed graph carries only the
+        // hand-authored descriptor with HandAuthored provenance.
+        var graphBuilder = new OntologyGraphBuilder()
+            .AddDomain<TradingOntology>();
+
+        var graph = graphBuilder.Build();
+
+        var position = graph.ObjectTypes.Single(ot => ot.Name == "HandPosition");
+        await Assert.That(position.Source).IsEqualTo(DescriptorSource.HandAuthored);
+        await Assert.That(position.ClrType).IsEqualTo(typeof(HandPosition));
+        await Assert.That(position.Properties.Any(p => p.Name == "Symbol")).IsTrue();
+    }
+
+    [Test]
+    public async Task Merge_IngestedOnly_GraphMatchesIngested()
+    {
+        // Source-only descriptor in a domain with no DomainOntology subclass.
+        // The OntologyGraphBuilder.Build() source-only branch wraps the
+        // ingested type into a synthetic DomainDescriptor.
+        var ingested = new ObjectTypeDescriptor
+        {
+            Name = "IngestedOnly",
+            DomainName = DomainName,
+            SymbolKey = "scip-typescript ./mod.ts#IngestedOnly",
+            SymbolFqn = "mod.IngestedOnly",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = IngestSourceId,
+        };
+
+        var source = new TestOntologySource
+        {
+            SourceId = IngestSourceId,
+            Deltas = ImmutableArray.Create<OntologyDelta>(IngestedAdd(ingested)),
+        };
+
+        var graph = new OntologyGraphBuilder()
+            .AddSources(new IOntologySource[] { source })
+            .Build();
+
+        var resolved = graph.ObjectTypes.Single(ot => ot.Name == "IngestedOnly");
+        await Assert.That(resolved.Source).IsEqualTo(DescriptorSource.Ingested);
+        await Assert.That(resolved.SymbolKey).IsEqualTo("scip-typescript ./mod.ts#IngestedOnly");
+        await Assert.That(resolved.LanguageId).IsEqualTo("typescript");
+        await Assert.That(resolved.ClrType).IsNull();
+    }
+
+    [Test]
+    public async Task Merge_HandOverridesIngestedProperty_HandWins()
+    {
+        // Same descriptor name + domain via two paths: hand declares a
+        // "Symbol" property typed string; ingestion contributes a parallel
+        // "Symbol" property with a different (ingested-only) provenance.
+        // Hand wins per DR-6 — the resulting property carries
+        // Source = HandAuthored.
+        var ingestedShadow = new ObjectTypeDescriptor
+        {
+            Name = "HandPosition",
+            DomainName = DomainName,
+            SymbolKey = "scip-typescript ./pos.ts#HandPosition",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = IngestSourceId,
+            Properties = new List<PropertyDescriptor>
+            {
+                // Same name as the hand-authored property; conflict-loser side.
+                new("Symbol", typeof(string)) { Source = DescriptorSource.Ingested },
+            },
+        };
+
+        var source = new TestOntologySource
+        {
+            SourceId = IngestSourceId,
+            Deltas = ImmutableArray.Create<OntologyDelta>(IngestedAdd(ingestedShadow)),
+        };
+
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<TradingOntology>()
+            .AddSources(new IOntologySource[] { source })
+            .Build();
+
+        var position = graph.ObjectTypes.Single(ot => ot.Name == "HandPosition");
+        // Record-level provenance resolves to hand after merge.
+        await Assert.That(position.Source).IsEqualTo(DescriptorSource.HandAuthored);
+        // Symbol still present and tagged hand-authored — the ingested
+        // conflicting entry was dropped.
+        var symbol = position.Properties.Single(p => p.Name == "Symbol");
+        await Assert.That(symbol.Source).IsEqualTo(DescriptorSource.HandAuthored);
+    }
+
+    [Test]
+    public async Task Merge_IngestedAddsLink_LinkAppearsWithIngestedProvenance()
+    {
+        // Hand-only descriptor for HandPosition; ingestion contributes a
+        // *new* link not declared by hand. The link must surface in the
+        // composed graph tagged with Source = Ingested.
+        var ingestedShadow = new ObjectTypeDescriptor
+        {
+            Name = "HandPosition",
+            DomainName = DomainName,
+            SymbolKey = "scip-typescript ./pos.ts#HandPosition",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = IngestSourceId,
+            Links = new List<LinkDescriptor>
+            {
+                new("RelatedOrders", "Order", LinkCardinality.OneToMany)
+                {
+                    Source = DescriptorSource.Ingested,
+                    TargetSymbolKey = "scip-typescript ./ord.ts#Order",
+                },
+            },
+        };
+
+        var source = new TestOntologySource
+        {
+            SourceId = IngestSourceId,
+            Deltas = ImmutableArray.Create<OntologyDelta>(IngestedAdd(ingestedShadow)),
+        };
+
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<TradingOntology>()
+            .AddSources(new IOntologySource[] { source })
+            .Build();
+
+        var position = graph.ObjectTypes.Single(ot => ot.Name == "HandPosition");
+        var link = position.Links.Single(l => l.Name == "RelatedOrders");
+        await Assert.That(link.Source).IsEqualTo(DescriptorSource.Ingested);
+        await Assert.That(link.TargetSymbolKey).IsEqualTo("scip-typescript ./ord.ts#Order");
+    }
+
+    // ---- Merge_IdentityFields_FollowLatticeRule, parameterized per DR-6 ----
+    //
+    // The lattice rule per identity field (DR-6 lateral):
+    //   ClrType    : hand wins, fallback to ingested
+    //   SymbolKey  : ingested wins, fallback to hand
+    //   SymbolFqn  : ingested wins, fallback to hand
+    //   LanguageId : hand wins
+    //
+    // Each case is asserted by constructing a hand-authored descriptor that
+    // sets one identity field and an ingested descriptor that sets a
+    // different value for the same identity field, then reading back the
+    // merged value off the graph.
+
+    [Test]
+    public async Task Merge_IdentityFields_FollowLatticeRule_ClrType()
+    {
+        // ClrType: hand carries it; ingestion does not. Hand wins on the
+        // happy path (and since ingestion can't carry CLR identity, the
+        // outcome is "hand's CLR type survives").
+        var ingestedShadow = new ObjectTypeDescriptor
+        {
+            Name = "HandPosition",
+            DomainName = DomainName,
+            ClrType = null,
+            SymbolKey = "scip-typescript ./pos.ts#HandPosition",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = IngestSourceId,
+        };
+
+        var source = new TestOntologySource
+        {
+            SourceId = IngestSourceId,
+            Deltas = ImmutableArray.Create<OntologyDelta>(IngestedAdd(ingestedShadow)),
+        };
+
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<TradingOntology>()
+            .AddSources(new IOntologySource[] { source })
+            .Build();
+
+        var position = graph.ObjectTypes.Single(ot => ot.Name == "HandPosition");
+        await Assert.That(position.ClrType).IsEqualTo(typeof(HandPosition));
+    }
+
+    [Test]
+    public async Task Merge_IdentityFields_FollowLatticeRule_SymbolKey()
+    {
+        // SymbolKey: ingestion is SCIP-authoritative — ingested wins.
+        var ingestedShadow = new ObjectTypeDescriptor
+        {
+            Name = "HandPosition",
+            DomainName = DomainName,
+            SymbolKey = "scip-typescript ./pos.ts#HandPosition",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = IngestSourceId,
+        };
+
+        var source = new TestOntologySource
+        {
+            SourceId = IngestSourceId,
+            Deltas = ImmutableArray.Create<OntologyDelta>(IngestedAdd(ingestedShadow)),
+        };
+
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<TradingOntology>()
+            .AddSources(new IOntologySource[] { source })
+            .Build();
+
+        var position = graph.ObjectTypes.Single(ot => ot.Name == "HandPosition");
+        await Assert.That(position.SymbolKey)
+            .IsEqualTo("scip-typescript ./pos.ts#HandPosition");
+    }
+
+    [Test]
+    public async Task Merge_IdentityFields_FollowLatticeRule_SymbolFqn()
+    {
+        // SymbolFqn: ingested wins.
+        var ingestedShadow = new ObjectTypeDescriptor
+        {
+            Name = "HandPosition",
+            DomainName = DomainName,
+            SymbolKey = "scip-typescript ./pos.ts#HandPosition",
+            SymbolFqn = "mod.HandPosition",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = IngestSourceId,
+        };
+
+        var source = new TestOntologySource
+        {
+            SourceId = IngestSourceId,
+            Deltas = ImmutableArray.Create<OntologyDelta>(IngestedAdd(ingestedShadow)),
+        };
+
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<TradingOntology>()
+            .AddSources(new IOntologySource[] { source })
+            .Build();
+
+        var position = graph.ObjectTypes.Single(ot => ot.Name == "HandPosition");
+        await Assert.That(position.SymbolFqn).IsEqualTo("mod.HandPosition");
+    }
+
+    [Test]
+    public async Task Merge_IdentityFields_FollowLatticeRule_LanguageId()
+    {
+        // LanguageId: hand wins, even when ingestion declares a different
+        // language. (The hand path's CLR origin pins the descriptor's
+        // primary language identity.)
+        var ingestedShadow = new ObjectTypeDescriptor
+        {
+            Name = "HandPosition",
+            DomainName = DomainName,
+            SymbolKey = "scip-typescript ./pos.ts#HandPosition",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = IngestSourceId,
+        };
+
+        var source = new TestOntologySource
+        {
+            SourceId = IngestSourceId,
+            Deltas = ImmutableArray.Create<OntologyDelta>(IngestedAdd(ingestedShadow)),
+        };
+
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<TradingOntology>()
+            .AddSources(new IOntologySource[] { source })
+            .Build();
+
+        var position = graph.ObjectTypes.Single(ot => ot.Name == "HandPosition");
+        await Assert.That(position.LanguageId).IsEqualTo("dotnet");
+    }
+}

--- a/src/Strategos.Ontology.Tests/Merge/MergeTwoIdentityTests.cs
+++ b/src/Strategos.Ontology.Tests/Merge/MergeTwoIdentityTests.cs
@@ -1,0 +1,147 @@
+using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Merge;
+
+namespace Strategos.Ontology.Tests.Merge;
+
+/// <summary>
+/// Task 14 — MergeTwo lattice identity field tests (DR-6 lateral rule).
+/// </summary>
+/// <remarks>
+/// Per basileus ADR §9.2 the identity-field lattice rule is:
+/// <list type="bullet">
+/// <item><description><c>ClrType</c>: hand wins, fallback to ingested.</description></item>
+/// <item><description><c>SymbolKey</c>: ingested wins (SCIP authoritative), fallback to hand.</description></item>
+/// <item><description><c>SymbolFqn</c>: ingested wins, fallback to hand.</description></item>
+/// <item><description><c>LanguageId</c>: hand wins.</description></item>
+/// <item><description><c>Source</c>: HandAuthored (record-level — hand wins on composition).</description></item>
+/// <item><description><c>Actions</c>, <c>Events</c>, <c>Lifecycle</c>: hand only.</description></item>
+/// </list>
+/// </remarks>
+public class MergeTwoIdentityTests
+{
+    private sealed class HandModel { public Guid Id { get; set; } }
+
+    private static ObjectTypeDescriptor HandDescriptor() => new()
+    {
+        Name = "TradeOrder",
+        DomainName = "trading",
+        ClrType = typeof(HandModel),
+        LanguageId = "dotnet",
+        Source = DescriptorSource.HandAuthored,
+    };
+
+    private static ObjectTypeDescriptor IngestedDescriptor() => new()
+    {
+        Name = "TradeOrder",
+        DomainName = "trading",
+        SymbolKey = "scip-typescript ./mod#TradeOrder",
+        SymbolFqn = "Mod.TradeOrder",
+        LanguageId = "typescript",
+        Source = DescriptorSource.Ingested,
+        SourceId = "scip-source",
+    };
+
+    [Test]
+    public async Task MergeTwo_ClrType_HandWinsOverIngested()
+    {
+        var hand = HandDescriptor();
+        var ingested = IngestedDescriptor() with { ClrType = typeof(string) };
+
+        var merged = MergeTwo.Merge(hand, ingested);
+
+        await Assert.That(merged.ClrType).IsEqualTo(typeof(HandModel));
+    }
+
+    [Test]
+    public async Task MergeTwo_ClrType_FallsBackToIngestedWhenHandNull()
+    {
+        // Hand-authored descriptor with no ClrType (e.g. constructed via the
+        // descriptor-by-name overload with only SymbolKey). The lattice rule
+        // says hand wins, fallback to ingested.
+        var hand = new ObjectTypeDescriptor
+        {
+            Name = "TradeOrder",
+            DomainName = "trading",
+            SymbolKey = "hand-only-symbol",
+            Source = DescriptorSource.HandAuthored,
+        };
+        var ingested = IngestedDescriptor() with { ClrType = typeof(HandModel) };
+
+        var merged = MergeTwo.Merge(hand, ingested);
+
+        await Assert.That(merged.ClrType).IsEqualTo(typeof(HandModel));
+    }
+
+    [Test]
+    public async Task MergeTwo_SymbolKey_IngestedWinsOverHand()
+    {
+        var hand = HandDescriptor() with { SymbolKey = "hand-key" };
+        var ingested = IngestedDescriptor();
+
+        var merged = MergeTwo.Merge(hand, ingested);
+
+        await Assert.That(merged.SymbolKey).IsEqualTo("scip-typescript ./mod#TradeOrder");
+    }
+
+    [Test]
+    public async Task MergeTwo_SymbolKey_FallsBackToHandWhenIngestedNull()
+    {
+        var hand = HandDescriptor() with { SymbolKey = "hand-key" };
+        var ingested = new ObjectTypeDescriptor
+        {
+            Name = "TradeOrder",
+            DomainName = "trading",
+            ClrType = typeof(HandModel),
+            Source = DescriptorSource.Ingested,
+        };
+
+        var merged = MergeTwo.Merge(hand, ingested);
+
+        await Assert.That(merged.SymbolKey).IsEqualTo("hand-key");
+    }
+
+    [Test]
+    public async Task MergeTwo_LanguageId_HandWins()
+    {
+        var hand = HandDescriptor();
+        var ingested = IngestedDescriptor();
+
+        var merged = MergeTwo.Merge(hand, ingested);
+
+        await Assert.That(merged.LanguageId).IsEqualTo("dotnet");
+    }
+
+    [Test]
+    public async Task MergeTwo_SymbolFqn_IngestedWinsOverHand()
+    {
+        var hand = HandDescriptor() with { SymbolFqn = "Hand.TradeOrder" };
+        var ingested = IngestedDescriptor();
+
+        var merged = MergeTwo.Merge(hand, ingested);
+
+        await Assert.That(merged.SymbolFqn).IsEqualTo("Mod.TradeOrder");
+    }
+
+    [Test]
+    public async Task MergeTwo_Source_AlwaysHandAuthoredOnComposition()
+    {
+        var hand = HandDescriptor();
+        var ingested = IngestedDescriptor();
+
+        var merged = MergeTwo.Merge(hand, ingested);
+
+        await Assert.That(merged.Source).IsEqualTo(DescriptorSource.HandAuthored);
+    }
+
+    [Test]
+    public async Task MergeTwo_NameAndDomain_TakenFromHand()
+    {
+        var hand = HandDescriptor();
+        var ingested = IngestedDescriptor() with { Name = "OtherName", DomainName = "other" };
+
+        var merged = MergeTwo.Merge(hand, ingested);
+
+        await Assert.That(merged.Name).IsEqualTo("TradeOrder");
+        await Assert.That(merged.DomainName).IsEqualTo("trading");
+    }
+}

--- a/src/Strategos.Ontology.Tests/Merge/MergeTwoPropertyLinkTests.cs
+++ b/src/Strategos.Ontology.Tests/Merge/MergeTwoPropertyLinkTests.cs
@@ -164,4 +164,42 @@ public class MergeTwoPropertyLinkTests
         var payments = merged.Links.Single(l => l.Name == "Payments");
         await Assert.That(payments.Source).IsEqualTo(DescriptorSource.Ingested);
     }
+
+    [Test]
+    public async Task MergeTwo_DuplicateIngestedProperty_CollapsesToSingleEntry()
+    {
+        // Two ingested entries with the same Name — mechanical noise from
+        // a misbehaving ingester. The seen-set bookkeeping must collapse
+        // these to a single output so downstream callers don't observe
+        // a property twice.
+        var dup1 = new PropertyDescriptor("Notional", typeof(decimal))
+        { Source = DescriptorSource.Ingested };
+        var dup2 = new PropertyDescriptor("Notional", typeof(decimal))
+        { Source = DescriptorSource.Ingested };
+
+        var hand = BaseHand();
+        var ingested = BaseIngested(dup1, dup2);
+
+        var merged = MergeTwo.Merge(hand, ingested);
+
+        var hits = merged.Properties.Where(p => p.Name == "Notional").ToList();
+        await Assert.That(hits.Count).IsEqualTo(1);
+        await Assert.That(hits[0].Source).IsEqualTo(DescriptorSource.Ingested);
+    }
+
+    [Test]
+    public async Task MergeTwo_DuplicateIngestedLink_CollapsesToSingleEntry()
+    {
+        var dup1 = new LinkDescriptor("Payments", "Payment", LinkCardinality.OneToMany);
+        var dup2 = new LinkDescriptor("Payments", "Payment", LinkCardinality.OneToMany);
+
+        var hand = BaseHandWithLinks();
+        var ingested = BaseIngestedWithLinks(dup1, dup2);
+
+        var merged = MergeTwo.Merge(hand, ingested);
+
+        var hits = merged.Links.Where(l => l.Name == "Payments").ToList();
+        await Assert.That(hits.Count).IsEqualTo(1);
+        await Assert.That(hits[0].Source).IsEqualTo(DescriptorSource.Ingested);
+    }
 }

--- a/src/Strategos.Ontology.Tests/Merge/MergeTwoPropertyLinkTests.cs
+++ b/src/Strategos.Ontology.Tests/Merge/MergeTwoPropertyLinkTests.cs
@@ -1,0 +1,167 @@
+using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Merge;
+
+namespace Strategos.Ontology.Tests.Merge;
+
+/// <summary>
+/// Task 15 — MergeTwo property + link union tests.
+/// </summary>
+/// <remarks>
+/// Per-name union with hand-on-conflict precedence. Ingested-only entries
+/// arrive with <see cref="DescriptorSource.Ingested"/> tagging so callers
+/// (and downstream AONT201–AONT206 diagnostics) can distinguish origins.
+/// </remarks>
+public class MergeTwoPropertyLinkTests
+{
+    private sealed class HandModel { public Guid Id { get; set; } }
+
+    private static ObjectTypeDescriptor BaseHand(params PropertyDescriptor[] props) => new()
+    {
+        Name = "TradeOrder",
+        DomainName = "trading",
+        ClrType = typeof(HandModel),
+        Properties = props,
+        Source = DescriptorSource.HandAuthored,
+    };
+
+    private static ObjectTypeDescriptor BaseHandWithLinks(params LinkDescriptor[] links) => new()
+    {
+        Name = "TradeOrder",
+        DomainName = "trading",
+        ClrType = typeof(HandModel),
+        Links = links,
+        Source = DescriptorSource.HandAuthored,
+    };
+
+    private static ObjectTypeDescriptor BaseIngested(params PropertyDescriptor[] props) => new()
+    {
+        Name = "TradeOrder",
+        DomainName = "trading",
+        SymbolKey = "scip-typescript ./mod#TradeOrder",
+        Properties = props,
+        Source = DescriptorSource.Ingested,
+    };
+
+    private static ObjectTypeDescriptor BaseIngestedWithLinks(params LinkDescriptor[] links) => new()
+    {
+        Name = "TradeOrder",
+        DomainName = "trading",
+        SymbolKey = "scip-typescript ./mod#TradeOrder",
+        Links = links,
+        Source = DescriptorSource.Ingested,
+    };
+
+    // --- Properties ---
+
+    [Test]
+    public async Task MergeTwo_HandPropertyMissingFromIngested_BothPresent()
+    {
+        var handOnly = new PropertyDescriptor("Quantity", typeof(int))
+        { Source = DescriptorSource.HandAuthored };
+        var ingestedOnly = new PropertyDescriptor("Price", typeof(decimal))
+        { Source = DescriptorSource.Ingested };
+
+        var hand = BaseHand(handOnly);
+        var ingested = BaseIngested(ingestedOnly);
+
+        var merged = MergeTwo.Merge(hand, ingested);
+
+        await Assert.That(merged.Properties.Count).IsEqualTo(2);
+        await Assert.That(merged.Properties.Any(p => p.Name == "Quantity")).IsTrue();
+        await Assert.That(merged.Properties.Any(p => p.Name == "Price")).IsTrue();
+    }
+
+    [Test]
+    public async Task MergeTwo_PropertyConflict_HandWins()
+    {
+        var handProp = new PropertyDescriptor("Quantity", typeof(int), IsRequired: true)
+        { Source = DescriptorSource.HandAuthored };
+        var ingestedProp = new PropertyDescriptor("Quantity", typeof(long), IsRequired: false)
+        { Source = DescriptorSource.Ingested };
+
+        var hand = BaseHand(handProp);
+        var ingested = BaseIngested(ingestedProp);
+
+        var merged = MergeTwo.Merge(hand, ingested);
+
+        await Assert.That(merged.Properties.Count).IsEqualTo(1);
+        var quantity = merged.Properties.Single(p => p.Name == "Quantity");
+        await Assert.That(quantity.PropertyType).IsEqualTo(typeof(int));
+        await Assert.That(quantity.IsRequired).IsTrue();
+        await Assert.That(quantity.Source).IsEqualTo(DescriptorSource.HandAuthored);
+    }
+
+    [Test]
+    public async Task MergeTwo_IngestedOnlyProperty_TaggedIngested()
+    {
+        // Even if the caller hands us an ingested-only PropertyDescriptor
+        // whose Source defaulted to HandAuthored (e.g. raw constructor),
+        // MergeTwo must restamp it as Ingested so downstream diagnostics
+        // can distinguish origin.
+        var ingestedRaw = new PropertyDescriptor("Notes", typeof(string));
+        // ^ Source defaults to HandAuthored
+
+        var hand = BaseHand();
+        var ingested = BaseIngested(ingestedRaw);
+
+        var merged = MergeTwo.Merge(hand, ingested);
+
+        var notes = merged.Properties.Single(p => p.Name == "Notes");
+        await Assert.That(notes.Source).IsEqualTo(DescriptorSource.Ingested);
+    }
+
+    // --- Links ---
+
+    [Test]
+    public async Task MergeTwo_HandLinkMissingFromIngested_BothPresent()
+    {
+        var handOnly = new LinkDescriptor("Lines", "OrderLine", LinkCardinality.OneToMany)
+        { Source = DescriptorSource.HandAuthored };
+        var ingestedOnly = new LinkDescriptor("Payments", "Payment", LinkCardinality.OneToMany)
+        { Source = DescriptorSource.Ingested };
+
+        var hand = BaseHandWithLinks(handOnly);
+        var ingested = BaseIngestedWithLinks(ingestedOnly);
+
+        var merged = MergeTwo.Merge(hand, ingested);
+
+        await Assert.That(merged.Links.Count).IsEqualTo(2);
+        await Assert.That(merged.Links.Any(l => l.Name == "Lines")).IsTrue();
+        await Assert.That(merged.Links.Any(l => l.Name == "Payments")).IsTrue();
+    }
+
+    [Test]
+    public async Task MergeTwo_LinkConflict_HandWins()
+    {
+        var handLink = new LinkDescriptor("Lines", "OrderLine", LinkCardinality.OneToMany)
+        { Source = DescriptorSource.HandAuthored };
+        var ingestedLink = new LinkDescriptor("Lines", "DifferentTarget", LinkCardinality.OneToOne)
+        { Source = DescriptorSource.Ingested };
+
+        var hand = BaseHandWithLinks(handLink);
+        var ingested = BaseIngestedWithLinks(ingestedLink);
+
+        var merged = MergeTwo.Merge(hand, ingested);
+
+        await Assert.That(merged.Links.Count).IsEqualTo(1);
+        var lines = merged.Links.Single(l => l.Name == "Lines");
+        await Assert.That(lines.TargetTypeName).IsEqualTo("OrderLine");
+        await Assert.That(lines.Cardinality).IsEqualTo(LinkCardinality.OneToMany);
+        await Assert.That(lines.Source).IsEqualTo(DescriptorSource.HandAuthored);
+    }
+
+    [Test]
+    public async Task MergeTwo_IngestedOnlyLink_TaggedIngested()
+    {
+        var ingestedRaw = new LinkDescriptor("Payments", "Payment", LinkCardinality.OneToMany);
+        // ^ Source defaults to HandAuthored
+
+        var hand = BaseHandWithLinks();
+        var ingested = BaseIngestedWithLinks(ingestedRaw);
+
+        var merged = MergeTwo.Merge(hand, ingested);
+
+        var payments = merged.Links.Single(l => l.Name == "Payments");
+        await Assert.That(payments.Source).IsEqualTo(DescriptorSource.Ingested);
+    }
+}

--- a/src/Strategos.Ontology.Tests/OntologyGraphBuilderAONT041LinkTargetTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphBuilderAONT041LinkTargetTests.cs
@@ -1,4 +1,8 @@
+using System.Collections.Immutable;
+
 using Strategos.Ontology.Builder;
+using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Tests.TestInfrastructure;
 
 namespace Strategos.Ontology.Tests;
 
@@ -52,8 +56,41 @@ public class TradeOrderDefaultNameOntology : DomainOntology
     }
 }
 
+// DR-8 Task 31: CLR-keyed multi-registration of TradeOrder under two names ("orders" and
+// "open_orders") in the same domain. Portfolio links to the simple CLR name "TradeOrder".
+// This exercises the *core* multi-registration check (not the explicit-name sub-rule), and
+// is what the polyglot retarget must preserve — same identity under multiple names trips
+// AONT041 whether the identity is keyed by ClrType (this fixture) or SymbolKey (Task 31's
+// new test below).
+public class TradeOrderClrMultiRegOntology : DomainOntology
+{
+    public override string DomainName => "trading-clr-multireg";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TradeOrder>("orders", obj =>
+        {
+            obj.Key(t => t.Id);
+        });
+
+        builder.Object<TradeOrder>("open_orders", obj =>
+        {
+            obj.Key(t => t.Id);
+        });
+
+        builder.Object<Portfolio>(obj =>
+        {
+            obj.Key(p => p.Id);
+            obj.HasMany<TradeOrder>("Orders");
+        });
+    }
+}
+
 public class OntologyGraphBuilderAONT041LinkTargetTests
 {
+    private static readonly DateTimeOffset Timestamp =
+        new(2026, 5, 14, 12, 0, 0, TimeSpan.Zero);
+
     [Test]
     public async Task AONT041_LinkTargetWithExplicitDescriptorName_ThrowsCompositionException()
     {
@@ -78,5 +115,117 @@ public class OntologyGraphBuilderAONT041LinkTargetTests
 
         await Assert.That(graph).IsNotNull();
         await Assert.That(graph.ObjectTypes.Any(ot => ot.Name == "TradeOrder")).IsTrue();
+    }
+
+    // DR-8 Task 31: ClrType-keyed multi-registration still fires after the retarget.
+    // TradeOrder is registered under two distinct names in the same domain; Portfolio has
+    // HasMany<TradeOrder>("Orders") which writes TargetTypeName="TradeOrder" — the polyglot
+    // (DomainName, Name)-keyed lookup must resolve through that simple-name link to find
+    // a multi-registered identity and trip AONT041.
+    [Test]
+    public async Task AONT041_ClrTypeMultiRegistrationInLink_StillFires()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain<TradeOrderClrMultiRegOntology>();
+
+        var exception = await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithExceptionType(typeof(OntologyCompositionException));
+
+        await Assert.That(exception!.Message).Contains("AONT041");
+        // Both registered names should appear in the diagnostic so operators can locate
+        // the conflicting registrations.
+        await Assert.That(exception.Message).Contains("orders");
+        await Assert.That(exception.Message).Contains("open_orders");
+    }
+
+    // DR-8 Task 31: SymbolKey-keyed multi-registration in a link participant trips AONT041.
+    // Two ingested descriptors share the same SymbolKey but register under different names
+    // ("User" and "Account") in the same domain — the polyglot identity reverse index keys
+    // these by SymbolKey since ClrType is null. A separate hand-authored "Portfolio"-style
+    // descriptor declares a link with TargetTypeName="User", which after retarget resolves
+    // (Domain, "User") → the SymbolKey-keyed multi-registered descriptor.
+    [Test]
+    public async Task AONT041_SymbolKeyKeyedMultiRegistration_InLinkParticipant_Fires()
+    {
+        const string sharedSymbolKey = "scip-typescript ./mod#User";
+        const string domain = "polyglot-trading";
+
+        var userDescriptor = new ObjectTypeDescriptor
+        {
+            Name = "User",
+            DomainName = domain,
+            ClrType = null,
+            SymbolKey = sharedSymbolKey,
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = "marten-typescript-a",
+        };
+
+        var accountDescriptor = new ObjectTypeDescriptor
+        {
+            Name = "Account",
+            DomainName = domain,
+            ClrType = null,
+            SymbolKey = sharedSymbolKey,
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = "marten-typescript-b",
+        };
+
+        // Holder is an ingested-only descriptor that declares a link to "User" by name.
+        // Carrying the link directly on the descriptor (rather than via AddLink delta)
+        // lets the AONT041 source-side scan reach it without additional fixture wiring.
+        var holderDescriptor = new ObjectTypeDescriptor
+        {
+            Name = "Holder",
+            DomainName = domain,
+            ClrType = null,
+            SymbolKey = "scip-typescript ./mod#Holder",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = "marten-typescript-holder",
+            Links = new List<LinkDescriptor>
+            {
+                new LinkDescriptor("Users", "User", LinkCardinality.OneToMany)
+                {
+                    Source = DescriptorSource.Ingested,
+                },
+            }.AsReadOnly(),
+        };
+
+        var source = new TestOntologySource
+        {
+            SourceId = "marten-typescript-multireg",
+            Deltas = ImmutableArray.Create<OntologyDelta>(
+                new OntologyDelta.AddObjectType(userDescriptor)
+                {
+                    SourceId = "marten-typescript-a",
+                    Timestamp = Timestamp,
+                },
+                new OntologyDelta.AddObjectType(accountDescriptor)
+                {
+                    SourceId = "marten-typescript-b",
+                    Timestamp = Timestamp,
+                },
+                new OntologyDelta.AddObjectType(holderDescriptor)
+                {
+                    SourceId = "marten-typescript-holder",
+                    Timestamp = Timestamp,
+                }),
+        };
+
+        var graphBuilder = new OntologyGraphBuilder()
+            .AddSources(new IOntologySource[] { source });
+
+        var exception = await Assert.That(() => graphBuilder.Build())
+            .ThrowsException()
+            .WithExceptionType(typeof(OntologyCompositionException));
+
+        await Assert.That(exception!.Message).Contains("AONT041");
+        // The diagnostic must surface both same-SymbolKey registrations and the link
+        // that introduced the participation.
+        await Assert.That(exception.Message).Contains("User");
+        await Assert.That(exception.Message).Contains("Account");
     }
 }

--- a/src/Strategos.Ontology.Tests/OntologyGraphBuilderSourcesTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphBuilderSourcesTests.cs
@@ -77,6 +77,115 @@ public class OntologyGraphBuilderSourcesTests
             .IsTrue();
     }
 
-    // Task 17 (Build_SourceThrowsDuringLoadAsync_ExceptionMessageContainsSourceId)
-    // is appended to this file at task time per the implementer instructions.
+    // ----- Task 17: source-error propagation -----
+
+    [Test]
+    public async Task Build_SourceThrowsDuringLoadAsync_ExceptionMessageContainsSourceId()
+    {
+        // DR-10 failure mode 1: source raises during LoadAsync ⇒
+        // OntologyGraphBuilder.Build() propagates the exception as an
+        // OntologyCompositionException whose message contains the
+        // offending source's SourceId so logs/incident reports attribute
+        // the failure to the right ingester.
+        var throwingSource = new ThrowingSource("flaky-typescript");
+
+        var graphBuilder = new OntologyGraphBuilder()
+            .AddSources(new IOntologySource[] { throwingSource });
+
+        OntologyCompositionException? caught = null;
+        try
+        {
+            graphBuilder.Build();
+        }
+        catch (OntologyCompositionException ex)
+        {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNotNull();
+        await Assert.That(caught!.Message).Contains("flaky-typescript");
+    }
+
+    [Test]
+    public async Task Build_SourceThrowsAfterFirstDelta_ExceptionContainsSourceId()
+    {
+        // Variant: the source yields one delta and then raises; the wrap
+        // still catches the post-yield exception and surfaces SourceId.
+        var source = new PartialDrainThrowingSource("partial-typescript", Timestamp);
+
+        var graphBuilder = new OntologyGraphBuilder()
+            .AddSources(new IOntologySource[] { source });
+
+        OntologyCompositionException? caught = null;
+        try
+        {
+            graphBuilder.Build();
+        }
+        catch (OntologyCompositionException ex)
+        {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNotNull();
+        await Assert.That(caught!.Message).Contains("partial-typescript");
+        // Inner exception preserves the original failure for diagnostics.
+        await Assert.That(caught.InnerException).IsNotNull();
+    }
+
+    private sealed class ThrowingSource(string sourceId) : IOntologySource
+    {
+        public string SourceId { get; } = sourceId;
+
+        public async IAsyncEnumerable<OntologyDelta> LoadAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        {
+            await Task.Yield();
+            throw new InvalidOperationException("synthetic source failure");
+#pragma warning disable CS0162 // Unreachable code detected
+            yield break;
+#pragma warning restore CS0162
+        }
+
+        public async IAsyncEnumerable<OntologyDelta> SubscribeAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        {
+            await Task.Yield();
+            yield break;
+        }
+    }
+
+    private sealed class PartialDrainThrowingSource(string sourceId, DateTimeOffset timestamp)
+        : IOntologySource
+    {
+        public string SourceId { get; } = sourceId;
+
+        public async IAsyncEnumerable<OntologyDelta> LoadAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        {
+            await Task.Yield();
+
+            yield return new OntologyDelta.AddObjectType(
+                new ObjectTypeDescriptor
+                {
+                    Name = "Half",
+                    DomainName = "Trading",
+                    SymbolKey = "scip ./half#Half",
+                    Source = DescriptorSource.Ingested,
+                    SourceId = SourceId,
+                })
+            {
+                SourceId = SourceId,
+                Timestamp = timestamp,
+            };
+
+            throw new InvalidOperationException("synthetic mid-stream failure");
+        }
+
+        public async IAsyncEnumerable<OntologyDelta> SubscribeAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        {
+            await Task.Yield();
+            yield break;
+        }
+    }
 }

--- a/src/Strategos.Ontology.Tests/OntologyGraphBuilderSourcesTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphBuilderSourcesTests.cs
@@ -1,0 +1,82 @@
+using System.Collections.Immutable;
+
+using Strategos.Ontology;
+using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Tests.TestInfrastructure;
+
+namespace Strategos.Ontology.Tests;
+
+/// <summary>
+/// DR-3 + DR-10 (Tasks 13, 17): integration coverage for the
+/// <see cref="OntologyGraphBuilder.Build"/> source-drain. Two sources
+/// contributing different fields both reach the composed graph; a source
+/// that throws during <c>LoadAsync</c> surfaces its <c>SourceId</c> in
+/// the propagated <see cref="OntologyCompositionException"/>.
+/// </summary>
+public class OntologyGraphBuilderSourcesTests
+{
+    private static readonly DateTimeOffset Timestamp =
+        new(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+
+    [Test]
+    public async Task Build_TwoSourcesContributingDifferentFields_BothAppearInGraph()
+    {
+        var positionDescriptor = new ObjectTypeDescriptor
+        {
+            Name = "Position",
+            DomainName = "Trading",
+            ClrType = null,
+            SymbolKey = "scip-typescript ./pos.ts#Position",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = "marten-typescript",
+        };
+
+        var orderDescriptor = new ObjectTypeDescriptor
+        {
+            Name = "Order",
+            DomainName = "Trading",
+            ClrType = null,
+            SymbolKey = "scip-typescript ./ord.ts#Order",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = "marten-typescript-orders",
+        };
+
+        var sourceA = new TestOntologySource
+        {
+            SourceId = "marten-typescript",
+            Deltas = ImmutableArray.Create<OntologyDelta>(
+                new OntologyDelta.AddObjectType(positionDescriptor)
+                {
+                    SourceId = "marten-typescript",
+                    Timestamp = Timestamp,
+                }),
+        };
+
+        var sourceB = new TestOntologySource
+        {
+            SourceId = "marten-typescript-orders",
+            Deltas = ImmutableArray.Create<OntologyDelta>(
+                new OntologyDelta.AddObjectType(orderDescriptor)
+                {
+                    SourceId = "marten-typescript-orders",
+                    Timestamp = Timestamp,
+                }),
+        };
+
+        var graphBuilder = new OntologyGraphBuilder()
+            .AddSources(new IOntologySource[] { sourceA, sourceB });
+
+        var graph = graphBuilder.Build();
+
+        await Assert.That(graph.ObjectTypes.Count).IsEqualTo(2);
+        await Assert.That(graph.ObjectTypes.Any(ot => ot.Name == "Position" && ot.Source == DescriptorSource.Ingested))
+            .IsTrue();
+        await Assert.That(graph.ObjectTypes.Any(ot => ot.Name == "Order" && ot.Source == DescriptorSource.Ingested))
+            .IsTrue();
+    }
+
+    // Task 17 (Build_SourceThrowsDuringLoadAsync_ExceptionMessageContainsSourceId)
+    // is appended to this file at task time per the implementer instructions.
+}

--- a/src/Strategos.Ontology.Tests/Sources/IOntologySourceContractTests.cs
+++ b/src/Strategos.Ontology.Tests/Sources/IOntologySourceContractTests.cs
@@ -1,0 +1,68 @@
+using System.Runtime.CompilerServices;
+
+using Strategos.Ontology;
+
+namespace Strategos.Ontology.Tests.Sources;
+
+/// <summary>
+/// DR-3 (Task 7): contract tests for the <see cref="IOntologySource"/>
+/// extension point. Asserts the public interface shape — <c>SourceId</c>,
+/// <c>LoadAsync</c>, <c>SubscribeAsync</c> — and basic implementability.
+/// </summary>
+public class IOntologySourceContractTests
+{
+    [Test]
+    public async Task IOntologySource_ImplementedByTestSource_ExposesSourceId()
+    {
+        IOntologySource source = new ContractTestSource("marten-typescript");
+
+        await Assert.That(source.SourceId).IsEqualTo("marten-typescript");
+    }
+
+    [Test]
+    public async Task IOntologySource_LoadAsync_ReturnsAsyncEnumerable()
+    {
+        IOntologySource source = new ContractTestSource("source-a");
+
+        var count = 0;
+        await foreach (var _ in source.LoadAsync(CancellationToken.None))
+        {
+            count++;
+        }
+
+        await Assert.That(count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task IOntologySource_SubscribeAsync_CompletesImmediately()
+    {
+        IOntologySource source = new ContractTestSource("source-b");
+
+        var count = 0;
+        await foreach (var _ in source.SubscribeAsync(CancellationToken.None))
+        {
+            count++;
+        }
+
+        await Assert.That(count).IsEqualTo(0);
+    }
+
+    private sealed class ContractTestSource(string sourceId) : IOntologySource
+    {
+        public string SourceId { get; } = sourceId;
+
+        public async IAsyncEnumerable<OntologyDelta> LoadAsync(
+            [EnumeratorCancellation] CancellationToken ct)
+        {
+            await Task.Yield();
+            yield break;
+        }
+
+        public async IAsyncEnumerable<OntologyDelta> SubscribeAsync(
+            [EnumeratorCancellation] CancellationToken ct)
+        {
+            await Task.Yield();
+            yield break;
+        }
+    }
+}

--- a/src/Strategos.Ontology.Tests/Sources/OntologyDeltaTests.cs
+++ b/src/Strategos.Ontology.Tests/Sources/OntologyDeltaTests.cs
@@ -1,0 +1,176 @@
+using Strategos.Ontology;
+using Strategos.Ontology.Descriptors;
+
+namespace Strategos.Ontology.Tests.Sources;
+
+/// <summary>
+/// DR-4 (Task 8): construction + round-trip equality coverage for each
+/// of the eight <see cref="OntologyDelta"/> variants. Asserts the
+/// rename-as-single-delta invariant.
+/// </summary>
+public class OntologyDeltaTests
+{
+    private static readonly DateTimeOffset Timestamp =
+        new(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+
+    private const string SourceId = "marten-typescript";
+
+    [Test]
+    public async Task AddObjectType_Construction_RoundTrips()
+    {
+        var descriptor = new ObjectTypeDescriptor("Position", typeof(string), "Trading");
+
+        OntologyDelta delta = new OntologyDelta.AddObjectType(descriptor)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        };
+
+        await Assert.That(delta).IsTypeOf<OntologyDelta.AddObjectType>();
+        var add = (OntologyDelta.AddObjectType)delta;
+        await Assert.That(add.Descriptor).IsEqualTo(descriptor);
+        await Assert.That(add.SourceId).IsEqualTo(SourceId);
+        await Assert.That(add.Timestamp).IsEqualTo(Timestamp);
+    }
+
+    [Test]
+    public async Task UpdateObjectType_Construction_RoundTrips()
+    {
+        var descriptor = new ObjectTypeDescriptor("Position", typeof(string), "Trading");
+
+        var delta = new OntologyDelta.UpdateObjectType(descriptor)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        };
+
+        await Assert.That(delta.Descriptor).IsEqualTo(descriptor);
+        await Assert.That(delta.SourceId).IsEqualTo(SourceId);
+        await Assert.That(delta.Timestamp).IsEqualTo(Timestamp);
+    }
+
+    [Test]
+    public async Task RemoveObjectType_Construction_RoundTrips()
+    {
+        var delta = new OntologyDelta.RemoveObjectType("Trading", "Position")
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        };
+
+        await Assert.That(delta.DomainName).IsEqualTo("Trading");
+        await Assert.That(delta.TypeName).IsEqualTo("Position");
+        await Assert.That(delta.SourceId).IsEqualTo(SourceId);
+    }
+
+    [Test]
+    public async Task AddProperty_Construction_RoundTrips()
+    {
+        var property = new PropertyDescriptor("Symbol", typeof(string));
+
+        var delta = new OntologyDelta.AddProperty("Trading", "Position", property)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        };
+
+        await Assert.That(delta.DomainName).IsEqualTo("Trading");
+        await Assert.That(delta.TypeName).IsEqualTo("Position");
+        await Assert.That(delta.Descriptor).IsEqualTo(property);
+    }
+
+    [Test]
+    public async Task RenameProperty_Construction_RoundTrips()
+    {
+        var delta = new OntologyDelta.RenameProperty("Trading", "Position", "Sym", "Symbol")
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        };
+
+        await Assert.That(delta.DomainName).IsEqualTo("Trading");
+        await Assert.That(delta.TypeName).IsEqualTo("Position");
+        await Assert.That(delta.FromName).IsEqualTo("Sym");
+        await Assert.That(delta.ToName).IsEqualTo("Symbol");
+    }
+
+    [Test]
+    public async Task RenameProperty_IsSingleDelta_NotRemoveThenAdd()
+    {
+        // DR-4 invariant: rename preserves identity through the matcher,
+        // so it is expressed as a single delta rather than Remove+Add.
+        OntologyDelta delta = new OntologyDelta.RenameProperty(
+            "Trading", "Position", "Sym", "Symbol")
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        };
+
+        await Assert.That(delta).IsTypeOf<OntologyDelta.RenameProperty>();
+        await Assert.That(delta).IsNotTypeOf<OntologyDelta.RemoveProperty>();
+        await Assert.That(delta).IsNotTypeOf<OntologyDelta.AddProperty>();
+    }
+
+    [Test]
+    public async Task RemoveProperty_Construction_RoundTrips()
+    {
+        var delta = new OntologyDelta.RemoveProperty("Trading", "Position", "Symbol")
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        };
+
+        await Assert.That(delta.DomainName).IsEqualTo("Trading");
+        await Assert.That(delta.TypeName).IsEqualTo("Position");
+        await Assert.That(delta.PropertyName).IsEqualTo("Symbol");
+    }
+
+    [Test]
+    public async Task AddLink_Construction_RoundTrips()
+    {
+        var link = new LinkDescriptor("Orders", "Order", LinkCardinality.OneToMany);
+
+        var delta = new OntologyDelta.AddLink("Trading", "Position", link)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        };
+
+        await Assert.That(delta.DomainName).IsEqualTo("Trading");
+        await Assert.That(delta.SourceTypeName).IsEqualTo("Position");
+        await Assert.That(delta.Descriptor).IsEqualTo(link);
+    }
+
+    [Test]
+    public async Task RemoveLink_Construction_RoundTrips()
+    {
+        var delta = new OntologyDelta.RemoveLink("Trading", "Position", "Orders")
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        };
+
+        await Assert.That(delta.DomainName).IsEqualTo("Trading");
+        await Assert.That(delta.SourceTypeName).IsEqualTo("Position");
+        await Assert.That(delta.LinkName).IsEqualTo("Orders");
+    }
+
+    [Test]
+    public async Task AddObjectType_RecordEquality_HoldsForSameValues()
+    {
+        var descriptor = new ObjectTypeDescriptor("Position", typeof(string), "Trading");
+
+        var a = new OntologyDelta.AddObjectType(descriptor)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        };
+        var b = new OntologyDelta.AddObjectType(descriptor)
+        {
+            SourceId = SourceId,
+            Timestamp = Timestamp,
+        };
+
+        await Assert.That(a).IsEqualTo(b);
+    }
+}

--- a/src/Strategos.Ontology.Tests/Strategos.Ontology.Tests.csproj
+++ b/src/Strategos.Ontology.Tests/Strategos.Ontology.Tests.csproj
@@ -3,11 +3,24 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <!--
+      DR-9 (Task 22): SkipRoslynIntegrationTests gates the Roslyn
+      SymbolKey round-trip fixture. When set to a truthy value at
+      build time (e.g. `dotnet build -p:SkipRoslynIntegrationTests=true`),
+      the SKIP_ROSLYN_INTEGRATION_TESTS preprocessor symbol is defined
+      so SkipIfRoslynIntegrationDisabledAttribute statically reports
+      the test as skipped. The same attribute also honors the
+      identically-named environment variable for ad-hoc runs without
+      a rebuild.
+    -->
+    <SkipRoslynIntegrationTests Condition="'$(SkipRoslynIntegrationTests)' == ''">false</SkipRoslynIntegrationTests>
+    <DefineConstants Condition="'$(SkipRoslynIntegrationTests)' == 'true'">$(DefineConstants);SKIP_ROSLYN_INTEGRATION_TESTS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="TUnit" />
     <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>

--- a/src/Strategos.Ontology.Tests/TestInfrastructure/TestOntologySource.cs
+++ b/src/Strategos.Ontology.Tests/TestInfrastructure/TestOntologySource.cs
@@ -25,6 +25,11 @@ public sealed class TestOntologySource : IOntologySource
     public async IAsyncEnumerable<OntologyDelta> LoadAsync(
         [EnumeratorCancellation] CancellationToken ct)
     {
+        // Honor pre-cancelled tokens before the first await — otherwise
+        // a pre-cancelled call would complete normally (no deltas) instead
+        // of failing fast, which masks bad callers in tests.
+        ct.ThrowIfCancellationRequested();
+
         // Yield once so the method body runs asynchronously even when the
         // delta list is empty — keeps the contract consistent with the
         // production source wiring.
@@ -40,6 +45,7 @@ public sealed class TestOntologySource : IOntologySource
     public async IAsyncEnumerable<OntologyDelta> SubscribeAsync(
         [EnumeratorCancellation] CancellationToken ct)
     {
+        ct.ThrowIfCancellationRequested();
         await Task.Yield();
         yield break;
     }

--- a/src/Strategos.Ontology.Tests/TestInfrastructure/TestOntologySource.cs
+++ b/src/Strategos.Ontology.Tests/TestInfrastructure/TestOntologySource.cs
@@ -1,0 +1,46 @@
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+
+using Strategos.Ontology;
+
+namespace Strategos.Ontology.Tests.TestInfrastructure;
+
+/// <summary>
+/// In-memory <see cref="IOntologySource"/> fixture for unit/merge/diagnostic
+/// tests. <c>LoadAsync</c> yields the configured <see cref="Deltas"/> in
+/// order; <c>SubscribeAsync</c> completes immediately.
+/// </summary>
+/// <remarks>
+/// DR-9 (Task 20). The fixture matches production source wiring (same
+/// <see cref="IOntologySource"/> interface) so test code paths and the
+/// real ingester drain identical surfaces. Cancellation is honored
+/// between yields.
+/// </remarks>
+public sealed class TestOntologySource : IOntologySource
+{
+    public required string SourceId { get; init; }
+
+    public required ImmutableArray<OntologyDelta> Deltas { get; init; }
+
+    public async IAsyncEnumerable<OntologyDelta> LoadAsync(
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        // Yield once so the method body runs asynchronously even when the
+        // delta list is empty — keeps the contract consistent with the
+        // production source wiring.
+        await Task.Yield();
+
+        foreach (var delta in Deltas)
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return delta;
+        }
+    }
+
+    public async IAsyncEnumerable<OntologyDelta> SubscribeAsync(
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        await Task.Yield();
+        yield break;
+    }
+}

--- a/src/Strategos.Ontology.Tests/TestInfrastructure/TestOntologySourceTests.cs
+++ b/src/Strategos.Ontology.Tests/TestInfrastructure/TestOntologySourceTests.cs
@@ -1,0 +1,122 @@
+using System.Collections.Immutable;
+
+using Strategos.Ontology;
+using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Tests.TestInfrastructure;
+
+namespace Strategos.Ontology.Tests.TestInfrastructure;
+
+/// <summary>
+/// DR-9 (Task 20): contract tests for the <see cref="TestOntologySource"/>
+/// fixture used across merge/diagnostic/integration tests. Verifies the
+/// fixture matches production source wiring (same <see cref="IOntologySource"/>
+/// interface) and that <c>LoadAsync</c> yields configured deltas in order
+/// while <c>SubscribeAsync</c> completes immediately.
+/// </summary>
+public class TestOntologySourceTests
+{
+    private static readonly DateTimeOffset Timestamp =
+        new(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+
+    [Test]
+    public async Task TestOntologySource_LoadAsync_YieldsConfiguredDeltas()
+    {
+        var d1 = new OntologyDelta.AddObjectType(
+            new ObjectTypeDescriptor("A", typeof(string), "X"))
+        {
+            SourceId = "test",
+            Timestamp = Timestamp,
+        };
+        var d2 = new OntologyDelta.RemoveObjectType("X", "B")
+        {
+            SourceId = "test",
+            Timestamp = Timestamp,
+        };
+        var d3 = new OntologyDelta.RenameProperty("X", "C", "Old", "New")
+        {
+            SourceId = "test",
+            Timestamp = Timestamp,
+        };
+
+        var source = new TestOntologySource
+        {
+            SourceId = "test",
+            Deltas = ImmutableArray.Create<OntologyDelta>(d1, d2, d3),
+        };
+
+        var collected = new List<OntologyDelta>();
+        await foreach (var delta in source.LoadAsync(CancellationToken.None))
+        {
+            collected.Add(delta);
+        }
+
+        await Assert.That(collected.Count).IsEqualTo(3);
+        await Assert.That(collected[0]).IsEqualTo((OntologyDelta)d1);
+        await Assert.That(collected[1]).IsEqualTo((OntologyDelta)d2);
+        await Assert.That(collected[2]).IsEqualTo((OntologyDelta)d3);
+    }
+
+    [Test]
+    public async Task TestOntologySource_SubscribeAsync_CompletesImmediately()
+    {
+        var source = new TestOntologySource
+        {
+            SourceId = "test",
+            Deltas = ImmutableArray<OntologyDelta>.Empty,
+        };
+
+        var count = 0;
+        await foreach (var _ in source.SubscribeAsync(CancellationToken.None))
+        {
+            count++;
+        }
+
+        await Assert.That(count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task TestOntologySource_ImplementsIOntologySource()
+    {
+        var source = new TestOntologySource
+        {
+            SourceId = "test",
+            Deltas = ImmutableArray<OntologyDelta>.Empty,
+        };
+
+        await Assert.That((object)source).IsAssignableTo<IOntologySource>();
+        await Assert.That(source.SourceId).IsEqualTo("test");
+    }
+
+    [Test]
+    public async Task TestOntologySource_LoadAsync_HonorsCancellation()
+    {
+        var d = new OntologyDelta.RemoveObjectType("X", "B")
+        {
+            SourceId = "test",
+            Timestamp = Timestamp,
+        };
+        var source = new TestOntologySource
+        {
+            SourceId = "test",
+            Deltas = ImmutableArray.Create<OntologyDelta>(d, d),
+        };
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        OperationCanceledException? caught = null;
+        try
+        {
+            await foreach (var _ in source.LoadAsync(cts.Token))
+            {
+                // expected to throw before yielding
+            }
+        }
+        catch (OperationCanceledException ex)
+        {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNotNull();
+    }
+}

--- a/src/Strategos.Ontology.Tests/TestInfrastructure/TestOntologySourceTests.cs
+++ b/src/Strategos.Ontology.Tests/TestInfrastructure/TestOntologySourceTests.cs
@@ -119,4 +119,62 @@ public class TestOntologySourceTests
 
         await Assert.That(caught).IsNotNull();
     }
+
+    [Test]
+    public async Task TestOntologySource_LoadAsync_PreCancelled_EmptyDeltas_StillThrows()
+    {
+        // Regression: a pre-cancelled token must fail fast even when the
+        // delta list is empty. Previously the per-iteration check was the
+        // only guard, so a no-deltas Load would complete normally on an
+        // already-cancelled token.
+        var source = new TestOntologySource
+        {
+            SourceId = "test",
+            Deltas = ImmutableArray<OntologyDelta>.Empty,
+        };
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        OperationCanceledException? caught = null;
+        try
+        {
+            await foreach (var _ in source.LoadAsync(cts.Token))
+            {
+            }
+        }
+        catch (OperationCanceledException ex)
+        {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNotNull();
+    }
+
+    [Test]
+    public async Task TestOntologySource_SubscribeAsync_PreCancelled_Throws()
+    {
+        var source = new TestOntologySource
+        {
+            SourceId = "test",
+            Deltas = ImmutableArray<OntologyDelta>.Empty,
+        };
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        OperationCanceledException? caught = null;
+        try
+        {
+            await foreach (var _ in source.SubscribeAsync(cts.Token))
+            {
+            }
+        }
+        catch (OperationCanceledException ex)
+        {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNotNull();
+    }
 }

--- a/src/Strategos.Ontology/Builder/IOntologyBuilder.cs
+++ b/src/Strategos.Ontology/Builder/IOntologyBuilder.cs
@@ -1,3 +1,5 @@
+using Strategos.Ontology.Descriptors;
+
 namespace Strategos.Ontology.Builder;
 
 public interface IOntologyBuilder
@@ -24,4 +26,17 @@ public interface IOntologyBuilder
         where T : class;
 
     ICrossDomainLinkBuilder CrossDomainLink(string name);
+
+    /// <summary>
+    /// Registers an <see cref="ObjectTypeDescriptor"/> directly, bypassing
+    /// the expression-tree DSL. This is the mechanism
+    /// <see cref="IOntologySource"/> contributions reach the graph —
+    /// necessary because ingested types may only be known by
+    /// <c>SymbolKey</c>, with no loaded CLR type.
+    /// </summary>
+    /// <remarks>
+    /// DR-5 (Task 9). The descriptor's <see cref="ObjectTypeDescriptor.Source"/>
+    /// is preserved unchanged so provenance flows through to graph-freeze.
+    /// </remarks>
+    void ObjectTypeFromDescriptor(ObjectTypeDescriptor descriptor);
 }

--- a/src/Strategos.Ontology/Builder/IOntologyBuilder.cs
+++ b/src/Strategos.Ontology/Builder/IOntologyBuilder.cs
@@ -39,4 +39,17 @@ public interface IOntologyBuilder
     /// is preserved unchanged so provenance flows through to graph-freeze.
     /// </remarks>
     void ObjectTypeFromDescriptor(ObjectTypeDescriptor descriptor);
+
+    /// <summary>
+    /// Applies an <see cref="OntologyDelta"/> against the current builder
+    /// state. Dispatches by variant; the
+    /// <see cref="OntologyDelta.AddObjectType"/> branch routes to
+    /// <see cref="ObjectTypeFromDescriptor"/>. Unknown variants throw
+    /// <see cref="NotSupportedException"/>.
+    /// </summary>
+    /// <remarks>
+    /// DR-5 (Tasks 10 + 11). Polyglot ingestion deltas reach the graph
+    /// through this entry point.
+    /// </remarks>
+    void ApplyDelta(OntologyDelta delta);
 }

--- a/src/Strategos.Ontology/Builder/OntologyBuilder.cs
+++ b/src/Strategos.Ontology/Builder/OntologyBuilder.cs
@@ -12,6 +12,27 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
     private readonly List<InterfaceDescriptor> _interfaces = [];
     private readonly List<CrossDomainLinkBuilder> _crossDomainLinkBuilders = [];
 
+    // DR-7 (Tasks 23-30): retain a snapshot of the original ingested
+    // descriptor (pre-merge) per (DomainName, Name). The graph-freeze
+    // checks need to compare the hand-declared property set against the
+    // pre-merge ingested set: by the time MergeTwo has run, hand-only
+    // properties have been merged in alongside ingested-only ones, so a
+    // direct inspection of the merged descriptor cannot tell which side
+    // each property came from "originally". Keyed by
+    // (DomainName, Name); only the most recent ingested original is kept
+    // when the same (Domain, Name) collides (deltas are
+    // last-write-wins on the merged side, this snapshot follows that).
+    private readonly Dictionary<(string DomainName, string Name), ObjectTypeDescriptor> _ingestedOriginals = new();
+
+    /// <summary>
+    /// DR-7 graph-freeze: pre-merge ingested originals keyed by
+    /// (DomainName, Name). Surfaces to <see cref="OntologyGraphBuilder"/>
+    /// so AONT201–AONT208 can compare hand vs ingested without losing
+    /// provenance after MergeTwo's per-name union.
+    /// </summary>
+    internal IReadOnlyDictionary<(string DomainName, string Name), ObjectTypeDescriptor> IngestedOriginals
+        => _ingestedOriginals;
+
     public IReadOnlyList<ObjectTypeDescriptor> ObjectTypes => _objectTypes.AsReadOnly();
 
     public IReadOnlyList<InterfaceDescriptor> Interfaces => _interfaces.AsReadOnly();
@@ -67,6 +88,11 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
     {
         ArgumentNullException.ThrowIfNull(descriptor);
         EnsureIdentityInvariant(descriptor);
+
+        // DR-7 (Tasks 23-30): snapshot the pre-merge ingested original so
+        // graph-freeze diagnostics can compare hand vs ingested property
+        // sets after MergeTwo collapses provenance into a single list.
+        SyncIngestedOriginal(descriptor);
 
         var existingIdx = FindObjectTypeIndex(descriptor.DomainName, descriptor.Name);
         if (existingIdx >= 0
@@ -239,6 +265,13 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
         var d = delta.Descriptor;
         EnsureIdentityInvariant(d);
 
+        // DR-7: keep the ingested-original snapshot synchronized with
+        // descriptor lifecycle. An Update that flips a descriptor from
+        // ingested → hand (or replaces a previous ingested original) must
+        // refresh / remove the snapshot; otherwise graph-freeze
+        // diagnostics compare against stale data.
+        SyncIngestedOriginal(d);
+
         var idx = FindObjectTypeIndex(d.DomainName, d.Name);
         if (idx < 0)
         {
@@ -266,6 +299,32 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
         if (idx >= 0)
         {
             _objectTypes.RemoveAt(idx);
+        }
+
+        // DR-7: drop any ingested-original snapshot for this
+        // (DomainName, Name) so a subsequent Add for the same key
+        // doesn't compare against a stale pre-merge snapshot.
+        _ingestedOriginals.Remove((delta.DomainName, delta.TypeName));
+    }
+
+    /// <summary>
+    /// DR-7: keep <see cref="_ingestedOriginals"/> consistent with the
+    /// descriptor at <c>(descriptor.DomainName, descriptor.Name)</c>.
+    /// An ingested descriptor refreshes the snapshot; a hand-authored
+    /// descriptor (overwriting a previous ingested entry via Update)
+    /// drops the snapshot so AONT201–AONT208 don't compare against the
+    /// stale ingested side.
+    /// </summary>
+    private void SyncIngestedOriginal(ObjectTypeDescriptor descriptor)
+    {
+        var key = (descriptor.DomainName, descriptor.Name);
+        if (descriptor.Source == DescriptorSource.Ingested)
+        {
+            _ingestedOriginals[key] = descriptor;
+        }
+        else
+        {
+            _ingestedOriginals.Remove(key);
         }
     }
 

--- a/src/Strategos.Ontology/Builder/OntologyBuilder.cs
+++ b/src/Strategos.Ontology/Builder/OntologyBuilder.cs
@@ -43,4 +43,16 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
         _crossDomainLinkBuilders.Add(builder);
         return builder;
     }
+
+    /// <summary>
+    /// DR-5 (Task 9): registers a fully-specified descriptor without the
+    /// expression-tree DSL. Source provenance is preserved so ingested
+    /// descriptors flow through to graph-freeze tagged as such.
+    /// </summary>
+    public void ObjectTypeFromDescriptor(ObjectTypeDescriptor descriptor)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        _objectTypes.Add(descriptor);
+    }
 }

--- a/src/Strategos.Ontology/Builder/OntologyBuilder.cs
+++ b/src/Strategos.Ontology/Builder/OntologyBuilder.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 
 using Strategos.Ontology.Descriptors;
 using Strategos.Ontology.Diagnostics;
+using Strategos.Ontology.Merge;
 
 namespace Strategos.Ontology.Builder;
 
@@ -52,9 +53,41 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
     /// expression-tree DSL. Source provenance is preserved so ingested
     /// descriptors flow through to graph-freeze tagged as such.
     /// </summary>
+    /// <remarks>
+    /// DR-6 + Task 21: when an existing descriptor already occupies the
+    /// incoming <c>(DomainName, Name)</c> slot with opposite provenance
+    /// (one hand, one ingested), the two are folded through
+    /// <see cref="MergeTwo.Merge"/> in place. This is what makes
+    /// hand-authored intent and mechanical ingest meet without tripping
+    /// AONT040 on duplicate names. Same-provenance collisions continue
+    /// to surface as duplicates (the dup-name diagnostic handles that
+    /// case downstream).
+    /// </remarks>
     public void ObjectTypeFromDescriptor(ObjectTypeDescriptor descriptor)
     {
         ArgumentNullException.ThrowIfNull(descriptor);
+
+        var existingIdx = FindObjectTypeIndex(descriptor.DomainName, descriptor.Name);
+        if (existingIdx >= 0)
+        {
+            var existing = _objectTypes[existingIdx];
+            // Cross-provenance fold: hand ↔ ingested. Identify the hand
+            // side regardless of arrival order so the merge contract
+            // (hand, ingested) is satisfied either way.
+            if (existing.Source == DescriptorSource.HandAuthored
+                && descriptor.Source == DescriptorSource.Ingested)
+            {
+                _objectTypes[existingIdx] = MergeTwo.Merge(hand: existing, ingested: descriptor);
+                return;
+            }
+
+            if (existing.Source == DescriptorSource.Ingested
+                && descriptor.Source == DescriptorSource.HandAuthored)
+            {
+                _objectTypes[existingIdx] = MergeTwo.Merge(hand: descriptor, ingested: existing);
+                return;
+            }
+        }
 
         _objectTypes.Add(descriptor);
     }

--- a/src/Strategos.Ontology/Builder/OntologyBuilder.cs
+++ b/src/Strategos.Ontology/Builder/OntologyBuilder.cs
@@ -57,10 +57,12 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
     }
 
     /// <summary>
-    /// DR-5 (Task 10): dispatches an <see cref="OntologyDelta"/> by
-    /// variant. The <see cref="OntologyDelta.AddObjectType"/> branch
-    /// routes to <see cref="ObjectTypeFromDescriptor"/>. Task 11 extends
-    /// this switch to the remaining variants.
+    /// DR-5 (Tasks 10 + 11): dispatches an <see cref="OntologyDelta"/>
+    /// by variant. The <see cref="OntologyDelta.AddObjectType"/> branch
+    /// routes to <see cref="ObjectTypeFromDescriptor"/>; the remaining
+    /// seven variants are handled inline below. The default arm throws
+    /// <see cref="NotSupportedException"/> naming the offending variant
+    /// type (AC2: explicit fallthrough).
     /// </summary>
     public void ApplyDelta(OntologyDelta delta)
     {
@@ -72,9 +74,151 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
                 ObjectTypeFromDescriptor(add.Descriptor);
                 break;
 
+            case OntologyDelta.UpdateObjectType update:
+                ApplyUpdateObjectType(update);
+                break;
+
+            case OntologyDelta.RemoveObjectType remove:
+                ApplyRemoveObjectType(remove);
+                break;
+
+            case OntologyDelta.AddProperty addProp:
+                ApplyAddProperty(addProp);
+                break;
+
+            case OntologyDelta.RenameProperty rename:
+                ApplyRenameProperty(rename);
+                break;
+
+            case OntologyDelta.RemoveProperty removeProp:
+                ApplyRemoveProperty(removeProp);
+                break;
+
+            case OntologyDelta.AddLink addLink:
+                ApplyAddLink(addLink);
+                break;
+
+            case OntologyDelta.RemoveLink removeLink:
+                ApplyRemoveLink(removeLink);
+                break;
+
             default:
                 throw new NotSupportedException(
                     $"Unknown delta variant: {delta.GetType().Name}");
         }
+    }
+
+    private void ApplyUpdateObjectType(OntologyDelta.UpdateObjectType delta)
+    {
+        var d = delta.Descriptor;
+        var idx = FindObjectTypeIndex(d.DomainName, d.Name);
+        if (idx < 0)
+        {
+            // Treat as add if not present — keeps the surface forgiving
+            // for sources that emit Update without a prior Add (e.g. a
+            // restart that lost partial state). Idempotent.
+            _objectTypes.Add(d);
+            return;
+        }
+
+        _objectTypes[idx] = d;
+    }
+
+    private void ApplyRemoveObjectType(OntologyDelta.RemoveObjectType delta)
+    {
+        var idx = FindObjectTypeIndex(delta.DomainName, delta.TypeName);
+        if (idx >= 0)
+        {
+            _objectTypes.RemoveAt(idx);
+        }
+    }
+
+    private void ApplyAddProperty(OntologyDelta.AddProperty delta)
+    {
+        var idx = FindObjectTypeIndex(delta.DomainName, delta.TypeName);
+        if (idx < 0)
+        {
+            return;
+        }
+
+        var current = _objectTypes[idx];
+        var updated = current.Properties.ToList();
+        updated.Add(delta.Descriptor);
+        _objectTypes[idx] = current with { Properties = updated.AsReadOnly() };
+    }
+
+    private void ApplyRenameProperty(OntologyDelta.RenameProperty delta)
+    {
+        var idx = FindObjectTypeIndex(delta.DomainName, delta.TypeName);
+        if (idx < 0)
+        {
+            return;
+        }
+
+        var current = _objectTypes[idx];
+        var updated = current.Properties.ToList();
+        for (var i = 0; i < updated.Count; i++)
+        {
+            if (updated[i].Name == delta.FromName)
+            {
+                updated[i] = updated[i] with { Name = delta.ToName };
+            }
+        }
+
+        _objectTypes[idx] = current with { Properties = updated.AsReadOnly() };
+    }
+
+    private void ApplyRemoveProperty(OntologyDelta.RemoveProperty delta)
+    {
+        var idx = FindObjectTypeIndex(delta.DomainName, delta.TypeName);
+        if (idx < 0)
+        {
+            return;
+        }
+
+        var current = _objectTypes[idx];
+        var updated = current.Properties.Where(p => p.Name != delta.PropertyName).ToList();
+        _objectTypes[idx] = current with { Properties = updated.AsReadOnly() };
+    }
+
+    private void ApplyAddLink(OntologyDelta.AddLink delta)
+    {
+        var idx = FindObjectTypeIndex(delta.DomainName, delta.SourceTypeName);
+        if (idx < 0)
+        {
+            return;
+        }
+
+        var current = _objectTypes[idx];
+        var updated = current.Links.ToList();
+        updated.Add(delta.Descriptor);
+        _objectTypes[idx] = current with { Links = updated.AsReadOnly() };
+    }
+
+    private void ApplyRemoveLink(OntologyDelta.RemoveLink delta)
+    {
+        var idx = FindObjectTypeIndex(delta.DomainName, delta.SourceTypeName);
+        if (idx < 0)
+        {
+            return;
+        }
+
+        var current = _objectTypes[idx];
+        var updated = current.Links.Where(l => l.Name != delta.LinkName).ToList();
+        _objectTypes[idx] = current with { Links = updated.AsReadOnly() };
+    }
+
+    private int FindObjectTypeIndex(string domainName, string typeName)
+    {
+        for (var i = 0; i < _objectTypes.Count; i++)
+        {
+            var ot = _objectTypes[i];
+            if (ot.DomainName == domainName && ot.Name == typeName)
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 }

--- a/src/Strategos.Ontology/Builder/OntologyBuilder.cs
+++ b/src/Strategos.Ontology/Builder/OntologyBuilder.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 
 using Strategos.Ontology.Descriptors;
 using Strategos.Ontology.Diagnostics;
@@ -31,7 +32,10 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
     /// provenance after MergeTwo's per-name union.
     /// </summary>
     internal IReadOnlyDictionary<(string DomainName, string Name), ObjectTypeDescriptor> IngestedOriginals
-        => _ingestedOriginals;
+        // Defensive wrapper: callers must not be able to cast back to
+        // Dictionary<,> and mutate the snapshot. A fresh ReadOnlyDictionary
+        // each access is cheap (graph-freeze reads it once per build).
+        => new ReadOnlyDictionary<(string DomainName, string Name), ObjectTypeDescriptor>(_ingestedOriginals);
 
     public IReadOnlyList<ObjectTypeDescriptor> ObjectTypes => _objectTypes.AsReadOnly();
 
@@ -265,13 +269,6 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
         var d = delta.Descriptor;
         EnsureIdentityInvariant(d);
 
-        // DR-7: keep the ingested-original snapshot synchronized with
-        // descriptor lifecycle. An Update that flips a descriptor from
-        // ingested → hand (or replaces a previous ingested original) must
-        // refresh / remove the snapshot; otherwise graph-freeze
-        // diagnostics compare against stale data.
-        SyncIngestedOriginal(d);
-
         var idx = FindObjectTypeIndex(d.DomainName, d.Name);
         if (idx < 0)
         {
@@ -279,6 +276,10 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
             // for sources that emit Update without a prior Add (e.g. a
             // restart that lost partial state). Idempotent.
             _objectTypes.Add(d);
+            // No prior descriptor means no cross-provenance fold could
+            // have happened: SyncIngestedOriginal applies its normal rule
+            // (ingested → store, hand → clear).
+            SyncIngestedOriginal(d);
             return;
         }
 
@@ -288,9 +289,34 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
         // the other. Same-provenance Updates replace at the existing
         // index (no duplicate created, unlike the Add path which lets
         // AONT040 surface duplicates downstream).
-        _objectTypes[idx] = TryCrossProvenanceMerge(_objectTypes[idx], d, out var merged)
+        var existing = _objectTypes[idx];
+        _objectTypes[idx] = TryCrossProvenanceMerge(existing, d, out var merged)
             ? merged
             : d;
+
+        // DR-7: sync the ingested-original snapshot AFTER the merge
+        // decision. When an incoming hand-authored Update folds against
+        // an existing ingested baseline, MergeTwo keeps the ingested
+        // contributions — so the snapshot must be preserved (not cleared
+        // as a vanilla hand Update would do). The order matters:
+        //   - incoming ingested → always refresh snapshot from incoming.
+        //   - incoming hand, existing ingested → preserve existing
+        //     snapshot so AONT201–AONT208 can still diff hand vs ingested.
+        //   - incoming hand, existing hand → no ingested side; clear any
+        //     stale snapshot defensively.
+        var key = (d.DomainName, d.Name);
+        if (d.Source == DescriptorSource.Ingested)
+        {
+            _ingestedOriginals[key] = d;
+        }
+        else if (existing.Source == DescriptorSource.Ingested)
+        {
+            _ingestedOriginals[key] = existing;
+        }
+        else
+        {
+            _ingestedOriginals.Remove(key);
+        }
     }
 
     private void ApplyRemoveObjectType(OntologyDelta.RemoveObjectType delta)
@@ -340,6 +366,13 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
         var updated = current.Properties.ToList();
         updated.Add(delta.Descriptor);
         _objectTypes[idx] = current with { Properties = updated.AsReadOnly() };
+
+        // DR-7: mirror the same property mutation into the ingested
+        // snapshot so DR-7 diagnostics don't read stale pre-delta
+        // properties. No-op if there's no ingested baseline for this key.
+        MutateIngestedOriginalProperties(
+            (delta.DomainName, delta.TypeName),
+            props => props.Add(delta.Descriptor));
     }
 
     private void ApplyRenameProperty(OntologyDelta.RenameProperty delta)
@@ -361,6 +394,19 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
         }
 
         _objectTypes[idx] = current with { Properties = updated.AsReadOnly() };
+
+        MutateIngestedOriginalProperties(
+            (delta.DomainName, delta.TypeName),
+            props =>
+            {
+                for (var i = 0; i < props.Count; i++)
+                {
+                    if (props[i].Name == delta.FromName)
+                    {
+                        props[i] = props[i] with { Name = delta.ToName };
+                    }
+                }
+            });
     }
 
     private void ApplyRemoveProperty(OntologyDelta.RemoveProperty delta)
@@ -374,6 +420,10 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
         var current = _objectTypes[idx];
         var updated = current.Properties.Where(p => p.Name != delta.PropertyName).ToList();
         _objectTypes[idx] = current with { Properties = updated.AsReadOnly() };
+
+        MutateIngestedOriginalProperties(
+            (delta.DomainName, delta.TypeName),
+            props => props.RemoveAll(p => p.Name == delta.PropertyName));
     }
 
     private void ApplyAddLink(OntologyDelta.AddLink delta)
@@ -388,6 +438,10 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
         var updated = current.Links.ToList();
         updated.Add(delta.Descriptor);
         _objectTypes[idx] = current with { Links = updated.AsReadOnly() };
+
+        MutateIngestedOriginalLinks(
+            (delta.DomainName, delta.SourceTypeName),
+            links => links.Add(delta.Descriptor));
     }
 
     private void ApplyRemoveLink(OntologyDelta.RemoveLink delta)
@@ -401,6 +455,48 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
         var current = _objectTypes[idx];
         var updated = current.Links.Where(l => l.Name != delta.LinkName).ToList();
         _objectTypes[idx] = current with { Links = updated.AsReadOnly() };
+
+        MutateIngestedOriginalLinks(
+            (delta.DomainName, delta.SourceTypeName),
+            links => links.RemoveAll(l => l.Name == delta.LinkName));
+    }
+
+    /// <summary>
+    /// DR-7: apply <paramref name="mutate"/> to the ingested-original
+    /// property list at <paramref name="key"/> if one exists; no-op if
+    /// the key has no ingested baseline (the snapshot drives DR-7
+    /// diagnostics only when both sides contributed).
+    /// </summary>
+    private void MutateIngestedOriginalProperties(
+        (string DomainName, string Name) key,
+        Action<List<PropertyDescriptor>> mutate)
+    {
+        if (!_ingestedOriginals.TryGetValue(key, out var current))
+        {
+            return;
+        }
+
+        var properties = current.Properties.ToList();
+        mutate(properties);
+        _ingestedOriginals[key] = current with { Properties = properties.AsReadOnly() };
+    }
+
+    /// <summary>
+    /// DR-7 link-mutation mirror — see
+    /// <see cref="MutateIngestedOriginalProperties"/>.
+    /// </summary>
+    private void MutateIngestedOriginalLinks(
+        (string DomainName, string Name) key,
+        Action<List<LinkDescriptor>> mutate)
+    {
+        if (!_ingestedOriginals.TryGetValue(key, out var current))
+        {
+            return;
+        }
+
+        var links = current.Links.ToList();
+        mutate(links);
+        _ingestedOriginals[key] = current with { Links = links.AsReadOnly() };
     }
 
     private int FindObjectTypeIndex(string domainName, string typeName)

--- a/src/Strategos.Ontology/Builder/OntologyBuilder.cs
+++ b/src/Strategos.Ontology/Builder/OntologyBuilder.cs
@@ -1,4 +1,7 @@
+using System.Collections.Immutable;
+
 using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Diagnostics;
 
 namespace Strategos.Ontology.Builder;
 
@@ -71,10 +74,12 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
         switch (delta)
         {
             case OntologyDelta.AddObjectType add:
+                ValidateIngestedIntentInvariant(add.Descriptor);
                 ObjectTypeFromDescriptor(add.Descriptor);
                 break;
 
             case OntologyDelta.UpdateObjectType update:
+                ValidateIngestedIntentInvariant(update.Descriptor);
                 ApplyUpdateObjectType(update);
                 break;
 
@@ -106,6 +111,57 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
                 throw new NotSupportedException(
                     $"Unknown delta variant: {delta.GetType().Name}");
         }
+    }
+
+    /// <summary>
+    /// DR-6 + DR-10 (Task 16): AONT205 invariant — a mechanical ingester
+    /// (descriptor with <see cref="DescriptorSource.Ingested"/>) cannot
+    /// contribute to the intent-only fields <see cref="ObjectTypeDescriptor.Actions"/>,
+    /// <see cref="ObjectTypeDescriptor.Events"/>, or
+    /// <see cref="ObjectTypeDescriptor.Lifecycle"/>. Hand-authored
+    /// descriptors pass through unchanged. On violation, throws
+    /// <see cref="OntologyCompositionException"/> with an AONT205
+    /// diagnostic naming the offending field, the domain, and the type.
+    /// </summary>
+    private static void ValidateIngestedIntentInvariant(ObjectTypeDescriptor descriptor)
+    {
+        if (descriptor.Source != DescriptorSource.Ingested)
+        {
+            return;
+        }
+
+        string? offendingField = null;
+        if (descriptor.Actions.Count > 0)
+        {
+            offendingField = "Actions";
+        }
+        else if (descriptor.Events.Count > 0)
+        {
+            offendingField = "Events";
+        }
+        else if (descriptor.Lifecycle is not null)
+        {
+            offendingField = "Lifecycle";
+        }
+
+        if (offendingField is null)
+        {
+            return;
+        }
+
+        var diagnostic = new OntologyDiagnostic(
+            Id: "AONT205",
+            Message:
+                $"AONT205: ingested descriptor '{descriptor.DomainName}.{descriptor.Name}' "
+                + $"contributes to intent-only field '{offendingField}'. "
+                + $"Mechanical ingesters (Source = Ingested, SourceId = '{descriptor.SourceId ?? "<unknown>"}') "
+                + $"must leave Actions, Events, and Lifecycle empty — those are hand-authored intent.",
+            Severity: OntologyDiagnosticSeverity.Error,
+            DomainName: descriptor.DomainName,
+            TypeName: descriptor.Name,
+            PropertyName: offendingField);
+
+        throw new OntologyCompositionException(ImmutableArray.Create(diagnostic));
     }
 
     private void ApplyUpdateObjectType(OntologyDelta.UpdateObjectType delta)

--- a/src/Strategos.Ontology/Builder/OntologyBuilder.cs
+++ b/src/Strategos.Ontology/Builder/OntologyBuilder.cs
@@ -55,4 +55,26 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
 
         _objectTypes.Add(descriptor);
     }
+
+    /// <summary>
+    /// DR-5 (Task 10): dispatches an <see cref="OntologyDelta"/> by
+    /// variant. The <see cref="OntologyDelta.AddObjectType"/> branch
+    /// routes to <see cref="ObjectTypeFromDescriptor"/>. Task 11 extends
+    /// this switch to the remaining variants.
+    /// </summary>
+    public void ApplyDelta(OntologyDelta delta)
+    {
+        ArgumentNullException.ThrowIfNull(delta);
+
+        switch (delta)
+        {
+            case OntologyDelta.AddObjectType add:
+                ObjectTypeFromDescriptor(add.Descriptor);
+                break;
+
+            default:
+                throw new NotSupportedException(
+                    $"Unknown delta variant: {delta.GetType().Name}");
+        }
+    }
 }

--- a/src/Strategos.Ontology/Builder/OntologyBuilder.cs
+++ b/src/Strategos.Ontology/Builder/OntologyBuilder.cs
@@ -66,30 +66,67 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
     public void ObjectTypeFromDescriptor(ObjectTypeDescriptor descriptor)
     {
         ArgumentNullException.ThrowIfNull(descriptor);
+        EnsureIdentityInvariant(descriptor);
 
         var existingIdx = FindObjectTypeIndex(descriptor.DomainName, descriptor.Name);
-        if (existingIdx >= 0)
+        if (existingIdx >= 0
+            && TryCrossProvenanceMerge(_objectTypes[existingIdx], descriptor, out var merged))
         {
-            var existing = _objectTypes[existingIdx];
-            // Cross-provenance fold: hand ↔ ingested. Identify the hand
-            // side regardless of arrival order so the merge contract
-            // (hand, ingested) is satisfied either way.
-            if (existing.Source == DescriptorSource.HandAuthored
-                && descriptor.Source == DescriptorSource.Ingested)
-            {
-                _objectTypes[existingIdx] = MergeTwo.Merge(hand: existing, ingested: descriptor);
-                return;
-            }
-
-            if (existing.Source == DescriptorSource.Ingested
-                && descriptor.Source == DescriptorSource.HandAuthored)
-            {
-                _objectTypes[existingIdx] = MergeTwo.Merge(hand: descriptor, ingested: existing);
-                return;
-            }
+            _objectTypes[existingIdx] = merged;
+            return;
         }
 
         _objectTypes.Add(descriptor);
+    }
+
+    /// <summary>
+    /// Attempts the DR-6 cross-provenance fold (hand ↔ ingested), returning
+    /// the merged descriptor when applicable. Returns <c>false</c> for
+    /// same-provenance pairs so the caller can choose between "duplicate
+    /// (surfaces AONT040 downstream)" semantics (add path) and "replace
+    /// at index" semantics (update path).
+    /// </summary>
+    private static bool TryCrossProvenanceMerge(
+        ObjectTypeDescriptor existing,
+        ObjectTypeDescriptor incoming,
+        out ObjectTypeDescriptor merged)
+    {
+        if (existing.Source == DescriptorSource.HandAuthored
+            && incoming.Source == DescriptorSource.Ingested)
+        {
+            merged = MergeTwo.Merge(hand: existing, ingested: incoming);
+            return true;
+        }
+
+        if (existing.Source == DescriptorSource.Ingested
+            && incoming.Source == DescriptorSource.HandAuthored)
+        {
+            merged = MergeTwo.Merge(hand: incoming, ingested: existing);
+            return true;
+        }
+
+        merged = existing;
+        return false;
+    }
+
+    /// <summary>
+    /// DR-1 identity invariant boundary check. The same invariant is
+    /// enforced inside <see cref="ObjectTypeDescriptor"/>'s
+    /// <c>ClrType</c>/<c>SymbolKey</c> init setters; this guards the
+    /// "neither field set in the object initializer" bypass — both
+    /// setters skipped, default-null values land on the descriptor, and
+    /// neither setter's invariant runs.
+    /// </summary>
+    private static void EnsureIdentityInvariant(ObjectTypeDescriptor descriptor)
+    {
+        if (descriptor.ClrType is null && descriptor.SymbolKey is null)
+        {
+            throw new InvalidOperationException(
+                $"ObjectTypeDescriptor '{descriptor.DomainName}.{descriptor.Name}' "
+                + "violates the DR-1 identity invariant: at least one of ClrType or "
+                + "SymbolKey must be non-null. Hand-authored descriptors must supply "
+                + "ClrType; ingested descriptors must supply SymbolKey.");
+        }
     }
 
     /// <summary>
@@ -200,6 +237,8 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
     private void ApplyUpdateObjectType(OntologyDelta.UpdateObjectType delta)
     {
         var d = delta.Descriptor;
+        EnsureIdentityInvariant(d);
+
         var idx = FindObjectTypeIndex(d.DomainName, d.Name);
         if (idx < 0)
         {
@@ -210,7 +249,15 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
             return;
         }
 
-        _objectTypes[idx] = d;
+        // DR-6 lateral lattice: an Update arriving from one provenance
+        // against an existing descriptor of the opposite provenance is
+        // folded through MergeTwo so neither origin silently overwrites
+        // the other. Same-provenance Updates replace at the existing
+        // index (no duplicate created, unlike the Add path which lets
+        // AONT040 surface duplicates downstream).
+        _objectTypes[idx] = TryCrossProvenanceMerge(_objectTypes[idx], d, out var merged)
+            ? merged
+            : d;
     }
 
     private void ApplyRemoveObjectType(OntologyDelta.RemoveObjectType delta)

--- a/src/Strategos.Ontology/Configuration/OntologyOptions.cs
+++ b/src/Strategos.Ontology/Configuration/OntologyOptions.cs
@@ -17,6 +17,7 @@ public sealed class OntologyOptions
     private readonly List<WorkflowMetadataBuilder> _workflowMetadata = [];
     private readonly List<Action<IServiceCollection>> _serviceRegistrations = [];
     private readonly List<(int Order, Func<IServiceProvider, IActionDispatcher, IActionDispatcher> Factory)> _dispatcherDecorators = [];
+    private readonly List<Func<IOntologySource>> _sourceFactories = [];
 
     internal IReadOnlyList<DomainOntology> Domains => _domains;
 
@@ -25,6 +26,18 @@ public sealed class OntologyOptions
     internal IReadOnlyList<Action<IServiceCollection>> ServiceRegistrations => _serviceRegistrations;
 
     internal List<(int Order, Func<IServiceProvider, IActionDispatcher, IActionDispatcher> Factory)> DispatcherDecorators => _dispatcherDecorators;
+
+    /// <summary>
+    /// DR-3 (Task 12): factories that activate each
+    /// <see cref="IOntologySource"/> implementation registered via
+    /// <see cref="AddSource{T}"/>. Surfaced to <c>AddOntology</c> so the
+    /// graph builder's source-drain instantiates them prior to
+    /// <c>Build()</c>. Each factory closes over the generic type
+    /// parameter so the trim/AOT annotation propagates correctly without
+    /// requiring downstream call sites to thread the annotation through
+    /// non-generic API boundaries.
+    /// </summary>
+    internal IReadOnlyList<Func<IOntologySource>> SourceFactories => _sourceFactories;
 
     public OntologyOptions AddDomain<T>()
         where T : DomainOntology, new()
@@ -77,6 +90,28 @@ public sealed class OntologyOptions
     {
         ArgumentNullException.ThrowIfNull(registration);
         _serviceRegistrations.Add(registration);
+        return this;
+    }
+
+    /// <summary>
+    /// DR-3 (Task 12): registers an <see cref="IOntologySource"/>
+    /// implementation as transient in the service container and surfaces
+    /// it to the <see cref="OntologyGraphBuilder"/> source-drain.
+    /// </summary>
+    /// <remarks>
+    /// Routes through the same <c>graphBuilder.AddSources(...)</c> surface
+    /// the in-memory test wiring uses — there is no parallel registration
+    /// path. The transient lifetime matches the contract described on
+    /// <see cref="IOntologySource"/>: each <c>LoadAsync</c> drain creates
+    /// a fresh source instance.
+    /// </remarks>
+    public OntologyOptions AddSource<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>()
+        where T : class, IOntologySource, new()
+    {
+        // Factory closes over the generic parameter — the `new()` constraint
+        // gives us a trim-safe activator without resorting to reflection.
+        _sourceFactories.Add(static () => new T());
+        _serviceRegistrations.Add(services => services.AddTransient<IOntologySource, T>());
         return this;
     }
 

--- a/src/Strategos.Ontology/Configuration/OntologyOptions.cs
+++ b/src/Strategos.Ontology/Configuration/OntologyOptions.cs
@@ -39,6 +39,15 @@ public sealed class OntologyOptions
     /// </summary>
     internal IReadOnlyList<Func<IOntologySource>> SourceFactories => _sourceFactories;
 
+    /// <summary>
+    /// DR-7 (Task 28): opt-in flag for AONT206 (hand-declared property
+    /// also contributed by ingestion — hygiene hint). Off by default to
+    /// avoid flooding telemetry with cosmetic info diagnostics; wired
+    /// through MSBuild via the <c>OntologyEnableHygieneHints</c> property
+    /// when consumers route it.
+    /// </summary>
+    public bool EnableHygieneHints { get; init; }
+
     public OntologyOptions AddDomain<T>()
         where T : DomainOntology, new()
     {

--- a/src/Strategos.Ontology/Configuration/OntologyServiceCollectionExtensions.cs
+++ b/src/Strategos.Ontology/Configuration/OntologyServiceCollectionExtensions.cs
@@ -33,6 +33,24 @@ public static class OntologyServiceCollectionExtensions
 
         graphBuilder.AddWorkflowMetadata(options.WorkflowMetadata);
 
+        // DR-3 (Task 12): instantiate each registered IOntologySource for
+        // the graph-builder source-drain. Sources are also registered as
+        // transient in `services` via options.ServiceRegistrations so
+        // live-invalidation consumers (v2.6.0+) resolve fresh instances
+        // from the real container; the activator path below is the
+        // bootstrap drain used at compose time, before the real container
+        // is built.
+        if (options.SourceFactories.Count > 0)
+        {
+            var sources = new IOntologySource[options.SourceFactories.Count];
+            for (var i = 0; i < options.SourceFactories.Count; i++)
+            {
+                sources[i] = options.SourceFactories[i]();
+            }
+
+            graphBuilder.AddSources(sources);
+        }
+
         var graph = graphBuilder.Build();
         services.AddSingleton(graph);
 

--- a/src/Strategos.Ontology/Descriptors/DescriptorSource.cs
+++ b/src/Strategos.Ontology/Descriptors/DescriptorSource.cs
@@ -1,0 +1,23 @@
+namespace Strategos.Ontology.Descriptors;
+
+/// <summary>
+/// Field-level provenance for ontology descriptors. Distinguishes hand-authored
+/// <c>DomainOntology.Define()</c> contributions from contributions arriving via
+/// <c>IOntologySource</c> ingestion paths.
+/// </summary>
+/// <remarks>
+/// Default is <see cref="HandAuthored"/>; this preserves existing descriptor
+/// construction sites which predate the polyglot ingestion path.
+/// </remarks>
+public enum DescriptorSource
+{
+    /// <summary>
+    /// Descriptor or field contributed by hand-authored <c>DomainOntology.Define()</c>.
+    /// </summary>
+    HandAuthored = 0,
+
+    /// <summary>
+    /// Descriptor or field contributed by an <c>IOntologySource</c> ingestion path.
+    /// </summary>
+    Ingested = 1,
+}

--- a/src/Strategos.Ontology/Descriptors/DomainEntityAttribute.cs
+++ b/src/Strategos.Ontology/Descriptors/DomainEntityAttribute.cs
@@ -1,0 +1,28 @@
+namespace Strategos.Ontology.Descriptors;
+
+/// <summary>
+/// Marks a hand-authored ontology type as opted-in to DR-7 strict mode.
+/// When <see cref="Strict"/> is <c>true</c>, the graph-freeze emits
+/// AONT203 (warning) for any property present on the ingested side of
+/// the descriptor but missing from the hand-authored
+/// <c>DomainOntology.Define()</c> declaration. The default
+/// (<c>Strict = false</c>) preserves the loose contract — ingested-only
+/// properties are absorbed without complaint.
+/// </summary>
+/// <remarks>
+/// DR-7 (Task 25). Applied to the CLR backing type of an
+/// <see cref="ObjectTypeDescriptor"/>; the graph-freeze reads the
+/// attribute from <see cref="ObjectTypeDescriptor.ClrType"/> at compose
+/// time. Hand-authored descriptors whose CLR type is decorated with
+/// <c>[DomainEntity(Strict = true)]</c> are flagged here; this is the
+/// only opt-in for AONT203.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface, Inherited = true, AllowMultiple = false)]
+public sealed class DomainEntityAttribute : Attribute
+{
+    /// <summary>
+    /// When <c>true</c>, ingested-only properties absent from hand
+    /// <c>Define()</c> emit AONT203 at graph-freeze time. Default: <c>false</c>.
+    /// </summary>
+    public bool Strict { get; init; }
+}

--- a/src/Strategos.Ontology/Descriptors/LinkDescriptor.cs
+++ b/src/Strategos.Ontology/Descriptors/LinkDescriptor.cs
@@ -1,5 +1,16 @@
 namespace Strategos.Ontology.Descriptors;
 
+/// <summary>
+/// Describes a structural link from an object type to another.
+/// </summary>
+/// <remarks>
+/// DR-1 polyglot: <see cref="TargetTypeName"/> remains the canonical
+/// string-keyed target name used by hand-authored paths. For ingested
+/// links whose target is identified by SCIP rather than CLR, set
+/// <see cref="TargetSymbolKey"/> alongside.
+/// DR-6 provenance: <see cref="Source"/> tags whether this link arrived
+/// hand-authored or via an <c>IOntologySource</c>.
+/// </remarks>
 public sealed record LinkDescriptor(
     string Name,
     string TargetTypeName,
@@ -12,4 +23,14 @@ public sealed record LinkDescriptor(
     public string? InverseLinkName { get; init; }
 
     public string? Description { get; init; }
+
+    /// <summary>
+    /// SCIP moniker of the link target, when known. Parallel to
+    /// <see cref="TargetTypeName"/>; populated by ingestion paths whose
+    /// target type is not loadable as a CLR <see cref="Type"/>.
+    /// </summary>
+    public string? TargetSymbolKey { get; init; }
+
+    /// <summary>Field-level provenance — hand-authored vs. ingested.</summary>
+    public DescriptorSource Source { get; init; } = DescriptorSource.HandAuthored;
 }

--- a/src/Strategos.Ontology/Descriptors/ObjectTypeDescriptor.cs
+++ b/src/Strategos.Ontology/Descriptors/ObjectTypeDescriptor.cs
@@ -34,6 +34,17 @@ public sealed record ObjectTypeDescriptor
     /// CLR type, when known. Null for purely-ingested descriptors whose
     /// language has no loaded .NET type (e.g. TypeScript via SCIP).
     /// </summary>
+    /// <remarks>
+    /// The DR-1 identity invariant (at least one of <see cref="ClrType"/>
+    /// or <see cref="SymbolKey"/> must be non-null) is enforced in the
+    /// <see cref="SymbolKey"/> init setter for the explicit-set cases.
+    /// The "neither field set" bypass — where the parameterless property-
+    /// init constructor runs and neither <see cref="ClrType"/> nor
+    /// <see cref="SymbolKey"/> appears in the object initializer — is
+    /// caught at <c>OntologyBuilder.ObjectTypeFromDescriptor</c> and
+    /// <c>ApplyDelta</c>, the two surfaces through which descriptors
+    /// reach the composed graph.
+    /// </remarks>
     public Type? ClrType
     {
         get => _clrType;

--- a/src/Strategos.Ontology/Descriptors/ObjectTypeDescriptor.cs
+++ b/src/Strategos.Ontology/Descriptors/ObjectTypeDescriptor.cs
@@ -1,10 +1,120 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Strategos.Ontology.Descriptors;
 
-public sealed record ObjectTypeDescriptor(
-    string Name,
-    Type ClrType,
-    string DomainName)
+/// <summary>
+/// Polyglot-capable description of an object type in the ontology.
+/// </summary>
+/// <remarks>
+/// <para>
+/// DR-1 (polyglot descriptor schema): identity is no longer CLR-only. A
+/// descriptor must carry at least one of <see cref="ClrType"/> (.NET CLR
+/// identity) or <see cref="SymbolKey"/> (SCIP moniker for cross-language
+/// ingestion). The invariant is enforced at construction time when both
+/// fields are explicitly set; ingestion paths always supply a SymbolKey
+/// and hand-authored paths always supply a ClrType.
+/// </para>
+/// <para>
+/// The existing positional constructor <c>(name, clrType, domainName)</c>
+/// is preserved to keep hand-authored call sites compiling unchanged.
+/// </para>
+/// </remarks>
+public sealed record ObjectTypeDescriptor
 {
+    private readonly Type? _clrType;
+    private readonly string? _symbolKey;
+
+    /// <summary>Canonical descriptor name (per-domain unique).</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Owning domain.</summary>
+    public required string DomainName { get; init; }
+
+    /// <summary>
+    /// CLR type, when known. Null for purely-ingested descriptors whose
+    /// language has no loaded .NET type (e.g. TypeScript via SCIP).
+    /// </summary>
+    public Type? ClrType
+    {
+        get => _clrType;
+        init => _clrType = value;
+    }
+
+    /// <summary>
+    /// SCIP moniker, when known. Mechanical truth for cross-language
+    /// identity; wins over <see cref="ClrType"/> at merge time per
+    /// basileus ADR §9.2.
+    /// </summary>
+    /// <remarks>
+    /// The DR-1 identity invariant (at least one of <see cref="ClrType"/>
+    /// or <see cref="SymbolKey"/> must be non-null) is enforced in the
+    /// <see cref="SymbolKey"/> init setter. By convention this property is
+    /// the "polyglot escape hatch" — callers using the property-init form
+    /// to construct an ingested descriptor always set <see cref="SymbolKey"/>;
+    /// callers using the positional <c>(name, clrType, domainName)</c>
+    /// constructor satisfy the invariant trivially without touching the
+    /// init setters.
+    /// </remarks>
+    public string? SymbolKey
+    {
+        get => _symbolKey;
+        init
+        {
+            _symbolKey = value;
+            if (_clrType is null && _symbolKey is null)
+            {
+                throw new InvalidOperationException(
+                    "ObjectTypeDescriptor violates the DR-1 identity invariant: "
+                    + "at least one of ClrType or SymbolKey must be non-null. "
+                    + "Hand-authored descriptors must supply ClrType; ingested descriptors must supply SymbolKey.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Language-formatted fully-qualified name; informational and used
+    /// for diagnostic messages.
+    /// </summary>
+    public string? SymbolFqn { get; init; }
+
+    /// <summary>
+    /// Language identifier per SCIP convention (e.g. <c>"dotnet"</c>,
+    /// <c>"typescript"</c>). Defaults to <c>"dotnet"</c> for hand-authored
+    /// descriptors.
+    /// </summary>
+    public string LanguageId { get; init; } = "dotnet";
+
+    /// <summary>Record-level provenance — hand-authored vs. ingested.</summary>
+    public DescriptorSource Source { get; init; } = DescriptorSource.HandAuthored;
+
+    /// <summary>
+    /// Identifier of the <c>IOntologySource</c> that contributed this
+    /// descriptor, when <see cref="Source"/> is <see cref="DescriptorSource.Ingested"/>.
+    /// </summary>
+    public string? SourceId { get; init; }
+
+    /// <summary>Wall-clock instant of ingestion, when applicable.</summary>
+    public DateTimeOffset? IngestedAt { get; init; }
+
+    /// <summary>Property-init constructor; identity invariant is enforced via the init setters.</summary>
+    public ObjectTypeDescriptor()
+    {
+    }
+
+    /// <summary>
+    /// Backward-compatible positional constructor. Hand-authored
+    /// <c>DomainOntology.Define()</c> sites always carry a CLR type, so
+    /// the invariant is trivially satisfied.
+    /// </summary>
+    [SetsRequiredMembers]
+    public ObjectTypeDescriptor(string name, Type clrType, string domainName)
+    {
+        ArgumentNullException.ThrowIfNull(clrType);
+        Name = name;
+        DomainName = domainName;
+        _clrType = clrType;
+    }
+
     public PropertyDescriptor? KeyProperty { get; init; }
 
     public IReadOnlyList<PropertyDescriptor> Properties { get; init; } = [];

--- a/src/Strategos.Ontology/Descriptors/PropertyDescriptor.cs
+++ b/src/Strategos.Ontology/Descriptors/PropertyDescriptor.cs
@@ -1,5 +1,16 @@
 namespace Strategos.Ontology.Descriptors;
 
+/// <summary>
+/// Describes a property of an object type.
+/// </summary>
+/// <remarks>
+/// DR-1 polyglot: <see cref="PropertyType"/> remains the canonical CLR
+/// type used by hand-authored paths. For reference-typed properties
+/// whose target type is identified by SCIP rather than CLR (ingestion
+/// path), <see cref="ReferenceSymbolKey"/> rides alongside.
+/// DR-6 provenance: <see cref="Source"/> tags whether this property
+/// arrived hand-authored or via an <c>IOntologySource</c>.
+/// </remarks>
 public sealed record PropertyDescriptor(
     string Name,
     Type PropertyType,
@@ -14,4 +25,14 @@ public sealed record PropertyDescriptor(
     public IReadOnlyList<DerivationSource> DerivedFrom { get; init; } = [];
 
     public IReadOnlyList<DerivationSource> TransitiveDerivedFrom { get; init; } = [];
+
+    /// <summary>
+    /// SCIP moniker identifying the target type of a reference property,
+    /// when the target type is not available as a loaded CLR
+    /// <see cref="Type"/>. Parallel to <see cref="PropertyType"/>.
+    /// </summary>
+    public string? ReferenceSymbolKey { get; init; }
+
+    /// <summary>Field-level provenance — hand-authored vs. ingested.</summary>
+    public DescriptorSource Source { get; init; } = DescriptorSource.HandAuthored;
 }

--- a/src/Strategos.Ontology/Diagnostics/OntologyDiagnostic.cs
+++ b/src/Strategos.Ontology/Diagnostics/OntologyDiagnostic.cs
@@ -1,0 +1,26 @@
+namespace Strategos.Ontology.Diagnostics;
+
+/// <summary>
+/// Structured ontology diagnostic carried by
+/// <see cref="OntologyCompositionException"/> and surfaced on
+/// <c>OntologyGraph.NonFatalDiagnostics</c>.
+/// </summary>
+/// <param name="Id">Stable identifier (e.g. <c>"AONT201"</c>, <c>"AONT205"</c>).</param>
+/// <param name="Message">Human-readable description; names specific identifiers per DR-10/DIM-8.</param>
+/// <param name="Severity">Severity classification.</param>
+/// <param name="DomainName">Owning domain, when applicable.</param>
+/// <param name="TypeName">Owning object type, when applicable.</param>
+/// <param name="PropertyName">Property or field involved, when applicable.</param>
+/// <remarks>
+/// Created in Task 5 to back <see cref="OntologyCompositionException"/>'s
+/// diagnostics aggregation. Task 6 fleshes out the surrounding
+/// <c>Strategos.Ontology.Diagnostics</c> machinery and the local
+/// severity mirror.
+/// </remarks>
+public sealed record OntologyDiagnostic(
+    string Id,
+    string Message,
+    OntologyDiagnosticSeverity Severity,
+    string? DomainName = null,
+    string? TypeName = null,
+    string? PropertyName = null);

--- a/src/Strategos.Ontology/Diagnostics/OntologyDiagnosticSeverity.cs
+++ b/src/Strategos.Ontology/Diagnostics/OntologyDiagnosticSeverity.cs
@@ -1,0 +1,24 @@
+namespace Strategos.Ontology.Diagnostics;
+
+/// <summary>
+/// Severity classification for ontology diagnostics. Mirrored locally
+/// (rather than re-exporting Roslyn's <c>DiagnosticSeverity</c>) so the
+/// runtime <c>Strategos.Ontology</c> assembly does not bind to
+/// <c>Microsoft.CodeAnalysis</c> at runtime.
+/// </summary>
+/// <remarks>
+/// Task 6 expands the surrounding diagnostics machinery; this enum is
+/// introduced in Task 5 so <see cref="OntologyCompositionException"/>
+/// can carry typed diagnostic severity.
+/// </remarks>
+public enum OntologyDiagnosticSeverity
+{
+    /// <summary>Informational; non-fatal, surfaces via <c>OntologyGraph.NonFatalDiagnostics</c>.</summary>
+    Info = 0,
+
+    /// <summary>Warning; non-fatal, surfaces via <c>OntologyGraph.NonFatalDiagnostics</c>.</summary>
+    Warning = 1,
+
+    /// <summary>Error; fatal at graph-freeze, surfaces via <see cref="OntologyCompositionException.Diagnostics"/>.</summary>
+    Error = 2,
+}

--- a/src/Strategos.Ontology/Internal/OntologyGraphHasher.cs
+++ b/src/Strategos.Ontology/Internal/OntologyGraphHasher.cs
@@ -359,13 +359,13 @@ internal static class OntologyGraphHasher
         // descriptor, so the tie-breaker is required for canonicalization.
         foreach (var w in graph.WorkflowChains
                               .OrderBy(w => w.WorkflowName, StringComparer.Ordinal)
-                              .ThenBy(w => w.ConsumedType.ClrType.FullName ?? string.Empty, StringComparer.Ordinal)
-                              .ThenBy(w => w.ProducedType.ClrType.FullName ?? string.Empty, StringComparer.Ordinal))
+                              .ThenBy(w => w.ConsumedType.ClrType?.FullName ?? w.ConsumedType.SymbolKey ?? string.Empty, StringComparer.Ordinal)
+                              .ThenBy(w => w.ProducedType.ClrType?.FullName ?? w.ProducedType.SymbolKey ?? string.Empty, StringComparer.Ordinal))
         {
             writer.Write("W|");
             WriteString(writer, w.WorkflowName);
-            WriteString(writer, w.ConsumedType.ClrType.FullName ?? string.Empty);
-            WriteString(writer, w.ProducedType.ClrType.FullName ?? string.Empty);
+            WriteString(writer, w.ConsumedType.ClrType?.FullName ?? w.ConsumedType.SymbolKey ?? string.Empty);
+            WriteString(writer, w.ProducedType.ClrType?.FullName ?? w.ProducedType.SymbolKey ?? string.Empty);
         }
 
         writer.Write("|END_WF");

--- a/src/Strategos.Ontology/Internal/OntologyGraphHasher.cs
+++ b/src/Strategos.Ontology/Internal/OntologyGraphHasher.cs
@@ -359,13 +359,13 @@ internal static class OntologyGraphHasher
         // descriptor, so the tie-breaker is required for canonicalization.
         foreach (var w in graph.WorkflowChains
                               .OrderBy(w => w.WorkflowName, StringComparer.Ordinal)
-                              .ThenBy(w => w.ConsumedType.ClrType?.FullName ?? w.ConsumedType.SymbolKey ?? string.Empty, StringComparer.Ordinal)
-                              .ThenBy(w => w.ProducedType.ClrType?.FullName ?? w.ProducedType.SymbolKey ?? string.Empty, StringComparer.Ordinal))
+                              .ThenBy(w => w.ConsumedType.ClrType?.FullName ?? w.ConsumedType.SymbolKey ?? w.ConsumedType.Name, StringComparer.Ordinal)
+                              .ThenBy(w => w.ProducedType.ClrType?.FullName ?? w.ProducedType.SymbolKey ?? w.ProducedType.Name, StringComparer.Ordinal))
         {
             writer.Write("W|");
             WriteString(writer, w.WorkflowName);
-            WriteString(writer, w.ConsumedType.ClrType?.FullName ?? w.ConsumedType.SymbolKey ?? string.Empty);
-            WriteString(writer, w.ProducedType.ClrType?.FullName ?? w.ProducedType.SymbolKey ?? string.Empty);
+            WriteString(writer, w.ConsumedType.ClrType?.FullName ?? w.ConsumedType.SymbolKey ?? w.ConsumedType.Name);
+            WriteString(writer, w.ProducedType.ClrType?.FullName ?? w.ProducedType.SymbolKey ?? w.ProducedType.Name);
         }
 
         writer.Write("|END_WF");

--- a/src/Strategos.Ontology/Merge/MergeTwo.cs
+++ b/src/Strategos.Ontology/Merge/MergeTwo.cs
@@ -1,0 +1,79 @@
+using Strategos.Ontology.Descriptors;
+
+namespace Strategos.Ontology.Merge;
+
+/// <summary>
+/// Two-input lattice fold over <see cref="ObjectTypeDescriptor"/>, combining
+/// a hand-authored contribution with an ingested contribution per the
+/// lattice rule from basileus ADR §9.1–§9.2.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Identity-field rule (DR-6 lateral):
+/// </para>
+/// <list type="bullet">
+/// <item><description><see cref="ObjectTypeDescriptor.ClrType"/>: hand wins, fallback to ingested.</description></item>
+/// <item><description><see cref="ObjectTypeDescriptor.SymbolKey"/>: ingested wins (SCIP authoritative), fallback to hand.</description></item>
+/// <item><description><see cref="ObjectTypeDescriptor.SymbolFqn"/>: ingested wins, fallback to hand.</description></item>
+/// <item><description><see cref="ObjectTypeDescriptor.LanguageId"/>: hand wins.</description></item>
+/// <item><description><see cref="ObjectTypeDescriptor.Source"/>: always <see cref="DescriptorSource.HandAuthored"/> — hand wins on composition.</description></item>
+/// <item><description><see cref="ObjectTypeDescriptor.Name"/> and <see cref="ObjectTypeDescriptor.DomainName"/>: taken from hand; mismatch with ingested surfaces as AONT006 upstream.</description></item>
+/// </list>
+/// <para>
+/// Intent-only fields are always taken from hand:
+/// <see cref="ObjectTypeDescriptor.Actions"/>,
+/// <see cref="ObjectTypeDescriptor.Events"/>,
+/// <see cref="ObjectTypeDescriptor.Lifecycle"/>. A mechanical ingester
+/// contributing to any of these is reported as AONT205 upstream.
+/// </para>
+/// <para>
+/// Per-name union for <see cref="ObjectTypeDescriptor.Properties"/> and
+/// <see cref="ObjectTypeDescriptor.Links"/> is implemented in Task 15.
+/// </para>
+/// </remarks>
+public static class MergeTwo
+{
+    /// <summary>
+    /// Merges a hand-authored descriptor with an ingested descriptor
+    /// per the DR-6 lateral lattice rule.
+    /// </summary>
+    /// <param name="hand">Hand-authored contribution.</param>
+    /// <param name="ingested">Ingested contribution.</param>
+    /// <returns>
+    /// A new <see cref="ObjectTypeDescriptor"/> with merged identity
+    /// fields and hand-only intent fields.
+    /// </returns>
+    public static ObjectTypeDescriptor Merge(
+        ObjectTypeDescriptor hand,
+        ObjectTypeDescriptor ingested)
+    {
+        ArgumentNullException.ThrowIfNull(hand);
+        ArgumentNullException.ThrowIfNull(ingested);
+
+        return new ObjectTypeDescriptor
+        {
+            Name = hand.Name,
+            DomainName = hand.DomainName,
+            ClrType = hand.ClrType ?? ingested.ClrType,
+            SymbolKey = ingested.SymbolKey ?? hand.SymbolKey,
+            SymbolFqn = ingested.SymbolFqn ?? hand.SymbolFqn,
+            LanguageId = hand.LanguageId,
+            Source = DescriptorSource.HandAuthored,
+            SourceId = hand.SourceId,
+            IngestedAt = hand.IngestedAt,
+            KeyProperty = hand.KeyProperty,
+            Properties = hand.Properties,
+            Links = hand.Links,
+            Actions = hand.Actions,
+            Events = hand.Events,
+            ImplementedInterfaces = hand.ImplementedInterfaces,
+            Lifecycle = hand.Lifecycle,
+            InterfaceActionMappings = hand.InterfaceActionMappings,
+            ExternalLinkExtensionPoints = hand.ExternalLinkExtensionPoints,
+            InterfacePropertyMappings = hand.InterfacePropertyMappings,
+            Kind = hand.Kind,
+            ParentType = hand.ParentType,
+            ParentTypeName = hand.ParentTypeName,
+        };
+    }
+}

--- a/src/Strategos.Ontology/Merge/MergeTwo.cs
+++ b/src/Strategos.Ontology/Merge/MergeTwo.cs
@@ -62,8 +62,8 @@ public static class MergeTwo
             SourceId = hand.SourceId,
             IngestedAt = hand.IngestedAt,
             KeyProperty = hand.KeyProperty,
-            Properties = hand.Properties,
-            Links = hand.Links,
+            Properties = MergeProperties(hand.Properties, ingested.Properties),
+            Links = MergeLinks(hand.Links, ingested.Links),
             Actions = hand.Actions,
             Events = hand.Events,
             ImplementedInterfaces = hand.ImplementedInterfaces,
@@ -75,5 +75,80 @@ public static class MergeTwo
             ParentType = hand.ParentType,
             ParentTypeName = hand.ParentTypeName,
         };
+    }
+
+    /// <summary>
+    /// Per-name union of <see cref="PropertyDescriptor"/> collections.
+    /// Hand wins on conflict; ingested-only entries are restamped with
+    /// <see cref="DescriptorSource.Ingested"/> so downstream consumers
+    /// can distinguish origin.
+    /// </summary>
+    /// <param name="hand">Hand-authored properties.</param>
+    /// <param name="ingested">Ingested properties.</param>
+    /// <returns>Merged property list (deterministic order: hand first, then ingested-only).</returns>
+    public static IReadOnlyList<PropertyDescriptor> MergeProperties(
+        IReadOnlyList<PropertyDescriptor> hand,
+        IReadOnlyList<PropertyDescriptor> ingested)
+    {
+        ArgumentNullException.ThrowIfNull(hand);
+        ArgumentNullException.ThrowIfNull(ingested);
+
+        // Hand entries pass through untouched (preserving their original Source).
+        var result = new List<PropertyDescriptor>(hand.Count + ingested.Count);
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var p in hand)
+        {
+            result.Add(p);
+            seen.Add(p.Name);
+        }
+
+        // Ingested-only entries are appended, restamped with Source = Ingested.
+        foreach (var p in ingested)
+        {
+            if (seen.Contains(p.Name))
+            {
+                continue;
+            }
+
+            result.Add(p with { Source = DescriptorSource.Ingested });
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Per-name union of <see cref="LinkDescriptor"/> collections.
+    /// Hand wins on conflict; ingested-only entries are restamped with
+    /// <see cref="DescriptorSource.Ingested"/>.
+    /// </summary>
+    /// <param name="hand">Hand-authored links.</param>
+    /// <param name="ingested">Ingested links.</param>
+    /// <returns>Merged link list (deterministic order: hand first, then ingested-only).</returns>
+    public static IReadOnlyList<LinkDescriptor> MergeLinks(
+        IReadOnlyList<LinkDescriptor> hand,
+        IReadOnlyList<LinkDescriptor> ingested)
+    {
+        ArgumentNullException.ThrowIfNull(hand);
+        ArgumentNullException.ThrowIfNull(ingested);
+
+        var result = new List<LinkDescriptor>(hand.Count + ingested.Count);
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var l in hand)
+        {
+            result.Add(l);
+            seen.Add(l.Name);
+        }
+
+        foreach (var l in ingested)
+        {
+            if (seen.Contains(l.Name))
+            {
+                continue;
+            }
+
+            result.Add(l with { Source = DescriptorSource.Ingested });
+        }
+
+        return result;
     }
 }

--- a/src/Strategos.Ontology/Merge/MergeTwo.cs
+++ b/src/Strategos.Ontology/Merge/MergeTwo.cs
@@ -113,7 +113,9 @@ public static class MergeTwo
             result.Add(p with { Source = DescriptorSource.Ingested });
         }
 
-        return result;
+        // AsReadOnly wraps the backing list so consumers cannot downcast
+        // to List<T> and mutate the merged collection.
+        return result.AsReadOnly();
     }
 
     /// <summary>
@@ -149,6 +151,8 @@ public static class MergeTwo
             result.Add(l with { Source = DescriptorSource.Ingested });
         }
 
-        return result;
+        // AsReadOnly wraps the backing list so consumers cannot downcast
+        // to List<T> and mutate the merged collection.
+        return result.AsReadOnly();
     }
 }

--- a/src/Strategos.Ontology/Merge/MergeTwo.cs
+++ b/src/Strategos.Ontology/Merge/MergeTwo.cs
@@ -103,9 +103,13 @@ public static class MergeTwo
         }
 
         // Ingested-only entries are appended, restamped with Source = Ingested.
+        // Mark newly-appended names in `seen` so a duplicate name within
+        // `ingested` itself collapses to a single emission (rule: ingested
+        // duplicates are silently de-duped — they're mechanical noise, not
+        // intent — same as the hand-side de-dup behavior).
         foreach (var p in ingested)
         {
-            if (seen.Contains(p.Name))
+            if (!seen.Add(p.Name))
             {
                 continue;
             }
@@ -143,7 +147,7 @@ public static class MergeTwo
 
         foreach (var l in ingested)
         {
-            if (seen.Contains(l.Name))
+            if (!seen.Add(l.Name))
             {
                 continue;
             }

--- a/src/Strategos.Ontology/OntologyCompositionException.cs
+++ b/src/Strategos.Ontology/OntologyCompositionException.cs
@@ -1,14 +1,98 @@
+using System.Collections.Immutable;
+
+using Strategos.Ontology.Diagnostics;
+
 namespace Strategos.Ontology;
 
+/// <summary>
+/// Raised when <c>OntologyGraphBuilder.Build()</c> or a runtime delta
+/// application detects a fatal composition condition.
+/// </summary>
+/// <remarks>
+/// DR-10 (failure modes): Error-severity diagnostics are aggregated on
+/// <see cref="Diagnostics"/>; warning/info diagnostics that did not
+/// fail the build are surfaced via <see cref="NonFatalDiagnostics"/>
+/// for telemetry consumers. Legacy single-message construction is
+/// preserved so existing throw sites compile unchanged.
+/// </remarks>
 public sealed class OntologyCompositionException : Exception
 {
+    /// <summary>
+    /// Error-severity diagnostics that caused the build to fail. Empty
+    /// when the exception was constructed via the legacy single-message
+    /// ctor.
+    /// </summary>
+    public ImmutableArray<OntologyDiagnostic> Diagnostics { get; }
+
+    /// <summary>
+    /// Non-fatal diagnostics (warning, info) observed during the build.
+    /// Provided for telemetry / log inspection; never empty when
+    /// constructed via the diagnostics-aware ctor and warnings were
+    /// observed.
+    /// </summary>
+    public ImmutableArray<OntologyDiagnostic> NonFatalDiagnostics { get; }
+
     public OntologyCompositionException(string message)
         : base(message)
     {
+        Diagnostics = ImmutableArray<OntologyDiagnostic>.Empty;
+        NonFatalDiagnostics = ImmutableArray<OntologyDiagnostic>.Empty;
     }
 
     public OntologyCompositionException(string message, Exception innerException)
         : base(message, innerException)
     {
+        Diagnostics = ImmutableArray<OntologyDiagnostic>.Empty;
+        NonFatalDiagnostics = ImmutableArray<OntologyDiagnostic>.Empty;
+    }
+
+    /// <summary>
+    /// Constructs an exception aggregating one or more error-severity
+    /// diagnostics. The default message lists the first diagnostic's
+    /// identifier to make logs scannable.
+    /// </summary>
+    public OntologyCompositionException(ImmutableArray<OntologyDiagnostic> diagnostics)
+        : base(BuildMessage(diagnostics, ImmutableArray<OntologyDiagnostic>.Empty))
+    {
+        Diagnostics = diagnostics.IsDefault ? ImmutableArray<OntologyDiagnostic>.Empty : diagnostics;
+        NonFatalDiagnostics = ImmutableArray<OntologyDiagnostic>.Empty;
+    }
+
+    /// <summary>
+    /// Constructs an exception aggregating both fatal and non-fatal
+    /// diagnostics. Non-fatal items are passed through so callers can
+    /// log warnings/info that surfaced before the build failed.
+    /// </summary>
+    public OntologyCompositionException(
+        ImmutableArray<OntologyDiagnostic> diagnostics,
+        ImmutableArray<OntologyDiagnostic> nonFatalDiagnostics)
+        : base(BuildMessage(diagnostics, nonFatalDiagnostics))
+    {
+        Diagnostics = diagnostics.IsDefault ? ImmutableArray<OntologyDiagnostic>.Empty : diagnostics;
+        NonFatalDiagnostics = nonFatalDiagnostics.IsDefault
+            ? ImmutableArray<OntologyDiagnostic>.Empty
+            : nonFatalDiagnostics;
+    }
+
+    private static string BuildMessage(
+        ImmutableArray<OntologyDiagnostic> diagnostics,
+        ImmutableArray<OntologyDiagnostic> nonFatalDiagnostics)
+    {
+        if (diagnostics.IsDefault || diagnostics.IsEmpty)
+        {
+            return "Ontology composition failed (no diagnostics attached).";
+        }
+
+        var first = diagnostics[0];
+        var nonFatalSuffix = nonFatalDiagnostics.IsDefault || nonFatalDiagnostics.IsEmpty
+            ? string.Empty
+            : $" ({nonFatalDiagnostics.Length} non-fatal diagnostic(s) recorded).";
+
+        if (diagnostics.Length == 1)
+        {
+            return $"{first.Id}: {first.Message}{nonFatalSuffix}";
+        }
+
+        return $"{first.Id}: {first.Message} (and {diagnostics.Length - 1} additional error-severity diagnostic(s)){nonFatalSuffix}";
     }
 }

--- a/src/Strategos.Ontology/OntologyCompositionException.cs
+++ b/src/Strategos.Ontology/OntologyCompositionException.cs
@@ -32,6 +32,11 @@ public sealed class OntologyCompositionException : Exception
     /// </summary>
     public ImmutableArray<OntologyDiagnostic> NonFatalDiagnostics { get; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OntologyCompositionException"/> class
+    /// with the supplied message and no aggregated diagnostics.
+    /// </summary>
+    /// <param name="message">Human-readable failure description.</param>
     public OntologyCompositionException(string message)
         : base(message)
     {
@@ -39,6 +44,12 @@ public sealed class OntologyCompositionException : Exception
         NonFatalDiagnostics = ImmutableArray<OntologyDiagnostic>.Empty;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OntologyCompositionException"/> class
+    /// with the supplied message wrapping a lower-level exception.
+    /// </summary>
+    /// <param name="message">Human-readable failure description.</param>
+    /// <param name="innerException">The lower-level exception that triggered the composition failure.</param>
     public OntologyCompositionException(string message, Exception innerException)
         : base(message, innerException)
     {
@@ -47,10 +58,11 @@ public sealed class OntologyCompositionException : Exception
     }
 
     /// <summary>
-    /// Constructs an exception aggregating one or more error-severity
-    /// diagnostics. The default message lists the first diagnostic's
-    /// identifier to make logs scannable.
+    /// Initializes a new instance of the <see cref="OntologyCompositionException"/> class
+    /// aggregating one or more error-severity diagnostics. The default message lists the
+    /// first diagnostic's identifier to make logs scannable.
     /// </summary>
+    /// <param name="diagnostics">Error-severity diagnostics that caused the build to fail.</param>
     public OntologyCompositionException(ImmutableArray<OntologyDiagnostic> diagnostics)
         : base(BuildMessage(diagnostics, ImmutableArray<OntologyDiagnostic>.Empty))
     {
@@ -59,10 +71,12 @@ public sealed class OntologyCompositionException : Exception
     }
 
     /// <summary>
-    /// Constructs an exception aggregating both fatal and non-fatal
-    /// diagnostics. Non-fatal items are passed through so callers can
-    /// log warnings/info that surfaced before the build failed.
+    /// Initializes a new instance of the <see cref="OntologyCompositionException"/> class
+    /// aggregating both fatal and non-fatal diagnostics. Non-fatal items are passed through
+    /// so callers can log warnings/info that surfaced before the build failed.
     /// </summary>
+    /// <param name="diagnostics">Error-severity diagnostics that caused the build to fail.</param>
+    /// <param name="nonFatalDiagnostics">Warning/info diagnostics observed before failure.</param>
     public OntologyCompositionException(
         ImmutableArray<OntologyDiagnostic> diagnostics,
         ImmutableArray<OntologyDiagnostic> nonFatalDiagnostics)

--- a/src/Strategos.Ontology/OntologyGraph.cs
+++ b/src/Strategos.Ontology/OntologyGraph.cs
@@ -1,5 +1,7 @@
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Diagnostics;
 using Strategos.Ontology.Internal;
 
 namespace Strategos.Ontology;
@@ -16,6 +18,15 @@ public sealed class OntologyGraph
     public IReadOnlyList<ResolvedCrossDomainLink> CrossDomainLinks { get; }
     public IReadOnlyList<WorkflowChain> WorkflowChains { get; }
     public IReadOnlyList<string> Warnings { get; }
+
+    /// <summary>
+    /// Non-fatal diagnostics (warning, info) observed during graph-freeze.
+    /// DR-7 / DR-10: warning-severity AONT202/AONT203/AONT207 and
+    /// info-severity AONT204/AONT206 surface here for telemetry. Empty
+    /// for graphs composed from purely hand-authored input without any
+    /// triggering condition.
+    /// </summary>
+    public ImmutableArray<OntologyDiagnostic> NonFatalDiagnostics { get; }
 
     /// <summary>
     /// SHA-256 of a stable serialization of the graph's structural fields,
@@ -46,7 +57,8 @@ public sealed class OntologyGraph
         IReadOnlyList<ResolvedCrossDomainLink> crossDomainLinks,
         IReadOnlyList<WorkflowChain> workflowChains,
         IReadOnlyDictionary<Type, IReadOnlyList<string>>? objectTypeNamesByType = null,
-        IReadOnlyList<string>? warnings = null)
+        IReadOnlyList<string>? warnings = null,
+        ImmutableArray<OntologyDiagnostic> nonFatalDiagnostics = default)
     {
         Domains = domains;
         ObjectTypes = objectTypes;
@@ -63,6 +75,9 @@ public sealed class OntologyGraph
                     kvp => kvp.Key,
                     kvp => (IReadOnlyList<string>)kvp.Value.ToList().AsReadOnly()));
         Warnings = warnings ?? [];
+        NonFatalDiagnostics = nonFatalDiagnostics.IsDefault
+            ? ImmutableArray<OntologyDiagnostic>.Empty
+            : nonFatalDiagnostics;
 
         _objectTypeLookup = BuildObjectTypeLookup(objectTypes);
         _implementorsLookup = BuildImplementorsLookup(objectTypes);

--- a/src/Strategos.Ontology/OntologyGraphBuilder.cs
+++ b/src/Strategos.Ontology/OntologyGraphBuilder.cs
@@ -39,12 +39,38 @@ public sealed class OntologyGraphBuilder
     public OntologyGraphBuilder AddSources(IEnumerable<IOntologySource> sources)
     {
         ArgumentNullException.ThrowIfNull(sources);
-        _sources.AddRange(sources);
+        foreach (var source in sources)
+        {
+            if (source is null)
+            {
+                throw new ArgumentException(
+                    "IOntologySource enumerable contains a null entry; sources must be non-null so the drain loop can attribute exceptions and deltas to a stable SourceId.",
+                    nameof(sources));
+            }
+
+            _sources.Add(source);
+        }
+
         return this;
     }
 
-    public OntologyGraph Build()
+    public OntologyGraph Build() => Build(CancellationToken.None);
+
+    /// <summary>
+    /// Composes the immutable ontology graph, threading a cancellation
+    /// token through the <see cref="IOntologySource"/> drain so a slow or
+    /// hung source cannot block startup indefinitely. The hand-authored
+    /// <c>DomainOntology.Define()</c> pass is purely in-memory and is not
+    /// cancellation-aware; cancellation is checked between phases.
+    /// </summary>
+    /// <param name="cancellationToken">
+    /// Cancels the source-drain loop (and intermediate phases). On
+    /// cancellation, a <see cref="OperationCanceledException"/> is thrown
+    /// and no graph is produced.
+    /// </param>
+    public OntologyGraph Build(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var domains = new List<DomainDescriptor>();
         var allObjectTypes = new List<ObjectTypeDescriptor>();
         var allInterfaces = new List<InterfaceDescriptor>();
@@ -72,7 +98,7 @@ public sealed class OntologyGraphBuilder
         // per-domain builder to be created on demand.
         // DR-10 (Task 17): wrap each source's drain in try/catch so the
         // SourceId is surfaced in any propagated composition exception.
-        DrainSources(buildersByDomain);
+        DrainSources(buildersByDomain, cancellationToken);
 
         foreach (var domainOntology in _domainOntologies)
         {
@@ -969,15 +995,24 @@ public sealed class OntologyGraphBuilder
             "(live invalidation lands in v2.6.0+ via SubscribeAsync). Task.Run + " +
             "ConfigureAwait(false) protects callers running under a captured " +
             "SynchronizationContext (e.g. WPF/UI).")]
-    private void DrainSources(Dictionary<string, OntologyBuilder> buildersByDomain)
+    private void DrainSources(
+        Dictionary<string, OntologyBuilder> buildersByDomain,
+        CancellationToken cancellationToken)
     {
         foreach (var source in _sources)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             try
             {
-                Task.Run(async () =>
-                    await DrainSourceCoreAsync(source, buildersByDomain).ConfigureAwait(false))
+                Task.Run(
+                    async () =>
+                        await DrainSourceCoreAsync(source, buildersByDomain, cancellationToken).ConfigureAwait(false),
+                    cancellationToken)
                     .GetAwaiter().GetResult();
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
             catch (OntologyCompositionException)
             {
@@ -994,9 +1029,10 @@ public sealed class OntologyGraphBuilder
 
     private static async Task DrainSourceCoreAsync(
         IOntologySource source,
-        Dictionary<string, OntologyBuilder> buildersByDomain)
+        Dictionary<string, OntologyBuilder> buildersByDomain,
+        CancellationToken cancellationToken)
     {
-        await foreach (var delta in source.LoadAsync(CancellationToken.None))
+        await foreach (var delta in source.LoadAsync(cancellationToken).WithCancellation(cancellationToken).ConfigureAwait(false))
         {
             var domainName = ResolveDeltaDomain(delta);
             if (domainName is null)

--- a/src/Strategos.Ontology/OntologyGraphBuilder.cs
+++ b/src/Strategos.Ontology/OntologyGraphBuilder.cs
@@ -1,5 +1,12 @@
+using System.Collections.Immutable;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
 using Strategos.Ontology.Builder;
+using Strategos.Ontology.Configuration;
 using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Diagnostics;
 using Strategos.Ontology.Extensions;
 
 namespace Strategos.Ontology;
@@ -9,6 +16,32 @@ public sealed class OntologyGraphBuilder
     private readonly List<DomainOntology> _domainOntologies = [];
     private readonly List<WorkflowMetadataBuilder> _workflowMetadata = [];
     private readonly List<IOntologySource> _sources = [];
+    private ILogger<OntologyGraphBuilder> _logger = NullLogger<OntologyGraphBuilder>.Instance;
+    private OntologyOptions? _options;
+
+    /// <summary>
+    /// DR-7 / DR-10: wires an <see cref="ILogger{T}"/> so graph-freeze
+    /// warnings (AONT202, AONT203) and info (AONT204, AONT206) are
+    /// surfaced via structured logging in addition to
+    /// <see cref="OntologyGraph.NonFatalDiagnostics"/>.
+    /// </summary>
+    public OntologyGraphBuilder WithLogger(ILogger<OntologyGraphBuilder> logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        _logger = logger;
+        return this;
+    }
+
+    /// <summary>
+    /// DR-7 (Task 28): wires opt-in flags (e.g.
+    /// <see cref="OntologyOptions.EnableHygieneHints"/> for AONT206).
+    /// </summary>
+    public OntologyGraphBuilder WithOptions(OntologyOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _options = options;
+        return this;
+    }
 
     public OntologyGraphBuilder AddDomain<T>()
         where T : DomainOntology, new()
@@ -207,6 +240,36 @@ public sealed class OntologyGraphBuilder
 
         var workflowChains = BuildWorkflowChains(allObjectTypes, _workflowMetadata, warnings);
 
+        // DR-7 + DR-10 (Tasks 23-30): graph-freeze AONT200-series checks.
+        // Pre-merge ingested originals are collected from each per-domain
+        // builder so hand vs ingested comparisons survive MergeTwo's
+        // per-name union. Error-severity diagnostics aggregate into the
+        // thrown exception; warning/info land on the returned graph and
+        // are mirrored to the structured logger.
+        var ingestedOriginals = new Dictionary<(string DomainName, string Name), ObjectTypeDescriptor>();
+        foreach (var (_, builder) in buildersByDomain)
+        {
+            foreach (var kvp in builder.IngestedOriginals)
+            {
+                ingestedOriginals[kvp.Key] = kvp.Value;
+            }
+        }
+
+        var fatalDiagnostics = ImmutableArray.CreateBuilder<OntologyDiagnostic>();
+        var nonFatalDiagnostics = ImmutableArray.CreateBuilder<OntologyDiagnostic>();
+        PerformGraphFreezeChecks(
+            allObjectTypes,
+            ingestedOriginals,
+            fatalDiagnostics,
+            nonFatalDiagnostics);
+
+        if (fatalDiagnostics.Count > 0)
+        {
+            throw new OntologyCompositionException(
+                fatalDiagnostics.ToImmutable(),
+                nonFatalDiagnostics.ToImmutable());
+        }
+
         return new OntologyGraph(
             domains: domains.ToArray(),
             objectTypes: allObjectTypes.ToArray(),
@@ -214,7 +277,385 @@ public sealed class OntologyGraphBuilder
             crossDomainLinks: resolvedLinks.ToArray(),
             workflowChains: workflowChains.ToArray(),
             objectTypeNamesByType: namesByType,
-            warnings: warnings.AsReadOnly());
+            warnings: warnings.AsReadOnly(),
+            nonFatalDiagnostics: nonFatalDiagnostics.ToImmutable());
+    }
+
+    /// <summary>
+    /// DR-7 (Tasks 23-30): graph-freeze AONT200-series diagnostics.
+    /// Iterates merged descriptors against their pre-merge ingested
+    /// originals to detect hand-vs-ingested property drift,
+    /// type/kind mismatches, missing references, language disagreements,
+    /// and other invariants. Error-severity entries land in
+    /// <paramref name="fatal"/>; warning + info entries land in
+    /// <paramref name="nonFatal"/> and are mirrored to the structured
+    /// logger so telemetry pipelines see them even when the build
+    /// succeeds.
+    /// </summary>
+    private void PerformGraphFreezeChecks(
+        List<ObjectTypeDescriptor> allObjectTypes,
+        IReadOnlyDictionary<(string DomainName, string Name), ObjectTypeDescriptor> ingestedOriginals,
+        ImmutableArray<OntologyDiagnostic>.Builder fatal,
+        ImmutableArray<OntologyDiagnostic>.Builder nonFatal)
+    {
+        // AONT201 — hand-declared property missing from ingested
+        // descriptor (after MergeTwo). Inspect the merged descriptor for
+        // hand-tagged properties and confirm each appears on the
+        // pre-merge ingested original. Skip descriptors that never had
+        // an ingested contribution (hand-only).
+        // AONT202 — hand-declared property type/kind mismatches ingested
+        // contribution (same name). Warning-severity; surfaces on the
+        // returned graph and is mirrored to the structured logger.
+        foreach (var descriptor in allObjectTypes)
+        {
+            if (!ingestedOriginals.TryGetValue((descriptor.DomainName, descriptor.Name), out var ingested))
+            {
+                continue;
+            }
+
+            // Defensive: an ingested source could in principle emit two
+            // properties with the same name on a single descriptor (e.g. a
+            // malformed source replaying a partial state). Plain
+            // ToDictionary would throw before AONT201/202 could surface
+            // the real problem to the operator. Group by name and take
+            // last-write-wins so the duplicate name survives downstream
+            // diagnostics (where AONT040/AONT042-style messaging belongs).
+            var ingestedByName = ingested.Properties
+                .GroupBy(p => p.Name, StringComparer.Ordinal)
+                .ToDictionary(g => g.Key, g => g.Last(), StringComparer.Ordinal);
+
+            foreach (var property in descriptor.Properties)
+            {
+                if (property.Source != DescriptorSource.HandAuthored)
+                {
+                    continue;
+                }
+
+                if (!ingestedByName.TryGetValue(property.Name, out var ingestedProp))
+                {
+                    fatal.Add(new OntologyDiagnostic(
+                        Id: "AONT201",
+                        Message:
+                            $"AONT201: hand-declared property '{property.Name}' on "
+                            + $"'{descriptor.DomainName}.{descriptor.Name}' is missing from the "
+                            + $"ingested descriptor. Pass-6b rename matcher may have missed this — "
+                            + $"verify the property name on the ingested side.",
+                        Severity: OntologyDiagnosticSeverity.Error,
+                        DomainName: descriptor.DomainName,
+                        TypeName: descriptor.Name,
+                        PropertyName: property.Name));
+                    continue;
+                }
+
+                // AONT202 — type/kind mismatch on a hand-vs-ingested
+                // property with the same name. Kind disagreement is
+                // sufficient (e.g. hand Scalar vs ingested Reference);
+                // a raw PropertyType inequality also trips the warning
+                // because ingested-side types may not be loadable as CLR
+                // (ReferenceSymbolKey carries the truth) but a non-null
+                // PropertyType disagreement is still meaningful drift.
+                // AONT206 — opt-in hygiene hint: the property is
+                // declared on both sides. Fires only when the consumer
+                // has set OntologyOptions.EnableHygieneHints (MSBuild
+                // property OntologyEnableHygieneHints). Always emitted
+                // alongside any AONT202 mismatch (the two are
+                // complementary: 202 says "they disagree", 206 says
+                // "you may not need both").
+                if (_options is { EnableHygieneHints: true })
+                {
+                    var hint = new OntologyDiagnostic(
+                        Id: "AONT206",
+                        Message:
+                            $"AONT206: property '{property.Name}' on "
+                            + $"'{descriptor.DomainName}.{descriptor.Name}' is declared in hand "
+                            + "Define() and also contributed by the ingested side — consider "
+                            + "removing the redundant hand declaration.",
+                        Severity: OntologyDiagnosticSeverity.Info,
+                        DomainName: descriptor.DomainName,
+                        TypeName: descriptor.Name,
+                        PropertyName: property.Name);
+
+                    nonFatal.Add(hint);
+                    LogNonFatal(hint);
+                }
+
+                if (property.Kind != ingestedProp.Kind || property.PropertyType != ingestedProp.PropertyType)
+                {
+                    var diag = new OntologyDiagnostic(
+                        Id: "AONT202",
+                        Message:
+                            $"AONT202: property '{property.Name}' on "
+                            + $"'{descriptor.DomainName}.{descriptor.Name}' has hand-declared "
+                            + $"type/kind ({property.PropertyType.Name}/{property.Kind}) that "
+                            + $"mismatches the ingested side "
+                            + $"({ingestedProp.PropertyType.Name}/{ingestedProp.Kind}).",
+                        Severity: OntologyDiagnosticSeverity.Warning,
+                        DomainName: descriptor.DomainName,
+                        TypeName: descriptor.Name,
+                        PropertyName: property.Name);
+
+                    nonFatal.Add(diag);
+                    LogNonFatal(diag);
+                }
+            }
+
+            // AONT203 fold — Strict-mode opt-in: ingested-only properties
+            // missing from hand Define() emit warning AONT203.
+            if (IsStrictDomainEntity(descriptor))
+            {
+                var handPropNames = new HashSet<string>(
+                    descriptor.Properties
+                        .Where(p => p.Source == DescriptorSource.HandAuthored)
+                        .Select(p => p.Name),
+                    StringComparer.Ordinal);
+
+                foreach (var ingestedProp in ingested.Properties)
+                {
+                    if (handPropNames.Contains(ingestedProp.Name))
+                    {
+                        continue;
+                    }
+
+                    var diag = new OntologyDiagnostic(
+                        Id: "AONT203",
+                        Message:
+                            $"AONT203: property '{ingestedProp.Name}' is present on the "
+                            + $"ingested descriptor of '{descriptor.DomainName}.{descriptor.Name}' "
+                            + $"but not declared in hand Define(); type is marked "
+                            + $"[DomainEntity(Strict = true)].",
+                        Severity: OntologyDiagnosticSeverity.Warning,
+                        DomainName: descriptor.DomainName,
+                        TypeName: descriptor.Name,
+                        PropertyName: ingestedProp.Name);
+
+                    nonFatal.Add(diag);
+                    LogNonFatal(diag);
+                }
+            }
+        }
+
+        // AONT208 — LanguageId disagreement between MergeTwo origins.
+        // After merge, the descriptor's LanguageId mirrors the hand-side
+        // value. We compare that against the pre-merge ingested
+        // original. The diagnostic fires only when the hand-side opted
+        // into a non-default LanguageId (i.e. value != "dotnet"); the
+        // common dotnet/typescript polyglot path is the expected
+        // composition mode and does not trip.
+        foreach (var descriptor in allObjectTypes)
+        {
+            if (!ingestedOriginals.TryGetValue((descriptor.DomainName, descriptor.Name), out var ingested))
+            {
+                continue;
+            }
+
+            var handLanguage = descriptor.LanguageId;
+            var ingestedLanguage = ingested.LanguageId;
+
+            if (string.Equals(handLanguage, "dotnet", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (string.Equals(handLanguage, ingestedLanguage, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            fatal.Add(new OntologyDiagnostic(
+                Id: "AONT208",
+                Message:
+                    $"AONT208: descriptor '{descriptor.DomainName}.{descriptor.Name}' has "
+                    + $"LanguageId disagreement between hand ('{handLanguage}') and ingested "
+                    + $"('{ingestedLanguage}') contributions.",
+                Severity: OntologyDiagnosticSeverity.Error,
+                DomainName: descriptor.DomainName,
+                TypeName: descriptor.Name,
+                PropertyName: null));
+        }
+
+        // AONT205 (defensive freeze-time surface) — Task 16 catches the
+        // common case at delta-apply, but a stress scenario where two
+        // ingested sources race intent fields could land a defective
+        // descriptor in the merged graph. Any descriptor with
+        // Source = Ingested that carries non-empty Actions/Events or a
+        // Lifecycle survives this check as an aggregated error.
+        foreach (var descriptor in allObjectTypes)
+        {
+            if (descriptor.Source != DescriptorSource.Ingested)
+            {
+                continue;
+            }
+
+            string? offending = null;
+            if (descriptor.Actions.Count > 0)
+            {
+                offending = "Actions";
+            }
+            else if (descriptor.Events.Count > 0)
+            {
+                offending = "Events";
+            }
+            else if (descriptor.Lifecycle is not null)
+            {
+                offending = "Lifecycle";
+            }
+
+            if (offending is null)
+            {
+                continue;
+            }
+
+            fatal.Add(new OntologyDiagnostic(
+                Id: "AONT205",
+                Message:
+                    $"AONT205: ingested descriptor '{descriptor.DomainName}.{descriptor.Name}' "
+                    + $"contributes to intent-only field '{offending}'. Mechanical ingesters must "
+                    + "leave Actions, Events, and Lifecycle empty — those are hand-authored intent.",
+                Severity: OntologyDiagnosticSeverity.Error,
+                DomainName: descriptor.DomainName,
+                TypeName: descriptor.Name,
+                PropertyName: offending));
+        }
+
+        // AONT204 — info-severity hint when a purely ingested descriptor
+        // (Source = Ingested at graph-level) is not referenced by any
+        // hand-authored descriptor via Links.TargetTypeName,
+        // ParentTypeName, or KeyProperty links. Orphan ingested types
+        // often indicate a misconfigured ingester or unused contribution
+        // worth pruning.
+        var handReferencedNames = CollectHandReferencedTypeNames(allObjectTypes);
+        foreach (var descriptor in allObjectTypes)
+        {
+            if (descriptor.Source != DescriptorSource.Ingested)
+            {
+                continue;
+            }
+
+            if (handReferencedNames.Contains((descriptor.DomainName, descriptor.Name)))
+            {
+                continue;
+            }
+
+            // Also consider domain-agnostic name references — the hand
+            // link DSL may resolve to a descriptor with the same simple
+            // name in another domain (rare, but the resolver does fall
+            // back to a name-only scan).
+            if (handReferencedNames.Any(k => k.Name == descriptor.Name))
+            {
+                continue;
+            }
+
+            var diag = new OntologyDiagnostic(
+                Id: "AONT204",
+                Message:
+                    $"AONT204: ingested-only descriptor '{descriptor.DomainName}.{descriptor.Name}' "
+                    + "is not referenced by any hand-authored type (no Links, ParentType, "
+                    + "or KeyProperty references found).",
+                Severity: OntologyDiagnosticSeverity.Info,
+                DomainName: descriptor.DomainName,
+                TypeName: descriptor.Name,
+                PropertyName: null);
+
+            nonFatal.Add(diag);
+            LogNonFatal(diag);
+        }
+    }
+
+    /// <summary>
+    /// Collects every (DomainName, TargetName) pair that a hand-authored
+    /// descriptor references via Links, ParentTypeName, or a property's
+    /// ReferenceSymbolKey. Used by AONT204 to detect orphan ingested
+    /// descriptors. Same-domain link targets are recorded under the
+    /// hand descriptor's own domain; an empty string is used for the
+    /// domain slot when the reference is domain-agnostic.
+    /// </summary>
+    private static HashSet<(string DomainName, string Name)> CollectHandReferencedTypeNames(
+        List<ObjectTypeDescriptor> allObjectTypes)
+    {
+        var refs = new HashSet<(string, string)>();
+
+        foreach (var descriptor in allObjectTypes)
+        {
+            if (descriptor.Source != DescriptorSource.HandAuthored)
+            {
+                continue;
+            }
+
+            if (descriptor.ParentTypeName is not null)
+            {
+                refs.Add((descriptor.DomainName, descriptor.ParentTypeName));
+            }
+
+            foreach (var link in descriptor.Links)
+            {
+                // Hand-tagged links (or any link declared by a hand
+                // descriptor) point at TargetTypeName in the same domain
+                // unless the source is genuinely ingested-only on this
+                // descriptor — which is impossible here because we
+                // already gated on descriptor.Source.
+                refs.Add((descriptor.DomainName, link.TargetTypeName));
+            }
+        }
+
+        return refs;
+    }
+
+    /// <summary>
+    /// Reads <see cref="DomainEntityAttribute"/> off a descriptor's
+    /// <see cref="ObjectTypeDescriptor.ClrType"/> and reports whether
+    /// the type opts in to strict mode. Returns <c>false</c> for
+    /// ingested-only descriptors (no CLR type) — strictness is a
+    /// hand-side opt-in by design.
+    /// </summary>
+    private static bool IsStrictDomainEntity(ObjectTypeDescriptor descriptor)
+    {
+        if (descriptor.ClrType is null)
+        {
+            return false;
+        }
+
+        var attr = (DomainEntityAttribute?)Attribute.GetCustomAttribute(
+            descriptor.ClrType,
+            typeof(DomainEntityAttribute));
+
+        return attr is { Strict: true };
+    }
+
+    /// <summary>
+    /// Routes a non-fatal diagnostic through the wired structured logger.
+    /// Warnings use <c>LogWarning</c>; info uses <c>LogInformation</c>.
+    /// Each call carries structured properties
+    /// <c>{DiagnosticId, DomainName, TypeName, PropertyName}</c> so log
+    /// pipelines can filter by diagnostic id.
+    /// </summary>
+    private void LogNonFatal(OntologyDiagnostic diagnostic)
+    {
+        if (diagnostic.Severity == OntologyDiagnosticSeverity.Warning)
+        {
+#pragma warning disable CA2254 // Template should be a static expression
+            _logger.LogWarning(
+                "{DiagnosticId}: {Message} ({DomainName}.{TypeName}.{PropertyName})",
+                diagnostic.Id,
+                diagnostic.Message,
+                diagnostic.DomainName,
+                diagnostic.TypeName,
+                diagnostic.PropertyName);
+#pragma warning restore CA2254
+            return;
+        }
+
+        if (diagnostic.Severity == OntologyDiagnosticSeverity.Info)
+        {
+#pragma warning disable CA2254
+            _logger.LogInformation(
+                "{DiagnosticId}: {Message} ({DomainName}.{TypeName}.{PropertyName})",
+                diagnostic.Id,
+                diagnostic.Message,
+                diagnostic.DomainName,
+                diagnostic.TypeName,
+                diagnostic.PropertyName);
+#pragma warning restore CA2254
+        }
     }
 
     private static List<ResolvedCrossDomainLink> ResolveCrossDomainLinks(
@@ -671,61 +1112,136 @@ public sealed class OntologyGraphBuilder
 
     /// <summary>
     /// AONT041 — MultiRegisteredTypeInLink (Track C3).
-    /// Enforces the Option X freeze invariant that a CLR type registered under more than
-    /// one descriptor name cannot participate in structural links — neither as a link
-    /// target nor as a link source, and neither in intra-domain <see cref="LinkDescriptor"/>s
-    /// nor in <see cref="CrossDomainLinkDescriptor"/>s. The Basileus happy path is a
-    /// multi-registered leaf type with no links anywhere — that remains legal.
+    /// Enforces the Option X freeze invariant that a descriptor identity (CLR type or
+    /// SCIP SymbolKey) registered under more than one descriptor name cannot participate
+    /// in structural links — neither as a link target nor as a link source, and neither
+    /// in intra-domain <see cref="LinkDescriptor"/>s nor in <see cref="CrossDomainLinkDescriptor"/>s.
+    /// The Basileus happy path is a multi-registered leaf type with no links anywhere —
+    /// that remains legal.
     /// </summary>
     /// <remarks>
-    /// Intra-domain link targets carry only a <see cref="LinkDescriptor.TargetTypeName"/>
-    /// string. Under the Track B builder, <c>HasMany&lt;TLinked&gt;(name)</c> writes
-    /// <c>typeof(TLinked).Name</c> into that field, so we match multi-registered CLR types
-    /// against the link target by simple type name. Cross-domain links carry the source
-    /// CLR <see cref="Type"/> directly on the descriptor and identify their target by
-    /// <c>(TargetDomain, TargetTypeName)</c>, so we resolve those positionally. Future
-    /// relaxation (see #32) can carry the source CLR <see cref="Type"/> on intra-domain
-    /// links too.
+    /// DR-8 (Task 31) retarget: the lookup is now polyglot-aware. The "identity" of a
+    /// descriptor is its <see cref="ObjectTypeDescriptor.ClrType"/> when non-null, else
+    /// its <see cref="ObjectTypeDescriptor.SymbolKey"/>. Link targets resolve by
+    /// <c>(DomainName, Name)</c> directly — the previous CLR-simple-name pre-filter
+    /// produced false negatives for ingested-only descriptors. Cross-domain links keep
+    /// their CLR source-type wiring because the From&lt;T&gt;() builder requires a CLR
+    /// type, but the target-side scan is now polyglot.
     /// </remarks>
     private static void ValidateMultiRegisteredTypesNotInLinks(
         IReadOnlyList<ObjectTypeDescriptor> allObjectTypes,
         IReadOnlyList<(string SourceDomain, CrossDomainLinkDescriptor Descriptor)> crossDomainLinks,
         IReadOnlyDictionary<Type, IReadOnlyList<string>> namesByType)
     {
-        var multiRegistered = namesByType
-            .Where(kvp => kvp.Value.Count > 1)
-            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        // Polyglot identity reverse index: identity (ClrType-or-SymbolKey, as object) →
+        // list of (DomainName, Name) registrations. A descriptor is "multi-registered"
+        // when its identity bucket holds more than one entry. Ingested-only descriptors
+        // (ClrType == null) participate via SymbolKey identity; descriptors with neither
+        // a ClrType nor a SymbolKey are skipped — there is nothing to key against.
+        var identityByDescriptor = new Dictionary<(string DomainName, string Name), object>();
+        var registrationsByIdentity = new Dictionary<object, List<(string DomainName, string Name)>>();
+        foreach (var ot in allObjectTypes)
+        {
+            object? identity = ot.ClrType is not null ? ot.ClrType : ot.SymbolKey;
+            if (identity is null)
+            {
+                continue;
+            }
 
-        // Map simple CLR-type names → CLR Type, restricted to multi-registered types.
-        // Simple names match what HasMany<TLinked>(name) writes into LinkDescriptor.TargetTypeName.
-        var multiRegisteredByClrSimpleName = multiRegistered
+            identityByDescriptor[(ot.DomainName, ot.Name)] = identity;
+            if (!registrationsByIdentity.TryGetValue(identity, out var list))
+            {
+                list = new List<(string DomainName, string Name)>();
+                registrationsByIdentity[identity] = list;
+            }
+
+            list.Add((ot.DomainName, ot.Name));
+        }
+
+        // Direct (DomainName, Name) → descriptor index. Replaces the prior
+        // (DomainName, ClrSimpleName) map and covers polyglot descriptors. Includes
+        // every descriptor regardless of whether ClrType is set.
+        var descriptorByDomainAndName = allObjectTypes
+            .GroupBy(ot => (ot.DomainName, ot.Name))
+            .ToDictionary(g => g.Key, g => g.First());
+
+        // CLR-simple-name fallback: HasMany<TLinked>(name) writes typeof(TLinked).Name
+        // into LinkDescriptor.TargetTypeName, which need not match any registered
+        // descriptor name when the underlying type was registered under one or more
+        // explicit names (e.g., "orders" / "open_orders" for TradeOrder). To preserve
+        // the legacy multi-registered-CLR-type-as-link-target diagnostic we keep a
+        // sidecar index from CLR simple name → registered CLR type for types whose
+        // identity bucket holds more than one (Domain, Name) registration.
+        var multiRegisteredClrByName = namesByType
+            .Where(kvp => kvp.Value.Count > 1)
             .GroupBy(kvp => kvp.Key.Name)
             .ToDictionary(g => g.Key, g => g.First().Key);
 
-        // Index descriptors by (DomainName, ClrSimpleName) for the explicit-name check below.
-        // A link's TargetTypeName carries the CLR simple name of the linked type — use this
-        // to find the registered descriptor and verify its name matches the CLR simple name.
-        // DR-1 polyglot: skip ingested-only descriptors (null ClrType); the (DomainName, Name)
-        // retarget covers them when DR-8 lands.
+        // Sidecar index for the explicit-name sub-rule: a link whose TargetTypeName is a
+        // CLR simple name that resolves to a descriptor registered under an *explicit*
+        // (non-default) name. The descriptor identity is keyed under its registered name
+        // in descriptorByDomainAndName above, but the link target — which carries the CLR
+        // simple name from HasMany<TLinked> — needs (DomainName, ClrSimpleName) to find
+        // it. Only descriptors with a non-null ClrType participate.
         var descriptorByDomainAndClrSimpleName = allObjectTypes
             .Where(ot => ot.ClrType is not null)
             .GroupBy(ot => (ot.DomainName, ot.ClrType!.Name))
             .ToDictionary(g => g.Key, g => g.First());
 
+        bool IsMultiRegistered(string domain, string name)
+        {
+            return identityByDescriptor.TryGetValue((domain, name), out var identity)
+                && registrationsByIdentity.TryGetValue(identity, out var regs)
+                && regs.Count > 1;
+        }
+
+        IReadOnlyList<(string DomainName, string Name)> RegistrationsFor(string domain, string name)
+        {
+            if (identityByDescriptor.TryGetValue((domain, name), out var identity)
+                && registrationsByIdentity.TryGetValue(identity, out var regs))
+            {
+                return regs;
+            }
+
+            return Array.Empty<(string, string)>();
+        }
+
         foreach (var descriptor in allObjectTypes)
         {
-            // Check: does this descriptor declare an outgoing link whose target
-            // resolves to a multi-registered CLR type?
+            // Check: does this descriptor declare an outgoing link whose target resolves
+            // (within the same domain) to a multi-registered identity? Intra-domain links
+            // identify their target by simple name, so we resolve (descriptor.DomainName,
+            // link.TargetTypeName) and consult the polyglot identity index.
             foreach (var link in descriptor.Links)
             {
-                if (multiRegisteredByClrSimpleName.TryGetValue(link.TargetTypeName, out var targetClrType))
+                // CLR-simple-name fallback first: when no descriptor is registered under
+                // link.TargetTypeName in this domain, but the CLR simple name matches a
+                // multi-registered CLR type, the HasMany<TLinked>() target would resolve
+                // ambiguously at runtime — surface AONT041 instead.
+                if (!descriptorByDomainAndName.ContainsKey((descriptor.DomainName, link.TargetTypeName))
+                    && multiRegisteredClrByName.TryGetValue(link.TargetTypeName, out var multiClrType))
                 {
-                    var names = multiRegistered[targetClrType];
+                    var names = namesByType[multiClrType];
                     throw new OntologyCompositionException(
-                        $"AONT041: CLR type '{targetClrType.FullName}' has multiple registrations " +
+                        $"AONT041: CLR type '{multiClrType.FullName}' has multiple registrations " +
                         $"({string.Join(", ", names.Select(n => $"'{n}'"))}) but is also referenced as a link target " +
                         $"in '{descriptor.Name}.{link.Name}'. Multi-registered types cannot participate in structural " +
                         $"links. See #32 for a future relaxation path.");
+                }
+
+                if (descriptorByDomainAndName.TryGetValue(
+                        (descriptor.DomainName, link.TargetTypeName), out var targetDescriptor)
+                    && IsMultiRegistered(targetDescriptor.DomainName, targetDescriptor.Name))
+                {
+                    var regs = RegistrationsFor(targetDescriptor.DomainName, targetDescriptor.Name);
+                    var identityLabel = targetDescriptor.ClrType?.FullName
+                        ?? $"SymbolKey '{targetDescriptor.SymbolKey}'";
+                    throw new OntologyCompositionException(
+                        $"AONT041: descriptor identity '{identityLabel}' has multiple registrations " +
+                        $"({string.Join(", ", regs.Select(r => $"'{r.DomainName}.{r.Name}'"))}) but is also " +
+                        $"referenced as a link target in '{descriptor.Name}.{link.Name}'. " +
+                        $"Multi-registered types cannot participate in structural links. " +
+                        $"See #32 for a future relaxation path.");
                 }
 
                 // AONT041 extension: reject a link whose target type is registered with an
@@ -734,45 +1250,56 @@ public sealed class OntologyGraphBuilder
                 // differs from the CLR simple name, reads and writes would diverge silently
                 // across two table names. Enforcing single-registration with default name
                 // is the Option X minimum-invasiveness fix (see #33 Finding 1).
+                // Polyglot note: only meaningful for CLR-typed descriptors — ingested-only
+                // descriptors have no CLR-simple-name baseline to diverge from.
+                // We consult the CLR-simple-name index here because link.TargetTypeName
+                // is the CLR simple name; the explicit-name divergence shows up precisely
+                // when that name does not match any registered descriptor by name.
                 if (descriptorByDomainAndClrSimpleName.TryGetValue(
-                        (descriptor.DomainName, link.TargetTypeName), out var targetDescriptor)
-                    && targetDescriptor.ClrType is not null
-                    && targetDescriptor.Name != targetDescriptor.ClrType.Name)
+                        (descriptor.DomainName, link.TargetTypeName), out var explicitNameTarget)
+                    && explicitNameTarget.ClrType is not null
+                    && explicitNameTarget.Name != explicitNameTarget.ClrType.Name)
                 {
                     throw new OntologyCompositionException(
                         $"AONT041: Link '{descriptor.Name}.{link.Name}' targets CLR type " +
-                        $"'{targetDescriptor.ClrType.FullName}' which is registered with explicit " +
-                        $"descriptor name '{targetDescriptor.Name}' (default would be '{targetDescriptor.ClrType.Name}'). " +
+                        $"'{explicitNameTarget.ClrType.FullName}' which is registered with explicit " +
+                        $"descriptor name '{explicitNameTarget.Name}' (default would be '{explicitNameTarget.ClrType.Name}'). " +
                         $"A link target registered under a non-default name causes read/write table-name " +
                         $"divergence. Either remove the explicit name or use the default registration. " +
                         $"See #33 Finding 1.");
                 }
             }
 
-            // Check: does this descriptor's own CLR type have multiple registrations
-            // AND declare outgoing links? The source side is just as invalid as the target side.
-            // DR-1 polyglot: skip when ClrType is null (ingested-only); DR-8 covers this path.
-            if (descriptor.ClrType is not null
-                && descriptor.Links.Count > 0
-                && multiRegistered.TryGetValue(descriptor.ClrType, out var ownNames))
+            // Check: does this descriptor's own identity have multiple registrations AND
+            // declare outgoing links? The source side is just as invalid as the target side.
+            // Polyglot: works for both CLR-typed and ingested-only descriptors.
+            if (descriptor.Links.Count > 0
+                && IsMultiRegistered(descriptor.DomainName, descriptor.Name))
             {
+                var regs = RegistrationsFor(descriptor.DomainName, descriptor.Name);
+                var identityLabel = descriptor.ClrType?.FullName
+                    ?? $"SymbolKey '{descriptor.SymbolKey}'";
                 throw new OntologyCompositionException(
-                    $"AONT041: CLR type '{descriptor.ClrType.FullName}' has multiple registrations " +
-                    $"({string.Join(", ", ownNames.Select(n => $"'{n}'"))}) but also declares outgoing links " +
-                    $"({string.Join(", ", descriptor.Links.Select(l => $"'{l.Name}'"))}). Multi-registered types cannot " +
-                    $"participate in structural links. See #32 for a future relaxation path.");
+                    $"AONT041: descriptor identity '{identityLabel}' has multiple registrations " +
+                    $"({string.Join(", ", regs.Select(r => $"'{r.DomainName}.{r.Name}'"))}) but also " +
+                    $"declares outgoing links ({string.Join(", ", descriptor.Links.Select(l => $"'{l.Name}'"))}). " +
+                    $"Multi-registered types cannot participate in structural links. " +
+                    $"See #32 for a future relaxation path.");
             }
         }
 
         // Cross-domain link checks. Carries the source CLR type on the descriptor and
         // identifies the target by (TargetDomain, TargetTypeName). We deliberately reject
-        // ANY cross-domain link whose source or target CLR type appears more than once
-        // in the reverse index, even if the (sourceDomain, ClrType) lookup would itself
-        // be unambiguous — Option X says multi-registered types are leaf-only, full stop.
+        // ANY cross-domain link whose source or target identity appears more than once
+        // in the polyglot reverse index, even if the (sourceDomain, ClrType) lookup would
+        // itself be unambiguous — Option X says multi-registered types are leaf-only,
+        // full stop.
         foreach (var (sourceDomain, link) in crossDomainLinks)
         {
-            // Source side: descriptor.SourceType is the CLR type the From<T>() builder set.
-            if (multiRegistered.TryGetValue(link.SourceType, out var srcNames))
+            // Source side: link.SourceType is the CLR type the From<T>() builder set.
+            // Cross-domain link sources are still strictly CLR-typed (the From<T>() API
+            // requires it), so the source check stays CLR-keyed via namesByType.
+            if (namesByType.TryGetValue(link.SourceType, out var srcNames) && srcNames.Count > 1)
             {
                 throw new OntologyCompositionException(
                     $"AONT041: CLR type '{link.SourceType.FullName}' has multiple registrations " +
@@ -782,18 +1309,21 @@ public sealed class OntologyGraphBuilder
             }
 
             // Target side: resolve the target descriptor by (TargetDomain, TargetTypeName)
-            // and check whether its CLR type is multi-registered. If the target is
-            // unresolvable here, leave the diagnostic to ResolveCrossDomainLinks below.
+            // and check whether its identity (CLR or SymbolKey) is multi-registered. If
+            // the target is unresolvable here, leave the diagnostic to
+            // ResolveCrossDomainLinks below.
             var targetDescriptor = allObjectTypes.FirstOrDefault(
                 ot => ot.DomainName == link.TargetDomain && ot.Name == link.TargetTypeName);
 
             if (targetDescriptor is not null
-                && targetDescriptor.ClrType is not null
-                && multiRegistered.TryGetValue(targetDescriptor.ClrType, out var tgtNames))
+                && IsMultiRegistered(targetDescriptor.DomainName, targetDescriptor.Name))
             {
+                var tgtRegs = RegistrationsFor(targetDescriptor.DomainName, targetDescriptor.Name);
+                var identityLabel = targetDescriptor.ClrType?.FullName
+                    ?? $"SymbolKey '{targetDescriptor.SymbolKey}'";
                 throw new OntologyCompositionException(
-                    $"AONT041: CLR type '{targetDescriptor.ClrType.FullName}' has multiple registrations " +
-                    $"({string.Join(", ", tgtNames.Select(n => $"'{n}'"))}) but is the target of cross-domain link " +
+                    $"AONT041: descriptor identity '{identityLabel}' has multiple registrations " +
+                    $"({string.Join(", ", tgtRegs.Select(r => $"'{r.DomainName}.{r.Name}'"))}) but is the target of cross-domain link " +
                     $"'{link.Name}' from domain '{sourceDomain}' to '{link.TargetDomain}.{link.TargetTypeName}'. " +
                     $"Multi-registered types cannot participate in structural links. See #32 for a future relaxation path.");
             }

--- a/src/Strategos.Ontology/OntologyGraphBuilder.cs
+++ b/src/Strategos.Ontology/OntologyGraphBuilder.cs
@@ -69,8 +69,8 @@ public sealed class OntologyGraphBuilder
                 {
                     throw new OntologyCompositionException(
                         $"AONT040: Object type name '{descriptor.Name}' is registered twice in domain '{group.Key}'. " +
-                        $"First registration: CLR type '{existing.ClrType.FullName}'. " +
-                        $"Second registration: CLR type '{descriptor.ClrType.FullName}'. " +
+                        $"First registration: CLR type '{existing.ClrType?.FullName ?? existing.SymbolKey ?? "<unknown>"}'. " +
+                        $"Second registration: CLR type '{descriptor.ClrType?.FullName ?? descriptor.SymbolKey ?? "<unknown>"}'. " +
                         $"Either remove one registration, or specify distinct names via Object<T>(\"name\", ...).");
                 }
 
@@ -85,8 +85,12 @@ public sealed class OntologyGraphBuilder
         // Track C2 — reverse index from CLR type → descriptor names in registration order.
         // Built after the AONT040 check so callers can trust name uniqueness-per-domain,
         // and used by C3 below to detect multi-registered types in link positions.
+        // DR-1 polyglot: descriptors with null ClrType (ingested-only) are excluded
+        // from this CLR-keyed index; the (DomainName, Name)-keyed retarget arrives
+        // with DR-8 (AONT041 retarget) in a later task.
         var namesByType = allObjectTypes
-            .GroupBy(ot => ot.ClrType)
+            .Where(ot => ot.ClrType is not null)
+            .GroupBy(ot => ot.ClrType!)
             .ToDictionary(
                 g => g.Key,
                 g => (IReadOnlyList<string>)g.Select(ot => ot.Name).ToList().AsReadOnly());
@@ -613,8 +617,11 @@ public sealed class OntologyGraphBuilder
         // Index descriptors by (DomainName, ClrSimpleName) for the explicit-name check below.
         // A link's TargetTypeName carries the CLR simple name of the linked type — use this
         // to find the registered descriptor and verify its name matches the CLR simple name.
+        // DR-1 polyglot: skip ingested-only descriptors (null ClrType); the (DomainName, Name)
+        // retarget covers them when DR-8 lands.
         var descriptorByDomainAndClrSimpleName = allObjectTypes
-            .GroupBy(ot => (ot.DomainName, ot.ClrType.Name))
+            .Where(ot => ot.ClrType is not null)
+            .GroupBy(ot => (ot.DomainName, ot.ClrType!.Name))
             .ToDictionary(g => g.Key, g => g.First());
 
         foreach (var descriptor in allObjectTypes)
@@ -641,6 +648,7 @@ public sealed class OntologyGraphBuilder
                 // is the Option X minimum-invasiveness fix (see #33 Finding 1).
                 if (descriptorByDomainAndClrSimpleName.TryGetValue(
                         (descriptor.DomainName, link.TargetTypeName), out var targetDescriptor)
+                    && targetDescriptor.ClrType is not null
                     && targetDescriptor.Name != targetDescriptor.ClrType.Name)
                 {
                     throw new OntologyCompositionException(
@@ -655,7 +663,10 @@ public sealed class OntologyGraphBuilder
 
             // Check: does this descriptor's own CLR type have multiple registrations
             // AND declare outgoing links? The source side is just as invalid as the target side.
-            if (descriptor.Links.Count > 0 && multiRegistered.TryGetValue(descriptor.ClrType, out var ownNames))
+            // DR-1 polyglot: skip when ClrType is null (ingested-only); DR-8 covers this path.
+            if (descriptor.ClrType is not null
+                && descriptor.Links.Count > 0
+                && multiRegistered.TryGetValue(descriptor.ClrType, out var ownNames))
             {
                 throw new OntologyCompositionException(
                     $"AONT041: CLR type '{descriptor.ClrType.FullName}' has multiple registrations " +
@@ -689,6 +700,7 @@ public sealed class OntologyGraphBuilder
                 ot => ot.DomainName == link.TargetDomain && ot.Name == link.TargetTypeName);
 
             if (targetDescriptor is not null
+                && targetDescriptor.ClrType is not null
                 && multiRegistered.TryGetValue(targetDescriptor.ClrType, out var tgtNames))
             {
                 throw new OntologyCompositionException(
@@ -702,8 +714,13 @@ public sealed class OntologyGraphBuilder
 
     private static void InferPropertyKinds(List<ObjectTypeDescriptor> allObjectTypes)
     {
+        // DR-1 polyglot: ingested-only descriptors (null ClrType) don't participate
+        // in CLR-keyed reference-property inference; they reach reference kinds via
+        // PropertyDescriptor.ReferenceSymbolKey instead (DR-1, Task 4+).
         var registeredClrTypes = allObjectTypes
             .Select(ot => ot.ClrType)
+            .Where(t => t is not null)
+            .Select(t => t!)
             .ToHashSet();
 
         for (var i = 0; i < allObjectTypes.Count; i++)
@@ -793,9 +810,10 @@ public sealed class OntologyGraphBuilder
         // Keyed by (DomainName, ClrType.Name) so that Consumes<T>()/Produces<T>() — which
         // store typeof(T).Name — resolve to the right descriptor in the specified domain
         // even when the descriptor was registered with an explicit (non-CLR) name.
-        // See #33 Finding 4.
+        // See #33 Finding 4. DR-1 polyglot: ingested-only types skipped here.
         var objectTypesByDomainAndClrName = allObjectTypes
-            .GroupBy(ot => (ot.DomainName, ot.ClrType.Name))
+            .Where(ot => ot.ClrType is not null)
+            .GroupBy(ot => (ot.DomainName, ot.ClrType!.Name))
             .ToDictionary(g => g.Key, g => g.First());
 
         foreach (var metadata in workflowMetadata)

--- a/src/Strategos.Ontology/OntologyGraphBuilder.cs
+++ b/src/Strategos.Ontology/OntologyGraphBuilder.cs
@@ -8,6 +8,7 @@ public sealed class OntologyGraphBuilder
 {
     private readonly List<DomainOntology> _domainOntologies = [];
     private readonly List<WorkflowMetadataBuilder> _workflowMetadata = [];
+    private readonly List<IOntologySource> _sources = [];
 
     public OntologyGraphBuilder AddDomain<T>()
         where T : DomainOntology, new()
@@ -28,6 +29,20 @@ public sealed class OntologyGraphBuilder
         return this;
     }
 
+    /// <summary>
+    /// DR-3 (Task 13): registers <see cref="IOntologySource"/> instances
+    /// to be drained at <see cref="Build"/> time. Each source's
+    /// <c>LoadAsync</c> is iterated and emitted deltas applied to the
+    /// matching per-domain builder. Sources contribute before composition
+    /// so all subsequent validation observes a unified descriptor set.
+    /// </summary>
+    public OntologyGraphBuilder AddSources(IEnumerable<IOntologySource> sources)
+    {
+        ArgumentNullException.ThrowIfNull(sources);
+        _sources.AddRange(sources);
+        return this;
+    }
+
     public OntologyGraph Build()
     {
         var domains = new List<DomainDescriptor>();
@@ -35,10 +50,33 @@ public sealed class OntologyGraphBuilder
         var allInterfaces = new List<InterfaceDescriptor>();
         var allCrossDomainLinkDescriptors = new List<(string SourceDomain, CrossDomainLinkDescriptor Descriptor)>();
 
+        // Per-domain builders are kept so source-emitted deltas land in
+        // the same OntologyBuilder that the hand-authored Define() pass
+        // populated. New domains contributed exclusively by sources get
+        // their own builder created on demand below.
+        var buildersByDomain = new Dictionary<string, OntologyBuilder>();
+
         foreach (var domainOntology in _domainOntologies)
         {
             var ontologyBuilder = new OntologyBuilder(domainOntology.DomainName);
             domainOntology.Build(ontologyBuilder);
+            buildersByDomain[domainOntology.DomainName] = ontologyBuilder;
+        }
+
+        // DR-3 (Task 13): drain registered IOntologySource instances and
+        // apply their deltas via the existing per-domain OntologyBuilder.
+        // Runs after the hand-authored pass so hand descriptors are in
+        // place when ingested deltas reference them (e.g. AddProperty
+        // against a hand-defined ObjectType). Sources whose deltas
+        // reference a domain unseen by the hand pass cause a new
+        // per-domain builder to be created on demand.
+        // DR-10 (Task 17): wrap each source's drain in try/catch so the
+        // SourceId is surfaced in any propagated composition exception.
+        DrainSources(buildersByDomain);
+
+        foreach (var domainOntology in _domainOntologies)
+        {
+            var ontologyBuilder = buildersByDomain[domainOntology.DomainName];
 
             var domainDescriptor = new DomainDescriptor(domainOntology.DomainName)
             {
@@ -52,6 +90,30 @@ public sealed class OntologyGraphBuilder
             foreach (var crossDomainLink in ontologyBuilder.CrossDomainLinks)
             {
                 allCrossDomainLinkDescriptors.Add((domainOntology.DomainName, crossDomainLink));
+            }
+        }
+
+        // Source-only domains (no DomainOntology subclass): fold into the
+        // top-level lists so AONT040 et al. see their descriptors.
+        foreach (var (domainName, ontologyBuilder) in buildersByDomain)
+        {
+            if (_domainOntologies.Any(d => d.DomainName == domainName))
+            {
+                continue; // already handled in the hand-authored loop above
+            }
+
+            var domainDescriptor = new DomainDescriptor(domainName)
+            {
+                ObjectTypes = ontologyBuilder.ObjectTypes.ToArray(),
+            };
+
+            domains.Add(domainDescriptor);
+            allObjectTypes.AddRange(ontologyBuilder.ObjectTypes);
+            allInterfaces.AddRange(ontologyBuilder.Interfaces);
+
+            foreach (var crossDomainLink in ontologyBuilder.CrossDomainLinks)
+            {
+                allCrossDomainLinkDescriptors.Add((domainName, crossDomainLink));
             }
         }
 
@@ -885,6 +947,85 @@ public sealed class OntologyGraphBuilder
 
         return true;
     }
+
+    /// <summary>
+    /// DR-3 + DR-10 (Tasks 13, 17): drains each registered
+    /// <see cref="IOntologySource"/>'s <c>LoadAsync</c> and applies each
+    /// emitted delta to the per-domain <see cref="OntologyBuilder"/>.
+    /// Synchronous bridging of the async stream is intentional —
+    /// <see cref="Build"/> is sync and Strategos 2.5.0 ships only the
+    /// startup drain. Source-raised exceptions are wrapped in
+    /// <see cref="OntologyCompositionException"/> with the offending
+    /// <see cref="IOntologySource.SourceId"/> in the message so logs and
+    /// incident reports attribute the failure to the right ingester.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Usage",
+        "VSTHRD002:Synchronously waiting on tasks or awaiters",
+        Justification =
+            "Intentional sync bridge at the OntologyGraphBuilder startup boundary. " +
+            "Build() is sync by design and Strategos 2.5.0 only drains LoadAsync " +
+            "once at composition; the async surface exists for forward compatibility " +
+            "(live invalidation lands in v2.6.0+ via SubscribeAsync). Task.Run + " +
+            "ConfigureAwait(false) protects callers running under a captured " +
+            "SynchronizationContext (e.g. WPF/UI).")]
+    private void DrainSources(Dictionary<string, OntologyBuilder> buildersByDomain)
+    {
+        foreach (var source in _sources)
+        {
+            try
+            {
+                Task.Run(async () =>
+                    await DrainSourceCoreAsync(source, buildersByDomain).ConfigureAwait(false))
+                    .GetAwaiter().GetResult();
+            }
+            catch (OntologyCompositionException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new OntologyCompositionException(
+                    $"IOntologySource '{source.SourceId}' raised during LoadAsync: {ex.Message}",
+                    ex);
+            }
+        }
+    }
+
+    private static async Task DrainSourceCoreAsync(
+        IOntologySource source,
+        Dictionary<string, OntologyBuilder> buildersByDomain)
+    {
+        await foreach (var delta in source.LoadAsync(CancellationToken.None))
+        {
+            var domainName = ResolveDeltaDomain(delta);
+            if (domainName is null)
+            {
+                continue;
+            }
+
+            if (!buildersByDomain.TryGetValue(domainName, out var ontologyBuilder))
+            {
+                ontologyBuilder = new OntologyBuilder(domainName);
+                buildersByDomain[domainName] = ontologyBuilder;
+            }
+
+            ontologyBuilder.ApplyDelta(delta);
+        }
+    }
+
+    private static string? ResolveDeltaDomain(OntologyDelta delta) => delta switch
+    {
+        OntologyDelta.AddObjectType a => a.Descriptor.DomainName,
+        OntologyDelta.UpdateObjectType u => u.Descriptor.DomainName,
+        OntologyDelta.RemoveObjectType r => r.DomainName,
+        OntologyDelta.AddProperty ap => ap.DomainName,
+        OntologyDelta.RenameProperty rp => rp.DomainName,
+        OntologyDelta.RemoveProperty rp => rp.DomainName,
+        OntologyDelta.AddLink al => al.DomainName,
+        OntologyDelta.RemoveLink rl => rl.DomainName,
+        _ => null,
+    };
 
     private static bool TryResolveUnambiguous(
         Dictionary<string, List<ObjectTypeDescriptor>> objectTypesByName,

--- a/src/Strategos.Ontology/Query/OntologyQueryService.cs
+++ b/src/Strategos.Ontology/Query/OntologyQueryService.cs
@@ -356,7 +356,12 @@ internal sealed class OntologyQueryService : IOntologyQuery
             return [];
         }
 
-        var targetOt = FindObjectType(link.TargetTypeName);
+        // The owning domain is known here (ot.DomainName), so the inverse-link
+        // hop must use the domain-qualified lookup. Otherwise a same-named
+        // target type registered in a different domain would trip the
+        // bare-name ambiguity throw on an internal hop that should never
+        // have been ambiguous.
+        var targetOt = FindObjectType(ot.DomainName, link.TargetTypeName);
         if (targetOt is null)
         {
             return [];
@@ -614,8 +619,47 @@ internal sealed class OntologyQueryService : IOntologyQuery
         return BlastRadiusScope.Domain;
     }
 
-    private ObjectTypeDescriptor? FindObjectType(string objectType) =>
-        graph.ObjectTypes.FirstOrDefault(ot => ot.Name == objectType);
+    /// <summary>
+    /// DR-8 Task 32: bare-name descriptor lookup. Resolves <paramref name="objectType"/>
+    /// against <see cref="OntologyGraph.ObjectTypes"/> by simple <see cref="ObjectTypeDescriptor.Name"/>.
+    /// Returns <c>null</c> when nothing matches; throws
+    /// <see cref="InvalidOperationException"/> when two or more descriptors across
+    /// distinct domains share the supplied name. This closes the PR #59 follow-up
+    /// where a domain-agnostic fallback could silently bind to the first match in
+    /// a cross-domain catalog. Callers that already know the domain should use
+    /// <see cref="FindObjectType(string, string)"/> instead.
+    /// </summary>
+    private ObjectTypeDescriptor? FindObjectType(string objectType)
+    {
+        var matches = graph.ObjectTypes.Where(ot => ot.Name == objectType).ToList();
+        if (matches.Count == 0)
+        {
+            return null;
+        }
+
+        if (matches.Count == 1)
+        {
+            return matches[0];
+        }
+
+        var candidates = string.Join(
+            ", ",
+            matches
+                .Select(ot => $"'{ot.DomainName}.{ot.Name}'")
+                .OrderBy(s => s, StringComparer.Ordinal));
+        throw new InvalidOperationException(
+            $"Object type name '{objectType}' is ambiguous: registered in multiple domains " +
+            $"({candidates}). Pass the owning domain explicitly to disambiguate.");
+    }
+
+    /// <summary>
+    /// DR-8 Task 32: domain-qualified descriptor lookup. Resolves
+    /// <c>(<paramref name="domain"/>, <paramref name="objectType"/>)</c> via
+    /// <see cref="OntologyGraph.GetObjectType(string, string)"/>. Always unambiguous
+    /// because per-domain name uniqueness is enforced by AONT040.
+    /// </summary>
+    private ObjectTypeDescriptor? FindObjectType(string domain, string objectType) =>
+        graph.GetObjectType(domain, objectType);
 
     private static IReadOnlyList<ConstraintEvaluation> EvaluateConstraints(
         IReadOnlyList<ActionPrecondition> preconditions,

--- a/src/Strategos.Ontology/Sources/IOntologySource.cs
+++ b/src/Strategos.Ontology/Sources/IOntologySource.cs
@@ -3,8 +3,8 @@ namespace Strategos.Ontology;
 /// <summary>
 /// Extension point enabling ontology graph contributions from sources
 /// beyond hand-authored <c>DomainOntology.Define()</c>. Registered via DI
-/// (see <c>OntologyBuilderOptions.AddSource&lt;T&gt;()</c>). Drained at
-/// startup by <see cref="OntologyGraphBuilder"/>.
+/// (see <c>OntologyOptions.AddSource&lt;T&gt;()</c>). Drained at startup
+/// by <see cref="OntologyGraphBuilder"/>.
 /// </summary>
 /// <remarks>
 /// DR-3 (Task 7). The Strategos 2.5.0 consumer ships the <see cref="LoadAsync"/>

--- a/src/Strategos.Ontology/Sources/IOntologySource.cs
+++ b/src/Strategos.Ontology/Sources/IOntologySource.cs
@@ -1,0 +1,35 @@
+namespace Strategos.Ontology;
+
+/// <summary>
+/// Extension point enabling ontology graph contributions from sources
+/// beyond hand-authored <c>DomainOntology.Define()</c>. Registered via DI
+/// (see <c>OntologyBuilderOptions.AddSource&lt;T&gt;()</c>). Drained at
+/// startup by <see cref="OntologyGraphBuilder"/>.
+/// </summary>
+/// <remarks>
+/// DR-3 (Task 7). The Strategos 2.5.0 consumer ships the <see cref="LoadAsync"/>
+/// drain; <see cref="SubscribeAsync"/> is part of the surface contract for
+/// forward compatibility with live invalidation (v2.6.0+), and may
+/// complete immediately for static sources.
+/// </remarks>
+public interface IOntologySource
+{
+    /// <summary>
+    /// Stable identifier; tags provenance and conflict diagnostics.
+    /// Used as the <c>SourceId</c> on emitted <see cref="OntologyDelta"/>
+    /// values and threaded through any composition exception originating
+    /// from this source.
+    /// </summary>
+    string SourceId { get; }
+
+    /// <summary>
+    /// Replays the source's full state as a stream of deltas. Called once
+    /// at <see cref="OntologyGraphBuilder.Build"/> time.
+    /// </summary>
+    IAsyncEnumerable<OntologyDelta> LoadAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Subscribes to incremental updates. Empty for static sources.
+    /// </summary>
+    IAsyncEnumerable<OntologyDelta> SubscribeAsync(CancellationToken ct);
+}

--- a/src/Strategos.Ontology/Sources/OntologyDelta.cs
+++ b/src/Strategos.Ontology/Sources/OntologyDelta.cs
@@ -1,3 +1,5 @@
+using Strategos.Ontology.Descriptors;
+
 namespace Strategos.Ontology;
 
 /// <summary>
@@ -5,11 +7,13 @@ namespace Strategos.Ontology;
 /// <see cref="IOntologySource"/> implementations.
 /// </summary>
 /// <remarks>
-/// DR-4 (Task 8) supplies the eight concrete variants. This file
-/// reserves the sealed-abstract shell — only <c>SourceId</c> and
-/// <c>Timestamp</c> required-init fields — so that the
-/// <see cref="IOntologySource"/> interface (Task 7) can refer to the
-/// base type without yet depending on the variant catalog.
+/// DR-4 (Task 8). Eight sealed-record variants cover object-type,
+/// property, and link granularity. The mechanical ingester is forbidden
+/// from constructing <c>Add</c>/<c>Update</c> deltas whose descriptors
+/// contain <c>Actions</c>, <c>Events</c>, or <c>Lifecycle</c> (AONT205);
+/// validation occurs at delta-apply time, not at delta-construction time.
+/// <see cref="RenameProperty"/> is a single delta — not a Remove+Add pair
+/// — to preserve identity through the matcher.
 /// </remarks>
 public abstract record OntologyDelta
 {
@@ -18,4 +22,32 @@ public abstract record OntologyDelta
 
     /// <summary>Wall-clock instant of the originating change.</summary>
     public required DateTimeOffset Timestamp { get; init; }
+
+    /// <summary>Adds an <see cref="ObjectTypeDescriptor"/> to the ontology graph.</summary>
+    public sealed record AddObjectType(ObjectTypeDescriptor Descriptor) : OntologyDelta;
+
+    /// <summary>Replaces the descriptor matching <c>(DomainName, Name)</c> of <paramref name="Descriptor"/>.</summary>
+    public sealed record UpdateObjectType(ObjectTypeDescriptor Descriptor) : OntologyDelta;
+
+    /// <summary>Removes the object type identified by <paramref name="DomainName"/> + <paramref name="TypeName"/>.</summary>
+    public sealed record RemoveObjectType(string DomainName, string TypeName) : OntologyDelta;
+
+    /// <summary>Appends a property to an existing object type.</summary>
+    public sealed record AddProperty(string DomainName, string TypeName, PropertyDescriptor Descriptor) : OntologyDelta;
+
+    /// <summary>
+    /// Renames a property in place, preserving identity through the
+    /// rename matcher. Always single-delta — never expanded into a
+    /// <see cref="RemoveProperty"/> + <see cref="AddProperty"/> pair.
+    /// </summary>
+    public sealed record RenameProperty(string DomainName, string TypeName, string FromName, string ToName) : OntologyDelta;
+
+    /// <summary>Removes a property by name from the parent object type.</summary>
+    public sealed record RemoveProperty(string DomainName, string TypeName, string PropertyName) : OntologyDelta;
+
+    /// <summary>Appends a link to an existing source object type.</summary>
+    public sealed record AddLink(string DomainName, string SourceTypeName, LinkDescriptor Descriptor) : OntologyDelta;
+
+    /// <summary>Removes a link by name from its source object type.</summary>
+    public sealed record RemoveLink(string DomainName, string SourceTypeName, string LinkName) : OntologyDelta;
 }

--- a/src/Strategos.Ontology/Sources/OntologyDelta.cs
+++ b/src/Strategos.Ontology/Sources/OntologyDelta.cs
@@ -1,0 +1,21 @@
+namespace Strategos.Ontology;
+
+/// <summary>
+/// Abstract base of the ontology event vocabulary emitted by
+/// <see cref="IOntologySource"/> implementations.
+/// </summary>
+/// <remarks>
+/// DR-4 (Task 8) supplies the eight concrete variants. This file
+/// reserves the sealed-abstract shell — only <c>SourceId</c> and
+/// <c>Timestamp</c> required-init fields — so that the
+/// <see cref="IOntologySource"/> interface (Task 7) can refer to the
+/// base type without yet depending on the variant catalog.
+/// </remarks>
+public abstract record OntologyDelta
+{
+    /// <summary>Identifier of the <see cref="IOntologySource"/> emitting the delta.</summary>
+    public required string SourceId { get; init; }
+
+    /// <summary>Wall-clock instant of the originating change.</summary>
+    public required DateTimeOffset Timestamp { get; init; }
+}


### PR DESCRIPTION
## Summary

First half of the Strategos 2.5.0 polyglot ingestion slice. Ships the descriptor schema, the source extension point, and the compile-time invariant — independently mergeable to unblock basileus on `MartenOntologySource`.

Closes (partially): #37 (`IOntologySource`+provenance), #48 (polyglot descriptors), #43 (AONT037 trigger; AONT200-series in PR-B).

**Design:** `docs/designs/2026-05-10-ontology-2-5-0-polyglot-ingestion.md`
**Plan:** `docs/plans/2026-05-10-ontology-2-5-0-polyglot-ingestion.md` (Tasks 1–22)

## What ships

| DR | Surface | Tasks |
|---|---|---|
| DR-1 | Polyglot descriptor schema (`ClrType?`, `SymbolKey`, `SymbolFqn`, `LanguageId` on Object/Link/Property) | 1–4 |
| DR-2 | AONT037 `PolyglotInvariantViolated` source-generator diagnostic | 18, 19 |
| DR-3 | `IOntologySource` interface + `OntologyOptions.AddSource<T>` DI | 7, 12 |
| DR-4 | `OntologyDelta` sealed-abstract record + 8 variants | 8 |
| DR-5 | `IOntologyBuilder.ObjectTypeFromDescriptor` + `ApplyDelta` (all 8 variants + unknown-variant guard) | 9, 10, 11 |
| DR-6 | `DescriptorSource` provenance + `MergeTwo` lattice (identity + property + link union) | 1, 14, 15 |
| DR-9 | `TestOntologySource` fixture + Roslyn `GetDocumentationCommentId` round-trip | 20, 22 |
| DR-10 | `OntologyCompositionException` aggregates diagnostics; source-error propagation with `SourceId`; AONT205 at delta-apply | 5, 16, 17 |
| (integration) | `OntologyGraphBuilder.Build()` drains registered sources; synthetic merge/diagnostic matrix | 13, 21 |

**Out of scope (PR-B):** AONT200-series graph-freeze diagnostics (AONT201–AONT208), AONT041 retarget, `OntologyValidateTool.FindObjectType` retarget. PR-B begins once this merges.

## Test plan

- [x] `dotnet build src/strategos.sln` — 0 warnings, 0 errors
- [x] `Strategos.Ontology.Tests`: 750/750 (+84 from baseline 666)
- [x] `Strategos.Ontology.Generators.Tests`: 86/86 (+8 from baseline 78)
- [x] `Strategos.Ontology.MCP.Tests`: 123/123 (unchanged)

## Notable deviations from the plan / design

1. **Identity-invariant guard is asymmetric** — enforced in `ObjectTypeDescriptor.SymbolKey` init setter only, not in the parameterless ctor. `new ObjectTypeDescriptor { Name=..., DomainName=... }` without either identity field compiles; AONT037 catches that case at the source-generator level, which is the design's intended detection layer.
2. **`AddSource<T>` is an instance method on `OntologyOptions`**, not an extension method — matches the surrounding `AddDomain<T>` pattern. Captures `static () => new T()` factories with `[DynamicallyAccessedMembers(PublicConstructors)]` for trim safety; avoids pulling `Microsoft.Extensions.DependencyInjection` (non-Abstractions) into `Strategos.Ontology`.
3. **`OntologyBuilder.ObjectTypeFromDescriptor` performs in-place cross-provenance `MergeTwo` fold** when an existing descriptor occupies the `(DomainName, Name)` slot with opposite provenance. Order-independent — works whether hand or ingested arrives first. Required for the Task 21 end-to-end matrix.
4. **AONT037 analyzer is purely syntactic** — matches `ObjectType` non-generic invocations with no `symbolKey:` named arg and no `typeof(...)` argument. Avoids semantic dependency on the descriptor-by-name overload (which doesn't ship in this PR).
5. **Roslyn `SymbolKey` substituted with `ISymbol.GetDocumentationCommentId()`** in Task 22 — Roslyn's `SymbolKey` is `internal`; cref ID is the stable public alternative and is what SCIP ingesters canonicalize on.
6. **`OntologyDelta` shell shipped in Task 7 commit**, variants filled in Task 8 — `IOntologySource` references `OntologyDelta` in its method signatures, so the shell had to exist for the Task 7 contract test to compile. Variant behavior is still pinned by Task 8's `OntologyDeltaTests`.
7. **`VSTHRD002` suppression on `OntologyGraphBuilder.DrainSources`** — bridges `IAsyncEnumerable` to sync `Build()` via `Task.Run + GetAwaiter().GetResult()`. Documented inline; live-invalidation via `SubscribeAsync` is the v2.6.0 path that returns the surface to fully async.

## Stack

PR-A of 2 in the Strategos 2.5.0 polyglot ingestion slice. PR-B follows once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)