### PR TITLE
feat(ontology): 2.6.0 PR-A — IKeywordSearchProvider seam (closes #56)

### DIFF
--- a/docs/designs/2026-05-15-ontology-2-6-0-hybrid-retrieval.md
+++ b/docs/designs/2026-05-15-ontology-2-6-0-hybrid-retrieval.md
@@ -1,0 +1,627 @@
+# Ontology 2.6.0 — Hybrid Retrieval Seams
+
+**Status.** Design — approved for planning.
+**Milestone.** Ontology 2.6.0 — Hybrid Retrieval Seams.
+**Umbrella issue.** [#47](https://github.com/lvlup-sw/strategos/issues/47).
+**Sub-issues.** [#56 (DR-1)](https://github.com/lvlup-sw/strategos/issues/56), [#57 (DR-2)](https://github.com/lvlup-sw/strategos/issues/57), [#58 (DR-3)](https://github.com/lvlup-sw/strategos/issues/58).
+**Predecessor.** Ontology 2.5.0 — Dispatch Guarantees + Polyglot Ingestion + MCP 2025-11-25 + Starlight docs. Released; tag pushed; merge-queue clear.
+**Successor.** Strategos 2.7.0 — Convergence (TypeSpec parity, IWorkflowBuilder PublicAPI baseline).
+
+---
+
+## 1. Problem statement
+
+Strategos 2.5.0 shipped a fully-typed, MCP-conformant ontology query surface (`OntologyQueryTool.QueryAsync` with optional semantic-vector branch) backed by `IOntologySource` and version-stamped `ResponseMeta`. Basileus's [Ontology MCP Endpoint epic (basileus#167)](https://github.com/lvlup-sw/basileus/issues/167) needs that surface to optionally fan out a *parallel* keyword (sparse / BM25) retrieval path and fuse it with the existing dense (vector) path — without Strategos owning the BM25 backend choice, the reranker, or the cache.
+
+The grounding research (`basileus:docs/research/2026-04-19-data-shape-query-performance-relevance.md`) and parent ADR (`basileus:docs/adrs/ontological-data-fabric.md` §4.3, §§9.8–9.9) establish that hybrid retrieval — dense + sparse + rank fusion — outperforms either path alone across the heterogeneous corpora Basileus indexes. The 2026 production consensus across Elasticsearch 8.16+, OpenSearch 2.19, Azure AI Search, Qdrant 1.11+, Vespa, Solr, and Pinecone is: RRF (Cormack 2009) generalized with per-source weights, with a score-aware sibling (DBSF, Qdrant 2024) for cases where score variance differs across paths.
+
+Strategos must expose just enough surface to let Basileus assemble this composition over `OntologyQueryTool` without taking on any infrastructure choice.
+
+## 2. Goals & non-goals
+
+### Goals
+
+1. **Backward-compatible extension.** 2.5.0 callers' compiled binaries and tests pass unmodified.
+2. **Three minimal seams.** Sparse provider interface (zero default impl), pure fusion utilities, optional `HybridQueryOptions` parameter wired into the semantic branch of `OntologyQueryTool.QueryAsync`.
+3. **Industry-default fusion semantics.** Weighted Reciprocal Rank Fusion as the default (matches Elasticsearch 8.16+ / Azure AI Search / Qdrant); Distribution-Based Score Fusion as a sibling option.
+4. **DIM-7 fail-closed semantics.** No silent fallbacks. `_meta.degraded` surfaces all degradation paths (`no-keyword-provider`, `sparse-failed`). Dense failure remains a hard failure (dense is the baseline).
+5. **Strategos owns no infrastructure choice.** No BM25 backend, no reranker, no cache. Basileus owns those (basileus#167).
+
+### Non-goals
+
+- **TypeSpec equivalents** in `Strategos.Contracts` for the new records — deferred to Strategos 2.7.0 (#3, Convergence).
+- **Default Azure / pgvector keyword provider** — Basileus owns the implementation.
+- **Reranker / cross-encoder layer** — Basileus owns this.
+- **Adaptive fusion** (DAT, entropy-based, LTR, TRF) — application concerns; not exposed by Strategos library.
+- **Score-aware fusion using `BmSaturationThreshold`** — the threshold is observational only in 2.6.0; future-iteration hook.
+- **TM2C2 / convex combination** with α tuning — best on tuned benchmarks (Bruch 2024) but α is domain-specific; application-layer.
+
+## 3. Design overview
+
+Three additive surfaces under a new namespace `Strategos.Ontology.Retrieval`, plus a typed extension of `ResponseMeta`. Three PRs (A/B/C) mirroring the 2.5.0 slice cadence.
+
+### 3.1 Three-PR slicing
+
+| PR | Slice | Issue | Files touched | Depends on |
+|---|---|---|---|---|
+| **PR-A** | DR-1: `IKeywordSearchProvider` seam | #56 | `Strategos.Ontology/Retrieval/IKeywordSearchProvider.cs` + records + exception; in-memory test provider in `Strategos.Ontology.Tests/Retrieval/`. | — |
+| **PR-B** | DR-2: `RankFusion` utilities | #57 | `Strategos.Ontology/Retrieval/RankFusion.cs` (+ partials), `RankedCandidate`, `ScoredCandidate`, `FusedResult` records, Qdrant DBSF parity oracle JSON, BenchmarkDotNet entries. | — |
+| **PR-C** | DR-3: `HybridQueryOptions` wiring | #58 | `Strategos.Ontology/Retrieval/HybridQueryOptions.cs`, `FusionMethod` enum, `HybridMeta` typed sub-record on `ResponseMeta`, modifications to `Strategos.Ontology.MCP/OntologyQueryTool.cs` and `Strategos.Ontology.MCP/ResponseMeta.cs`. | PR-A, PR-B |
+
+PR-A and PR-B touch disjoint files. They can be developed and merged in any order. PR-C is the wiring slice and depends on both.
+
+### 3.2 Architectural sketch
+
+```
+                ┌─────────────────────────────────────────────┐
+                │            OntologyQueryTool                │
+                │                                             │
+                │  QueryAsync(...,                            │
+                │      HybridQueryOptions? hybridOptions,     │ ← NEW (PR-C)
+                │      CancellationToken ct)                  │
+                └──────────────────┬──────────────────────────┘
+                                   │
+                       ┌───────────┴───────────┐
+                       │  semanticQuery null?  │
+                       └───────────┬───────────┘
+                                   │
+              ┌────────────────────┼────────────────────┐
+              │ yes                │ no                 │
+              ▼                    ▼                    ▼
+       structural path      ┌────────────────────────────────┐
+       (2.5.0 unchanged)    │ hybridOptions enabled & valid? │
+                            └────────┬───────────────────────┘
+                                     │
+                          ┌──────────┴──────────┐
+                          │ no                  │ yes
+                          ▼                     ▼
+                  dense-only semantic    ┌────────────────────────────┐
+                  (2.5.0 unchanged)      │ Task.WhenAll(               │
+                                         │   dense (vector similarity),│ ← existing
+                                         │   sparse (provider.Search)) │ ← NEW (PR-A)
+                                         └──────────┬─────────────────┘
+                                                    │
+                                                    ▼
+                                         ┌──────────────────────────┐
+                                         │ RankFusion.Reciprocal    │ ← NEW (PR-B)
+                                         │   | .DistributionBased   │
+                                         └──────────┬───────────────┘
+                                                    │
+                                                    ▼
+                                              SemanticQueryResult
+                                              with HybridMeta
+```
+
+### 3.3 Public-surface summary
+
+Net new public types in `Strategos.Ontology.Retrieval`:
+
+- **Interface:** `IKeywordSearchProvider` (no default DI registration).
+- **Records:** `KeywordSearchRequest`, `KeywordSearchResult`, `RankedCandidate`, `ScoredCandidate`, `FusedResult`, `HybridQueryOptions`.
+- **Exception:** `KeywordSearchException`.
+- **Enum:** `FusionMethod` (`Reciprocal = 0`, `DistributionBased = 1`).
+- **Static class:** `RankFusion` (`Reciprocal`, `DistributionBased`).
+
+Modified types:
+
+- **`Strategos.Ontology.MCP.OntologyQueryTool`** — `QueryAsync` gains a `HybridQueryOptions? hybridOptions = null` parameter, positional before `CancellationToken`.
+- **`Strategos.Ontology.MCP.ResponseMeta`** — gains a `HybridMeta? Hybrid` typed sub-record (sealed, immutable).
+- **`Strategos.Ontology.MCP.HybridMeta`** — new sealed record co-located with `ResponseMeta`.
+
+All additive. No type removed; no signature broken. 2.5.0 callers passing nothing additional see byte-for-byte 2.5.0 behavior.
+
+---
+
+## 4. Detailed design — PR-A (DR-1, #56)
+
+`IKeywordSearchProvider` is the sparse-retrieval extension point. Strategos defines the contract; consumers register an implementation via DI.
+
+### 4.1 Surface
+
+```csharp
+namespace Strategos.Ontology.Retrieval;
+
+public interface IKeywordSearchProvider
+{
+    /// <summary>
+    /// Executes a keyword (sparse / BM25) search against the underlying backend.
+    /// </summary>
+    /// <remarks>
+    /// Rank semantics: 1-indexed (rank 1 = highest score). Matches BM25 / Lucene convention.
+    /// Score semantics: non-negative, unbounded, provider-specific scale. Downstream RRF
+    /// is rank-based so scale need not align across providers. DBSF normalizes scale
+    /// via μ±3σ internally.
+    /// </remarks>
+    Task<IReadOnlyList<KeywordSearchResult>> SearchAsync(
+        KeywordSearchRequest request,
+        CancellationToken ct = default);
+}
+
+public sealed record KeywordSearchRequest(
+    string Query,
+    string CollectionName,
+    int TopK,
+    IReadOnlyDictionary<string, string>? MetadataFilters = null);
+
+public sealed record KeywordSearchResult(
+    string DocumentId,
+    double Score,
+    int Rank);
+
+public sealed class KeywordSearchException : Exception
+{
+    public KeywordSearchException(string message, Exception? inner = null)
+        : base(message, inner) { }
+}
+```
+
+### 4.2 Behavior table (provider contract)
+
+| Concern | Specification |
+|---|---|
+| Rank semantics | 1-indexed; rank 1 = highest score. Documented in XML doc-comments. |
+| Score semantics | Non-negative, unbounded, provider-specific scale. |
+| Result ordering | Sorted by `Score` descending. Ties broken by `DocumentId` ordinal ascending for stability. |
+| Empty results | Return empty `IReadOnlyList<KeywordSearchResult>`. Never `null`. |
+| `TopK == 0` | Valid; return empty list without invoking the backend. |
+| `TopK > collection size` | Return all matching documents ranked. |
+| `MetadataFilters` | AND semantics across all key-value pairs. Provider may map to backend-native filters. |
+| Collection not found | Throw `KeywordSearchException` naming the missing collection. |
+| Cancellation | Must propagate `OperationCanceledException` honoring `ct`. |
+| Provider faults | Wrap underlying transport exceptions as `KeywordSearchException(inner: ex)` — callers see one exception type. |
+
+### 4.3 DI registration
+
+Strategos provides **no** default registration. Consumers register their implementation in their own composition root:
+
+```csharp
+services.AddSingleton<IKeywordSearchProvider, MyAzureSearchKeywordProvider>();
+```
+
+The wiring slice (PR-C) consults the registered provider via constructor injection of `IKeywordSearchProvider?` into `OntologyQueryTool`. Absence is observable via `_meta.degraded = "no-keyword-provider"` when `HybridQueryOptions` is supplied.
+
+### 4.4 In-memory test provider
+
+Lives at `Strategos.Ontology.Tests/Retrieval/InMemoryKeywordSearchProvider.cs`. Deterministic; takes a `Dictionary<string, IReadOnlyList<(string DocId, double Score)>>` indexed by collection name. Used by PR-C tests too.
+
+### 4.5 Acceptance criteria
+
+- [ ] Interface, three records, and exception under `Strategos.Ontology.Retrieval`.
+- [ ] XML doc-comments document rank-1-indexed and scale-agnostic conventions.
+- [ ] No default registration in Strategos DI extensions.
+- [ ] In-memory provider exercises the full behavior table.
+- [ ] Public-API baseline (#51, if landed) updated; otherwise PR notes the addition.
+
+---
+
+## 5. Detailed design — PR-B (DR-2, #57)
+
+Two pure static fusion methods under `RankFusion`. No DI, no global state, no I/O. Each method is deterministic, sub-1ms for 2-list × 100-candidate fusion.
+
+### 5.1 Reciprocal (weighted RRF — Cormack 2009 generalized)
+
+```csharp
+namespace Strategos.Ontology.Retrieval;
+
+public static partial class RankFusion
+{
+    /// <summary>
+    /// Reciprocal Rank Fusion (Cormack et al., SIGIR 2009), generalized to per-list weights.
+    /// </summary>
+    /// <remarks>
+    /// Score for each document = Σ_L  weight_L / (k + rank_in_L).
+    /// Documents not present in a list contribute 0 from that list.
+    /// When <paramref name="weights"/> is null or all 1.0, output is bit-identical to
+    /// Cormack 2009 RRF.
+    /// </remarks>
+    public static IReadOnlyList<FusedResult> Reciprocal(
+        IReadOnlyList<IReadOnlyList<RankedCandidate>> rankedLists,
+        IReadOnlyList<double>? weights = null,
+        int k = 60,
+        int topK = 10);
+}
+
+public sealed record RankedCandidate(string DocumentId, int Rank);
+public sealed record FusedResult(string DocumentId, double FusedScore, int Rank);
+```
+
+Formula:
+
+```
+fused_score(d) = Σ_{L ∈ rankedLists}  weight_L / (k + rank_L(d))
+                                     where rank_L(d) = position in L if present, else +∞
+                                     (term ≡ 0 by convention when d ∉ L)
+```
+
+Output sorted by `fused_score` descending; ties broken by `DocumentId` ordinal ascending. `Rank` 1-indexed reflects post-fusion ordering. Sliced to `topK`. The weighted-RRF curve is `weight_L / (k + rank_L(d))` — matches **Elasticsearch 8.16+** convention (and Bruch 2024's parametric RRF analysis), not Qdrant's client-side `1 / ((pos+1)/weight + k - 1)` formula. This is a deliberate choice: ES form is the dominant production interpretation and the curve the literature analyzes.
+
+### 5.2 DistributionBased (DBSF — Qdrant 2024)
+
+```csharp
+public static partial class RankFusion
+{
+    /// <summary>
+    /// Distribution-Based Score Fusion (Qdrant, 2024). Per-list normalize via μ±3σ,
+    /// clamp to [μ-3σ, μ+3σ], scale to [0,1], then weighted sum across lists.
+    /// </summary>
+    public static IReadOnlyList<FusedResult> DistributionBased(
+        IReadOnlyList<IReadOnlyList<ScoredCandidate>> scoredLists,
+        IReadOnlyList<double>? weights = null,
+        int topK = 10);
+}
+
+public sealed record ScoredCandidate(string DocumentId, double Score);
+```
+
+Algorithm:
+
+```
+1. For each list L: μ_L ← mean, σ_L ← stdev
+2. low_L ← μ_L - 3σ_L,  high_L ← μ_L + 3σ_L
+3. For each candidate (id, score) in L:
+     normalized(id, L) = (clamp(score, low_L, high_L) - low_L) / (high_L - low_L)
+4. fused_score(d) = Σ_L  weight_L · normalized(d, L)
+                                    where normalized(d, L) = 0 if d ∉ L
+```
+
+### 5.3 Behavior table (Reciprocal)
+
+| Concern | Specification |
+|---|---|
+| Default weights | `weights = null` → all 1.0 → bit-identical Cormack 2009 RRF. **Regression-tested.** |
+| Argument validation | `k > 0`, `topK >= 0`, all `weight_L >= 0`, `weights.Count == rankedLists.Count` (when non-null). Negative or zero `k` throws `ArgumentOutOfRangeException`. Length mismatch throws `ArgumentException`. |
+| Zero-weight list | A list with `weight_L = 0` contributes nothing to the fused score (effectively excluded). |
+| Determinism | Identical inputs → identical outputs across runs and platforms. Tie-break by `DocumentId` ordinal. |
+| Empty input | Zero lists or all-empty lists → empty output. |
+| Single-list input | Equivalent to taking `topK` from that list with `weight_L / (k + rank)` scoring. |
+| Duplicate within a list | Caller's contract: input lists must not contain duplicates. Enforced as `Debug.Assert` only. |
+| Rank gaps | Caller's ranks need not be contiguous; RRF uses them as-is. |
+| `topK == 0` | Valid; returns empty list. |
+| Float stability | Sum left-to-right in input order. Tolerance `1e-12`. |
+
+### 5.4 Behavior table (DistributionBased)
+
+| Concern | Specification |
+|---|---|
+| Argument validation | `topK >= 0`, all `weight_L >= 0`, `weights.Count == scoredLists.Count` (when non-null). |
+| Single-element list | Normalize that one element to `0.5` (Qdrant convention). |
+| Zero-variance list (σ < 1e-9) | All elements normalize to `0.5` (Qdrant convention). |
+| Empty list | Skip (contributes 0 to all documents). |
+| Score scale | Any real-valued scores accepted (positive or negative). |
+| Outlier handling | Clamp to `[μ-3σ, μ+3σ]` before normalizing (DBSF's stated advantage over min-max). |
+| Determinism | Identical inputs → identical outputs. Tie-break by `DocumentId` ordinal. |
+| Float stability | Mean and variance computed in single pass per list. |
+
+### 5.5 Test strategy
+
+**Reciprocal:**
+
+- **Cormack regression.** A fixed reference set (Cormack 2009 §3.3 worked example) computed with `weights = null` matches the unweighted RRF output bit-identically. **Hard gate.**
+- **Weighted-vs-unweighted parity.** All-`1.0` weights produce bit-identical output to `weights = null`.
+- **Edge cases.** Empty input, single-list, n-list disjoint, n-list full overlap, `topK = 0`, `topK > size`, zero-weight list, length-mismatch (throws).
+- **Property tests.** Output is a permutation of the union of input `DocumentId`s capped at `topK`; pairwise ordering follows fused score; increasing `k` is monotonic in flattening; uniform-weight scaling does not change ordering.
+- **Benchmark.** 2-list × 100-candidate < 1 ms median on x64 (BenchmarkDotNet entry under `Strategos.Benchmarks/Subsystems/RankFusion/`).
+
+**DistributionBased:**
+
+- **Qdrant parity oracle.** A fixed test corpus computed via Qdrant's reference Python implementation (`qdrant_client/hybrid/fusion.py::distribution_based_score_fusion`) committed as JSON at `Strategos.Ontology.Tests/Retrieval/Fixtures/qdrant-dbsf-oracle.json`; C# reproduces ordering and per-document scores within `1e-9`. **Hard gate.** Regenerator script at `scripts/regenerate-dbsf-oracle.py` (Python, manual run; not in CI).
+- **Edge cases.** Empty list, single-element list (→ 0.5), zero-variance list (→ 0.5), heavily-skewed scores, mixed positive/negative scores.
+- **Outlier-robustness.** Queries with heavy outliers in one path; DBSF tracks expected ordering, min-max-baseline would not.
+- **Property tests.** Translation invariance (adding constant offset to all scores in a list doesn't change output); scale invariance (multiplying by positive constant doesn't change output); weight monotonicity.
+- **Benchmark.** Same 2×100 < 1 ms gate.
+
+### 5.6 Caller guidance (in XML doc-comments)
+
+> **Default to `RankFusion.Reciprocal` with all weights = 1.0.** Production default across Elasticsearch, OpenSearch, Azure AI Search, Qdrant, Vespa, Pinecone.
+>
+> **Add per-source weights** for known quality asymmetries. Production data shows per-source weighting moves NDCG more than `k` tuning.
+>
+> **Switch to `DistributionBased`** when score variance differs significantly across paths.
+>
+> **Look outside the library** for adaptive (DAT), learned (LTR), or tensor-rerank (ColBERT/TRF) fusion. Application concerns.
+
+### 5.7 Acceptance criteria
+
+- [ ] Static partial class + records under `Strategos.Ontology.Retrieval`.
+- [ ] `Reciprocal` with `weights = null` is bit-identical to Cormack 2009 reference.
+- [ ] Cormack 2009 §3.3 reference vectors green.
+- [ ] DBSF Qdrant parity JSON oracle green within `1e-9`.
+- [ ] Edge-case and property tests for both methods green.
+- [ ] BenchmarkDotNet entries green at < 1 ms for 2×100 fusion.
+- [ ] XML doc-comments cite Cormack 2009 and Qdrant DBSF.
+
+---
+
+## 6. Detailed design — PR-C (DR-3, #58)
+
+The wiring slice. Adds `HybridQueryOptions` and a typed `HybridMeta` sub-record; threads them through the semantic branch of `OntologyQueryTool.QueryAsync`.
+
+### 6.1 HybridQueryOptions
+
+```csharp
+namespace Strategos.Ontology.Retrieval;
+
+public enum FusionMethod
+{
+    /// <summary>Reciprocal Rank Fusion (Cormack 2009). Generalizes to weighted RRF when SourceWeights is set.</summary>
+    Reciprocal = 0,
+
+    /// <summary>Distribution-Based Score Fusion (Qdrant). Score-aware via μ±3σ normalization.</summary>
+    DistributionBased = 1,
+}
+
+public sealed record HybridQueryOptions
+{
+    /// <summary>Master switch. False forces dense-only even if a provider is registered.</summary>
+    public bool EnableKeyword { get; init; } = true;
+
+    /// <summary>Sparse-path TopK before fusion.</summary>
+    public int SparseTopK { get; init; } = 50;
+
+    /// <summary>Dense-path TopK before fusion.</summary>
+    public int DenseTopK { get; init; } = 50;
+
+    /// <summary>Fusion method. Default: Reciprocal.</summary>
+    public FusionMethod FusionMethod { get; init; } = FusionMethod.Reciprocal;
+
+    /// <summary>RRF smoothing constant. Used only when FusionMethod = Reciprocal.</summary>
+    public int RrfK { get; init; } = 60;
+
+    /// <summary>Optional per-source weights [denseWeight, sparseWeight]. Null = both 1.0. Each weight ≥ 0.</summary>
+    public IReadOnlyList<double>? SourceWeights { get; init; } = null;
+
+    /// <summary>BM25 score threshold; informational, surfaced in _meta.hybrid.bmSaturationThreshold. Does NOT affect fusion math in 2.6.0.</summary>
+    public double BmSaturationThreshold { get; init; } = 18.0;
+}
+```
+
+### 6.2 OntologyQueryTool signature change
+
+```csharp
+// 2.5.0 (existing)
+public async Task<QueryResultUnion> QueryAsync(
+    string objectType,
+    string? domain = null,
+    string? filter = null,
+    string? traverseLink = null,
+    string? interfaceName = null,
+    string? include = null,
+    string? semanticQuery = null,
+    int topK = 5,
+    double minRelevance = 0.7,
+    string? distanceMetric = null,
+    CancellationToken ct = default)
+
+// 2.6.0 (additive — one new positional optional parameter before ct)
+public async Task<QueryResultUnion> QueryAsync(
+    string objectType,
+    string? domain = null,
+    string? filter = null,
+    string? traverseLink = null,
+    string? interfaceName = null,
+    string? include = null,
+    string? semanticQuery = null,
+    int topK = 5,
+    double minRelevance = 0.7,
+    string? distanceMetric = null,
+    HybridQueryOptions? hybridOptions = null,    // ← NEW
+    CancellationToken ct = default)
+```
+
+`OntologyQueryTool`'s constructor gains an optional `IKeywordSearchProvider? keywordProvider = null` parameter resolved from DI.
+
+### 6.3 Surface-attachment rationale (DIM analysis)
+
+`HybridQueryOptions` attaches *semantically*: it has effect only on the `semanticQuery is not null` branch. The structural-query branch ignores `hybridOptions` entirely and returns 2.5.0 `QueryResult` byte-for-byte.
+
+| Dimension | Semantic-only | Universal w/ throw | QueryRequest refactor |
+|---|---|---|---|
+| **DIM-1 cohesion** | ✓ hybrid IS semantic | argues unused param | over-engineered for the change |
+| **DIM-2 coupling** | ✓ smallest change | adds runtime validation | touches every call site |
+| **DIM-3 backward compat** | ✓ strictly additive | strictly additive | **breaks** existing callers |
+| **DIM-4 surface clarity** | ✓ obvious in XML doc | ambiguous: "why allow it?" | clearer record shape but tax of refactor |
+| **DIM-5 failure mode** | ✓ no confusion path | ArgumentException on misuse | clean but moot |
+| **DIM-6 test surface** | ✓ semantic-only tests | + new failure tests | full re-test of structural paths |
+| **DIM-7 fail-closed** | ✓ no degraded structural | requires explicit throw | tangential |
+| **DIM-8 ops ergonomics** | ✓ minimal cognitive load | extra reading | breaks Basileus call sites today |
+
+Semantic-only wins on every dimension. The issue text's `QueryRequest`-style signature was illustrative of intent, not a hard constraint — the milestone gate is *"2.5.0 test suite passes unmodified"*, which the QueryRequest refactor would violate. Semantic-only honors that gate exactly.
+
+### 6.4 Behavior decision tree
+
+```
+hybridOptions is null
+  └─ existing 2.5.0 behavior (byte-for-byte). No HybridMeta on ResponseMeta.
+
+hybridOptions non-null AND semanticQuery is null
+  └─ structural path. hybridOptions silently ignored. No HybridMeta.
+
+hybridOptions non-null AND semanticQuery non-null
+  ├─ no IKeywordSearchProvider registered
+  │   └─ dense-only semantic path; warn once per process.
+  │       └─ HybridMeta { Hybrid = false, Degraded = "no-keyword-provider" }
+  │
+  ├─ hybridOptions.EnableKeyword == false
+  │   └─ dense-only semantic path.
+  │       └─ HybridMeta { Hybrid = false, Degraded = null }
+  │
+  └─ provider registered AND EnableKeyword
+      ├─ Task.WhenAll(dense, sparse)
+      │   ├─ dense throws → propagate (baseline)
+      │   └─ sparse throws → catch, log with stack, fall back to dense-only.
+      │       └─ HybridMeta { Hybrid = false, Degraded = "sparse-failed" }
+      ├─ both complete → fuse:
+      │   ├─ Reciprocal → RankFusion.Reciprocal(rankedLists, SourceWeights, RrfK, topK)
+      │   └─ DistributionBased → RankFusion.DistributionBased(scoredLists, SourceWeights, topK)
+      └─ HybridMeta {
+            Hybrid = true,
+            FusionMethod = "reciprocal" | "distribution_based",
+            DenseTopScore = ..., SparseTopScore = ...,
+            BmSaturationThreshold = options.BmSaturationThreshold,
+            Degraded = null
+        }
+```
+
+### 6.5 Extended ResponseMeta
+
+```csharp
+public sealed record ResponseMeta(
+    [property: JsonPropertyName("ontologyVersion")] string OntologyVersion)
+{
+    /// <summary>Hybrid retrieval metadata. Null when hybridOptions was not supplied or
+    /// when the semantic-query branch was not taken.</summary>
+    [JsonPropertyName("hybrid")]
+    public HybridMeta? Hybrid { get; init; }
+
+    public static ResponseMeta ForGraph(OntologyGraph graph) { /* unchanged */ }
+    internal static string WireFormat(string version) { /* unchanged */ }
+}
+
+public sealed record HybridMeta(
+    [property: JsonPropertyName("hybrid")] bool Hybrid,
+    [property: JsonPropertyName("fusionMethod")] string? FusionMethod = null,
+    [property: JsonPropertyName("degraded")] string? Degraded = null,
+    [property: JsonPropertyName("denseTopScore")] double? DenseTopScore = null,
+    [property: JsonPropertyName("sparseTopScore")] double? SparseTopScore = null,
+    [property: JsonPropertyName("bmSaturationThreshold")] double? BmSaturationThreshold = null);
+```
+
+Wire shape:
+
+```jsonc
+// dense-only (2.5.0 byte-for-byte; Hybrid sub-record absent)
+{ "ontologyVersion": "sha256:..." }
+
+// hybrid healthy
+{
+  "ontologyVersion": "sha256:...",
+  "hybrid": {
+    "hybrid": true,
+    "fusionMethod": "reciprocal",
+    "denseTopScore": 0.91,
+    "sparseTopScore": 17.4,
+    "bmSaturationThreshold": 18.0
+  }
+}
+
+// hybrid degraded (sparse failed)
+{
+  "ontologyVersion": "sha256:...",
+  "hybrid": { "hybrid": false, "degraded": "sparse-failed" }
+}
+```
+
+`HybridMeta` is `null` (and serialized as absent) when `hybridOptions` was not supplied or when the structural branch was taken — DIM-3 backward-compat for 2.5.0 snapshots.
+
+### 6.6 Behavior table
+
+| Concern | Specification |
+|---|---|
+| Backward compat (DIM-3) | 2.5.0 `OntologyQueryTool` test suite passes unmodified. **Hard gate.** |
+| Default fusion | `FusionMethod.Reciprocal` (production default). |
+| `HybridMeta.Hybrid` | `true` only when sparse path actually contributed results. |
+| `HybridMeta.FusionMethod` | Present when `Hybrid = true`. Values: `"reciprocal"` or `"distribution_based"`. |
+| `HybridMeta.Degraded` | Present only on degraded paths (`"no-keyword-provider"`, `"sparse-failed"`). Null on healthy. |
+| Cancellation | Single `ct` propagated to both legs via `Task.WhenAll`. |
+| Parallelism | `Task.WhenAll(denseTask, sparseTask)` — both await before fusion. |
+| Argument validation | `SparseTopK >= 0`, `DenseTopK >= 0`, `RrfK > 0`, `SourceWeights` (when non-null) length = 2, all weights ≥ 0. Otherwise `ArgumentOutOfRangeException` / `ArgumentException`. |
+| `SourceWeights` order | `[denseWeight, sparseWeight]`. Documented in XML. |
+| `BmSaturationThreshold` | Surfaces in `HybridMeta.BmSaturationThreshold`. **Does not affect fusion math in 2.6.0.** |
+| Warning-once | Missing provider warning emitted exactly once per process via `Interlocked.CompareExchange` flag on the tool. |
+
+### 6.7 Test strategy
+
+- **Regression.** Full 2.5.0 `OntologyQueryTool` test suite green with `hybridOptions = null`. Zero diffs in shape, ranking, `_meta`.
+- **Hybrid happy path — Reciprocal.** Provider registered, both legs return → `HybridMeta { Hybrid = true, FusionMethod = "reciprocal" }`, output matches `RankFusion.Reciprocal` over the inputs.
+- **Hybrid happy path — DistributionBased.** Same as above with `FusionMethod.DistributionBased`.
+- **Weighted Reciprocal.** `SourceWeights = [1.0, 0.5]` snapshot.
+- **Weighted DistributionBased.** Snapshot.
+- **Structural query w/ hybridOptions.** `semanticQuery = null` + non-null `hybridOptions` → returns 2.5.0 `QueryResult`; no `HybridMeta`; logs nothing.
+- **Provider absent.** Options non-null, no `IKeywordSearchProvider` registered → dense-only, `Degraded = "no-keyword-provider"`, warning logged once (second call: no second warning).
+- **Sparse failure.** Provider throws → dense-only fallback, `Degraded = "sparse-failed"`, exception+stack logged.
+- **Dense failure.** Dense throws → entire call fails (no fallback to sparse-only).
+- **Parallelism.** Instrumented timing assertion — sparse and dense overlap.
+- **Cancellation.** `ct` cancellation propagates to both legs; `OperationCanceledException` surfaces.
+- **`HybridMeta` snapshot.** `null` / healthy-Reciprocal / healthy-DistributionBased / no-provider / sparse-failed paths captured as snapshots.
+
+### 6.8 Acceptance criteria
+
+- [ ] `HybridQueryOptions` record + `FusionMethod` enum under `Strategos.Ontology.Retrieval`.
+- [ ] `HybridMeta` typed sub-record on `ResponseMeta`.
+- [ ] `OntologyQueryTool.QueryAsync` accepts `HybridQueryOptions? hybridOptions = null` as additive positional parameter before `ct`.
+- [ ] `OntologyQueryTool` constructor accepts optional `IKeywordSearchProvider? keywordProvider = null`.
+- [ ] Full 2.5.0 test suite green unmodified (backward-compat gate).
+- [ ] Hybrid happy-path tests green for both fusion methods.
+- [ ] Weighted-fusion tests green for both methods.
+- [ ] Provider-absent test green with degraded `_meta` and warn-once.
+- [ ] Sparse-failure test green.
+- [ ] Dense-failure propagation test green.
+- [ ] Parallelism overlap assertion green.
+- [ ] Cancellation propagation test green.
+- [ ] `HybridMeta` snapshot tests green on all five paths.
+- [ ] Structural-query-with-hybridOptions test green (silent ignore, no `HybridMeta`).
+
+---
+
+## 7. Strategos invariant audit
+
+Applied `/strategos-design-invariants` against the proposed design:
+
+| Invariant | Compliance | Rationale |
+|---|---|---|
+| **Workflows lower to Wolverine+Marten via Roslyn SG** | N/A | No workflow surface touched. Retrieval is a leaf Ontology subsystem. |
+| **Ontology is analyzer-validated and self-contained** | ✓ | New types live in `Strategos.Ontology.Retrieval` namespace, under `Strategos.Ontology` project. `Strategos.Ontology` already self-contains the ontology slice; no upward dependency added. `OntologyQueryTool` (`Strategos.Ontology.MCP`) consumes the new namespace. |
+| **MCP tracks latest protocol spec (2025-11-25)** | ✓ | `ResponseMeta` extension is additive; sub-record `Hybrid` is omittable JSON when null. MCP `_meta` envelope (#40 / 2.5.0) remains the carrier; we're enriching the typed C# side without changing wire-protocol layer assumptions. |
+| **Workflow DSL uses concrete domain nomenclature** | ✓ (vacuously) | Not a workflow surface. New names: `IKeywordSearchProvider`, `KeywordSearchResult`, `HybridQueryOptions`, `FusionMethod`, `RankFusion.Reciprocal`, `RankFusion.DistributionBased`. All concrete domain terms (no `IService`, no `Manager`, no `Handler`). |
+| **State is immutable** | ✓ | Every new record is `sealed record` with `init`-only properties. No `set`. `FusedResult`, `RankedCandidate`, `ScoredCandidate`, `HybridQueryOptions`, `HybridMeta`, `KeywordSearchRequest`, `KeywordSearchResult` all sealed and immutable. |
+| **Types are sealed-by-default** | ✓ | All new records, classes, and exceptions are `sealed`. `RankFusion` is `static partial`. `IKeywordSearchProvider` is the only interface — by definition extensibility. |
+| **Descriptor identity is polyglot** | N/A | No descriptors involved. Documents identified by `DocumentId : string` (opaque to Strategos). |
+
+**No invariant violations.** Two non-applicable lines noted above.
+
+## 8. Axiom DIM-1..DIM-8 design audit
+
+Applied `/axiom:design` across the design. Key takeaways carried into the design above:
+
+- **DIM-1 (composition / SRP).** Each PR has a single responsibility. PR-A is a contract, PR-B is pure math, PR-C is wiring. The semantic-only attachment of `HybridQueryOptions` (§6.3) reinforces SRP — hybrid is a property of the semantic-retrieval operation, not of structural queries.
+- **DIM-2 (coupling).** PR-A and PR-B touch disjoint files. PR-C depends on both but only adds one parameter and one provider constructor injection. No transitive coupling introduced.
+- **DIM-3 (backward compat).** Hard gate. Hybrid sub-record is omittable; new parameter is optional and last positional; provider is optional in DI; structural queries see byte-for-byte 2.5.0 behavior. Verified via "2.5.0 test suite passes unmodified" acceptance criterion.
+- **DIM-4 (surface clarity).** XML doc-comments call out: rank-1-indexed convention, score-scale-agnostic semantics, when to pick `Reciprocal` vs `DistributionBased`, `[denseWeight, sparseWeight]` ordering, that `BmSaturationThreshold` is informational only.
+- **DIM-5 (failure mode visibility).** All degradation paths surface in `HybridMeta.Degraded`. Dense failure propagates (baseline). Sparse failure logs with stack. Provider absence warns once per process. No silent fallback to a "looks fine" wire envelope.
+- **DIM-6 (test surface).** Three test layers: (a) PR-A in-memory provider exercises the full contract; (b) PR-B has Cormack 2009 + Qdrant DBSF parity oracles as hard gates plus property tests; (c) PR-C has snapshot tests on all five `HybridMeta` shapes. BenchmarkDotNet for PR-B.
+- **DIM-7 (fail-closed).** No silent fall-through. `HybridMeta.Hybrid = true` if and only if the sparse path actually contributed. Provider absence is explicit; sparse failure is explicit; dense failure is hard. `EnableKeyword = false` is explicit caller opt-out.
+- **DIM-8 (operational ergonomics).** Defaults match production consensus (`Reciprocal`, `k = 60`, weights = 1.0, `SparseTopK = DenseTopK = 50`). Library-level concerns (algorithm choice, weights) exposed; infrastructure-level concerns (backend, cache, reranker) left to consumers per parent ADR.
+
+## 9. Release plan
+
+### 9.1 Milestone close criteria
+
+- All three PRs (A/B/C) merged.
+- Full 2.5.0 `OntologyQueryTool` test suite green on `main` post-PR-C.
+- BenchmarkDotNet entries green at < 1 ms for 2×100 fusion.
+- Cormack 2009 and Qdrant DBSF parity oracles green.
+- CHANGELOG.md updated under `## [2.6.0]`.
+- Milestone "Ontology 2.6.0 — Hybrid Retrieval Seams" closed; issues #56, #57, #58, #47 closed.
+- Downstream basileus#167 unblocked (verified by Basileus dev environment compose).
+
+### 9.2 Deferrals tracked into 2.7.0 (Convergence)
+
+- TypeSpec equivalents in `Strategos.Contracts 0.2.0` for the new records (`KeywordSearchRequest`, `KeywordSearchResult`, `HybridQueryOptions`, `HybridMeta`).
+- Public-API baseline extension once #51 lands.
+
+### 9.3 Out-of-scope (intentionally not in 2.6.0)
+
+Score-aware fusion consuming `BmSaturationThreshold`; reranker/cross-encoder layer (Basileus's responsibility); per-call provider override; adaptive fusion (DAT / entropy / LTR / TRF); CombSUM / CombMNZ / Relative Score Fusion building blocks.
+
+## 10. References
+
+- **Parent ADR.** [basileus/docs/adrs/ontological-data-fabric.md §4.3, §§9.8–9.9](https://github.com/lvlup-sw/basileus).
+- **Grounding research.** `basileus:docs/research/2026-04-19-data-shape-query-performance-relevance.md`.
+- **Rank-fusion algorithm spike.** `exarchos/docs/research/2026-05-06-rank-fusion-algorithm-spike-strategos-57.md`.
+- **Cormack, Clarke, Buettcher (2009).** *Reciprocal Rank Fusion outperforms Condorcet and individual Rank Learning Methods.* SIGIR.
+- **Bruch, Gai, Ingber (2024).** *An Analysis of Fusion Functions for Hybrid Retrieval.* ACM TOIS (arXiv:2210.11934).
+- **Qdrant DBSF.** `qdrant_client/hybrid/fusion.py::distribution_based_score_fusion`, Qdrant 1.11+.
+- **Elasticsearch wRRF.** *Weighted Reciprocal Rank Fusion in Elasticsearch* (Search Labs, 2025-09-15).
+- **Umbrella issue.** [strategos#47](https://github.com/lvlup-sw/strategos/issues/47).
+- **Sub-issues.** [#56](https://github.com/lvlup-sw/strategos/issues/56), [#57](https://github.com/lvlup-sw/strategos/issues/57), [#58](https://github.com/lvlup-sw/strategos/issues/58).
+- **Predecessor design.** `docs/designs/2026-05-08-ontology-2-5-0-dispatch-validation.md`, `docs/designs/2026-05-10-ontology-2-5-0-polyglot-ingestion.md`.

--- a/docs/plans/2026-05-15-ontology-2-6-0-hybrid-retrieval.md
+++ b/docs/plans/2026-05-15-ontology-2-6-0-hybrid-retrieval.md
@@ -1,0 +1,706 @@
+# Implementation Plan: Ontology 2.6.0 — Hybrid Retrieval Seams
+
+**Date:** 2026-05-15
+**Design:** `docs/designs/2026-05-15-ontology-2-6-0-hybrid-retrieval.md`
+**Feature ID:** `ontology-2-6-0-hybrid-retrieval`
+**Closes:** strategos#56, strategos#57, strategos#58; resolves milestone #47.
+**Iron Law:** **NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST**
+
+## Cadence
+
+Three PRs, partial-parallel:
+
+- **PR-A** (Tasks 1–9): `IKeywordSearchProvider` seam (#56, DR-1). No `OntologyQueryTool` change.
+- **PR-B** (Tasks 10–22): `RankFusion` utilities — weighted RRF + DBSF (#57, DR-2). No `OntologyQueryTool` change.
+- **PR-C** (Tasks 23–43): `HybridQueryOptions` wiring on `OntologyQueryTool.QueryAsync` (#58, DR-3). **Depends on PR-A merged AND PR-B merged.**
+
+PR-A and PR-B touch disjoint files and may be developed and merged in any order. PR-C is the integration slice.
+
+## Traceability matrix (design → tasks)
+
+| DR | Section | Title | Tasks |
+|---|---|---|---|
+| DR-1 | §4 | `IKeywordSearchProvider` seam | 1, 2, 3, 4, 5, 6, 7, 8, 9 |
+| DR-2 | §5 | `RankFusion` utilities | 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22 |
+| DR-3 | §6 | `HybridQueryOptions` wiring | 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43 |
+
+## Conventions
+
+- **Test naming:** `Method_Scenario_Outcome` (e.g., `Reciprocal_UnweightedAgainstCormack2009Reference_BitIdentical`).
+- **Test framework:** TUnit (Strategos convention). Invocation:
+  `dotnet test src/<TestProject>/<TestProject>.csproj -- --treenode-filter "/*/*/*/<TestName>"`.
+- **TDD discipline:** Each task starts with a failing test ([RED]), then minimum implementation ([GREEN]), then optional [REFACTOR].
+- **File paths:** absolute from repo root (e.g., `src/Strategos.Ontology/Retrieval/...`).
+- **Project mapping:** New types live in `Strategos.Ontology` (project) under `Retrieval/` folder, namespace `Strategos.Ontology.Retrieval`. Tests in `Strategos.Ontology.Tests/Retrieval/`. Wiring tests in `Strategos.Ontology.MCP.Tests/`.
+- **Public-API baseline:** Each public addition updates `PublicAPI.Unshipped.txt` if the file exists for the project; otherwise PR notes the addition.
+
+---
+
+## PR-A: `IKeywordSearchProvider` seam (DR-1, #56)
+
+### Task 1: `KeywordSearchRequest` record
+
+**Implements:** DR-1
+**Phase:** RED → GREEN
+
+1. [RED] Add test `Ctor_DefaultMetadataFilters_IsNull` to `src/Strategos.Ontology.Tests/Retrieval/KeywordSearchRequestTests.cs` asserting `new KeywordSearchRequest("q", "c", 5).MetadataFilters == null`. Expected failure: type does not exist.
+2. [RED] Add test `WithExpression_NewTopK_PreservesImmutability` asserting `with` semantics.
+3. [GREEN] Create `src/Strategos.Ontology/Retrieval/KeywordSearchRequest.cs`:
+   ```csharp
+   namespace Strategos.Ontology.Retrieval;
+
+   public sealed record KeywordSearchRequest(
+       string Query,
+       string CollectionName,
+       int TopK,
+       IReadOnlyDictionary<string, string>? MetadataFilters = null);
+   ```
+
+**Dependencies:** None
+**Parallelizable:** Yes
+**testingStrategy:** unit
+
+### Task 2: `KeywordSearchResult` record
+
+**Implements:** DR-1
+**Phase:** RED → GREEN
+
+1. [RED] Add test `Ctor_Constructs_AllFieldsRoundTrip` to `src/Strategos.Ontology.Tests/Retrieval/KeywordSearchResultTests.cs`. Expected failure: type does not exist.
+2. [GREEN] Create `src/Strategos.Ontology/Retrieval/KeywordSearchResult.cs`:
+   ```csharp
+   public sealed record KeywordSearchResult(string DocumentId, double Score, int Rank);
+   ```
+
+**Dependencies:** None
+**Parallelizable:** Yes
+**testingStrategy:** unit
+
+### Task 3: `KeywordSearchException`
+
+**Implements:** DR-1
+**Phase:** RED → GREEN
+
+1. [RED] Add test `Ctor_MessageAndInner_PreservesBothViaThrow` to `src/Strategos.Ontology.Tests/Retrieval/KeywordSearchExceptionTests.cs`. Expected failure: type does not exist.
+2. [GREEN] Create `src/Strategos.Ontology/Retrieval/KeywordSearchException.cs`:
+   ```csharp
+   public sealed class KeywordSearchException : Exception
+   {
+       public KeywordSearchException(string message, Exception? inner = null) : base(message, inner) { }
+   }
+   ```
+
+**Dependencies:** None
+**Parallelizable:** Yes
+**testingStrategy:** unit
+
+### Task 4: `IKeywordSearchProvider` interface
+
+**Implements:** DR-1
+**Phase:** GREEN (no test — interface; behavior tested via in-memory provider)
+
+1. [GREEN] Create `src/Strategos.Ontology/Retrieval/IKeywordSearchProvider.cs` with the interface and XML doc-comments stating: rank-1-indexed; non-negative unbounded provider-scale scores; AND-semantics filters; collection-not-found → `KeywordSearchException`; cancellation propagates; transport faults wrap to `KeywordSearchException`.
+
+**Dependencies:** Tasks 1, 2, 3
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 5: In-memory test provider (`InMemoryKeywordSearchProvider`)
+
+**Implements:** DR-1 (test infrastructure)
+**Phase:** GREEN (no test — test support code; behavior tested via Task 6)
+
+1. [GREEN] Create `src/Strategos.Ontology.Tests/Retrieval/InMemoryKeywordSearchProvider.cs` implementing `IKeywordSearchProvider`. Constructor takes `Dictionary<string, IReadOnlyList<(string DocId, double Score)>>` keyed by collection name. Implements: sort by Score desc, tie-break by DocumentId ordinal, 1-indexed Rank assignment, AND filter semantics (passes through to caller-supplied predicate dict, treated as exact-match on a synthetic metadata dict per doc supplied via secondary constructor parameter), throws `KeywordSearchException` for missing collection, honors `ct`.
+
+**Dependencies:** Task 4
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 6: Contract behavior table — `InMemoryKeywordSearchProvider`
+
+**Implements:** DR-1 (provider contract conformance)
+**Phase:** RED → GREEN
+
+1. [RED] Add tests to `src/Strategos.Ontology.Tests/Retrieval/KeywordSearchProviderContractTests.cs`:
+   - `SearchAsync_TwoMatchingDocs_RankIs1Indexed_TopRankHighestScore`
+   - `SearchAsync_EmptyMatchingDocs_ReturnsEmptyList_NeverNull`
+   - `SearchAsync_TopKZero_ReturnsEmptyList_NoBackendInvoked` (assert via tracking flag on provider)
+   - `SearchAsync_TopKExceedsCollectionSize_ReturnsAllMatchingRanked`
+   - `SearchAsync_MetadataFiltersAllMatch_ReturnsFiltered`
+   - `SearchAsync_MetadataFiltersOneMismatch_ExcludesDoc`
+   - `SearchAsync_UnknownCollection_ThrowsKeywordSearchException_NamesCollection`
+   - `SearchAsync_CancelledTokenAtCall_ThrowsOperationCanceledException`
+   - `SearchAsync_TiedScores_TieBrokenByDocumentIdOrdinalAscending`
+   - Expected failure: provider does not implement the table.
+2. [GREEN] Implement the in-memory provider behaviors needed to pass.
+
+**Dependencies:** Task 5
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 7: Provider-fault wrap test
+
+**Implements:** DR-1 (transport-fault wrap)
+**Phase:** RED → GREEN
+
+1. [RED] Add a sibling fault-throwing test provider `ThrowingKeywordSearchProvider` (inline private class in test file) wrapping an inner `IOException`. Add test `SearchAsync_TransportFault_WrapsAsKeywordSearchException_InnerPreserved`. Expected failure: must demonstrate the wrap pattern is documented/expected (no production code needed beyond what Task 6 covers; this verifies the inner-preservation contract from `KeywordSearchException`).
+2. [GREEN] No production change; this is a contract conformance assertion. If the `KeywordSearchException` constructor regression is detected, fix the inner-preservation in Task 3's class.
+
+**Dependencies:** Task 6
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 8: XML doc-comment audit on public surface
+
+**Implements:** DR-1 (surface documentation)
+**Phase:** GREEN
+
+1. [GREEN] Audit `IKeywordSearchProvider`, `KeywordSearchRequest`, `KeywordSearchResult`, `KeywordSearchException` XML doc-comments. Each public member documents rank-1-indexed convention, scale-agnostic semantics, filter AND-semantics, collection-not-found behavior, cancellation behavior, and transport-fault wrap behavior.
+
+**Dependencies:** Tasks 1–4
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 9: PublicAPI baseline + PR-A close-out
+
+**Implements:** DR-1 (release plumbing)
+**Phase:** GREEN
+
+1. [GREEN] If `src/Strategos.Ontology/PublicAPI.Unshipped.txt` exists, add the new public types. Otherwise note the addition in PR description.
+2. [GREEN] Sanity-build: `dotnet build src/Strategos.Ontology/Strategos.Ontology.csproj` + `dotnet test src/Strategos.Ontology.Tests/Strategos.Ontology.Tests.csproj -- --treenode-filter "/*/*/*/Retrieval*"`.
+
+**Dependencies:** Tasks 1–8
+**Parallelizable:** No
+**testingStrategy:** unit
+
+---
+
+## PR-B: `RankFusion` utilities — wRRF + DBSF (DR-2, #57)
+
+### Task 10: `RankedCandidate` record
+
+**Implements:** DR-2
+**Phase:** RED → GREEN
+
+1. [RED] Add test `Ctor_Constructs_FieldsRoundTrip` to `src/Strategos.Ontology.Tests/Retrieval/RankedCandidateTests.cs`. Expected failure: type does not exist.
+2. [GREEN] Create `src/Strategos.Ontology/Retrieval/RankedCandidate.cs`:
+   ```csharp
+   public sealed record RankedCandidate(string DocumentId, int Rank);
+   ```
+
+**Dependencies:** None
+**Parallelizable:** Yes
+**testingStrategy:** unit
+
+### Task 11: `ScoredCandidate` record
+
+**Implements:** DR-2
+**Phase:** RED → GREEN
+
+1. [RED] Add test `Ctor_Constructs_FieldsRoundTrip` to `src/Strategos.Ontology.Tests/Retrieval/ScoredCandidateTests.cs`.
+2. [GREEN] Create `src/Strategos.Ontology/Retrieval/ScoredCandidate.cs`:
+   ```csharp
+   public sealed record ScoredCandidate(string DocumentId, double Score);
+   ```
+
+**Dependencies:** None
+**Parallelizable:** Yes
+**testingStrategy:** unit
+
+### Task 12: `FusedResult` record
+
+**Implements:** DR-2
+**Phase:** RED → GREEN
+
+1. [RED] Add test `Ctor_Constructs_FieldsRoundTrip` to `src/Strategos.Ontology.Tests/Retrieval/FusedResultTests.cs`.
+2. [GREEN] Create `src/Strategos.Ontology/Retrieval/FusedResult.cs`:
+   ```csharp
+   public sealed record FusedResult(string DocumentId, double FusedScore, int Rank);
+   ```
+
+**Dependencies:** None
+**Parallelizable:** Yes
+**testingStrategy:** unit
+
+### Task 13: `RankFusion.Reciprocal` — Cormack 2009 reference vectors
+
+**Implements:** DR-2 (canonical RRF correctness)
+**Phase:** RED → GREEN
+
+1. [RED] Add test `Reciprocal_UnweightedAgainstCormack2009Reference_BitIdentical` to `src/Strategos.Ontology.Tests/Retrieval/RankFusionReciprocalTests.cs`. Build the Cormack 2009 §3.3 worked example (3 rankers × ~6 docs) as `IReadOnlyList<IReadOnlyList<RankedCandidate>>`. Assert the fused ordering and per-doc scores match the published table within `1e-12`. Expected failure: `RankFusion.Reciprocal` does not exist.
+2. [GREEN] Create `src/Strategos.Ontology/Retrieval/RankFusion.cs` (`static partial class`) and `src/Strategos.Ontology/Retrieval/RankFusion.Reciprocal.cs` with the method.
+   - Signature: `IReadOnlyList<FusedResult> Reciprocal(IReadOnlyList<IReadOnlyList<RankedCandidate>>, IReadOnlyList<double>?, int k = 60, int topK = 10)`.
+   - Implementation: for each candidate union, sum `weight_L / (k + rank)` over input lists; sort desc; tie-break by `DocumentId` ordinal; assign 1-indexed `Rank`; slice to `topK`.
+
+**Dependencies:** Tasks 10, 12
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 14: `RankFusion.Reciprocal` — weighted-vs-unweighted parity
+
+**Implements:** DR-2 (regression gate)
+**Phase:** RED → GREEN
+
+1. [RED] Add tests:
+   - `Reciprocal_AllOnesWeights_BitIdenticalToNullWeights` — pass `weights = [1.0, 1.0, 1.0]` and expect output equal to `weights = null`.
+   - `Reciprocal_WeightsLengthMismatch_ThrowsArgumentException`.
+   - `Reciprocal_NegativeWeight_ThrowsArgumentException`.
+   - `Reciprocal_ZeroWeightList_ContributesNothing` — assert doc ordering equals fusion over the *other* lists only.
+   - Expected failure: weighted form not yet present.
+2. [GREEN] Extend `Reciprocal` to honor `weights` per the design formula.
+
+**Dependencies:** Task 13
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 15: `RankFusion.Reciprocal` — edge cases
+
+**Implements:** DR-2
+**Phase:** RED → GREEN
+
+1. [RED] Add tests:
+   - `Reciprocal_EmptyInput_ReturnsEmptyList`.
+   - `Reciprocal_AllListsEmpty_ReturnsEmptyList`.
+   - `Reciprocal_SingleListInput_EquivalentToTopKOverThatList`.
+   - `Reciprocal_DisjointLists_AllUniqueDocsAppear`.
+   - `Reciprocal_FullOverlap_DocOrderingMatchesUnweightedRrf`.
+   - `Reciprocal_TopKZero_ReturnsEmptyList`.
+   - `Reciprocal_TopKGreaterThanUniqueDocs_ReturnsAllRanked`.
+   - `Reciprocal_KZero_ThrowsArgumentOutOfRangeException`.
+   - `Reciprocal_KNegative_ThrowsArgumentOutOfRangeException`.
+   - Expected failures pin all edge-case branches.
+2. [GREEN] Add validation guards and edge-case fast-paths in `Reciprocal`.
+
+**Dependencies:** Task 14
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 16: `RankFusion.Reciprocal` — property tests
+
+**Implements:** DR-2 (algebraic invariants)
+**Phase:** RED → GREEN
+
+1. [RED] Add tests in `src/Strategos.Ontology.Tests/Retrieval/RankFusionReciprocalPropertyTests.cs`:
+   - `Reciprocal_OutputIsPermutationOfUnionInputs_CappedAtTopK` (hand-rolled cases over 20 randomized seeds).
+   - `Reciprocal_PairwiseOrderingMatchesFusedScoreDescending`.
+   - `Reciprocal_IncreasingKMonotonicallyFlattensCurve_ResultSetUnchanged` (set equality, allow rank perturbation under ties).
+   - `Reciprocal_UniformWeightDoublingDoesNotChangeOrdering`.
+2. [GREEN] No production change expected if Task 13 is correct; this verifies invariants.
+
+**Dependencies:** Task 15
+**Parallelizable:** No
+**testingStrategy:** property
+
+### Task 17: Qdrant DBSF parity oracle — fixture + regenerator
+
+**Implements:** DR-2 (parity gate infrastructure)
+**Phase:** GREEN
+
+1. [GREEN] Create `scripts/regenerate-dbsf-oracle.py`: Python script using `qdrant_client.hybrid.fusion.distribution_based_score_fusion` to compute fused outputs over a fixed set of 6 hand-authored test queries (mix of: 2-list balanced, single-element list, zero-variance list, outlier-heavy list, mixed positive/negative scores, large-skew list). Emit `Strategos.Ontology.Tests/Retrieval/Fixtures/qdrant-dbsf-oracle.json` with `{query_id, lists, expected_fused: [{document_id, fused_score, rank}]}`.
+2. [GREEN] Run the script once locally; commit the JSON oracle. Add README note that regenerator is manual.
+
+**Dependencies:** None
+**Parallelizable:** Yes
+**testingStrategy:** parity-oracle
+
+### Task 18: `RankFusion.DistributionBased` — Qdrant parity
+
+**Implements:** DR-2 (DBSF correctness)
+**Phase:** RED → GREEN
+
+1. [RED] Add test `DistributionBased_AgainstQdrantOracle_AllQueriesMatch_Within1eMinus9` to `src/Strategos.Ontology.Tests/Retrieval/RankFusionDistributionBasedTests.cs`. Load `qdrant-dbsf-oracle.json`, iterate queries, call `RankFusion.DistributionBased`, assert per-doc score within `1e-9` and ordering identical. Expected failure: method does not exist.
+2. [GREEN] Create `src/Strategos.Ontology/Retrieval/RankFusion.DistributionBased.cs` with the method. Implementation: per-list compute μ, σ; clamp to `[μ-3σ, μ+3σ]`; normalize to `[0,1]`; weighted sum; sort desc; tie-break by DocumentId; 1-indexed Rank; slice to topK.
+
+**Dependencies:** Tasks 11, 12, 17
+**Parallelizable:** No
+**testingStrategy:** parity-oracle
+
+### Task 19: `RankFusion.DistributionBased` — edge cases
+
+**Implements:** DR-2
+**Phase:** RED → GREEN
+
+1. [RED] Add tests:
+   - `DistributionBased_EmptyInput_ReturnsEmptyList`.
+   - `DistributionBased_SingleElementList_NormalizesToHalf`.
+   - `DistributionBased_ZeroVarianceList_AllElementsNormalizeToHalf` (use `1e-9` epsilon).
+   - `DistributionBased_MixedPositiveAndNegativeScores_NormalizesCorrectly`.
+   - `DistributionBased_OutlierPath_TracksExpectedOrdering` — versus a min-max-baseline computed in-test to assert DBSF differs.
+   - `DistributionBased_WeightsLengthMismatch_ThrowsArgumentException`.
+   - `DistributionBased_NegativeWeight_ThrowsArgumentException`.
+   - `DistributionBased_TopKZero_ReturnsEmptyList`.
+2. [GREEN] Add edge-case branches and validation guards.
+
+**Dependencies:** Task 18
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 20: `RankFusion.DistributionBased` — property tests
+
+**Implements:** DR-2
+**Phase:** RED → GREEN
+
+1. [RED] Add tests in `src/Strategos.Ontology.Tests/Retrieval/RankFusionDistributionBasedPropertyTests.cs`:
+   - `DistributionBased_TranslationInvariance_AddingConstantOffsetPreservesOutput`.
+   - `DistributionBased_ScaleInvariance_MultiplyingByPositiveConstantPreservesOutput`.
+   - `DistributionBased_WeightMonotonicity_IncreasingWeightIncreasesContribution`.
+2. [GREEN] No production change expected.
+
+**Dependencies:** Task 19
+**Parallelizable:** No
+**testingStrategy:** property
+
+### Task 21: BenchmarkDotNet entries
+
+**Implements:** DR-2 (perf gate)
+**Phase:** GREEN
+
+1. [GREEN] Create `src/Strategos.Benchmarks/Subsystems/RankFusion/ReciprocalBenchmark.cs` and `DistributionBasedBenchmark.cs`. Configurations: 2 lists × 100 candidates with disjoint and overlapping inputs. Assert median < 1 ms via BenchmarkDotNet's stats.
+2. [GREEN] Add a corresponding TUnit test in `src/Strategos.Benchmarks.Tests/RankFusionBenchmarkTests.cs` that exercises a coarse perf budget (assert call completes within 50 ms wall under 10 invocations — defensive non-CI-flake gate; pristine perf measurement is left to BenchmarkDotNet runs).
+
+**Dependencies:** Tasks 13–20
+**Parallelizable:** Yes (with Task 22)
+**testingStrategy:** benchmark
+
+### Task 22: PublicAPI baseline + PR-B close-out
+
+**Implements:** DR-2 (release plumbing)
+**Phase:** GREEN
+
+1. [GREEN] If `Strategos.Ontology/PublicAPI.Unshipped.txt` exists, add `RankFusion`, all records, `FusionMethod` is **not** added here (PR-C). Otherwise note in PR description.
+2. [GREEN] Sanity-build + run all `RankFusion*` tests + benchmark dry-run.
+
+**Dependencies:** Tasks 10–21
+**Parallelizable:** No
+**testingStrategy:** unit
+
+---
+
+## PR-C: `HybridQueryOptions` wiring (DR-3, #58)
+
+### Task 23: `FusionMethod` enum
+
+**Implements:** DR-3
+**Phase:** RED → GREEN
+
+1. [RED] Add test `FusionMethod_HasReciprocalAndDistributionBased_NumericValuesStable` to `src/Strategos.Ontology.Tests/Retrieval/FusionMethodTests.cs` asserting `(int)FusionMethod.Reciprocal == 0`, `(int)FusionMethod.DistributionBased == 1`. Expected failure: enum does not exist.
+2. [GREEN] Create `src/Strategos.Ontology/Retrieval/FusionMethod.cs` with the enum and XML doc-comments per design §6.1.
+
+**Dependencies:** None
+**Parallelizable:** Yes
+**testingStrategy:** unit
+
+### Task 24: `HybridQueryOptions` record + defaults
+
+**Implements:** DR-3
+**Phase:** RED → GREEN
+
+1. [RED] Add tests to `src/Strategos.Ontology.Tests/Retrieval/HybridQueryOptionsTests.cs`:
+   - `Defaults_EnableKeywordTrue_FusionMethodReciprocal_K60_SparseAndDenseTopK50`.
+   - `Defaults_SourceWeightsNull_BmSaturationThreshold18`.
+   - `With_OverrideFusionMethod_PreservesOthers`.
+   - Expected failure: type does not exist.
+2. [GREEN] Create `src/Strategos.Ontology/Retrieval/HybridQueryOptions.cs` per design §6.1. Sealed record with `init` properties.
+
+**Dependencies:** Task 23
+**Parallelizable:** Yes (with 25, 26)
+**testingStrategy:** unit
+
+### Task 25: `HybridQueryOptions` argument validation
+
+**Implements:** DR-3
+**Phase:** RED → GREEN
+
+1. [RED] Add tests:
+   - `Validate_SparseTopKNegative_ThrowsArgumentOutOfRangeException`.
+   - `Validate_DenseTopKNegative_ThrowsArgumentOutOfRangeException`.
+   - `Validate_RrfKZero_ThrowsArgumentOutOfRangeException`.
+   - `Validate_RrfKNegative_ThrowsArgumentOutOfRangeException`.
+   - `Validate_SourceWeightsLengthThree_ThrowsArgumentException`.
+   - `Validate_SourceWeightsNegativeElement_ThrowsArgumentException`.
+   - Expected failure: no validation present.
+2. [GREEN] Add `internal void Validate()` (or static `EnsureValid`) on `HybridQueryOptions` invoked from `OntologyQueryTool` once at call-entry. Throws per design §6.6.
+
+**Dependencies:** Task 24
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 26: `HybridMeta` sub-record
+
+**Implements:** DR-3
+**Phase:** RED → GREEN
+
+1. [RED] Add tests to `src/Strategos.Ontology.MCP.Tests/HybridMetaTests.cs`:
+   - `Defaults_HybridFalse_FusionMethodNull_AllOptionalsNull`.
+   - `JsonShape_HealthyReciprocal_EmitsExpectedKeys` — serialize and assert keys: `hybrid`, `fusionMethod`, `denseTopScore`, `sparseTopScore`, `bmSaturationThreshold`.
+   - `JsonShape_OmitsNullOptionals` — degraded shape: only `hybrid` and `degraded` keys when others null.
+   - Expected failure: type does not exist.
+2. [GREEN] Create `src/Strategos.Ontology.MCP/HybridMeta.cs` per design §6.5. Sealed record with `init` properties and `JsonPropertyName` attributes. Configure JSON to ignore-null for optional fields (or `JsonIgnoreCondition.WhenWritingNull`).
+
+**Dependencies:** None
+**Parallelizable:** Yes
+**testingStrategy:** unit
+
+### Task 27: `ResponseMeta.Hybrid` extension
+
+**Implements:** DR-3
+**Phase:** RED → GREEN
+
+1. [RED] Add tests to `src/Strategos.Ontology.MCP.Tests/ResponseMetaHybridTests.cs`:
+   - `Default_HybridIsNull` — `ResponseMeta.ForGraph(graph).Hybrid == null`.
+   - `JsonShape_HybridNull_KeyAbsent` — serialized JSON has no `"hybrid"` key when `Hybrid == null` (backward-compat with 2.5.0 snapshots).
+   - `JsonShape_HybridSet_KeyPresent`.
+   - `With_HybridSet_PreservesOntologyVersion`.
+   - Expected failure: `Hybrid` property does not exist.
+2. [GREEN] Modify `src/Strategos.Ontology.MCP/ResponseMeta.cs` to add `HybridMeta? Hybrid { get; init; }` with `[JsonPropertyName("hybrid")]` and `[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`.
+
+**Dependencies:** Task 26
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 28: `OntologyQueryTool` constructor — optional `IKeywordSearchProvider?`
+
+**Implements:** DR-3
+**Phase:** RED → GREEN
+
+1. [RED] Add test `Ctor_WithoutKeywordProvider_Constructs` and `Ctor_WithKeywordProvider_StoresField` to `src/Strategos.Ontology.MCP.Tests/OntologyQueryToolConstructorTests.cs`. Expected failure: ctor signature does not accept provider.
+2. [GREEN] Modify `OntologyQueryTool` to accept `IKeywordSearchProvider? keywordProvider = null` as the last constructor parameter; store in field.
+
+**Dependencies:** Task 4 (interface exists — comes from PR-A merged)
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 29: `OntologyQueryTool.QueryAsync` — additive `hybridOptions` parameter, null preserves 2.5.0
+
+**Implements:** DR-3 (DIM-3 hard gate)
+**Phase:** RED → GREEN
+
+1. [RED] Add test `QueryAsync_HybridOptionsNull_StructuralBranch_ReturnsQueryResult_NoHybridMeta` and `QueryAsync_HybridOptionsNull_SemanticBranch_ReturnsSemanticQueryResult_NoHybridMeta` to `src/Strategos.Ontology.MCP.Tests/OntologyQueryToolHybridTests.cs`. Use existing 2.5.0 fixture; assert `_meta.Hybrid == null`. Expected failure: `hybridOptions` parameter does not exist.
+2. [GREEN] Add `HybridQueryOptions? hybridOptions = null` to `QueryAsync` as the parameter immediately before `CancellationToken ct`. When `hybridOptions is null`, take the 2.5.0 path unchanged.
+
+**Dependencies:** Tasks 25, 27, 28
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 30: Structural query + non-null `hybridOptions` → silent ignore
+
+**Implements:** DR-3 (DIM-3 / surface clarity)
+**Phase:** RED → GREEN
+
+1. [RED] Add test `QueryAsync_StructuralQueryWithHybridOptions_IgnoresOptions_NoHybridMeta_NoWarnLog`. Use a `TestLogger` to assert no log entry was emitted; assert returned `QueryResult` shape unchanged.
+2. [GREEN] In `QueryAsync`, gate hybrid-path branch on `semanticQuery is not null && hybridOptions is not null`. Structural branch ignores `hybridOptions`.
+
+**Dependencies:** Task 29
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 31: Semantic + `hybridOptions` + no provider → degraded `no-keyword-provider` + warn-once
+
+**Implements:** DR-3 (fail-closed DIM-7)
+**Phase:** RED → GREEN
+
+1. [RED] Add test `QueryAsync_SemanticWithHybridOptions_NoProviderRegistered_DenseOnly_DegradedNoKeywordProvider_WarnsOnce`. Assert `HybridMeta { Hybrid = false, Degraded = "no-keyword-provider" }`. Two consecutive calls produce exactly one warning log entry.
+2. [GREEN] Implement provider-absent branch in `QueryAsync`. Use `Interlocked.CompareExchange` on a private `int _noProviderWarnedOnce` field to ensure single emission per `OntologyQueryTool` instance.
+
+**Dependencies:** Task 30
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 32: Semantic + `hybridOptions.EnableKeyword = false` → dense-only
+
+**Implements:** DR-3
+**Phase:** RED → GREEN
+
+1. [RED] Add test `QueryAsync_SemanticWithHybridOptionsEnableKeywordFalse_DenseOnly_HybridMetaHybridFalse_NoDegraded`. Provider IS registered; option flag forces dense-only. Assert `HybridMeta { Hybrid = false, Degraded = null }`.
+2. [GREEN] Branch in `QueryAsync` on `hybridOptions.EnableKeyword == false`.
+
+**Dependencies:** Task 31
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 33: Hybrid happy path — Reciprocal
+
+**Implements:** DR-3
+**Phase:** RED → GREEN
+
+1. [RED] Add test `QueryAsync_HybridReciprocal_BothLegsReturn_FusedOutputMatchesRankFusionReciprocal_HybridMetaHealthyReciprocal` to `OntologyQueryToolHybridTests.cs`. Register `InMemoryKeywordSearchProvider` with known input; the dense path returns a known fixture. Assert: returned `SemanticQueryResult` items ordering matches an explicit call to `RankFusion.Reciprocal(ranked, weights=null, k=60, topK=request.topK)` applied to the same inputs. Assert `HybridMeta { Hybrid = true, FusionMethod = "reciprocal" }` with non-null `DenseTopScore` and `SparseTopScore`.
+2. [GREEN] Implement the dense+sparse parallel-fan-out + fusion path: convert dense similarity results to `RankedCandidate` list, convert sparse provider results, call `RankFusion.Reciprocal(...)`, project fused order back into the existing `SemanticQueryResult` items list.
+
+**Dependencies:** Task 32
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 34: Hybrid happy path — DistributionBased
+
+**Implements:** DR-3
+**Phase:** RED → GREEN
+
+1. [RED] Add test `QueryAsync_HybridDistributionBased_BothLegsReturn_FusedOutputMatchesRankFusionDistributionBased_HybridMetaHealthyDistributionBased`. Same setup as Task 33 but `FusionMethod = DistributionBased`; assert items ordering matches `RankFusion.DistributionBased(scored, weights=null, topK=request.topK)`.
+2. [GREEN] Branch in fusion-selection to dispatch to `RankFusion.DistributionBased` when `hybridOptions.FusionMethod == DistributionBased`.
+
+**Dependencies:** Task 33
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 35: Weighted Reciprocal snapshot
+
+**Implements:** DR-3
+**Phase:** RED → GREEN
+
+1. [RED] Add test `QueryAsync_HybridReciprocalWeighted_DenseDominantWeights_SnapshotOrdering`. `SourceWeights = [1.0, 0.5]` over known inputs; assert ordering matches snapshot computed via `RankFusion.Reciprocal(..., weights: [1.0, 0.5], k: 60, topK: ...)`.
+2. [GREEN] Ensure `SourceWeights` is propagated through the fusion call.
+
+**Dependencies:** Task 34
+**Parallelizable:** No
+**testingStrategy:** unit-snapshot
+
+### Task 36: Weighted DistributionBased snapshot
+
+**Implements:** DR-3
+**Phase:** RED → GREEN
+
+1. [RED] Add test `QueryAsync_HybridDistributionBasedWeighted_DenseDominantWeights_SnapshotOrdering`. Same as Task 35 with `FusionMethod = DistributionBased`.
+2. [GREEN] Ensure `SourceWeights` is propagated through DBSF call.
+
+**Dependencies:** Task 35
+**Parallelizable:** No
+**testingStrategy:** unit-snapshot
+
+### Task 37: Sparse failure → fallback to dense-only with `Degraded = "sparse-failed"`
+
+**Implements:** DR-3 (fail-closed DIM-7)
+**Phase:** RED → GREEN
+
+1. [RED] Add test `QueryAsync_HybridSparseProviderThrows_FallsBackToDenseOnly_DegradedSparseFailed_ExceptionAndStackLogged`. Use a `ThrowingKeywordSearchProvider` that raises an `IOException` mid-flight. Assert returned items match dense-only, `HybridMeta { Hybrid = false, Degraded = "sparse-failed" }`, log captures both exception type and stack frame.
+2. [GREEN] Wrap sparse task in a try/catch within the parallel-fan-out coordination. On catch: log error with `ILogger.LogError(ex, ...)`; fall back to dense-only.
+
+**Dependencies:** Task 36
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 38: Dense failure → hard failure (no fallback to sparse-only)
+
+**Implements:** DR-3 (baseline-failure semantics)
+**Phase:** RED → GREEN
+
+1. [RED] Add test `QueryAsync_HybridDenseThrows_PropagatesException_NoFallbackToSparseOnly`. Inject a dense-path failure; expect the exception to bubble; assert no `HybridMeta` returned because there's no return.
+2. [GREEN] No catch on dense in the hybrid coordinator; dense remains baseline (existing 2.5.0 throw-through behavior preserved).
+
+**Dependencies:** Task 37
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 39: Cancellation propagation through both legs
+
+**Implements:** DR-3
+**Phase:** RED → GREEN
+
+1. [RED] Add test `QueryAsync_HybridCancellationMidFlight_BothLegsCancelled_ThrowsOperationCanceledException`. Use a delaying in-memory provider that observes `ct`. Cancel `ct` after 10ms; assert `OperationCanceledException`.
+2. [GREEN] Propagate `ct` to both `denseTask` and `sparseTask`; `Task.WhenAll` lets `OperationCanceledException` surface naturally.
+
+**Dependencies:** Task 38
+**Parallelizable:** No
+**testingStrategy:** unit
+
+### Task 40: Parallelism overlap timing assertion
+
+**Implements:** DR-3 (DIM-8 ops ergonomics)
+**Phase:** RED → GREEN
+
+1. [RED] Add test `QueryAsync_HybridBothLegs_RunInParallel_TimingOverlapWithinTolerance`. Use a delaying provider for sparse (50ms artificial delay) and instrument dense to record start/end timestamps. Assert sparse-start < dense-end and sparse-end > dense-start (true overlap).
+2. [GREEN] Ensure both leg `Task`s are *started* (`Task.Run` or `_ = task` pattern) before `Task.WhenAll`. Confirm no accidental sequential await.
+
+**Dependencies:** Task 39
+**Parallelizable:** No
+**testingStrategy:** integration-timing
+
+### Task 41: `HybridMeta` snapshot tests on all five paths
+
+**Implements:** DR-3 (DIM-6 test surface coverage)
+**Phase:** RED → GREEN
+
+1. [RED] Add `src/Strategos.Ontology.MCP.Tests/OntologyQueryToolHybridMetaSnapshotTests.cs` with five snapshot tests for the JSON shape of `ResponseMeta` / `_meta`:
+   - `Snapshot_HybridOptionsNull_NoHybridKey`.
+   - `Snapshot_HybridHealthyReciprocal`.
+   - `Snapshot_HybridHealthyDistributionBased`.
+   - `Snapshot_HybridDegradedNoKeywordProvider`.
+   - `Snapshot_HybridDegradedSparseFailed`.
+   - Capture committed snapshots under `src/Strategos.Ontology.MCP.Tests/__snapshots__/`.
+2. [GREEN] No production change expected; snapshots verify wire shape per design §6.5.
+
+**Dependencies:** Tasks 31, 32, 33, 34, 37
+**Parallelizable:** No
+**testingStrategy:** snapshot
+
+### Task 42: 2.5.0 regression suite green with `hybridOptions = null`
+
+**Implements:** DR-3 (DIM-3 hard gate — milestone-close criterion)
+**Phase:** GREEN
+
+1. [GREEN] Run full `Strategos.Ontology.MCP.Tests` and `Strategos.Ontology.Tests` suites. All pre-existing tests must pass without modification. If any test fails because of changed wire shape, regress to Task 27 / Task 29 and tighten the omit-null shape.
+
+**Dependencies:** Tasks 23–41
+**Parallelizable:** No
+**testingStrategy:** regression
+
+### Task 43: CHANGELOG + milestone-close + PR-C close-out
+
+**Implements:** DR-3 (release plumbing)
+**Phase:** GREEN
+
+1. [GREEN] Update `CHANGELOG.md` under `## [2.6.0] — 2026-MM-DD` heading. Sections: Added (IKeywordSearchProvider, RankFusion, HybridQueryOptions, HybridMeta), Changed (OntologyQueryTool additive parameter; ResponseMeta extended), Migration notes (no migration needed for 2.5.0 callers).
+2. [GREEN] If `PublicAPI.Unshipped.txt` exists, finalize entries for PR-C.
+3. [GREEN] Sanity build: `dotnet build` solution; full test suite green.
+
+**Dependencies:** Task 42
+**Parallelizable:** No
+**testingStrategy:** release-plumbing
+
+---
+
+## Parallelization summary
+
+### Within PR-A (no inter-task parallelism beyond Tasks 1–3)
+
+- **Parallel group α** (no deps): Tasks 1, 2, 3 (independent records/exception).
+- **Serial**: Task 4 → 5 → 6 → 7 → 8 → 9.
+
+### Within PR-B (no inter-task parallelism beyond Tasks 10–12, 17)
+
+- **Parallel group β** (no deps): Tasks 10, 11, 12, 17.
+- **Serial**: 13 → 14 → 15 → 16; 18 (waits on 17) → 19 → 20; 21 (after 13–20); 22 (after 10–21).
+
+### Within PR-C
+
+- **Parallel group γ** (no deps): Tasks 23, 24, 26.
+- **Serial**: 25 (after 24); 27 (after 26); 28 (after PR-A merged); 29 (after 25, 27, 28); 30 → 31 → 32 → 33 → 34 → 35 → 36 → 37 → 38 → 39 → 40; 41 (after 31, 32, 33, 34, 37); 42 (after 23–41); 43 (after 42).
+
+### Cross-PR parallelism
+
+- **PR-A and PR-B can run concurrently in separate worktrees.** They touch disjoint files.
+- **PR-C must wait** for both PR-A and PR-B to be merged into `main`.
+
+---
+
+## Acceptance gate (milestone close)
+
+- [ ] All 43 tasks completed.
+- [ ] PR-A, PR-B, PR-C all merged to `main`.
+- [ ] Full 2.5.0 `OntologyQueryTool` test suite green unmodified (Task 42).
+- [ ] Cormack 2009 §3.3 parity passes within `1e-12` (Task 13).
+- [ ] Qdrant DBSF parity oracle passes within `1e-9` (Task 18).
+- [ ] BenchmarkDotNet entries green at < 1 ms median for 2×100 fusion (Task 21).
+- [ ] CHANGELOG.md `## [2.6.0]` section published.
+- [ ] Issues #56, #57, #58, #47 closed; milestone "Ontology 2.6.0 — Hybrid Retrieval Seams" closed.
+
+---
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Qdrant Python regenerator output diverges from C# DBSF due to subtle float ops ordering | Pin Qdrant version in the regenerator script's requirements (single-row `requirements.txt` co-located); commit Python script + JSON oracle together; tolerance `1e-9` (not `1e-12`) absorbs minor reordering. |
+| BenchmarkDotNet flake on shared CI runners | Coarse 50ms wall budget on the TUnit smoke test (Task 21 step 2); rely on local benchmark runs for true perf characterization. |
+| `Task.WhenAll` exception-aggregation behavior masks logging context for sparse failure | Wrap each leg in its own try/catch before `Task.WhenAll`; rethrow only after logging (Task 37). |
+| `IReadOnlyDictionary<string, string>?` value-equality semantics in records | Use `with` testing pattern in Task 1; record-equality across `null` and `{}` is distinct in C# — documented in XML doc-comments. |
+| Existing `ResponseMeta` consumers depend on `default(ResponseMeta)` value-equality | New `Hybrid` property defaults to `null`; equality still well-defined; verified via Task 27 `Default_HybridIsNull`. |
+| In-memory test provider drift from real BM25 backends in basileus | Provider contract test (Task 6) is the spec; basileus's real provider must conform. Cross-product compose validation (parent ADR) catches drift at release. |

--- a/src/Strategos.Ontology.Tests/Retrieval/InMemoryKeywordSearchProvider.cs
+++ b/src/Strategos.Ontology.Tests/Retrieval/InMemoryKeywordSearchProvider.cs
@@ -1,0 +1,88 @@
+using Strategos.Ontology.Retrieval;
+
+namespace Strategos.Ontology.Tests.Retrieval;
+
+/// <summary>
+/// Deterministic in-process <see cref="IKeywordSearchProvider"/> used by Strategos tests
+/// (and by PR-C wiring tests once <c>OntologyQueryTool</c> learns the hybrid path).
+/// </summary>
+/// <remarks>
+/// Backed by a per-collection list of <c>(documentId, score)</c> tuples and an optional
+/// per-document synthetic metadata dictionary used to evaluate
+/// <see cref="KeywordSearchRequest.MetadataFilters"/> under AND-semantics. Implements every
+/// behavior required by the <see cref="IKeywordSearchProvider"/> contract.
+/// </remarks>
+internal sealed class InMemoryKeywordSearchProvider : IKeywordSearchProvider
+{
+    private readonly IReadOnlyDictionary<string, IReadOnlyList<(string DocId, double Score)>> _collections;
+    private readonly IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> _metadata;
+    private int _backendInvokedCount;
+
+    /// <summary>The number of times the backend "search" path was actually executed.</summary>
+    /// <remarks>Used by tests to assert TopK==0 short-circuit semantics.</remarks>
+    public int BackendInvokedCount => _backendInvokedCount;
+
+    public InMemoryKeywordSearchProvider(
+        Dictionary<string, IReadOnlyList<(string DocId, double Score)>> collections,
+        IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>>? metadata = null)
+    {
+        _collections = collections;
+        _metadata = metadata ?? new Dictionary<string, IReadOnlyDictionary<string, string>>();
+    }
+
+    public Task<IReadOnlyList<KeywordSearchResult>> SearchAsync(
+        KeywordSearchRequest request,
+        CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        // TopK==0: short-circuit before touching the backend.
+        if (request.TopK <= 0)
+        {
+            return Task.FromResult<IReadOnlyList<KeywordSearchResult>>(Array.Empty<KeywordSearchResult>());
+        }
+
+        if (!_collections.TryGetValue(request.CollectionName, out var docs))
+        {
+            throw new KeywordSearchException(
+                $"Collection '{request.CollectionName}' does not exist.");
+        }
+
+        Interlocked.Increment(ref _backendInvokedCount);
+
+        // AND-semantics filter: keep only docs whose synthetic metadata matches every k/v pair.
+        IEnumerable<(string DocId, double Score)> filtered = docs;
+        if (request.MetadataFilters is { Count: > 0 } filters)
+        {
+            filtered = docs.Where(d => MatchesAllFilters(d.DocId, filters));
+        }
+
+        // Sort by Score desc, tie-break by DocumentId ordinal asc for stable 1-indexed rank.
+        var sorted = filtered
+            .OrderByDescending(d => d.Score)
+            .ThenBy(d => d.DocId, StringComparer.Ordinal)
+            .Take(request.TopK)
+            .Select((d, index) => new KeywordSearchResult(d.DocId, d.Score, Rank: index + 1))
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<KeywordSearchResult>>(sorted);
+    }
+
+    private bool MatchesAllFilters(string docId, IReadOnlyDictionary<string, string> filters)
+    {
+        if (!_metadata.TryGetValue(docId, out var docMeta))
+        {
+            return false;
+        }
+
+        foreach (var (key, expected) in filters)
+        {
+            if (!docMeta.TryGetValue(key, out var actual) || !string.Equals(actual, expected, StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Strategos.Ontology.Tests/Retrieval/KeywordSearchExceptionTests.cs
+++ b/src/Strategos.Ontology.Tests/Retrieval/KeywordSearchExceptionTests.cs
@@ -1,0 +1,22 @@
+using Strategos.Ontology.Retrieval;
+
+namespace Strategos.Ontology.Tests.Retrieval;
+
+public class KeywordSearchExceptionTests
+{
+    [Test]
+    public async Task Ctor_MessageAndInner_PreservesBothViaThrow()
+    {
+        var inner = new IOException("boom");
+
+        try
+        {
+            throw new KeywordSearchException("collection missing", inner);
+        }
+        catch (KeywordSearchException ex)
+        {
+            await Assert.That(ex.Message).IsEqualTo("collection missing");
+            await Assert.That(ex.InnerException).IsSameReferenceAs(inner);
+        }
+    }
+}

--- a/src/Strategos.Ontology.Tests/Retrieval/KeywordSearchProviderContractTests.cs
+++ b/src/Strategos.Ontology.Tests/Retrieval/KeywordSearchProviderContractTests.cs
@@ -1,0 +1,187 @@
+using Strategos.Ontology.Retrieval;
+
+namespace Strategos.Ontology.Tests.Retrieval;
+
+/// <summary>
+/// Behavior-table conformance for <see cref="IKeywordSearchProvider"/> implementations,
+/// exercised against <see cref="InMemoryKeywordSearchProvider"/>. Per design §4.2 this
+/// table is the authoritative provider contract.
+/// </summary>
+public class KeywordSearchProviderContractTests
+{
+    private const string Collection = "docs";
+
+    [Test]
+    public async Task SearchAsync_TwoMatchingDocs_RankIs1Indexed_TopRankHighestScore()
+    {
+        var provider = new InMemoryKeywordSearchProvider(new()
+        {
+            [Collection] = new (string, double)[]
+            {
+                ("doc-a", 1.0),
+                ("doc-b", 3.0),
+            }
+        });
+
+        var results = await provider.SearchAsync(new KeywordSearchRequest("q", Collection, TopK: 10));
+
+        await Assert.That(results).HasCount().EqualTo(2);
+        await Assert.That(results[0].DocumentId).IsEqualTo("doc-b");
+        await Assert.That(results[0].Rank).IsEqualTo(1);
+        await Assert.That(results[0].Score).IsEqualTo(3.0);
+        await Assert.That(results[1].DocumentId).IsEqualTo("doc-a");
+        await Assert.That(results[1].Rank).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task SearchAsync_EmptyMatchingDocs_ReturnsEmptyList_NeverNull()
+    {
+        var provider = new InMemoryKeywordSearchProvider(new()
+        {
+            [Collection] = Array.Empty<(string, double)>(),
+        });
+
+        var results = await provider.SearchAsync(new KeywordSearchRequest("q", Collection, TopK: 10));
+
+        await Assert.That(results).IsNotNull();
+        await Assert.That(results).IsEmpty();
+    }
+
+    [Test]
+    public async Task SearchAsync_TopKZero_ReturnsEmptyList_NoBackendInvoked()
+    {
+        var provider = new InMemoryKeywordSearchProvider(new()
+        {
+            [Collection] = new (string, double)[] { ("doc-a", 5.0) },
+        });
+
+        var results = await provider.SearchAsync(new KeywordSearchRequest("q", Collection, TopK: 0));
+
+        await Assert.That(results).IsEmpty();
+        // Provider must short-circuit before invoking the backend — assert via tracking flag.
+        await Assert.That(provider.BackendInvokedCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task SearchAsync_TopKExceedsCollectionSize_ReturnsAllMatchingRanked()
+    {
+        var provider = new InMemoryKeywordSearchProvider(new()
+        {
+            [Collection] = new (string, double)[]
+            {
+                ("doc-a", 1.0),
+                ("doc-b", 2.0),
+                ("doc-c", 3.0),
+            }
+        });
+
+        var results = await provider.SearchAsync(new KeywordSearchRequest("q", Collection, TopK: 100));
+
+        await Assert.That(results).HasCount().EqualTo(3);
+        await Assert.That(results[0].Rank).IsEqualTo(1);
+        await Assert.That(results[1].Rank).IsEqualTo(2);
+        await Assert.That(results[2].Rank).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task SearchAsync_MetadataFiltersAllMatch_ReturnsFiltered()
+    {
+        var docs = new (string, double)[]
+        {
+            ("doc-a", 1.0),
+            ("doc-b", 2.0),
+            ("doc-c", 3.0),
+        };
+        var metadata = new Dictionary<string, IReadOnlyDictionary<string, string>>
+        {
+            ["doc-a"] = new Dictionary<string, string> { ["lang"] = "en", ["kind"] = "spec" },
+            ["doc-b"] = new Dictionary<string, string> { ["lang"] = "en", ["kind"] = "spec" },
+            ["doc-c"] = new Dictionary<string, string> { ["lang"] = "fr", ["kind"] = "spec" },
+        };
+        var provider = new InMemoryKeywordSearchProvider(
+            new() { [Collection] = docs },
+            metadata);
+
+        var filter = new Dictionary<string, string> { ["lang"] = "en", ["kind"] = "spec" };
+        var results = await provider.SearchAsync(new KeywordSearchRequest("q", Collection, TopK: 10, filter));
+
+        await Assert.That(results).HasCount().EqualTo(2);
+        await Assert.That(results.Select(r => r.DocumentId)).Contains("doc-a");
+        await Assert.That(results.Select(r => r.DocumentId)).Contains("doc-b");
+    }
+
+    [Test]
+    public async Task SearchAsync_MetadataFiltersOneMismatch_ExcludesDoc()
+    {
+        var docs = new (string, double)[]
+        {
+            ("doc-a", 1.0),
+            ("doc-b", 2.0),
+        };
+        var metadata = new Dictionary<string, IReadOnlyDictionary<string, string>>
+        {
+            ["doc-a"] = new Dictionary<string, string> { ["lang"] = "en", ["kind"] = "spec" },
+            ["doc-b"] = new Dictionary<string, string> { ["lang"] = "en", ["kind"] = "draft" },
+        };
+        var provider = new InMemoryKeywordSearchProvider(
+            new() { [Collection] = docs },
+            metadata);
+
+        // doc-b mismatches kind=spec — must be excluded under AND semantics.
+        var filter = new Dictionary<string, string> { ["lang"] = "en", ["kind"] = "spec" };
+        var results = await provider.SearchAsync(new KeywordSearchRequest("q", Collection, TopK: 10, filter));
+
+        await Assert.That(results).HasCount().EqualTo(1);
+        await Assert.That(results[0].DocumentId).IsEqualTo("doc-a");
+    }
+
+    [Test]
+    public async Task SearchAsync_UnknownCollection_ThrowsKeywordSearchException_NamesCollection()
+    {
+        var provider = new InMemoryKeywordSearchProvider(new()
+        {
+            [Collection] = new (string, double)[] { ("doc-a", 1.0) },
+        });
+
+        var ex = await Assert.ThrowsAsync<KeywordSearchException>(async () =>
+            await provider.SearchAsync(new KeywordSearchRequest("q", "missing-collection", TopK: 10)));
+
+        await Assert.That(ex!.Message).Contains("missing-collection");
+    }
+
+    [Test]
+    public async Task SearchAsync_CancelledTokenAtCall_ThrowsOperationCanceledException()
+    {
+        var provider = new InMemoryKeywordSearchProvider(new()
+        {
+            [Collection] = new (string, double)[] { ("doc-a", 1.0) },
+        });
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await provider.SearchAsync(new KeywordSearchRequest("q", Collection, TopK: 10), cts.Token));
+    }
+
+    [Test]
+    public async Task SearchAsync_TiedScores_TieBrokenByDocumentIdOrdinalAscending()
+    {
+        var provider = new InMemoryKeywordSearchProvider(new()
+        {
+            [Collection] = new (string, double)[]
+            {
+                ("doc-z", 1.0),
+                ("doc-a", 1.0),
+                ("doc-m", 1.0),
+            }
+        });
+
+        var results = await provider.SearchAsync(new KeywordSearchRequest("q", Collection, TopK: 10));
+
+        await Assert.That(results.Select(r => r.DocumentId).ToArray())
+            .IsEquivalentTo(new[] { "doc-a", "doc-m", "doc-z" });
+        await Assert.That(results[0].Rank).IsEqualTo(1);
+        await Assert.That(results[1].Rank).IsEqualTo(2);
+        await Assert.That(results[2].Rank).IsEqualTo(3);
+    }
+}

--- a/src/Strategos.Ontology.Tests/Retrieval/KeywordSearchProviderFaultWrapTests.cs
+++ b/src/Strategos.Ontology.Tests/Retrieval/KeywordSearchProviderFaultWrapTests.cs
@@ -1,0 +1,49 @@
+using Strategos.Ontology.Retrieval;
+
+namespace Strategos.Ontology.Tests.Retrieval;
+
+/// <summary>
+/// Verifies the transport-fault wrap contract: providers that catch an underlying
+/// transport / backend exception must rethrow as <see cref="KeywordSearchException"/>
+/// with the original exception preserved as <see cref="Exception.InnerException"/>.
+/// </summary>
+public class KeywordSearchProviderFaultWrapTests
+{
+    /// <summary>
+    /// Test-only provider that demonstrates the canonical wrap pattern by catching an
+    /// inner <see cref="IOException"/> and rethrowing as <see cref="KeywordSearchException"/>.
+    /// </summary>
+    private sealed class ThrowingKeywordSearchProvider : IKeywordSearchProvider
+    {
+        public Task<IReadOnlyList<KeywordSearchResult>> SearchAsync(
+            KeywordSearchRequest request,
+            CancellationToken ct = default)
+        {
+            try
+            {
+                throw new IOException("simulated transport failure");
+            }
+            catch (IOException ex)
+            {
+                throw new KeywordSearchException(
+                    $"Keyword search backend unreachable for collection '{request.CollectionName}'.",
+                    inner: ex);
+            }
+        }
+    }
+
+    [Test]
+    public async Task SearchAsync_TransportFault_WrapsAsKeywordSearchException_InnerPreserved()
+    {
+        IKeywordSearchProvider provider = new ThrowingKeywordSearchProvider();
+
+        var ex = await Assert.ThrowsAsync<KeywordSearchException>(async () =>
+            await provider.SearchAsync(new KeywordSearchRequest("q", "docs", TopK: 10)));
+
+        // The caller sees one exception type (KeywordSearchException); diagnostics may
+        // walk InnerException to recover the real transport failure.
+        await Assert.That(ex!.InnerException).IsNotNull();
+        await Assert.That(ex.InnerException).IsTypeOf<IOException>();
+        await Assert.That(ex.InnerException!.Message).IsEqualTo("simulated transport failure");
+    }
+}

--- a/src/Strategos.Ontology.Tests/Retrieval/KeywordSearchRequestTests.cs
+++ b/src/Strategos.Ontology.Tests/Retrieval/KeywordSearchRequestTests.cs
@@ -1,0 +1,32 @@
+using Strategos.Ontology.Retrieval;
+
+namespace Strategos.Ontology.Tests.Retrieval;
+
+public class KeywordSearchRequestTests
+{
+    [Test]
+    public async Task Ctor_DefaultMetadataFilters_IsNull()
+    {
+        var request = new KeywordSearchRequest("q", "c", 5);
+
+        await Assert.That(request.Query).IsEqualTo("q");
+        await Assert.That(request.CollectionName).IsEqualTo("c");
+        await Assert.That(request.TopK).IsEqualTo(5);
+        await Assert.That(request.MetadataFilters).IsNull();
+    }
+
+    [Test]
+    public async Task WithExpression_NewTopK_PreservesImmutability()
+    {
+        var original = new KeywordSearchRequest("q", "c", 5);
+
+        var mutated = original with { TopK = 10 };
+
+        // Original unchanged, mutated has new TopK, other fields preserved.
+        await Assert.That(original.TopK).IsEqualTo(5);
+        await Assert.That(mutated.TopK).IsEqualTo(10);
+        await Assert.That(mutated.Query).IsEqualTo("q");
+        await Assert.That(mutated.CollectionName).IsEqualTo("c");
+        await Assert.That(ReferenceEquals(original, mutated)).IsFalse();
+    }
+}

--- a/src/Strategos.Ontology.Tests/Retrieval/KeywordSearchResultTests.cs
+++ b/src/Strategos.Ontology.Tests/Retrieval/KeywordSearchResultTests.cs
@@ -1,0 +1,16 @@
+using Strategos.Ontology.Retrieval;
+
+namespace Strategos.Ontology.Tests.Retrieval;
+
+public class KeywordSearchResultTests
+{
+    [Test]
+    public async Task Ctor_Constructs_AllFieldsRoundTrip()
+    {
+        var result = new KeywordSearchResult(DocumentId: "doc-42", Score: 7.5, Rank: 1);
+
+        await Assert.That(result.DocumentId).IsEqualTo("doc-42");
+        await Assert.That(result.Score).IsEqualTo(7.5);
+        await Assert.That(result.Rank).IsEqualTo(1);
+    }
+}

--- a/src/Strategos.Ontology/Retrieval/IKeywordSearchProvider.cs
+++ b/src/Strategos.Ontology/Retrieval/IKeywordSearchProvider.cs
@@ -1,0 +1,107 @@
+namespace Strategos.Ontology.Retrieval;
+
+/// <summary>
+/// Extension point for sparse / keyword (e.g. BM25 / Lucene) search.
+/// </summary>
+/// <remarks>
+/// Strategos defines this contract and provides no default DI registration. Consumers
+/// register an implementation in their composition root and the wiring slice
+/// (<c>OntologyQueryTool</c>) consults it through optional constructor injection.
+/// Implementations must conform to the behavior table below; the contract is exercised
+/// by <c>KeywordSearchProviderContractTests</c> against the in-memory test provider.
+/// <para>
+/// Behavior contract:
+/// <list type="bullet">
+///   <item>
+///     <description>
+///       <b>Rank semantics.</b> Returned <see cref="KeywordSearchResult.Rank"/> is
+///       1-indexed (rank 1 = highest score). Matches the BM25 / Lucene convention.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///       <b>Score semantics.</b> <see cref="KeywordSearchResult.Score"/> is non-negative,
+///       unbounded, and provider-specific scale. Downstream RRF fusion is rank-based, so
+///       scales need not align across providers. Downstream DBSF fusion normalizes scale
+///       via μ±3σ internally.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///       <b>Ordering.</b> Results sorted by <see cref="KeywordSearchResult.Score"/>
+///       descending; ties broken by <see cref="KeywordSearchResult.DocumentId"/> ordinal
+///       ascending for stable rank assignment.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///       <b>Empty results.</b> Return an empty list — never <c>null</c>.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///       <b><see cref="KeywordSearchRequest.TopK"/> == 0.</b> Valid. Return an empty list
+///       without invoking the backend.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///       <b><see cref="KeywordSearchRequest.TopK"/> greater than collection size.</b>
+///       Return all matching documents ranked.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///       <b>Metadata filters.</b> AND-semantics across all key/value pairs in
+///       <see cref="KeywordSearchRequest.MetadataFilters"/>. A document is included only
+///       if every key matches its value exactly. Providers may map these to backend-native
+///       filters.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///       <b>Collection not found.</b> Throw <see cref="KeywordSearchException"/> whose
+///       message names the missing collection.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///       <b>Cancellation.</b> Must honor <paramref name="ct"/> and propagate
+///       <see cref="OperationCanceledException"/>. Cancellation is NOT wrapped as
+///       <see cref="KeywordSearchException"/>.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///       <b>Transport / backend faults.</b> Wrap any underlying transport, parse, or
+///       backend exception as the inner exception of a <see cref="KeywordSearchException"/>.
+///       Callers observe exactly one exception type from this seam.
+///     </description>
+///   </item>
+/// </list>
+/// </para>
+/// </remarks>
+public interface IKeywordSearchProvider
+{
+    /// <summary>
+    /// Executes a keyword (sparse / BM25) search against the underlying backend.
+    /// </summary>
+    /// <param name="request">The search request. See <see cref="KeywordSearchRequest"/>.</param>
+    /// <param name="ct">
+    /// Cancellation token. Implementations must observe this and propagate
+    /// <see cref="OperationCanceledException"/> on cancellation.
+    /// </param>
+    /// <returns>
+    /// An ordered, 1-indexed-ranked, never-<c>null</c> list of <see cref="KeywordSearchResult"/>.
+    /// </returns>
+    /// <exception cref="KeywordSearchException">
+    /// The collection named in <paramref name="request"/> does not exist, or the underlying
+    /// transport/backend faulted (with the original exception as <see cref="Exception.InnerException"/>).
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// <paramref name="ct"/> was cancelled before or during execution.
+    /// </exception>
+    Task<IReadOnlyList<KeywordSearchResult>> SearchAsync(
+        KeywordSearchRequest request,
+        CancellationToken ct = default);
+}

--- a/src/Strategos.Ontology/Retrieval/KeywordSearchException.cs
+++ b/src/Strategos.Ontology/Retrieval/KeywordSearchException.cs
@@ -1,0 +1,28 @@
+namespace Strategos.Ontology.Retrieval;
+
+/// <summary>
+/// The single exception type thrown by <see cref="IKeywordSearchProvider"/> implementations.
+/// </summary>
+/// <remarks>
+/// Providers must wrap any underlying transport, parse, or backend exception as the inner
+/// exception of a <see cref="KeywordSearchException"/> so that callers observe exactly one
+/// exception type from this seam. Collection-not-found is signalled by throwing a
+/// <see cref="KeywordSearchException"/> whose <see cref="Exception.Message"/> names the
+/// missing collection. <see cref="OperationCanceledException"/> from cancellation is NOT
+/// wrapped — it must propagate.
+/// </remarks>
+public sealed class KeywordSearchException : Exception
+{
+    /// <summary>
+    /// Initializes a new <see cref="KeywordSearchException"/>.
+    /// </summary>
+    /// <param name="message">A human-readable description of the failure.</param>
+    /// <param name="inner">
+    /// The underlying transport / backend exception, if any. Must be preserved so callers
+    /// can inspect it for diagnostics.
+    /// </param>
+    public KeywordSearchException(string message, Exception? inner = null)
+        : base(message, inner)
+    {
+    }
+}

--- a/src/Strategos.Ontology/Retrieval/KeywordSearchRequest.cs
+++ b/src/Strategos.Ontology/Retrieval/KeywordSearchRequest.cs
@@ -1,0 +1,26 @@
+namespace Strategos.Ontology.Retrieval;
+
+/// <summary>
+/// A request to an <see cref="IKeywordSearchProvider"/>.
+/// </summary>
+/// <param name="Query">The free-text query string to match against the keyword (BM25 / sparse) index.</param>
+/// <param name="CollectionName">
+/// The logical collection (index) to search. If the provider does not recognize this
+/// collection it must throw <see cref="KeywordSearchException"/>.
+/// </param>
+/// <param name="TopK">
+/// The maximum number of results to return. A value of <c>0</c> is valid and the provider
+/// must return an empty list without invoking the backend. Negative values are not defined
+/// by this contract; providers may treat them as <c>0</c> or throw.
+/// </param>
+/// <param name="MetadataFilters">
+/// Optional metadata filters with AND semantics across all key/value pairs. A document is
+/// included only if every key matches its corresponding value exactly. <c>null</c> means
+/// "no filter" and is distinct from an empty dictionary, which also means "no filter" but
+/// has different record-equality semantics.
+/// </param>
+public sealed record KeywordSearchRequest(
+    string Query,
+    string CollectionName,
+    int TopK,
+    IReadOnlyDictionary<string, string>? MetadataFilters = null);

--- a/src/Strategos.Ontology/Retrieval/KeywordSearchResult.cs
+++ b/src/Strategos.Ontology/Retrieval/KeywordSearchResult.cs
@@ -1,0 +1,20 @@
+namespace Strategos.Ontology.Retrieval;
+
+/// <summary>
+/// A single result returned from an <see cref="IKeywordSearchProvider"/>.
+/// </summary>
+/// <param name="DocumentId">The stable, unique identifier for the matching document.</param>
+/// <param name="Score">
+/// A non-negative, unbounded, provider-specific keyword-search score. Higher means a better
+/// match. The scale is not aligned across providers: downstream RRF fusion is rank-based,
+/// and downstream DBSF fusion normalizes the scale via μ±3σ internally.
+/// </param>
+/// <param name="Rank">
+/// The 1-indexed rank of this result within its result list (rank 1 = highest scored).
+/// Matches the BM25 / Lucene convention. Ties in <paramref name="Score"/> must be broken
+/// by <paramref name="DocumentId"/> ordinal ascending so that rank assignment is stable.
+/// </param>
+public sealed record KeywordSearchResult(
+    string DocumentId,
+    double Score,
+    int Rank);


### PR DESCRIPTION
## Summary
- Adds the `IKeywordSearchProvider` seam (DR-1 from the 2026-05-15 hybrid retrieval design) to `Strategos.Ontology` as a strictly-additive surface under the new `Strategos.Ontology.Retrieval` namespace.
- Establishes the keyword-search contract that PR-C will consume to wire the hybrid path on `OntologyQueryTool` once PR-A and PR-B are both on main.
- Plan tasks 1–9 of `docs/plans/2026-05-15-ontology-2-6-0-hybrid-retrieval.md`. No `OntologyQueryTool` or `ResponseMeta` changes.

## New public surface
`Strategos.Ontology` has no `PublicAPI.Unshipped.txt` baseline, so the new public surface is enumerated here:

- `Strategos.Ontology.Retrieval.IKeywordSearchProvider` — `Task<IReadOnlyList<KeywordSearchResult>> SearchAsync(KeywordSearchRequest, CancellationToken)`
- `Strategos.Ontology.Retrieval.KeywordSearchRequest` — sealed record `(string Query, string CollectionName, int TopK, IReadOnlyDictionary<string,string>? MetadataFilters = null)`
- `Strategos.Ontology.Retrieval.KeywordSearchResult` — sealed record `(string DocumentId, double Score, int Rank)`
- `Strategos.Ontology.Retrieval.KeywordSearchException` — sealed `Exception` with `(message, inner=null)` ctor

## Contract semantics (XML-doc'd + test-pinned)
- Rank is 1-indexed; Score is non-negative, unbounded, provider-scale (consumer normalizes).
- `MetadataFilters` AND-semantics across keys; missing key excludes the document.
- Unknown collection → `KeywordSearchException` naming the collection.
- `CancellationToken` propagates `OperationCanceledException` (unwrapped).
- Transport faults wrap as `KeywordSearchException` with inner exception preserved.

## Test plan
- [x] 9 contract behavior tests (`KeywordSearchProviderContractTests.cs`) cover all rows of the design §4.2 behavior table.
- [x] Transport-fault wrap test confirms `KeywordSearchException` inner-preservation invariant.
- [x] Constructor/record tests for the 3 records (`Ctor_*`, `WithExpression_*`).
- [x] `dotnet build src/Strategos.Ontology/Strategos.Ontology.csproj` — 0 warnings, 0 errors.
- [x] `Strategos.Ontology.Tests` full suite — 795/795 passing (will be 814/814 once PR-B lands the RankFusion tests).
- [x] Two-stage internal review: spec compliance PASS, code quality APPROVED (0 HIGH, 0 MEDIUM, 4 LOW — all idiomatic test-pattern `null!` and one plan-doc glob nit).

## Out of scope
- `OntologyQueryTool.QueryAsync` wiring → PR-C (#58)
- `RankFusion` utilities → PR-B (#57)
- `HybridQueryOptions` / `FusionMethod` enum → PR-C (#58)

Closes #56. Part of milestone "Ontology 2.6.0 — Hybrid Retrieval Seams" (#47).

🤖 Generated with [Claude Code](https://claude.com/claude-code)