### PR TITLE
feat(strategos): 2.7.0-preview.1 — G1 agent-identity seam

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,16 @@ jobs:
       - name: Pack
         run: dotnet pack src/strategos.sln --configuration Release --output ./packages
 
+      - name: Consumer dep-flow probe (G1 / F1 regression net)
+        # Verifies that a clean consumer referencing only the packed
+        # LevelUp.Strategos + LevelUp.Strategos.Generators nupkgs can resolve
+        # IPhaseAwareSaga at compile time. This guards against a regression of
+        # the v2.7.0-preview.1 G1 packaging bug where PrivateAssets="all" on
+        # the Generators -> Identity.Abstractions ProjectReference (combined
+        # with <DevelopmentDependency>true</DevelopmentDependency>) stripped
+        # the abstractions package from the consumer's compile classpath.
+        run: bash scripts/verify-generator-consumer-build.sh ./packages
+
   coverage-gate:
     needs: build-test
     if: github.event_name == 'pull_request'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Migration
 
+- **Package consumption.** `LevelUp.Strategos.Identity.Abstractions`
+  flows transitively from the `LevelUp.Strategos` core metapackage —
+  consumers that already reference `LevelUp.Strategos` need no
+  additional `PackageReference`. The dependency is routed through the
+  core (not through `LevelUp.Strategos.Generators`) because the
+  generator package is marked `<DevelopmentDependency>true</DevelopmentDependency>`,
+  which causes NuGet to suppress transitive flow from that package. A
+  CI consumer-build probe (`scripts/verify-generator-consumer-build.sh`,
+  wired into the `pack-verify` job) guards against regression of this
+  packaging contract.
 - **Consumers register** the Wolverine header-propagation policy in
   their `UseWolverine` block to enable cross-message workflow-identity
   propagation:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.7.0-preview.1] - 2026-05-16
+
+### G1 — Agent Identity Seam (DR-1..DR-10, supersedes #67/#68/#69, design 2026-05-16-g1-agent-identity-seam)
+
+#### Added
+
+- **`Strategos.Identity.Abstractions`** package debut. New
+  netstandard2.0 package shipping the agent-identity ports consumed by
+  the basileus SPIFFE adapter:
+  - `WorkflowIdentity` and `AgentIdentity` sealed records — opaque,
+    printable-ASCII-validated string values that ride on Wolverine
+    envelope headers without additional encoding.
+  - `IAgentIdentityProvider` — port for deriving per-step agent
+    identities from `(workflow, phaseName)`. Strategos owns the
+    contract; basileus is the SPIFFE-shaped adapter.
+  - `IAgentIdentityAccessor` — read-only port that exposes the active
+    envelope's identity to in-handler code. Returns `null` outside a
+    Wolverine handler context (mirrors `IHttpContextAccessor`).
+  - `IPhaseAwareSaga` — marker interface emitted on every generated
+    saga so middleware can read `saga.CurrentPhaseName` without
+    binding to the workflow's phase enum.
+  - `StrategosHeaders` constants — `x-strategos-workflow-identity`
+    and `x-strategos-agent-identity` wire-protocol header keys.
+
+#### Changed
+
+- **`Strategos.Generators`** emits a computed `CurrentPhaseName`
+  property (`=> Phase.ToString()`) and adds `IPhaseAwareSaga` to the
+  generated saga's base list. Both additions are additive — no
+  breaking changes to the existing 2.6.0 generator surface. The
+  generator ships `Strategos.Identity.Abstractions.dll` alongside
+  itself in `analyzers/dotnet/cs` so the analyzer assembly loads at
+  SG time.
+
+#### Migration
+
+- **Consumers register** the Wolverine header-propagation policy in
+  their `UseWolverine` block to enable cross-message workflow-identity
+  propagation:
+  ```csharp
+  opts.Policies.PropagateIncomingHeaderToOutgoing(
+      StrategosHeaders.WorkflowIdentity);
+  ```
+  `StrategosHeaders.AgentIdentity` is per-message-derived and is NOT
+  propagated — each handler stamps its own.
+- The basileus SPIFFE adapter (lvlup-sw/basileus PR #184) is the
+  reference `IAgentIdentityProvider` implementation. See
+  `docs/coordination/2026-05-16-basileus-handoff.md` for the
+  cross-repo handoff.
+
 ## [2.6.0] - 2026-05-17
 
 ### Ontology 2.6.0 — Hybrid Retrieval Seams (DR-1/DR-2/DR-3, #56/#57/#58, milestone #47)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [2.7.0-preview.1] - 2026-05-16
+## [2.7.0-preview.1] - 2026-05-17
 
 ### G1 — Agent Identity Seam (DR-1..DR-10, supersedes #67/#68/#69, design 2026-05-16-g1-agent-identity-seam)
 
@@ -231,6 +231,8 @@ First stable release of the Strategos library for building production-grade agen
 - Transactional outbox pattern
 - Time-travel debugging via event replay
 
+[2.7.0-preview.1]: https://github.com/lvlup-sw/strategos/releases/tag/v2.7.0-preview.1
+[2.6.0]: https://github.com/lvlup-sw/strategos/releases/tag/v2.6.0
 [1.1.1]: https://github.com/lvlup-sw/strategos/releases/tag/v1.1.1
 [1.1.0]: https://github.com/lvlup-sw/strategos/releases/tag/v1.1.0
 [1.0.0]: https://github.com/lvlup-sw/strategos/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The library builds on proven .NET infrastructure rather than reinventing durabil
 |---------|---------|
 | `Strategos` | Core fluent DSL and abstractions |
 | `Strategos.Generators` | Compile-time source generation (sagas, events, phase enums) |
+| `Strategos.Identity.Abstractions` | Agent-identity ports (workflow + agent identity records, IPhaseAwareSaga, IAgentIdentityProvider, StrategosHeaders) |
 | `Strategos.Infrastructure` | Production implementations (Thompson Sampling, loop detection, budgets) |
 | `Strategos.Agents` | Microsoft Agent Framework integration for LLM-powered steps |
 | `Strategos.Rag` | Vector store adapters for RAG patterns |
@@ -94,6 +95,34 @@ dotnet add package LevelUp.Strategos.Infrastructure
 ```
 
 See [Package Documentation](docs/packages.md) for detailed guidance.
+
+### Identity Seam (v2.7.0-preview.1)
+
+Sagas surface their current phase via the `IPhaseAwareSaga` marker
+interface (every generated saga implements it automatically). The
+basileus SPIFFE adapter uses this seam to attribute every outgoing
+message to a per-step `AgentIdentity` derived from
+`(WorkflowIdentity, saga.CurrentPhaseName)`. Identity rides on
+Wolverine envelope headers — there are no new fields on the saga.
+
+Consumers register the workflow-identity propagation policy in their
+`UseWolverine` block:
+
+```csharp
+using Strategos.Identity.Abstractions;
+
+services.AddWolverine(opts =>
+{
+    opts.Policies.PropagateIncomingHeaderToOutgoing(
+        StrategosHeaders.WorkflowIdentity);
+});
+```
+
+`StrategosHeaders.AgentIdentity` is per-message-derived — each handler
+stamps its own (matches OpenTelemetry `traceparent` semantics). The
+basileus middleware (lvlup-sw/basileus PR #184) provides the SPIFFE
+provider + the stamping middleware; see
+`docs/designs/2026-05-16-g1-agent-identity-seam.md` for the design.
 
 ## How It Compares
 

--- a/docs/coordination/2026-05-16-basileus-handoff.md
+++ b/docs/coordination/2026-05-16-basileus-handoff.md
@@ -1,0 +1,197 @@
+# Basileus G1 coordination handoff — Strategos 2.7.0-preview.1
+
+**Date:** 2026-05-16
+**Author drafted for:** lvlup-sw/strategos maintainer to action manually
+**Status:** Drafted — not yet filed / commented / closed
+
+This document holds the three pieces of cross-repo text required by
+[DR-9](../designs/2026-05-16-g1-agent-identity-seam.md#dr-9--cross-repo-coordination-basileus)
+and T13 of [the implementation plan](../plans/2026-05-16-g1-agent-identity-seam.md#task-13-dr-9-basileus-coordination-handoff).
+The implementer agent does NOT have permission to file issues or post
+comments on behalf of the maintainer; this file is the staging area
+for the actions the maintainer will take after merge.
+
+---
+
+## (a) Basileus tracking issue to file
+
+**Repository:** `lvlup-sw/basileus`
+**Title:** `G1-strategos integration: re-cut PR #184 against Strategos.Identity.Abstractions 2.7.0-preview.1`
+**Labels:** `g1`, `integration`, `breaking-change`, `phase-0`
+
+### Body
+
+```markdown
+## Context
+
+Strategos has shipped the G1 agent-identity seam in
+`LevelUp.Strategos.Identity.Abstractions 2.7.0-preview.1`. Identity
+storage now lives on Wolverine envelope headers rather than on saga
+fields — this supersedes the saga-emit approach the basileus G1 Phase 0
+draft proposed.
+
+- Strategos plan:
+  `docs/plans/2026-05-16-g1-agent-identity-seam.md`
+- Strategos design (canonical):
+  `docs/designs/2026-05-16-g1-agent-identity-seam.md`
+- Strategos releases the abstractions, generator, and core packages at
+  `2.7.0-preview.1`.
+
+## Required basileus changes
+
+PR #184 must be re-cut to:
+
+1. Reference `LevelUp.Strategos.Identity.Abstractions 2.7.0-preview.1`
+   and `LevelUp.Strategos.Generators 2.7.0-preview.1` (or higher).
+2. Move
+   `Basileus.Core.Contracts.Identity.{SpiffeId, WorkflowId, WorkflowIdentity, AgentIdentity, IAgentIdentityProvider}`
+   to `Basileus.Identity.Spiffe.*` as adapter implementations, or
+   delete them and consume the new Strategos types directly.
+3. Implement
+   `Basileus.Identity.Spiffe.SpiffeAgentIdentityProvider : Strategos.Identity.Abstractions.IAgentIdentityProvider`
+   producing values of the SPIFFE shape
+   `spiffe://td/workflow/<id>/step/<phase>`.
+4. Implement `Basileus.AgentHost.Middleware.StrategosHeaderMiddleware`
+   per Strategos design §9:
+   - Read `IMessageContext.Envelope.Headers[StrategosHeaders.WorkflowIdentity]`
+     or generate a new identity keyed to `sagaId` when missing
+     (Strategos DR-8 row 2 is a basileus contract).
+   - After Wolverine resolves the saga (as method parameter
+     `IPhaseAwareSaga saga`), read `saga.CurrentPhaseName`.
+   - Call `provider.DeriveStepIdentity(workflowId, saga.CurrentPhaseName)`.
+   - Stamp
+     `context.Envelope.Headers[StrategosHeaders.AgentIdentity] = agent.Value`.
+5. Configure
+   `opts.Policies.PropagateIncomingHeaderToOutgoing(StrategosHeaders.WorkflowIdentity)`
+   in the basileus `UseWolverine` registration so workflow identity
+   survives across handler hops without per-handler stamping.
+6. Revise basileus design doc
+   `docs/designs/2026-05-13-g1-implementation-phase-0.md` to reflect
+   envelope-header storage. Preserve §4 INV-8 (derivation-from-saga-state)
+   rationale; update §6 Strategos-side deliverables to read:
+   > Strategos owns identity ports; this PR is the basileus adapter only.
+
+## Acceptance criteria
+
+- [ ] PR #184 builds against the published `2.7.0-preview.1`.
+- [ ] Integration test on the basileus side verifies that an outbound
+      envelope carries both `x-strategos-workflow-identity` and
+      `x-strategos-agent-identity` headers populated after handler
+      completion.
+- [ ] basileus design doc revision is committed in the same PR.
+- [ ] Acceptance criteria mirrored from Strategos DR-9 are checked off.
+```
+
+---
+
+## (b) Comment to post on basileus PR #184
+
+```markdown
+Update from lvlup-sw/strategos: the G1 agent-identity seam shipped in
+`LevelUp.Strategos.Identity.Abstractions 2.7.0-preview.1` — published
+alongside `LevelUp.Strategos.Generators 2.7.0-preview.1` and
+`LevelUp.Strategos 2.7.0-preview.1`. Identity lives on Wolverine
+envelope headers, not on saga fields; the Strategos-side saga-emit
+work that this PR's Phase 0 draft anticipated has been descoped.
+
+This PR will need to be re-cut to consume the new abstractions
+package; see the tracking issue at lvlup-sw/basileus#[ISSUE-NUMBER]
+for the full task list.
+
+Reference material:
+- Strategos design — `docs/designs/2026-05-16-g1-agent-identity-seam.md`
+- Strategos plan — `docs/plans/2026-05-16-g1-agent-identity-seam.md`
+
+Once 2.7.0-preview.1 lands on nuget.org, this PR can pin to it.
+```
+
+(Replace `[ISSUE-NUMBER]` with the basileus tracking-issue number
+filed under section (a).)
+
+---
+
+## (c) Strategos issue closeout text
+
+### Comment to post on #71 (G1 epic)
+
+```markdown
+G1 Slice (D) — agent-identity seam — has shipped in v2.7.0-preview.1.
+
+Three packages now exist:
+- `LevelUp.Strategos.Identity.Abstractions 2.7.0-preview.1` (new)
+- `LevelUp.Strategos.Generators 2.7.0-preview.1`
+- `LevelUp.Strategos 2.7.0-preview.1`
+
+Cross-repo work tracked at lvlup-sw/basileus#[ISSUE-NUMBER]
+(re-cut PR #184 against the new abstractions package).
+
+Closing #67, #68, #69 as superseded — the basileus-draft A1/A2/A3
+emit was descoped in favor of one computed `CurrentPhaseName` property
++ `IPhaseAwareSaga` marker interface. See
+`docs/designs/2026-05-16-g1-agent-identity-seam.md` §10 for the
+before/after table.
+```
+
+### #67 closeout comment + close as `not planned` (superseded)
+
+```markdown
+Superseded by the v2.7.0-preview.1 envelope-header design. The
+generator no longer needs to emit a `CurrentAgentIdentity` property —
+the basileus middleware reads `IMessageContext.Envelope.Headers`
+through `IAgentIdentityAccessor`. See
+`docs/designs/2026-05-16-g1-agent-identity-seam.md` §10 (Option E vs
+Option C) for the rationale, and the Phase 2 ideation that ruled out
+Option C on INV-7 / outbox-survival grounds.
+
+Closing as superseded.
+```
+
+### #68 closeout comment + close as `not planned` (superseded)
+
+```markdown
+Superseded by the v2.7.0-preview.1 envelope-header design. There is
+no `InitializeIdentity` helper to emit — identity stamping happens in
+the basileus `StrategosHeaderMiddleware` once per handler invocation,
+not at saga construction. See
+`docs/designs/2026-05-16-g1-agent-identity-seam.md` §10.
+
+The DR-7 negation tests in `Strategos.Generators.Tests/SagaIdentityNegationTests.cs`
+mechanically guard against any future drift toward this descoped
+shape.
+
+Closing as superseded.
+```
+
+### #69 closeout comment + close as `not planned` (superseded)
+
+```markdown
+Superseded by the v2.7.0-preview.1 envelope-header design. The
+compile-test-with-stubs work this issue tracked is replaced by:
+
+- `Strategos.Identity.Abstractions.Tests` — full T2/T3/T4/T5/T6/T7
+  contract tests for every port + every value record.
+- `Strategos.Generators.Tests/EndToEndStubIntegrationTests.cs` —
+  T11 end-to-end stub seam verification (generator emit + fake
+  middleware stamp + fake accessor read-back).
+
+See `docs/designs/2026-05-16-g1-agent-identity-seam.md` for the full
+design.
+
+Closing as superseded.
+```
+
+---
+
+## Maintainer action checklist
+
+After merge of the Strategos v2.7.0-preview.1 release tag:
+
+- [ ] Publish the three nupkg files to nuget.org (or your private feed).
+- [ ] File the basileus tracking issue (section (a)). Capture its
+      number.
+- [ ] Post the PR #184 comment (section (b)) with the captured issue
+      number substituted.
+- [ ] Comment on #71 (section (c)) with the basileus tracking issue
+      linked.
+- [ ] Close #67, #68, #69 as `not planned` with the respective
+      closeout comments.

--- a/docs/designs/2026-05-16-g1-agent-identity-seam.md
+++ b/docs/designs/2026-05-16-g1-agent-identity-seam.md
@@ -1,0 +1,311 @@
+# G1-Strategos — Agent-Identity Seam via Wolverine Envelope Headers
+
+**Date:** 2026-05-16
+**Feature ID:** `g1-agent-identity-seam`
+**Slice:** v2.7.0 Slice (D) — pins `Strategos.Identity.Abstractions 2.7.0-preview.1`
+**Status:** Design — pending plan-review
+**Tracking:** epic [#71](https://github.com/lvlup-sw/strategos/issues/71); supersedes sub-issues [#67](https://github.com/lvlup-sw/strategos/issues/67) / [#68](https://github.com/lvlup-sw/strategos/issues/68) / [#69](https://github.com/lvlup-sw/strategos/issues/69) (saga-emit work is no longer required)
+**Consumer:** lvlup-sw/basileus PR #184 — to be re-cut as SPIFFE adapter
+
+---
+
+## 1. Problem Statement
+
+Basileus's `IReviewEvent` audit trail carries an empty `AgentId` field. Sagas have no programmatic access to their own identity beyond the workflow `Guid`, and downstream gaps (G3 ProvenanceEnvelope, G5 SubagentSpawn OBO, G6 causal attribution) all require per-step agent identity. v2.7.0 Slice (D) closes this gap. The basileus G1 Phase 0 design (lvlup-sw/basileus `docs/designs/2026-05-13-g1-implementation-phase-0.md`) drafted a Strategos-side property-on-saga seam. This document supersedes that draft on the Strategos side after grounding in three official sources:
+
+1. **Wolverine `docs/guide/messaging/header-propagation.md`** — first-class envelope header propagation across handler contexts, surviving outbox and all transports (Kafka / RabbitMQ / ASB). The published example is literally `x-on-behalf-of`.
+2. **`Microsoft.Extensions.AsyncState` README + dotnet/extensions issue [#4623](https://github.com/dotnet/extensions/issues/4623), PR [#4852](https://github.com/dotnet/extensions/pull/4852)** — explicit thread-safety caveat: not designed for concurrent flows. Strategos's Fork/Join emit produces concurrent handler invocations against the same workflow.
+3. **Roslyn SG cookbook** — generator packages may take a public dependency on a contract package; this is the cookbook-supported pattern for generator-emitted code that references domain types.
+
+The combination drives the Strategos-side answer: **identity lives on the Wolverine envelope, not on the saga.**
+
+## 2. Core problem (one sentence)
+
+Attribute every outbound message produced inside a saga handler to a specific `(workflow-identity, phase-name)` agent-identity tuple, durably across the outbox, transports, and saga step transitions.
+
+## 3. Chosen Approach
+
+**Strategos owns the port abstractions** (`WorkflowIdentity`, `AgentIdentity`, `IAgentIdentityProvider`, `StrategosHeaders`, `IAgentIdentityAccessor`) in a new `Strategos.Identity.Abstractions` package. **Identity is stored as Wolverine envelope headers**, not as saga fields. Basileus provides the SPIFFE-shaped adapter implementing the ports and the Wolverine middleware that stamps headers. The generator emits one new piece of state per saga: a computed `string CurrentPhaseName` property exposed via an `IPhaseAwareSaga` marker interface — a single small change, not the four-issue scope of the original A1/A2/A3/A4 plan.
+
+## 4. Technical Design — port / adapter architecture
+
+Following the hexagonal convention (nrjohnstone/ports-adapters-examples, guiferreira, justifiedcode): the domain owns the ports, the adapter implements them. Strategos is the domain (durable workflow state machine); Basileus is the adapter (SPIFFE / SPIRE identity provider).
+
+```
+┌─────────────────────────────────┐   ┌─────────────────────────────────┐
+│  Strategos.Identity.Abstractions│   │  Basileus.Identity.Spiffe       │
+│  (ports — owned by domain)      │←──│  (adapter — owned by infra)     │
+│                                 │   │                                 │
+│  WorkflowIdentity (record)      │   │  SpiffeAgentIdentityProvider    │
+│  AgentIdentity (record)         │   │    : IAgentIdentityProvider     │
+│  IAgentIdentityProvider         │   │  StrategosHeaderMiddleware      │
+│  IAgentIdentityAccessor         │   │    (Wolverine middleware)       │
+│  IPhaseAwareSaga                │   │                                 │
+│  StrategosHeaders (constants)   │   │  Phase 0: HMAC-shaped impl      │
+└─────────────────────────────────┘   │  Phase 1: SPIRE X.509-SVID swap │
+         ↑                            └─────────────────────────────────┘
+         │ public dep (Roslyn SG cookbook)
+┌─────────────────────────────────┐
+│  Strategos.Generators           │
+│  emits :Saga, IPhaseAwareSaga   │
+│  emits CurrentPhaseName         │
+└─────────────────────────────────┘
+```
+
+Dependencies flow inward. Strategos.Identity.Abstractions has zero dependency on Basileus. Phase 1 (HMAC → SPIRE) is purely an adapter swap with **zero change to Strategos**.
+
+## Requirements
+
+### DR-1 — `Strategos.Identity.Abstractions` package
+
+A new netstandard2.0 package shipping the ports plus header constants. Versioned at `2.7.0-preview.1` aligned with `Strategos.Generators 2.7.0-preview.1`. No dependency on `Microsoft.Extensions.AsyncState`. No dependency on any non-Strategos library beyond `Wolverine` for the accessor's envelope-reading impl (which lives in a sibling `Strategos.Identity` package if we choose to ship a default accessor; otherwise accessor is contract-only and consumers implement).
+
+**Acceptance criteria:**
+- `dotnet pack` produces `Strategos.Identity.Abstractions.2.7.0-preview.1.nupkg`
+- Package has zero references to `Basileus.*`
+- All public types XML-documented with `<summary>` blocks
+- PublicAPI baseline tracked per [#51](https://github.com/lvlup-sw/strategos/issues/51) protocol
+
+### DR-2 — `WorkflowIdentity` and `AgentIdentity` sealed records
+
+```csharp
+public sealed record WorkflowIdentity(string Value);
+public sealed record AgentIdentity(string Value);
+```
+
+Opaque-string-valued. Strategos does not inspect the value. SPIFFE shape (`spiffe://td/workflow/<id>/step/<phase>`) is a basileus-adapter concern.
+
+**Acceptance criteria:**
+- Both records are `sealed` (INV-6)
+- `Value` is `string` (header-serializable by construction)
+- `Value` must be non-null non-empty — record constructor throws `ArgumentException` if violated
+- Roundtrip: `new WorkflowIdentity("x").Value == "x"`
+
+### DR-3 — `IAgentIdentityProvider` port
+
+```csharp
+public interface IAgentIdentityProvider
+{
+    AgentIdentity DeriveStepIdentity(WorkflowIdentity workflow, string phaseName);
+    WorkflowIdentity ParseWorkflowHeader(string headerValue);
+}
+```
+
+`DeriveStepIdentity` uses `phaseName` (not numeric step number) because the Strategos saga's authoritative step identifier is `Phase.ToString()` — workflows with forks / branches / failure handlers don't have stable numeric ordinals. This refines basileus G1 INV-8 (derivation from saga state) without duplicating state.
+
+**Acceptance criteria:**
+- Interface is `public`
+- Both methods are pure (no side effects, deterministic given inputs)
+- Null/empty inputs throw `ArgumentException` (boundary validation per axiom DIM-7)
+
+### DR-4 — `StrategosHeaders` constants
+
+```csharp
+public static class StrategosHeaders
+{
+    public const string WorkflowIdentity = "x-strategos-workflow-identity";
+    public const string AgentIdentity = "x-strategos-agent-identity";
+}
+```
+
+Header keys are versioned by the package. Consumers MUST register `opts.Policies.PropagateIncomingHeaderToOutgoing(StrategosHeaders.WorkflowIdentity)` to enable cross-message propagation. `AgentIdentity` is per-message-derived; it is NOT propagated to outgoing messages (each handler stamps its own).
+
+**Acceptance criteria:**
+- Constants are `public const string`
+- Names match `x-strategos-*` prefix
+- README documents the required `PropagateIncomingHeaderToOutgoing` registration
+
+### DR-5 — `IAgentIdentityAccessor` for in-handler reads
+
+```csharp
+public interface IAgentIdentityAccessor
+{
+    WorkflowIdentity? CurrentWorkflow { get; }
+    AgentIdentity? CurrentAgent { get; }
+}
+```
+
+Reads from `IMessageContext.Envelope.Headers`. Returns `null` outside an active message handler context (saga inspected from a Marten projection, a debugger, etc.). Strategos may ship a default implementation in a sibling `Strategos.Identity` package; basileus may also provide an alternate impl.
+
+**Acceptance criteria:**
+- Both properties return `null` when no envelope context is active (no throw)
+- Both properties return parsed records when headers are present
+- Implementations are NOT required to cache (envelope lifetime IS the cache)
+
+### DR-6 — Generator emits `CurrentPhaseName` + `IPhaseAwareSaga`
+
+The Roslyn generator (`Strategos.Generators` `SagaPropertiesEmitter` or a new `SagaPhaseAccessorEmitter`) emits:
+
+```csharp
+public partial class {Saga} : Saga, IPhaseAwareSaga
+{
+    // existing emit: Phase, WorkflowId, State, ...
+    public string CurrentPhaseName => Phase.ToString();
+}
+```
+
+This is the **only** generator emit change. No `InitializeIdentity` helper, no `CurrentAgentIdentity` property, no private mutable fields. The existing four basileus issues (#67/#68/#69) are descoped — `CurrentPhaseName` is one computed read-only property and one interface declaration.
+
+**Acceptance criteria:**
+- Snapshot test asserts `CurrentPhaseName` emit
+- Snapshot test asserts `IPhaseAwareSaga` is in the saga's base list
+- `CurrentPhaseName` is a get-only computed property (no setter, no backing field)
+- Existing saga snapshots (Phronesis, review-loop, AgenticCoder, ContentPipeline, MultiModelRouter samples) regenerate successfully with the additive change
+
+### DR-7 — Strategos generator emits NO other identity-related code
+
+Confirms what's NOT in scope: no `CurrentAgentIdentity` property emit, no `InitializeIdentity(...)` helper, no `_workflowIdentity` / `_identityProvider` backing fields, no `InternalsVisibleTo` requirement on the generated assembly. Identity propagation happens via Wolverine envelope headers and the host-side middleware.
+
+**Acceptance criteria:**
+- A search of generated `*Saga.g.cs` finds no occurrence of `WorkflowIdentity`, `AgentIdentity`, `IAgentIdentityProvider`, or `InternalsVisibleTo`
+- INV-1 audit passes — generated saga lowering is unchanged except for the `IPhaseAwareSaga` base-list entry and the `CurrentPhaseName` computed property
+- INV-7 audit passes — no new mutable fields on any generated saga
+
+### DR-8 — Error handling and edge cases
+
+| Scenario | Behavior | Mechanical enforcement |
+|---|---|---|
+| Accessor read outside a Wolverine handler context | `CurrentWorkflow` / `CurrentAgent` return `null` | Default impl checks `IMessageContext` resolution; returns null on failure |
+| Incoming envelope has no `x-strategos-workflow-identity` header | Middleware generates a new `WorkflowIdentity` keyed to `sagaId` | basileus middleware contract; Strategos provides no enforcement |
+| `WorkflowIdentity` record constructed with null/empty value | `ArgumentException` at record construction | Sealed record positional constructor validates |
+| Provider returns null from `DeriveStepIdentity` | `InvalidOperationException` thrown by middleware (basileus side) | basileus middleware contract |
+| Saga handler emits a message with no Wolverine outbox context | Headers are still set; outgoing message carries them via Wolverine's standard envelope mechanism | Wolverine native |
+| Header value contains non-UTF8 / control characters | Wolverine's transport layer is responsible for header encoding; values must be ASCII-safe | Strategos `WorkflowIdentity.Value` setter validates ASCII subset |
+
+**Acceptance criteria:**
+- Unit tests cover each row above
+- `WorkflowIdentity` and `AgentIdentity` constructors throw `ArgumentException` on null, empty, or non-ASCII-safe input
+- Accessor null-handling has a test case that runs WITHOUT a Wolverine message context
+
+### DR-9 — Cross-repo coordination (basileus)
+
+Basileus PR #184 is re-cut to:
+- Reference `Strategos.Identity.Abstractions 2.7.0-preview.1`
+- Drop `Basileus.Core.Contracts.Identity.{SpiffeId, WorkflowId, WorkflowIdentity, AgentIdentity, IAgentIdentityProvider}` — these become Strategos types or are re-shaped as adapter-internal concerns
+- Add `Basileus.Identity.Spiffe.SpiffeAgentIdentityProvider : IAgentIdentityProvider`
+- Add `Basileus.AgentHost.Middleware.StrategosHeaderMiddleware` — Wolverine middleware that:
+  1. Reads `IMessageContext.Envelope.Headers[StrategosHeaders.WorkflowIdentity]` or generates a new one keyed to `sagaId`
+  2. After Wolverine loads the saga (e.g., as a method parameter `IPhaseAwareSaga saga`), reads `saga.CurrentPhaseName`
+  3. Calls `provider.DeriveStepIdentity(workflowId, saga.CurrentPhaseName)`
+  4. Stamps `context.Envelope.Headers[StrategosHeaders.AgentIdentity] = agent.Value`
+- Configure `opts.Policies.PropagateIncomingHeaderToOutgoing(StrategosHeaders.WorkflowIdentity)` in `UseWolverine`
+- The basileus design doc `2026-05-13-g1-implementation-phase-0.md` is revised to reflect the envelope-header storage choice; the §4 derivation-site rationale (INV-8) is preserved unchanged
+
+**Acceptance criteria:**
+- basileus PR #184 builds against `Strategos.Identity.Abstractions 2.7.0-preview.1` published to nuget.org (or a local feed)
+- An integration test in basileus verifies an outbound message has `x-strategos-workflow-identity` and `x-strategos-agent-identity` headers populated after handler completion
+- basileus design doc revision is committed in the same PR
+
+### DR-10 — Release: `Strategos.Identity.Abstractions 2.7.0-preview.1`
+
+Per [#70](https://github.com/lvlup-sw/strategos/issues/70) protocol, but with revised scope:
+
+- CHANGELOG `## [2.7.0-preview.1]` section describes:
+  - New package `Strategos.Identity.Abstractions` debuts at 2.7.0-preview.1
+  - Generator emits `CurrentPhaseName` + `IPhaseAwareSaga` on all sagas (additive; existing consumers unaffected unless they redefine the same identifier)
+  - No breaking changes to existing 2.6.0 surface
+- Bump `LevelUp.Strategos`, `LevelUp.Strategos.Generators` to 2.7.0-preview.1
+- Tag `v2.7.0-preview.1`
+- Comment on [#70](https://github.com/lvlup-sw/strategos/issues/70) with the nuget.org URL once published
+
+**Acceptance criteria:**
+- Three packages published: `LevelUp.Strategos.2.7.0-preview.1`, `LevelUp.Strategos.Generators.2.7.0-preview.1`, `LevelUp.Strategos.Identity.Abstractions.2.7.0-preview.1`
+- All three resolvable from nuget.org
+- basileus PR #184 successfully pins to this preview
+
+## 6. Invariant audit (INV-1..INV-8)
+
+| Invariant | Severity | Verdict | Notes |
+|---|---|---|---|
+| INV-1 workflow lowering via Wolverine+Marten | HIGH | ✓ | Uses Wolverine's native envelope-header primitive — strongest possible alignment |
+| INV-2 ontology analyzer-only and self-contained | HIGH | N/A | Does not touch ontology |
+| INV-3 MCP first-class | MEDIUM | N/A | Does not touch MCP |
+| INV-4 concrete DSL nomenclature | MEDIUM | ✓ | `WorkflowIdentity`, `AgentIdentity`, `PhaseAwareSaga` — all concrete domain terms |
+| INV-5 three-tiered validation, stable diagnostic IDs | HIGH | N/A | No new diagnostics required (no compile-time check available — runtime DI registration check is consumer's responsibility) |
+| INV-6 sealed-by-default | HIGH | ✓ | Both records explicitly `sealed`; interfaces by their nature are extension points |
+| INV-7 immutable record state | HIGH | ✓ | Zero new mutable fields on any saga; `CurrentPhaseName` is read-only computed; sealed records are immutable |
+| INV-8 polyglot identity (`ClrType` / `SymbolKey`) | HIGH | N/A | Different identity concept (ontology descriptor identity, not agent identity) |
+
+## 7. axiom dimensions audit (DIM-1..DIM-8)
+
+| Dimension | Verdict | Notes |
+|---|---|---|
+| DIM-1 architecture | ✓ | Hexagonal port/adapter; SRP-clean package split |
+| DIM-2 tests | ✓ | Per-DR acceptance criteria, snapshot tests, integration test on basileus side |
+| DIM-3 surface design | ✓ | 6 types (2 records, 3 interfaces, 1 static constants class) — each load-bearing |
+| DIM-4 concurrency | ✓ | Stateless ports; envelope headers are per-message immutable |
+| DIM-5 performance | ✓ | Header read is O(1) dictionary lookup; no AsyncLocal overhead |
+| DIM-6 coupling | ✓ | Strategos.Identity.Abstractions has zero Basileus reference; dependency arrow points correctly |
+| DIM-7 errors | ✓ | DR-8 enumerates each edge case with mechanical enforcement |
+| DIM-8 distillation | ✓ | No A1/A2/A3 emit work; only `CurrentPhaseName` + interface declaration added to generator |
+
+## 8. Alternatives Considered
+
+Phase 2 of `/exarchos:ideate` evaluated five options end-to-end. Summarized:
+
+| Option | Shape | Why rejected (or adopted) |
+|---|---|---|
+| **A** — pure name-string emit | Generator emits `CurrentAgentIdentity` + `InitializeIdentity` referring to consumer-provided types | Strategos owns no port — Basileus owns both port and adapter. Anti-hexagonal. |
+| **B** — A + empty `ISagaIdentityHost` marker | Same as A plus a Strategos-side empty marker interface | Marker doesn't load-bear; INV-4 friction with structural "Host" name; DIM-8 demerit. |
+| **C** — Strategos-owned ports + saga-field emit | Strategos ships abstractions; generator emits `_workflowIdentity`/`_identityProvider` private fields + `InitializeIdentity` helper + `CurrentAgentIdentity` property | INV-7 friction (mutable transient fields); requires `InternalsVisibleTo` on consumer; doesn't survive outbox without explicit per-message stamping. |
+| **D** — `Microsoft.Extensions.AsyncState` ambient context | Identity flows via `IAsyncContext<T>`, zero saga emit | dotnet/extensions PR #4852 + issue #4623 confirm AsyncState is **not designed for concurrent flows**; Fork/Join emit produces concurrent handler invocations against the same workflow. Doesn't survive outbox without explicit stamping. |
+| **E** — Wolverine envelope-header propagation **(adopted)** | Identity stored on `IMessageContext.Envelope.Headers`; consumer registers `PropagateIncomingHeaderToOutgoing` | Uses Wolverine's first-class header-propagation primitive ([`docs/guide/messaging/header-propagation.md`](https://github.com/jasperfx/wolverine/blob/main/docs/guide/messaging/header-propagation.md), published example: `x-on-behalf-of` — identical to G5 OBO use case). Native outbox + transport survival. Zero mutable saga state. |
+
+The decisive factor was Wolverine's published header-propagation primitive — it solves the harder problem (cross-outbox + cross-transport identity propagation) that C/D both punt on, AND uses the platform Strategos already lowers to per INV-1.
+
+## 9. Integration Points
+
+- **Wolverine** — header propagation policy (`opts.Policies.PropagateIncomingHeaderToOutgoing(StrategosHeaders.WorkflowIdentity)`) registered in consumer's `UseWolverine` block; middleware reads/stamps `IMessageContext.Envelope.Headers`
+- **Marten** — outbox row contains the Wolverine envelope (with headers) — no schema change required
+- **Basileus.AgentHost** — provides Wolverine middleware (`StrategosHeaderMiddleware`) and the SPIFFE-shaped `IAgentIdentityProvider` implementation
+- **Strategos.Generators** — emits `: Saga, IPhaseAwareSaga` + `public string CurrentPhaseName => Phase.ToString()` on every generated saga partial
+- **NuGet publishing** — new package `Strategos.Identity.Abstractions` ships alongside `Strategos.Generators` and `Strategos` at `2.7.0-preview.1`
+
+## 10. What changed vs the basileus G1 Phase 0 draft
+
+| | basileus draft (Option C in ideation) | This design (Option E — adopted) |
+|---|---|---|
+| Identity storage | private fields on saga (`_workflowIdentity`, `_identityProvider`) | Wolverine envelope headers |
+| Saga reads identity | `this.CurrentAgentIdentity` property | injected `IAgentIdentityAccessor.CurrentAgent` |
+| Generator A1 (CurrentAgentIdentity property) | required | **descoped** |
+| Generator A2 (InitializeIdentity helper) | required | **descoped** |
+| Generator A3 (compile test with stubs) | required | **descoped** |
+| Generator A4 (release) | required | retained (scope changes to ship abstractions package) |
+| New generator emit | property + helper + 2 mutable fields per saga | one computed property + one interface declaration |
+| `InternalsVisibleTo` requirement on consumer | yes | **none** |
+| Outbox / transport survival | requires explicit per-message stamping | **native via Wolverine** |
+| Cross-message identity propagation | requires consumer code | **native via `PropagateIncomingHeaderToOutgoing`** |
+| basileus INV-8 (derivation from saga state) | direct field read | middleware reads `saga.CurrentPhaseName` before stamping |
+| Strategos INV-1 alignment | weakened (adds emit) | strengthened (uses Wolverine native primitive) |
+| Strategos INV-7 alignment | violated transiently (mutable fields, mitigated) | preserved fully |
+
+## 11. Out of scope (deferred)
+
+- **G3 ProvenanceEnvelope** ([#61](https://github.com/lvlup-sw/strategos/issues/61)) — provenance envelope contracts build on top of this seam; the natural shape is additional `x-strategos-provenance-*` headers using the same Wolverine propagation policy
+- **G5 SubagentSpawn OBO** ([#62](https://github.com/lvlup-sw/strategos/issues/62)) — token exchange uses agent identity but happens on the basileus side
+- **G4 PartitionablePair** ([#60](https://github.com/lvlup-sw/strategos/issues/60)) — independent
+- **Phase 1 SPIRE swap** — basileus-internal adapter change; zero Strategos work
+- **`Strategos.Identity` default accessor implementation** — may ship in 2.7.0 GA; preview.1 ships abstractions only and basileus provides its own accessor impl
+
+## 12. Testing Strategy
+
+1. **Unit tests in `Strategos.Identity.Abstractions.Tests`** (new project)
+   - Record construction: null/empty/non-ASCII rejection
+   - `StrategosHeaders` constant values stable
+2. **Snapshot tests in `Strategos.Generators.Tests`**
+   - Every existing saga snapshot regenerates with `IPhaseAwareSaga` and `CurrentPhaseName` additions
+   - New snapshot test asserts `CurrentPhaseName` exists and returns `Phase.ToString()`
+   - Existing sample workflows (AgenticCoder, ContentPipeline, MultiModelRouter) still build
+3. **Integration test (basileus side, in PR #184)**
+   - End-to-end Wolverine handler test: incoming message → middleware stamps headers → handler emits cascading message → outgoing envelope contains both headers
+   - Header value roundtrip: `WorkflowIdentity.Value` matches across in→out
+
+## 13. Open Questions (resolve during plan phase, not blocking)
+
+1. Whether to ship a default `IAgentIdentityAccessor` impl in `Strategos.Identity` (sibling package) in preview.1 or defer to GA
+2. Whether `WorkflowIdentity.Value` ASCII validation is too strict (SPIFFE URIs are ASCII; basileus's HMAC scheme is base64-url which is ASCII; safe default but worth confirming)
+3. Whether to also propagate `x-strategos-agent-identity` to outgoing messages (vs. each handler stamping its own — current design says each stamps its own; this matches OpenTelemetry `traceparent` semantics)
+
+---
+
+**Provenance:** Phase 1 understanding driven by [#71](https://github.com/lvlup-sw/strategos/issues/71) and the basileus G1 Phase 0 design. Phase 2 exploration evaluated four options (name-string emit, empty marker, port abstractions + saga emit, AsyncLocal ambient context) and discovered the Wolverine-canonical envelope-header pattern via official Wolverine docs `header-propagation.md`. Phase 3 (this document) commits to envelope-header storage with Strategos-owned ports.

--- a/docs/designs/2026-05-16-g1-agent-identity-seam.md
+++ b/docs/designs/2026-05-16-g1-agent-identity-seam.md
@@ -31,7 +31,7 @@ Attribute every outbound message produced inside a saga handler to a specific `(
 
 Following the hexagonal convention (nrjohnstone/ports-adapters-examples, guiferreira, justifiedcode): the domain owns the ports, the adapter implements them. Strategos is the domain (durable workflow state machine); Basileus is the adapter (SPIFFE / SPIRE identity provider).
 
-```
+```text
 ┌─────────────────────────────────┐   ┌─────────────────────────────────┐
 │  Strategos.Identity.Abstractions│   │  Basileus.Identity.Spiffe       │
 │  (ports — owned by domain)      │←──│  (adapter — owned by infra)     │

--- a/docs/plans/2026-05-16-g1-agent-identity-seam.md
+++ b/docs/plans/2026-05-16-g1-agent-identity-seam.md
@@ -390,7 +390,7 @@
 
 **Phase:** Coordination (not RED-GREEN per se — this is a cross-repo task)
 **DR coverage:** DR-9
-**Parallelizable:** No (final coordination step, runs after T12 release)
+**Parallelizable:** No (final coordination step, runs after T14 release)
 **Estimated:** 8 min
 
 1. **Open basileus tracking issue** on lvlup-sw/basileus titled `G1-strategos integration: re-cut PR #184 against Strategos.Identity.Abstractions 2.7.0-preview.1` with body including:
@@ -419,7 +419,7 @@
 - PR #184 comment is posted
 - Strategos issues #67/#68/#69 are closed-as-superseded with cross-links
 
-**Dependencies:** T12 (preview release must be published first so basileus can pin to it)
+**Dependencies:** T14 (preview release must be published first so basileus can pin to it)
 **Not parallelizable:** runs last
 **Note:** This is coordination work, not Strategos code. It belongs in the Strategos plan because it's required for the design to actually deliver value (basileus is the inaugural consumer).
 
@@ -446,7 +446,7 @@
    - Bump `MinVer` minimum to `2.7.0-preview.1` (or pass via `dotnet pack /p:MinVerSkip=true /p:Version=2.7.0-preview.1` if MinVer is git-tag-driven)
    - Pre-tag verification: `dotnet pack src/Strategos.Identity.Abstractions/` produces a valid nupkg
    - `README.md` (Strategos root) — add a new `### Identity Seam (v2.7.0-preview.1)` subsection documenting the abstractions package, `StrategosHeaders`, and the `PropagateIncomingHeaderToOutgoing` consumer-side registration
-   - Move `PublicAPI.Unshipped.txt` entries → `PublicAPI.Shipped.txt` (preview API is still pre-shipped per #51 protocol; defer this move to GA, but document the surface in CHANGELOG)
+   - Leave `PublicAPI.Unshipped.txt` entries in place — moving them to `PublicAPI.Shipped.txt` is **deferred to 2.7.0 GA** per #51 protocol (preview API is not yet "shipped" in that sense). The preview surface is documented in the CHANGELOG instead.
 
 3. **[REFACTOR]** None — release artifacts speak for themselves
 

--- a/docs/plans/2026-05-16-g1-agent-identity-seam.md
+++ b/docs/plans/2026-05-16-g1-agent-identity-seam.md
@@ -1,0 +1,501 @@
+# Implementation Plan — G1-Strategos Agent-Identity Seam
+
+**Date:** 2026-05-16
+**Feature ID:** `g1-agent-identity-seam`
+**Design:** [`docs/designs/2026-05-16-g1-agent-identity-seam.md`](../designs/2026-05-16-g1-agent-identity-seam.md)
+**Release target:** `LevelUp.Strategos.Identity.Abstractions 2.7.0-preview.1` + `LevelUp.Strategos.Generators 2.7.0-preview.1` + `LevelUp.Strategos 2.7.0-preview.1`
+**Test framework:** TUnit 1.2.11 + Verify.SourceGenerators 2.5.0 + NSubstitute 5.3.0
+**TUnit invocation:** `dotnet test src/Strategos.Identity.Abstractions.Tests/ -- --treenode-filter "/*/*/*/{TestName}"` (per [feedback_tunit_test_invocation](../../.claude/memory/feedback_tunit_test_invocation.md))
+
+## Iron Law
+
+**NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST.** Every task starts with `[RED]` — a test that fails for a specific reason — before any production code is written.
+
+## Topology overview
+
+```text
+                            ┌───────────────┐
+                            │ T1 skeleton   │  (sln, csproj, packages, PublicAPI)
+                            └───────┬───────┘
+                                    │
+            ┌───────────────────────┼───────────────────────────┐
+            │           │           │           │           │
+        ┌───▼──┐    ┌───▼──┐    ┌──▼──┐    ┌───▼──┐    ┌────▼───┐
+        │ T2   │    │ T3   │    │ T4  │    │ T5   │    │  T6    │ ◄── PARALLEL
+        │ Wkfl │    │ Agnt │    │ Hdrs│    │ IPhase│   │ Provid │     (5 tasks)
+        │ Id   │    │ Id   │    │     │    │ Aware │   │ Port   │
+        └──────┘    └───┬──┘    └─────┘    └──┬───┘    └────────┘
+                        │                     │
+                        │                     │
+                    ┌───▼─────────────────┐   │
+                    │ T7 Accessor port    │   │
+                    │ + Fake impl         │   │
+                    └─────────────────────┘   │
+                                              │
+                              ┌───────────────▼────────────┐
+                              │ T8 Generator emit          │  ◄── BLOCKING
+                              │   CurrentPhaseName +       │      (touches generators)
+                              │   IPhaseAwareSaga          │
+                              └───────────┬────────────────┘
+                                          │
+                  ┌───────────────┬───────────────┬───────────────┬───────────────┐
+                  │               │               │               │               │
+              ┌───▼──┐         ┌──▼──┐         ┌──▼──┐         ┌──▼──┐         ┌──▼──┐
+              │ T9   │         │ T10 │         │ T11 │         │ T12 │         │ T13 │ ◄── PARALLEL
+              │ DR-7 │         │ Snap│         │ E2E │         │ DR-8│         │coord│     (5 tasks
+              │ neg. │         │ regn│         │ stub│         │sweep│         │basil│      after T8)
+              └──────┘         └─────┘         └─────┘         └─────┘         └──┬──┘
+                                          │                                       │
+                                  ┌───────▼──────┐                                │
+                                  │ T14 Release  │  ◄── FINAL                     │
+                                  │   CHANGELOG  │ (T13 runs *after* T14 since    │
+                                  │   versions   │  basileus needs preview.1)     │
+                                  │   pack       │◄───────────────────────────────┘
+                                  └──────────────┘
+```
+
+## Task list
+
+---
+
+### Task 1: Bootstrap `Strategos.Identity.Abstractions` project skeleton
+
+**Phase:** RED → GREEN → REFACTOR
+**DR coverage:** DR-1, DR-7 (foundation)
+**Parallelizable:** No (blocks all subsequent tasks)
+**Estimated:** 5 min
+
+1. **[RED]** Write `tests/build/ProjectStructureTests.cs::Strategos_Identity_Abstractions_Csproj_Exists_AndTargetsNetStandard20`
+   - File: `src/Strategos.Identity.Abstractions.Tests/ProjectStructureTests.cs`
+   - Asserts `Strategos.Identity.Abstractions.csproj` exists, `TargetFramework=netstandard2.0`, `ManagePackageVersionsCentrally=true`
+   - **Expected failure:** csproj does not yet exist
+
+2. **[GREEN]** Create minimum skeleton
+   - File: `src/Strategos.Identity.Abstractions/Strategos.Identity.Abstractions.csproj` (netstandard2.0 + Lvlup.Build + MinVer + PackageId `LevelUp.Strategos.Identity.Abstractions`)
+   - File: `src/Strategos.Identity.Abstractions.Tests/Strategos.Identity.Abstractions.Tests.csproj` (net10.0 + TUnit + NSubstitute + Verify.SourceGenerators + ProjectReference to abstractions)
+   - File: `src/Strategos.Identity.Abstractions/PublicAPI.Shipped.txt` (empty — preview, no shipped surface yet)
+   - File: `src/Strategos.Identity.Abstractions/PublicAPI.Unshipped.txt` (empty; tasks T2..T7 will populate)
+   - Update `src/strategos.sln` — add both projects
+   - Update `src/Directory.Packages.props` — no new PackageVersion entries required (uses existing TUnit/NSubstitute/Verify versions)
+   - Update `src/stylecop.json` — inherit existing
+   - **Iron law check:** the structural test now passes
+
+3. **[REFACTOR]** None — minimal skeleton
+
+**Dependencies:** None
+**Output artifact:** project skeleton committed; `dotnet build src/Strategos.Identity.Abstractions/` passes with no source
+
+---
+
+### Task 2: `WorkflowIdentity` sealed record
+
+**Phase:** RED → GREEN → REFACTOR
+**DR coverage:** DR-2, DR-8 (rows 3, 6)
+**Parallelizable:** Yes (with T3, T4, T5, T6)
+**Estimated:** 5 min
+
+1. **[RED]** Write `WorkflowIdentityTests.cs` with TUnit tests:
+   - `WorkflowIdentity_ConstructedWithValue_StoresValueExactly`
+   - `WorkflowIdentity_NullValue_ThrowsArgumentNullException`
+   - `WorkflowIdentity_EmptyValue_ThrowsArgumentException`
+   - `WorkflowIdentity_WhitespaceValue_ThrowsArgumentException`
+   - `WorkflowIdentity_NonAsciiValue_ThrowsArgumentException`
+   - `WorkflowIdentity_IsSealedRecord_ViaReflection` (asserts `typeof(WorkflowIdentity).IsSealed`)
+   - File: `src/Strategos.Identity.Abstractions.Tests/WorkflowIdentityTests.cs`
+   - **Expected failure:** `WorkflowIdentity` type does not exist
+
+2. **[GREEN]** Implement the record
+   - File: `src/Strategos.Identity.Abstractions/WorkflowIdentity.cs`
+   - `public sealed record WorkflowIdentity` with positional `string Value` parameter
+   - Constructor body validates: non-null, non-empty after trim, ASCII-safe (each char `<= 0x7E && >= 0x20`)
+   - Update `PublicAPI.Unshipped.txt` with the new public surface
+
+3. **[REFACTOR]** Extract ASCII validation into `internal static class IdentityValueValidator` if shared with `AgentIdentity` (likely needed)
+
+**Dependencies:** T1
+**Test names:** TUnit `Method_Scenario_Outcome` convention
+
+---
+
+### Task 3: `AgentIdentity` sealed record
+
+**Phase:** RED → GREEN → REFACTOR
+**DR coverage:** DR-2, DR-8 (rows 3, 6)
+**Parallelizable:** Yes (with T2, T4, T5, T6)
+**Estimated:** 4 min
+
+1. **[RED]** Write `AgentIdentityTests.cs` — mirrors T2 tests:
+   - `AgentIdentity_ConstructedWithValue_StoresValueExactly`
+   - `AgentIdentity_NullValue_ThrowsArgumentNullException`
+   - `AgentIdentity_EmptyValue_ThrowsArgumentException`
+   - `AgentIdentity_NonAsciiValue_ThrowsArgumentException`
+   - `AgentIdentity_IsSealedRecord_ViaReflection`
+   - File: `src/Strategos.Identity.Abstractions.Tests/AgentIdentityTests.cs`
+   - **Expected failure:** `AgentIdentity` type does not exist
+
+2. **[GREEN]** Implement
+   - File: `src/Strategos.Identity.Abstractions/AgentIdentity.cs`
+   - `public sealed record AgentIdentity(string Value)` with validation in constructor
+   - Reuses `IdentityValueValidator` from T2's refactor
+   - Update `PublicAPI.Unshipped.txt`
+
+3. **[REFACTOR]** Confirm shared validator pattern
+
+**Dependencies:** T1 (T2 if validator is shared — coordinate)
+
+---
+
+### Task 4: `StrategosHeaders` constants
+
+**Phase:** RED → GREEN
+**DR coverage:** DR-4
+**Parallelizable:** Yes
+**Estimated:** 3 min
+
+1. **[RED]** Write `StrategosHeadersTests.cs`:
+   - `StrategosHeaders_WorkflowIdentity_EqualsExpectedConstantValue` (`"x-strategos-workflow-identity"`)
+   - `StrategosHeaders_AgentIdentity_EqualsExpectedConstantValue` (`"x-strategos-agent-identity"`)
+   - `StrategosHeaders_AllKeys_FollowXStrategosPrefix` (reflection over public consts)
+   - `StrategosHeaders_AllKeys_AreAsciiLowerKebabCase`
+   - File: `src/Strategos.Identity.Abstractions.Tests/StrategosHeadersTests.cs`
+   - **Expected failure:** type does not exist
+
+2. **[GREEN]** Implement
+   - File: `src/Strategos.Identity.Abstractions/StrategosHeaders.cs`
+   - `public static class StrategosHeaders` with `public const string WorkflowIdentity` and `AgentIdentity`
+   - Update `PublicAPI.Unshipped.txt`
+
+**Dependencies:** T1
+
+---
+
+### Task 5: `IPhaseAwareSaga` interface
+
+**Phase:** RED → GREEN
+**DR coverage:** DR-6 (interface portion)
+**Parallelizable:** Yes
+**Estimated:** 3 min
+
+1. **[RED]** Write `IPhaseAwareSagaTests.cs`:
+   - `IPhaseAwareSaga_IsPublicInterface_ViaReflection`
+   - `IPhaseAwareSaga_HasCurrentPhaseNameProperty_AsStringGetter`
+   - `IPhaseAwareSaga_CurrentPhaseName_HasNoSetter`
+   - File: `src/Strategos.Identity.Abstractions.Tests/IPhaseAwareSagaTests.cs`
+   - **Expected failure:** type does not exist
+
+2. **[GREEN]** Implement
+   - File: `src/Strategos.Identity.Abstractions/IPhaseAwareSaga.cs`
+   - `public interface IPhaseAwareSaga { string CurrentPhaseName { get; } }`
+   - Update `PublicAPI.Unshipped.txt`
+
+**Dependencies:** T1
+
+---
+
+### Task 6: `IAgentIdentityProvider` port + stub fake
+
+**Phase:** RED → GREEN → REFACTOR
+**DR coverage:** DR-3, DR-8 (row 4)
+**Parallelizable:** Yes (depends on T2, T3)
+**Estimated:** 6 min
+
+1. **[RED]** Write contract tests using a `StubAgentIdentityProvider` fake:
+   - `StubAgentIdentityProvider_DeriveStepIdentity_ReturnsAgentIdentity_ContainingWorkflowAndPhase`
+   - `StubAgentIdentityProvider_DeriveStepIdentity_NullWorkflow_ThrowsArgumentNullException`
+   - `StubAgentIdentityProvider_DeriveStepIdentity_NullPhaseName_ThrowsArgumentNullException`
+   - `StubAgentIdentityProvider_DeriveStepIdentity_EmptyPhaseName_ThrowsArgumentException`
+   - `StubAgentIdentityProvider_ParseWorkflowHeader_NullValue_ThrowsArgumentNullException`
+   - `StubAgentIdentityProvider_ParseWorkflowHeader_ValidValue_RoundTrips`
+   - File: `src/Strategos.Identity.Abstractions.Tests/IAgentIdentityProviderContractTests.cs`
+   - File: `src/Strategos.Identity.Abstractions.Tests/Fakes/StubAgentIdentityProvider.cs`
+   - **Expected failure:** `IAgentIdentityProvider` type does not exist
+
+2. **[GREEN]** Implement the port
+   - File: `src/Strategos.Identity.Abstractions/IAgentIdentityProvider.cs`
+   - Two methods: `AgentIdentity DeriveStepIdentity(WorkflowIdentity, string)`, `WorkflowIdentity ParseWorkflowHeader(string)`
+   - File: `src/Strategos.Identity.Abstractions.Tests/Fakes/StubAgentIdentityProvider.cs` — minimal impl that concatenates inputs (e.g., `$"{workflow.Value}#{phaseName}"`)
+   - Update `PublicAPI.Unshipped.txt`
+
+3. **[REFACTOR]** Stabilize XML docs; ensure both methods document their argument-validation contract
+
+**Dependencies:** T2, T3
+
+---
+
+### Task 7: `IAgentIdentityAccessor` port + fake
+
+**Phase:** RED → GREEN → REFACTOR
+**DR coverage:** DR-5, DR-8 (row 1)
+**Parallelizable:** Yes (depends on T2, T3; can run with T6)
+**Estimated:** 6 min
+
+1. **[RED]** Write contract tests using a `FakeAgentIdentityAccessor`:
+   - `FakeAgentIdentityAccessor_NoEnvelopeContext_CurrentWorkflowReturnsNull`
+   - `FakeAgentIdentityAccessor_NoEnvelopeContext_CurrentAgentReturnsNull`
+   - `FakeAgentIdentityAccessor_BothHeadersPresent_ReturnsParsedRecords`
+   - `FakeAgentIdentityAccessor_OnlyWorkflowHeader_CurrentAgentReturnsNull`
+   - `FakeAgentIdentityAccessor_HeaderValueInvalid_ReturnsNullNoThrow`
+   - File: `src/Strategos.Identity.Abstractions.Tests/IAgentIdentityAccessorContractTests.cs`
+   - File: `src/Strategos.Identity.Abstractions.Tests/Fakes/FakeAgentIdentityAccessor.cs` (in-memory dictionary-backed)
+   - **Expected failure:** `IAgentIdentityAccessor` type does not exist
+
+2. **[GREEN]** Implement
+   - File: `src/Strategos.Identity.Abstractions/IAgentIdentityAccessor.cs`
+   - `public interface IAgentIdentityAccessor { WorkflowIdentity? CurrentWorkflow { get; } AgentIdentity? CurrentAgent { get; } }`
+   - File: `Fakes/FakeAgentIdentityAccessor.cs` — constructed with `IDictionary<string,string>?` representing envelope headers; returns null when constructed with null
+   - Update `PublicAPI.Unshipped.txt`
+
+3. **[REFACTOR]** Ensure XML docs note that `null` is the contract for "no envelope context" (matches `IHttpContextAccessor` convention)
+
+**Dependencies:** T2, T3
+
+---
+
+### Task 8: Generator emits `CurrentPhaseName` + `IPhaseAwareSaga` base
+
+**Phase:** RED → GREEN → REFACTOR
+**DR coverage:** DR-6 (generator portion)
+**Parallelizable:** No (touches the generator; T9, T10, T11 depend on this)
+**Estimated:** 10 min
+
+1. **[RED]** Add tests to `Strategos.Generators.Tests`:
+   - `SagaEmitter_GeneratesPartialClass_WithIPhaseAwareSagaInBaseList`
+     - Uses existing `CSharpGeneratorDriver` pattern from `SagaEmitterIntegrationTests.cs`
+     - Asserts generated source contains `: Saga, IPhaseAwareSaga`
+   - `SagaEmitter_GeneratesCurrentPhaseNameProperty_AsComputedReadOnlyOverPhaseToString`
+     - Asserts generated source contains `public string CurrentPhaseName => Phase.ToString();`
+   - `SagaEmitter_GeneratesUsingForStrategosIdentityAbstractions`
+     - Asserts usings list includes the abstractions namespace
+   - File: `src/Strategos.Generators.Tests/SagaIdentityEmitterTests.cs` (new)
+   - **Expected failure:** generated output does not contain the new lines
+
+2. **[GREEN]** Modify generator:
+   - File: `src/Strategos.Generators/Strategos.Generators.csproj` — add `<ProjectReference Include="..\Strategos.Identity.Abstractions\Strategos.Identity.Abstractions.csproj" PrivateAssets="all" />` AND add `<None Include="..\Strategos.Identity.Abstractions\bin\$(Configuration)\netstandard2.0\Strategos.Identity.Abstractions.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />` so the analyzer assembly is published alongside the generator
+   - File: `src/Strategos.Generators/Emitters/SagaEmitter.cs` lines 75-80 — add `"Strategos.Identity.Abstractions"` to the `usings` list
+   - File: `src/Strategos.Generators/Emitters/SagaEmitter.cs` line 156 — change `$"public partial class {sagaClassName} : Saga"` to `$"public partial class {sagaClassName} : Saga, IPhaseAwareSaga"`
+   - File: `src/Strategos.Generators/Emitters/Saga/SagaPropertiesEmitter.cs` — after the `Phase` property block (after line 65), append:
+     ```csharp
+     sb.AppendLine("    /// <summary>Gets the current saga phase as a stable string identifier (Phase.ToString()).</summary>");
+     sb.AppendLine("    public string CurrentPhaseName => Phase.ToString();");
+     sb.AppendLine();
+     ```
+
+3. **[REFACTOR]** Consider extracting to a dedicated `SagaIdentityComponentEmitter : ISagaComponentEmitter` if cohesion improves; otherwise leave inline in `SagaPropertiesEmitter` (the property logically belongs with other saga properties)
+
+**Dependencies:** T1, T5
+**Note:** the generator assembly ships analyzer-style; consumer packages reference `Strategos.Identity.Abstractions` at runtime separately
+
+---
+
+### Task 9: DR-7 negation tests (generator does NOT emit identity fields)
+
+**Phase:** RED → GREEN (no-op; just adds the regression net)
+**DR coverage:** DR-7
+**Parallelizable:** Yes (with T10, T11; depends on T8)
+**Estimated:** 4 min
+
+1. **[RED]** Write negation tests in `Strategos.Generators.Tests`:
+   - `SagaEmitter_DoesNotEmit_CurrentAgentIdentity_Property`
+   - `SagaEmitter_DoesNotEmit_InitializeIdentity_Helper`
+   - `SagaEmitter_DoesNotEmit_WorkflowIdentityField`
+   - `SagaEmitter_DoesNotEmit_IdentityProviderField`
+   - `SagaEmitter_DoesNotEmit_InternalsVisibleTo_Attribute`
+   - Each test asserts the generated source string does NOT contain the named token
+   - File: `src/Strategos.Generators.Tests/SagaIdentityEmitterTests.cs` (append; or separate file `SagaIdentityNegationTests.cs`)
+   - **Expected outcome:** these tests pass on the first run (T8 didn't emit any of these) — this is the regression net for any future drift
+
+**Dependencies:** T8
+**Note:** because these tests pass immediately, they are a regression-guard. Document explicitly in the test file that they enforce DR-7.
+
+---
+
+### Task 10: Existing saga snapshots regenerate
+
+**Phase:** REGRESSION
+**DR coverage:** DR-6 (acceptance criteria — existing samples)
+**Parallelizable:** Yes (with T9, T11; depends on T8)
+**Estimated:** 5 min
+
+1. **[RED]** Run `dotnet test src/Strategos.Generators.Tests/` — expect existing snapshot tests for Phronesis, review-loop, fork/join samples, and `samples/{AgenticCoder,ContentPipeline,MultiModelRouter}` to FAIL because their snapshots now contain the new `CurrentPhaseName` + `IPhaseAwareSaga` lines
+
+2. **[GREEN]** Run Verify auto-accept (e.g., `dotnet verify accept` or copy `.received.txt` to `.verified.txt`) and inspect each snapshot diff to confirm the ONLY changes are:
+   - `: Saga` → `: Saga, IPhaseAwareSaga`
+   - one new property block `public string CurrentPhaseName => Phase.ToString();`
+   - one new `using Strategos.Identity.Abstractions;`
+
+3. **[REFACTOR]** None — snapshots are the regression spec
+
+**Dependencies:** T8
+**Manual verification step:** human eyeballs the diff on at least one sample snapshot to confirm scope
+
+---
+
+### Task 11: End-to-end seam verification (no Basileus reference)
+
+**Phase:** RED → GREEN
+**DR coverage:** DR-6 acceptance criteria (compile + runtime behavior with stubs)
+**Parallelizable:** Yes (with T9, T10; depends on T6, T8)
+**Estimated:** 8 min
+
+1. **[RED]** Write `EndToEndStubIntegrationTests.cs`:
+   - `GeneratedSaga_WithStubProvider_CompilesAndExposesPhaseName_WithoutBasileusReference`
+     - Compiles a trivial workflow definition through `CSharpGeneratorDriver`
+     - Builds the resulting assembly referencing ONLY `Strategos.*` (assert csproj of the test fixture, or check loaded assemblies don't include `Basileus.*`)
+     - Loads + instantiates the saga via reflection
+     - Asserts `saga is IPhaseAwareSaga`
+     - Asserts `saga.CurrentPhaseName` returns `Phase.ToString()` (e.g., `"NotStarted"` before any step runs)
+   - `IPhaseAwareSaga_FakeMiddlewareStampsEnvelopeHeaders_StubProviderDerivesAgent`
+     - Constructs a `FakeAgentIdentityAccessor` populated from a fake envelope-header dictionary
+     - Constructs a `StubAgentIdentityProvider`
+     - Simulates middleware: read `saga.CurrentPhaseName`, call `provider.DeriveStepIdentity(workflow, phase)`, stamp header, read via accessor
+     - Asserts the derived `AgentIdentity` is read back correctly
+   - File: `src/Strategos.Generators.Tests/EndToEndStubIntegrationTests.cs`
+   - **Expected failure:** generator hasn't been updated yet (T8 dependency)
+
+2. **[GREEN]** Tests pass once T8 lands; no additional code beyond what T6/T8 produced
+
+3. **[REFACTOR]** None — this is the acceptance gate
+
+**Dependencies:** T6, T8
+
+---
+
+### Task 12: DR-8 error handling and edge cases integration sweep
+
+**Phase:** RED → GREEN
+**DR coverage:** DR-8 — error handling and edge cases (all six rows of the table — integration-level)
+**Parallelizable:** Yes (with T9, T10, T11; depends on T6, T7, T8)
+**Estimated:** 5 min
+
+1. **[RED]** Write a single integration test class that asserts the DR-8 table holds end-to-end:
+   - `DR8_AccessorReadOutsideHandler_ReturnsNull_NoThrow` (covers DR-8 row 1; instantiates `FakeAgentIdentityAccessor` with null envelope and reads both properties)
+   - `DR8_NoIncomingWorkflowHeader_MiddlewareGeneratesNewIdentity_DocumentedAsBasileusContract` (covers DR-8 row 2; asserts a TODO/skip flag that the basileus middleware is responsible; this test is a *documentation* test — passes trivially but anchors the contract)
+   - `DR8_IdentityRecordConstructedWithNullValue_ThrowsArgumentException` (covers DR-8 row 3; runs against both `WorkflowIdentity` and `AgentIdentity` parametrically)
+   - `DR8_ProviderReturnsNull_DocumentedAsBasileusContract_NotEnforcedHere` (covers DR-8 row 4; documentation test; the stub provider's contract is enforced in T6)
+   - `DR8_HandlerEmitsMessage_HeadersRideOnEnvelope_NativeWolverineMechanism_DocumentedNotTested` (covers DR-8 row 5; documentation test; Wolverine-native, covered by Wolverine's own test suite)
+   - `DR8_HeaderValueWithNonAsciiCharacter_RecordConstructorRejects` (covers DR-8 row 6; parametric over both identity records)
+   - File: `src/Strategos.Identity.Abstractions.Tests/DR8EdgeCasesIntegrationTests.cs`
+   - **Expected failure:** at least one assertion path doesn't yet exist (likely the parametric coverage)
+
+2. **[GREEN]** Tests pass once T2, T3, T7 land; no additional production code needed — this is the DR-8 acceptance gate, not new behavior
+
+3. **[REFACTOR]** None — this is the explicit DR-8 traceability anchor
+
+**Dependencies:** T2, T3, T6, T7
+**Note:** Rows 2 and 4 and 5 of DR-8 are basileus-middleware contracts; the tests here document the boundary but enforce only the Strategos-side rows (1, 3, 6).
+
+---
+
+### Task 13: DR-9 basileus coordination handoff
+
+**Phase:** Coordination (not RED-GREEN per se — this is a cross-repo task)
+**DR coverage:** DR-9
+**Parallelizable:** No (final coordination step, runs after T12 release)
+**Estimated:** 8 min
+
+1. **Open basileus tracking issue** on lvlup-sw/basileus titled `G1-strategos integration: re-cut PR #184 against Strategos.Identity.Abstractions 2.7.0-preview.1` with body including:
+   - Link to this plan and the design doc
+   - Required basileus changes:
+     - Reference `LevelUp.Strategos.Identity.Abstractions 2.7.0-preview.1`
+     - Move `Basileus.Core.Contracts.Identity.{SpiffeId, WorkflowId, WorkflowIdentity, AgentIdentity, IAgentIdentityProvider}` to `Basileus.Identity.Spiffe.*` as adapter implementations (or delete; consume Strategos types)
+     - Implement `Basileus.Identity.Spiffe.SpiffeAgentIdentityProvider : Strategos.Identity.Abstractions.IAgentIdentityProvider`
+     - Implement `Basileus.AgentHost.Middleware.StrategosHeaderMiddleware` (Wolverine middleware spec from the design §9)
+     - Configure `opts.Policies.PropagateIncomingHeaderToOutgoing(StrategosHeaders.WorkflowIdentity)` in `UseWolverine` registration
+     - Revise basileus design doc `2026-05-13-g1-implementation-phase-0.md` to reflect envelope-header storage (preserve §4 INV-8 derivation-from-saga-state rationale; update §6 Strategos-side deliverables to read "Strategos owns identity ports; this PR is the basileus adapter only")
+   - Acceptance criteria mirrored from design DR-9:
+     - basileus PR #184 builds against the published `2.7.0-preview.1`
+     - Integration test on basileus side verifies outbound envelope carries both `x-strategos-workflow-identity` and `x-strategos-agent-identity` headers
+     - basileus design doc revision committed in the same PR
+
+2. **Comment on basileus PR #184** linking to the new tracking issue, this plan, and the Strategos design
+
+3. **Update this Strategos issue (#71) and #70** with:
+   - Note that A1/A2/A3 (issues #67/#68/#69) are descoped per this design
+   - Link to the published `Strategos.Identity.Abstractions 2.7.0-preview.1` on nuget.org
+   - Mark #67/#68/#69 closed-as-superseded with reference to this design
+
+**Acceptance criteria:**
+- basileus tracking issue exists with full task list
+- PR #184 comment is posted
+- Strategos issues #67/#68/#69 are closed-as-superseded with cross-links
+
+**Dependencies:** T12 (preview release must be published first so basileus can pin to it)
+**Not parallelizable:** runs last
+**Note:** This is coordination work, not Strategos code. It belongs in the Strategos plan because it's required for the design to actually deliver value (basileus is the inaugural consumer).
+
+---
+
+### Task 14: Release: CHANGELOG + version bump + pack verification
+
+**Phase:** RED → GREEN
+**DR coverage:** DR-10
+**Parallelizable:** No (final step, depends on T1..T11)
+**Estimated:** 6 min
+
+1. **[RED]** Write a release-shape verification test (TUnit `[Test]` in `Strategos.Identity.Abstractions.Tests`):
+   - `Release_DotnetPack_ProducesThreePackages_AtPreviewVersion`
+     - Shells `dotnet pack src/ -c Release` (or reads from a pre-packed staging directory)
+     - Asserts existence of `LevelUp.Strategos.Identity.Abstractions.2.7.0-preview.1.nupkg`, `LevelUp.Strategos.Generators.2.7.0-preview.1.nupkg`, `LevelUp.Strategos.2.7.0-preview.1.nupkg`
+   - **Expected failure:** version is still 2.6.0; CHANGELOG missing
+
+2. **[GREEN]** Apply release deltas:
+   - `CHANGELOG.md` — add `## [2.7.0-preview.1] - 2026-05-16` section under the existing `## Unreleased`. Body:
+     - `### Added` — `Strategos.Identity.Abstractions` package debut (`WorkflowIdentity`, `AgentIdentity`, `IAgentIdentityProvider`, `IAgentIdentityAccessor`, `IPhaseAwareSaga`, `StrategosHeaders`)
+     - `### Changed` — generator emits `CurrentPhaseName` computed property on every saga; saga base list adds `IPhaseAwareSaga` interface. Additive — no breaking changes.
+     - `### Migration` — basileus consumers register `opts.Policies.PropagateIncomingHeaderToOutgoing(StrategosHeaders.WorkflowIdentity)` in their `UseWolverine` block
+   - Bump `MinVer` minimum to `2.7.0-preview.1` (or pass via `dotnet pack /p:MinVerSkip=true /p:Version=2.7.0-preview.1` if MinVer is git-tag-driven)
+   - Pre-tag verification: `dotnet pack src/Strategos.Identity.Abstractions/` produces a valid nupkg
+   - `README.md` (Strategos root) — add a new `### Identity Seam (v2.7.0-preview.1)` subsection documenting the abstractions package, `StrategosHeaders`, and the `PropagateIncomingHeaderToOutgoing` consumer-side registration
+   - Move `PublicAPI.Unshipped.txt` entries → `PublicAPI.Shipped.txt` (preview API is still pre-shipped per #51 protocol; defer this move to GA, but document the surface in CHANGELOG)
+
+3. **[REFACTOR]** None — release artifacts speak for themselves
+
+**Dependencies:** T1..T11
+
+---
+
+## Parallelization groups
+
+| Wave | Tasks | Concurrency |
+|---|---|---|
+| 0 | T1 | 1 |
+| 1 | T2, T3, T4, T5 | 4 |
+| 2 | T6, T7 | 2 |
+| 3 | T8 | 1 (touches generators — serial) |
+| 4 | T9, T10, T11, T12 | 4 |
+| 5 | T14 (release) | 1 |
+| 6 | T13 (basileus coordination, after T14 publishes) | 1 |
+
+**Total expected critical path:** ~45 min (T1 + T2 + T6 + T8 + T11 + T14 + T13 = 5 + 5 + 6 + 10 + 8 + 6 + 8 = 48 min).
+
+**Worktree strategy:** Wave 1 can run in 4 parallel worktrees; Wave 2 in 2; Wave 4 in 4. All must rebase onto T8 once it lands. T13 is coordination (no code) and runs after T14 publishes to nuget.org.
+
+## Design-to-Task Coverage Matrix
+
+| DR | Title | Task(s) |
+|---|---|---|
+| DR-1 | `Strategos.Identity.Abstractions` package | T1 (skeleton), T12 (pack verification) |
+| DR-2 | `WorkflowIdentity` + `AgentIdentity` sealed records | T2, T3 |
+| DR-3 | `IAgentIdentityProvider` port | T6 |
+| DR-4 | `StrategosHeaders` constants | T4 |
+| DR-5 | `IAgentIdentityAccessor` for in-handler reads | T7 |
+| DR-6 | Generator emits `CurrentPhaseName` + `IPhaseAwareSaga` | T5 (interface), T8 (emit), T10 (snapshot regen), T11 (e2e verification) |
+| DR-7 | Generator emits NO other identity code | T9 (negation tests) |
+| DR-8 | Error handling and edge cases | T2 (rows 3, 6), T3 (rows 3, 6), T6 (row 4), T7 (row 1), **T12 (consolidated sweep across all six rows)** |
+| DR-9 | Cross-repo coordination (basileus PR #184 re-cut) | **T13 (basileus tracking issue + PR #184 comment + Strategos issue closeout)** |
+| DR-10 | Release `2.7.0-preview.1` | T14 |
+
+## Risks and mitigations
+
+1. **Generator-package layout (ProjectReference vs analyzer pack):** the generator must ship `Strategos.Identity.Abstractions` as an analyzer-side reference so the generator can compile against it at SG-time. T8 step 2 covers this with `<None Include=... Pack="true" PackagePath="analyzers/dotnet/cs" />`. If the analyzer-pack approach fails, fallback is `<PackageReference Include="LevelUp.Strategos.Identity.Abstractions" Version="2.7.0-preview.1" PrivateAssets="all" GeneratePathProperty="true" />` and embed via `<TargetPath>analyzers/dotnet/cs/$(PackageStrategos_Identity_Abstractions)\lib\netstandard2.0\Strategos.Identity.Abstractions.dll</TargetPath>` — well-documented Roslyn SG pattern.
+2. **MinVer tag-driven versioning:** the repo uses MinVer for versioning from git tags. T12 may need to pre-create a `v2.7.0-preview.1` git tag *before* pack, or use `/p:Version=2.7.0-preview.1` override.
+3. **Existing snapshot test count:** T10 may regenerate 20+ snapshot files. Manual diff inspection is needed on at least one representative sample (AgenticCoder) to confirm the change is *only* the additive `CurrentPhaseName` + base-list update.
+4. **TUnit filter syntax:** all `dotnet test` invocations use `-- --treenode-filter "/*/*/*/{TestName}"` per project convention (see memory).
+
+## Out of scope for this plan
+
+- Wolverine middleware implementation (lives in basileus repo)
+- SPIFFE adapter (lives in basileus repo)
+- basileus design doc revision (cross-repo task)
+- `Strategos.Identity` default accessor implementation package (deferred to 2.7.0 GA)
+- G3 ProvenanceEnvelope (#61), G5 SubagentSpawn (#62), G4 PartitionablePair (#60)

--- a/scripts/verify-generator-consumer-build.sh
+++ b/scripts/verify-generator-consumer-build.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------
+# verify-generator-consumer-build.sh
+#
+# G1 / F1 regression net (v2.7.0-preview.1).
+#
+# Builds a throwaway consumer project that PackageReferences only the packed
+# LevelUp.Strategos + LevelUp.Strategos.Generators nupkgs from the given
+# package source directory, then writes a trivial type that derives from
+# IPhaseAwareSaga. If the abstractions package does NOT flow transitively
+# from the metapackage, this build fails with CS0246, which is exactly the
+# bug that motivated this script.
+#
+# Usage:
+#   scripts/verify-generator-consumer-build.sh <path-to-packages-dir>
+#
+# Exit codes:
+#   0  consumer build succeeded
+#   1  invalid arguments / setup error
+#   2  consumer build FAILED (regression detected)
+# -----------------------------------------------------------------------
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <packages-dir>" >&2
+  exit 1
+fi
+
+PACKAGES_DIR="$(realpath "$1")"
+
+if [[ ! -d "$PACKAGES_DIR" ]]; then
+  echo "packages dir does not exist: $PACKAGES_DIR" >&2
+  exit 1
+fi
+
+# Discover the versions that were packed (so we don't hard-code a number).
+GEN_NUPKG="$(ls -1 "$PACKAGES_DIR"/LevelUp.Strategos.Generators.*.nupkg 2>/dev/null | head -1 || true)"
+CORE_NUPKG="$(ls -1 "$PACKAGES_DIR"/LevelUp.Strategos.*.nupkg 2>/dev/null \
+  | grep -v 'Generators' | grep -v 'Identity' | grep -v 'Ontology' | grep -v 'Agents' \
+  | grep -v 'Infrastructure' | grep -v 'Benchmarks' | grep -v 'Rag' | grep -v 'snupkg' \
+  | head -1 || true)"
+
+if [[ -z "$GEN_NUPKG" || -z "$CORE_NUPKG" ]]; then
+  echo "could not find LevelUp.Strategos.Generators.*.nupkg or LevelUp.Strategos.*.nupkg in $PACKAGES_DIR" >&2
+  exit 1
+fi
+
+# Extract version from the generator nupkg filename.
+GEN_FILENAME="$(basename "$GEN_NUPKG")"
+VERSION="$(echo "$GEN_FILENAME" | sed -E 's/^LevelUp\.Strategos\.Generators\.(.+)\.nupkg$/\1/')"
+
+echo "Consumer probe: Strategos $VERSION from $PACKAGES_DIR"
+
+PROBE_DIR="$(mktemp -d)"
+trap 'rm -rf "$PROBE_DIR"' EXIT
+
+cat > "$PROBE_DIR/ConsumerProbe.csproj" <<EOF
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RestoreAdditionalProjectSources>$PACKAGES_DIR</RestoreAdditionalProjectSources>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="LevelUp.Strategos" Version="$VERSION" />
+    <PackageReference Include="LevelUp.Strategos.Generators" Version="$VERSION" />
+  </ItemGroup>
+</Project>
+EOF
+
+cat > "$PROBE_DIR/Probe.cs" <<'EOF'
+// Mirrors what the Strategos source generator emits: a saga deriving from
+// IPhaseAwareSaga. If LevelUp.Strategos.Identity.Abstractions does NOT flow
+// transitively to consumers (the F1 bug), this fails with CS0246.
+using Strategos.Identity.Abstractions;
+
+namespace ConsumerProbe;
+
+public partial class ProbeSaga : IPhaseAwareSaga
+{
+    public string CurrentPhaseName { get; private set; } = "init";
+}
+EOF
+
+# Use a project-local global-packages dir so this probe is hermetic and not
+# influenced by stale entries in the developer's user-wide ~/.nuget/packages.
+# Critical: without this isolation, a stale cached copy of a previously-
+# published nupkg (with different metadata) can mask a regression.
+PROBE_GLOBAL_PACKAGES="$PROBE_DIR/.nuget-packages"
+mkdir -p "$PROBE_GLOBAL_PACKAGES"
+
+if dotnet build "$PROBE_DIR/ConsumerProbe.csproj" \
+     --nologo \
+     -v:m \
+     --no-cache \
+     /p:RestorePackagesPath="$PROBE_GLOBAL_PACKAGES" \
+     /p:NuGetPackageRoot="$PROBE_GLOBAL_PACKAGES"; then
+  echo "OK: consumer build succeeded; IPhaseAwareSaga is reachable transitively."
+  exit 0
+else
+  echo "FAIL: consumer build failed. The generator + abstractions dep flow is broken (F1 regression)." >&2
+  exit 2
+fi

--- a/src/Strategos.Generators.Tests/EndToEndStubIntegrationTests.cs
+++ b/src/Strategos.Generators.Tests/EndToEndStubIntegrationTests.cs
@@ -1,0 +1,152 @@
+// -----------------------------------------------------------------------
+// <copyright file="EndToEndStubIntegrationTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Tests.Fixtures;
+using Strategos.Identity.Abstractions;
+
+namespace Strategos.Generators.Tests;
+
+/// <summary>
+/// T11: end-to-end seam verification. Two paths are exercised:
+/// </summary>
+/// <list type="number">
+///   <item><description>The generated saga (a) carries the <c>IPhaseAwareSaga</c> base list
+///   entry, (b) emits the <c>CurrentPhaseName</c> property returning <c>Phase.ToString()</c>,
+///   and (c) the generated assembly does not pull in any Basileus reference.</description></item>
+///   <item><description>The middleware seam works end-to-end: a fake middleware uses the
+///   stub provider to derive an agent identity, stamps the envelope headers, and the
+///   accessor reads them back.</description></item>
+/// </list>
+[Property("Category", "Integration")]
+public class EndToEndStubIntegrationTests
+{
+    /// <summary>
+    /// Stub-provider-only path: the generator emits the IPhaseAwareSaga interface
+    /// directly, the abstractions namespace is imported, the CurrentPhaseName
+    /// property returns Phase.ToString() literally, and no generated tree references
+    /// any Basileus.* type.
+    /// </summary>
+    [Test]
+    public async Task GeneratedSaga_WithStubProvider_CompilesAndExposesPhaseName_WithoutBasileusReference()
+    {
+        var result = GeneratorTestHelper.RunGenerator(SourceTexts.LinearWorkflow);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+
+        // (a) IPhaseAwareSaga is in the base list.
+        await Assert.That(sagaSource).Contains(": Saga, IPhaseAwareSaga");
+
+        // (b) CurrentPhaseName returns Phase.ToString().
+        await Assert.That(sagaSource).Contains("public string CurrentPhaseName => Phase.ToString();");
+
+        // (c) The generated saga uses the abstractions namespace, NOT Basileus.
+        await Assert.That(sagaSource).Contains("using Strategos.Identity.Abstractions;");
+
+        // (c, negation) — no Basileus token anywhere in any generated tree.
+        foreach (var tree in result.GeneratedTrees)
+        {
+            var src = tree.GetText().ToString();
+            await Assert.That(src).DoesNotContain("Basileus");
+        }
+    }
+
+    /// <summary>
+    /// Middleware seam: a fake middleware that stamps headers from the stub
+    /// provider produces an envelope the accessor can read back without any
+    /// generated-saga runtime instance.
+    /// </summary>
+    [Test]
+    public async Task IPhaseAwareSaga_FakeMiddlewareStampsEnvelopeHeaders_StubProviderDerivesAgent()
+    {
+        // Stand-in for IMessageContext.Envelope.Headers.
+        var envelope = new Dictionary<string, string>();
+
+        var provider = new StubAgentIdentityProvider();
+        var workflow = new WorkflowIdentity("wf-001");
+
+        // Simulate what the basileus StrategosHeaderMiddleware does:
+        // 1. Stamp the workflow identity on the outgoing envelope.
+        envelope[StrategosHeaders.WorkflowIdentity] = workflow.Value;
+
+        // 2. Read the saga's current phase via IPhaseAwareSaga.
+        var saga = new StubPhaseAwareSaga(currentPhaseName: "Drafting");
+        var phase = saga.CurrentPhaseName;
+
+        // 3. Derive the per-step agent identity from (workflow, phase).
+        var agent = provider.DeriveStepIdentity(workflow, phase);
+
+        // 4. Stamp the agent identity on the outgoing envelope.
+        envelope[StrategosHeaders.AgentIdentity] = agent.Value;
+
+        // Downstream handler reads the envelope through the accessor.
+        var accessor = new FakeMiddlewareSeamAccessor(envelope);
+
+        await Assert.That(accessor.CurrentWorkflow).IsNotNull();
+        await Assert.That(accessor.CurrentWorkflow!.Value).IsEqualTo("wf-001");
+        await Assert.That(accessor.CurrentAgent).IsNotNull();
+        await Assert.That(accessor.CurrentAgent!.Value).IsEqualTo("wf-001#Drafting");
+    }
+
+    /// <summary>
+    /// Test-local IPhaseAwareSaga stand-in. Mirrors the generator emit shape
+    /// (<c>CurrentPhaseName =&gt; Phase.ToString()</c>) but bypasses the
+    /// Phase enum so this test does not need a full workflow context.
+    /// </summary>
+    private sealed class StubPhaseAwareSaga : IPhaseAwareSaga
+    {
+        public StubPhaseAwareSaga(string currentPhaseName)
+        {
+            this.CurrentPhaseName = currentPhaseName;
+        }
+
+        public string CurrentPhaseName { get; }
+    }
+
+    /// <summary>
+    /// Local stub of an envelope-header-backed <see cref="IAgentIdentityAccessor"/>.
+    /// Production reads via Wolverine <c>IMessageContext.Envelope.Headers</c>;
+    /// this test uses an in-memory dictionary.
+    /// </summary>
+    private sealed class FakeMiddlewareSeamAccessor : IAgentIdentityAccessor
+    {
+        private readonly IDictionary<string, string> envelope;
+
+        public FakeMiddlewareSeamAccessor(IDictionary<string, string> envelope)
+        {
+            this.envelope = envelope;
+        }
+
+        public WorkflowIdentity? CurrentWorkflow =>
+            this.envelope.TryGetValue(StrategosHeaders.WorkflowIdentity, out var v) ? new WorkflowIdentity(v) : null;
+
+        public AgentIdentity? CurrentAgent =>
+            this.envelope.TryGetValue(StrategosHeaders.AgentIdentity, out var v) ? new AgentIdentity(v) : null;
+    }
+
+    /// <summary>
+    /// Generators-tests-local copy of the provider stub kept inline so the
+    /// production abstractions package stays minimal.
+    /// </summary>
+    private sealed class StubAgentIdentityProvider : IAgentIdentityProvider
+    {
+        public AgentIdentity DeriveStepIdentity(WorkflowIdentity workflow, string phaseName)
+        {
+            if (workflow is null)
+            {
+                throw new ArgumentNullException(nameof(workflow));
+            }
+
+            if (string.IsNullOrWhiteSpace(phaseName))
+            {
+                throw new ArgumentException("Phase name must be non-empty.", nameof(phaseName));
+            }
+
+            return new AgentIdentity($"{workflow.Value}#{phaseName}");
+        }
+
+        public WorkflowIdentity ParseWorkflowHeader(string headerValue)
+            => new(headerValue ?? throw new ArgumentNullException(nameof(headerValue)));
+    }
+}

--- a/src/Strategos.Generators.Tests/EndToEndStubIntegrationTests.cs
+++ b/src/Strategos.Generators.Tests/EndToEndStubIntegrationTests.cs
@@ -44,11 +44,17 @@ public class EndToEndStubIntegrationTests
         // (c) The generated saga uses the abstractions namespace, NOT Basileus.
         await Assert.That(sagaSource).Contains("using Strategos.Identity.Abstractions;");
 
-        // (c, negation) — no Basileus token anywhere in any generated tree.
+        // (c, negation) — no Basileus binding anywhere in any generated tree.
+        // We assert against the specific "using Basileus" / "Basileus." tokens
+        // (rather than a bare "Basileus" substring) so the test stays robust
+        // against future case-variation in comments / xmldoc and won't false-
+        // positive on prose. The generated saga must not import any Basileus
+        // namespace nor reference any Basileus.* type.
         foreach (var tree in result.GeneratedTrees)
         {
             var src = tree.GetText().ToString();
-            await Assert.That(src).DoesNotContain("Basileus");
+            await Assert.That(src).DoesNotContain("using Basileus");
+            await Assert.That(src).DoesNotContain("Basileus.");
         }
     }
 
@@ -127,7 +133,12 @@ public class EndToEndStubIntegrationTests
 
     /// <summary>
     /// Generators-tests-local copy of the provider stub kept inline so the
-    /// production abstractions package stays minimal.
+    /// production abstractions package stays minimal. Mirrors the null-handling
+    /// shape of <c>StubAgentIdentityProvider</c> in
+    /// <c>Strategos.Identity.Abstractions.Tests/Fakes</c>: null phaseName throws
+    /// <see cref="ArgumentNullException"/> (not the generic
+    /// <see cref="ArgumentException"/>), and empty/whitespace throws the more
+    /// general <see cref="ArgumentException"/>.
     /// </summary>
     private sealed class StubAgentIdentityProvider : IAgentIdentityProvider
     {
@@ -136,6 +147,11 @@ public class EndToEndStubIntegrationTests
             if (workflow is null)
             {
                 throw new ArgumentNullException(nameof(workflow));
+            }
+
+            if (phaseName is null)
+            {
+                throw new ArgumentNullException(nameof(phaseName));
             }
 
             if (string.IsNullOrWhiteSpace(phaseName))

--- a/src/Strategos.Generators.Tests/SagaIdentityEmitterTests.cs
+++ b/src/Strategos.Generators.Tests/SagaIdentityEmitterTests.cs
@@ -1,0 +1,61 @@
+// -----------------------------------------------------------------------
+// <copyright file="SagaIdentityEmitterTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Tests.Fixtures;
+
+namespace Strategos.Generators.Tests;
+
+/// <summary>
+/// Verifies the additive G1-Strategos identity emit changes: the saga base list
+/// includes <c>IPhaseAwareSaga</c>, a computed <c>CurrentPhaseName</c> property
+/// exists, and the abstractions namespace is in the usings list.
+/// </summary>
+/// <remarks>
+/// Anchors DR-6 (generator portion). DR-7 negation tests live in
+/// <see cref="SagaIdentityNegationTests"/>.
+/// </remarks>
+[Property("Category", "Integration")]
+public class SagaIdentityEmitterTests
+{
+    /// <summary>
+    /// The generated saga base list must include <c>IPhaseAwareSaga</c> so
+    /// the basileus middleware can bind to the marker interface.
+    /// </summary>
+    [Test]
+    public async Task SagaEmitter_GeneratesPartialClass_WithIPhaseAwareSagaInBaseList()
+    {
+        var result = GeneratorTestHelper.RunGenerator(SourceTexts.LinearWorkflow);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+
+        await Assert.That(sagaSource).Contains(": Saga, IPhaseAwareSaga");
+    }
+
+    /// <summary>
+    /// The generator emits a computed read-only property over <c>Phase.ToString()</c>;
+    /// this is the only new instance member added per DR-6.
+    /// </summary>
+    [Test]
+    public async Task SagaEmitter_GeneratesCurrentPhaseNameProperty_AsComputedReadOnlyOverPhaseToString()
+    {
+        var result = GeneratorTestHelper.RunGenerator(SourceTexts.LinearWorkflow);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+
+        await Assert.That(sagaSource).Contains("public string CurrentPhaseName => Phase.ToString();");
+    }
+
+    /// <summary>
+    /// The usings list must contain the abstractions namespace so the generated
+    /// source resolves the <c>IPhaseAwareSaga</c> base-list reference.
+    /// </summary>
+    [Test]
+    public async Task SagaEmitter_GeneratesUsingForStrategosIdentityAbstractions()
+    {
+        var result = GeneratorTestHelper.RunGenerator(SourceTexts.LinearWorkflow);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+
+        await Assert.That(sagaSource).Contains("using Strategos.Identity.Abstractions;");
+    }
+}

--- a/src/Strategos.Generators.Tests/SagaIdentityNegationTests.cs
+++ b/src/Strategos.Generators.Tests/SagaIdentityNegationTests.cs
@@ -1,0 +1,74 @@
+// -----------------------------------------------------------------------
+// <copyright file="SagaIdentityNegationTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Tests.Fixtures;
+
+namespace Strategos.Generators.Tests;
+
+/// <summary>
+/// DR-7 regression net: locks in that the generator emits NO identity-related
+/// code beyond the additive <c>CurrentPhaseName</c> + <c>IPhaseAwareSaga</c>
+/// pieces verified in <see cref="SagaIdentityEmitterTests"/>.
+/// </summary>
+/// <remarks>
+/// These tests pass immediately on first run after T8; their purpose is to
+/// fail loudly if a future change tries to re-introduce the descoped
+/// A1/A2/A3 emit (private fields, helpers, additional properties, or
+/// <c>InternalsVisibleTo</c>).
+/// </remarks>
+[Property("Category", "Integration")]
+public class SagaIdentityNegationTests
+{
+    /// <summary>DR-7: no CurrentAgentIdentity property is emitted on the saga.</summary>
+    [Test]
+    public async Task SagaEmitter_DoesNotEmit_CurrentAgentIdentity_Property()
+    {
+        var result = GeneratorTestHelper.RunGenerator(SourceTexts.LinearWorkflow);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+
+        await Assert.That(sagaSource).DoesNotContain("CurrentAgentIdentity");
+    }
+
+    /// <summary>DR-7: no InitializeIdentity helper method is emitted.</summary>
+    [Test]
+    public async Task SagaEmitter_DoesNotEmit_InitializeIdentity_Helper()
+    {
+        var result = GeneratorTestHelper.RunGenerator(SourceTexts.LinearWorkflow);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+
+        await Assert.That(sagaSource).DoesNotContain("InitializeIdentity");
+    }
+
+    /// <summary>DR-7: no _workflowIdentity backing field is emitted.</summary>
+    [Test]
+    public async Task SagaEmitter_DoesNotEmit_WorkflowIdentityField()
+    {
+        var result = GeneratorTestHelper.RunGenerator(SourceTexts.LinearWorkflow);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+
+        await Assert.That(sagaSource).DoesNotContain("_workflowIdentity");
+    }
+
+    /// <summary>DR-7: no _identityProvider backing field is emitted.</summary>
+    [Test]
+    public async Task SagaEmitter_DoesNotEmit_IdentityProviderField()
+    {
+        var result = GeneratorTestHelper.RunGenerator(SourceTexts.LinearWorkflow);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+
+        await Assert.That(sagaSource).DoesNotContain("_identityProvider");
+    }
+
+    /// <summary>DR-7: the generated saga assembly does not require InternalsVisibleTo.</summary>
+    [Test]
+    public async Task SagaEmitter_DoesNotEmit_InternalsVisibleTo_Attribute()
+    {
+        var result = GeneratorTestHelper.RunGenerator(SourceTexts.LinearWorkflow);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+
+        await Assert.That(sagaSource).DoesNotContain("InternalsVisibleTo");
+    }
+}

--- a/src/Strategos.Generators.Tests/SagaSnapshotInspectionTests.cs
+++ b/src/Strategos.Generators.Tests/SagaSnapshotInspectionTests.cs
@@ -1,0 +1,82 @@
+// -----------------------------------------------------------------------
+// <copyright file="SagaSnapshotInspectionTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Tests.Fixtures;
+
+namespace Strategos.Generators.Tests;
+
+/// <summary>
+/// T10: programmatic equivalent of snapshot regeneration. The project has no
+/// Verify <c>.verified.txt</c> baseline files, so the contract is anchored
+/// here by per-shape string-contains assertions across the major workflow
+/// shapes: linear, looped, fork/join, and branched.
+/// </summary>
+/// <remarks>
+/// <para>
+/// For each shape we assert:
+/// </para>
+/// <list type="number">
+///   <item><description>The base list reads <c>: Saga, IPhaseAwareSaga</c> — additive only.</description></item>
+///   <item><description>The CurrentPhaseName property is emitted exactly once.</description></item>
+///   <item><description>The Strategos.Identity.Abstractions using is present.</description></item>
+///   <item><description>No DR-7 negated token appears (descoped Option C state).</description></item>
+/// </list>
+/// <para>
+/// Failures here mean the generator regressed across one of the existing
+/// representative workflow shapes.
+/// </para>
+/// </remarks>
+[Property("Category", "Integration")]
+public class SagaSnapshotInspectionTests
+{
+    /// <summary>Linear workflow saga: additive emit only.</summary>
+    [Test]
+    public async Task SnapshotRegeneration_LinearWorkflow_IsAdditiveOnly()
+    {
+        await AssertAdditiveOnly(SourceTexts.LinearWorkflow, "ProcessOrderSaga.g.cs");
+    }
+
+    /// <summary>Looped workflow saga: additive emit only.</summary>
+    [Test]
+    public async Task SnapshotRegeneration_WorkflowWithLoop_IsAdditiveOnly()
+    {
+        await AssertAdditiveOnly(SourceTexts.WorkflowWithLoop, "IterativeRefinementSaga.g.cs");
+    }
+
+    /// <summary>Forked workflow saga: additive emit only.</summary>
+    [Test]
+    public async Task SnapshotRegeneration_WorkflowWithFork_IsAdditiveOnly()
+    {
+        await AssertAdditiveOnly(SourceTexts.WorkflowWithFork, "ParallelOrderSaga.g.cs");
+    }
+
+    /// <summary>Branched workflow saga: additive emit only.</summary>
+    [Test]
+    public async Task SnapshotRegeneration_WorkflowWithEnumBranch_IsAdditiveOnly()
+    {
+        await AssertAdditiveOnly(SourceTexts.WorkflowWithEnumBranch, "ProcessClaimSaga.g.cs");
+    }
+
+    private static async Task AssertAdditiveOnly(string source, string sagaHintNameSuffix)
+    {
+        var result = GeneratorTestHelper.RunGenerator(source);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, sagaHintNameSuffix);
+
+        await Assert.That(sagaSource).IsNotNull().And.IsNotEmpty();
+
+        // Additive emit
+        await Assert.That(sagaSource).Contains(": Saga, IPhaseAwareSaga");
+        await Assert.That(sagaSource).Contains("public string CurrentPhaseName => Phase.ToString();");
+        await Assert.That(sagaSource).Contains("using Strategos.Identity.Abstractions;");
+
+        // DR-7 negations: no Option-C state leaked into emit
+        await Assert.That(sagaSource).DoesNotContain("CurrentAgentIdentity");
+        await Assert.That(sagaSource).DoesNotContain("InitializeIdentity");
+        await Assert.That(sagaSource).DoesNotContain("_workflowIdentity");
+        await Assert.That(sagaSource).DoesNotContain("_identityProvider");
+        await Assert.That(sagaSource).DoesNotContain("InternalsVisibleTo");
+    }
+}

--- a/src/Strategos.Generators.Tests/SagaSnapshotInspectionTests.cs
+++ b/src/Strategos.Generators.Tests/SagaSnapshotInspectionTests.cs
@@ -70,6 +70,14 @@ public class SagaSnapshotInspectionTests
         // Additive emit
         await Assert.That(sagaSource).Contains(": Saga, IPhaseAwareSaga");
         await Assert.That(sagaSource).Contains("public string CurrentPhaseName => Phase.ToString();");
+
+        // The contract is "exactly once" — duplicate emits (e.g., a regression where
+        // SagaPropertiesEmitter ran twice) would silently slip past a plain Contains check.
+        var currentPhaseNameOccurrences = System.Text.RegularExpressions.Regex.Matches(
+            sagaSource,
+            @"public string CurrentPhaseName => Phase\.ToString\(\);").Count;
+        await Assert.That(currentPhaseNameOccurrences).IsEqualTo(1);
+
         await Assert.That(sagaSource).Contains("using Strategos.Identity.Abstractions;");
 
         // DR-7 negations: no Option-C state leaked into emit

--- a/src/Strategos.Generators.Tests/Strategos.Generators.Tests.csproj
+++ b/src/Strategos.Generators.Tests/Strategos.Generators.Tests.csproj
@@ -18,6 +18,7 @@
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="true" />
     <ProjectReference Include="..\Strategos\Strategos.csproj" />
+    <ProjectReference Include="..\Strategos.Identity.Abstractions\Strategos.Identity.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Strategos.Generators.Tests/_SagaEmitDumpTests.cs
+++ b/src/Strategos.Generators.Tests/_SagaEmitDumpTests.cs
@@ -11,8 +11,8 @@ using Strategos.Generators.Tests.Fixtures;
 namespace Strategos.Generators.Tests;
 
 /// <summary>
-/// One-shot diagnostic that writes a representative saga emit to /tmp for
-/// manual diff inspection during T10.
+/// One-shot diagnostic that writes a representative saga emit to the system temp
+/// directory for manual diff inspection during T10.
 /// </summary>
 /// <remarks>
 /// Disabled by default. Enable via the <c>STRATEGOS_DUMP_SAGA</c> env var.
@@ -22,7 +22,7 @@ namespace Strategos.Generators.Tests;
 [Property("Category", "Diagnostic")]
 public class _SagaEmitDumpTests
 {
-    /// <summary>Writes the linear workflow saga emit to /tmp/ProcessOrderSaga.emit.cs.</summary>
+    /// <summary>Writes the linear workflow saga emit to <c>Path.GetTempPath()/ProcessOrderSaga.emit.cs</c>.</summary>
     [Test]
     public async Task DumpEmit_LinearWorkflow_WhenEnvVarSet()
     {
@@ -34,7 +34,8 @@ public class _SagaEmitDumpTests
         var result = GeneratorTestHelper.RunGenerator(SourceTexts.LinearWorkflow);
         var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
 
-        File.WriteAllText("/tmp/ProcessOrderSaga.emit.cs", sagaSource);
+        var dumpPath = Path.Combine(Path.GetTempPath(), "ProcessOrderSaga.emit.cs");
+        File.WriteAllText(dumpPath, sagaSource);
 
         await Assert.That(sagaSource).IsNotEmpty();
     }

--- a/src/Strategos.Generators.Tests/_SagaEmitDumpTests.cs
+++ b/src/Strategos.Generators.Tests/_SagaEmitDumpTests.cs
@@ -1,0 +1,41 @@
+// -----------------------------------------------------------------------
+// <copyright file="_SagaEmitDumpTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.IO;
+
+using Strategos.Generators.Tests.Fixtures;
+
+namespace Strategos.Generators.Tests;
+
+/// <summary>
+/// One-shot diagnostic that writes a representative saga emit to /tmp for
+/// manual diff inspection during T10.
+/// </summary>
+/// <remarks>
+/// Disabled by default. Enable via the <c>STRATEGOS_DUMP_SAGA</c> env var.
+/// Not intended for CI — the snapshot inspection contract lives in
+/// <see cref="SagaSnapshotInspectionTests"/>.
+/// </remarks>
+[Property("Category", "Diagnostic")]
+public class _SagaEmitDumpTests
+{
+    /// <summary>Writes the linear workflow saga emit to /tmp/ProcessOrderSaga.emit.cs.</summary>
+    [Test]
+    public async Task DumpEmit_LinearWorkflow_WhenEnvVarSet()
+    {
+        if (Environment.GetEnvironmentVariable("STRATEGOS_DUMP_SAGA") is null)
+        {
+            return;
+        }
+
+        var result = GeneratorTestHelper.RunGenerator(SourceTexts.LinearWorkflow);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+
+        File.WriteAllText("/tmp/ProcessOrderSaga.emit.cs", sagaSource);
+
+        await Assert.That(sagaSource).IsNotEmpty();
+    }
+}

--- a/src/Strategos.Generators/Emitters/Saga/SagaPropertiesEmitter.cs
+++ b/src/Strategos.Generators/Emitters/Saga/SagaPropertiesEmitter.cs
@@ -64,6 +64,13 @@ internal sealed class SagaPropertiesEmitter : ISagaComponentEmitter
         sb.AppendLine($"    public {phaseEnumName} Phase {{ get; set; }} = {phaseEnumName}.NotStarted;");
         sb.AppendLine();
 
+        // IPhaseAwareSaga.CurrentPhaseName — the ONLY identity-related emit per DR-6
+        sb.AppendLine("    /// <summary>");
+        sb.AppendLine("    /// Gets the current saga phase as a stable string identifier (Phase.ToString()).");
+        sb.AppendLine("    /// </summary>");
+        sb.AppendLine("    public string CurrentPhaseName => Phase.ToString();");
+        sb.AppendLine();
+
         // State property (if state type is specified)
         if (!string.IsNullOrEmpty(model.StateTypeName))
         {

--- a/src/Strategos.Generators/Emitters/SagaEmitter.cs
+++ b/src/Strategos.Generators/Emitters/SagaEmitter.cs
@@ -72,6 +72,7 @@ internal static class SagaEmitter
             "System",
             "System.CodeDom.Compiler",
             "System.Collections.Generic",
+            "Strategos.Identity.Abstractions",
             "Strategos.Services",
             "Marten.Schema",
             "Microsoft.Extensions.Logging",
@@ -153,7 +154,7 @@ internal static class SagaEmitter
         sb.AppendLine($"/// Wolverine saga for the {model.WorkflowName} workflow.");
         sb.AppendLine("/// </summary>");
         sb.AppendLine("[GeneratedCode(\"Strategos.Generators\", \"1.0.0\")]");
-        sb.AppendLine($"public partial class {sagaClassName} : Saga");
+        sb.AppendLine($"public partial class {sagaClassName} : Saga, IPhaseAwareSaga");
         sb.AppendLine("{");
     }
 }

--- a/src/Strategos.Generators/Strategos.Generators.csproj
+++ b/src/Strategos.Generators/Strategos.Generators.csproj
@@ -30,9 +30,24 @@
     </PackageReference>
   </ItemGroup>
 
+  <!--
+    Strategos.Identity.Abstractions ships alongside the generator as a sibling
+    analyzer-side reference. The generator emits a base-list entry against
+    IPhaseAwareSaga; the consumer also needs the abstractions assembly on the
+    target's runtime classpath. We reference the project here with PrivateAssets="all"
+    to keep it out of the package's compile dependency closure, and pack the
+    DLL into analyzers/dotnet/cs so it loads next to the generator at SG time.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\Strategos.Identity.Abstractions\Strategos.Identity.Abstractions.csproj"
+                      PrivateAssets="all"
+                      ReferenceOutputAssembly="true" />
+  </ItemGroup>
+
   <!-- Pack the generator as an analyzer -->
   <ItemGroup>
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)\Strategos.Identity.Abstractions.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
   <!-- Expose internals to test project -->

--- a/src/Strategos.Generators/Strategos.Generators.csproj
+++ b/src/Strategos.Generators/Strategos.Generators.csproj
@@ -31,12 +31,24 @@
   </ItemGroup>
 
   <!--
-    Strategos.Identity.Abstractions ships alongside the generator as a sibling
-    analyzer-side reference. The generator emits a base-list entry against
-    IPhaseAwareSaga; the consumer also needs the abstractions assembly on the
-    target's runtime classpath. We reference the project here with PrivateAssets="all"
-    to keep it out of the package's compile dependency closure, and pack the
-    DLL into analyzers/dotnet/cs so it loads next to the generator at SG time.
+    Strategos.Identity.Abstractions is consumed on two distinct classpaths:
+      1. ANALYZER SIDE — at source-generation time, the generator emits a base-list
+         entry against IPhaseAwareSaga, so the abstractions DLL is packed into
+         analyzers/dotnet/cs (see the <None Include=...> below) and loaded next to
+         the generator inside Roslyn. The ProjectReference here is kept private
+         (PrivateAssets="all") because this generator package is marked
+         <DevelopmentDependency>true</DevelopmentDependency> — NuGet suppresses
+         transitive flow regardless of PrivateAssets, so we cannot flow the
+         contract from THIS package.
+      2. CONSUMER SIDE — the generated code references IPhaseAwareSaga at compile
+         time AND at runtime. The runtime/compile dep flows via the
+         LevelUp.Strategos core metapackage's explicit PackageReference to
+         LevelUp.Strategos.Identity.Abstractions (see src/Strategos/Strategos.csproj).
+         Every consumer of the generator package is expected to also reference
+         the core Strategos package, so abstractions is on their compile classpath
+         via that route. This decoupling keeps the generator package itself a
+         pure development-time dependency while routing the runtime contract
+         through the consumer-facing metapackage.
   -->
   <ItemGroup>
     <ProjectReference Include="..\Strategos.Identity.Abstractions\Strategos.Identity.Abstractions.csproj"

--- a/src/Strategos.Identity.Abstractions.Tests/AgentIdentityTests.cs
+++ b/src/Strategos.Identity.Abstractions.Tests/AgentIdentityTests.cs
@@ -61,4 +61,40 @@ public class AgentIdentityTests
 
         await Assert.That(t.IsSealed).IsTrue();
     }
+
+    /// <summary>
+    /// DR-2 must hold under <c>with</c>-clone too. Body-syntax records expose an
+    /// <c>init</c> setter that bypasses the constructor, so a clone with a bad
+    /// value would silently succeed. Positional-record primary-constructor
+    /// validation runs on every clone via the synthetic copy constructor.
+    /// </summary>
+    [Test]
+    public async Task AgentIdentity_WithClone_NonAsciiValue_ThrowsArgumentException()
+    {
+        var original = new AgentIdentity("valid-value");
+
+        await Assert.That(() => original with { Value = "agent-é" }).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// DR-2 must hold under <c>with</c>-clone for empty values too.
+    /// </summary>
+    [Test]
+    public async Task AgentIdentity_WithClone_EmptyValue_ThrowsArgumentException()
+    {
+        var original = new AgentIdentity("valid-value");
+
+        await Assert.That(() => original with { Value = string.Empty }).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// DR-2 must hold under <c>with</c>-clone for null values too.
+    /// </summary>
+    [Test]
+    public async Task AgentIdentity_WithClone_NullValue_ThrowsArgumentNullException()
+    {
+        var original = new AgentIdentity("valid-value");
+
+        await Assert.That(() => original with { Value = null! }).Throws<ArgumentNullException>();
+    }
 }

--- a/src/Strategos.Identity.Abstractions.Tests/AgentIdentityTests.cs
+++ b/src/Strategos.Identity.Abstractions.Tests/AgentIdentityTests.cs
@@ -1,0 +1,64 @@
+// -----------------------------------------------------------------------
+// <copyright file="AgentIdentityTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Strategos.Identity.Abstractions.Tests;
+
+/// <summary>
+/// Behavior tests for <see cref="AgentIdentity"/>. Mirrors WorkflowIdentityTests
+/// since both records share the same validation contract.
+/// </summary>
+[Property("Category", "Unit")]
+public class AgentIdentityTests
+{
+    /// <summary>
+    /// Verifies that the record stores the supplied value byte-for-byte.
+    /// </summary>
+    [Test]
+    public async Task AgentIdentity_ConstructedWithValue_StoresValueExactly()
+    {
+        var identity = new AgentIdentity("spiffe://td/workflow/abc/step/Drafting");
+
+        await Assert.That(identity.Value).IsEqualTo("spiffe://td/workflow/abc/step/Drafting");
+    }
+
+    /// <summary>
+    /// A null value violates DR-2 boundary validation.
+    /// </summary>
+    [Test]
+    public async Task AgentIdentity_NullValue_ThrowsArgumentNullException()
+    {
+        await Assert.That(() => new AgentIdentity(null!)).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>
+    /// An empty value violates DR-2 boundary validation.
+    /// </summary>
+    [Test]
+    public async Task AgentIdentity_EmptyValue_ThrowsArgumentException()
+    {
+        await Assert.That(() => new AgentIdentity(string.Empty)).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Non-ASCII characters violate the header-safe ASCII subset enforced by DR-8 row 6.
+    /// </summary>
+    [Test]
+    public async Task AgentIdentity_NonAsciiValue_ThrowsArgumentException()
+    {
+        await Assert.That(() => new AgentIdentity("agent-é")).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// INV-6: sealed-by-default invariant must hold via reflection.
+    /// </summary>
+    [Test]
+    public async Task AgentIdentity_IsSealedRecord_ViaReflection()
+    {
+        var t = typeof(AgentIdentity);
+
+        await Assert.That(t.IsSealed).IsTrue();
+    }
+}

--- a/src/Strategos.Identity.Abstractions.Tests/Build/ProjectStructureTests.cs
+++ b/src/Strategos.Identity.Abstractions.Tests/Build/ProjectStructureTests.cs
@@ -1,0 +1,65 @@
+// -----------------------------------------------------------------------
+// <copyright file="ProjectStructureTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.IO;
+
+namespace Strategos.Identity.Abstractions.Tests.Build;
+
+/// <summary>
+/// Verifies the bootstrap shape of the Strategos.Identity.Abstractions project skeleton.
+/// </summary>
+/// <remarks>
+/// These checks anchor T1 of the G1 agent-identity seam plan: the project must target
+/// netstandard2.0 (matches the generator analyzer target), enable central package management,
+/// and ship PublicAPI tracking files so issue #51 protocol stays in force from the first commit.
+/// </remarks>
+[Property("Category", "Build")]
+public class ProjectStructureTests
+{
+    private static string RepoRoot
+    {
+        get
+        {
+            // Walk up from the test assembly until we find the src/ directory.
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "src")))
+            {
+                dir = dir.Parent;
+            }
+
+            return dir?.FullName ?? throw new InvalidOperationException("Could not locate repo root from test assembly base directory.");
+        }
+    }
+
+    /// <summary>
+    /// Asserts that the new abstractions csproj exists and declares the expected target framework
+    /// and central-package-management opt-in.
+    /// </summary>
+    [Test]
+    public async Task Strategos_Identity_Abstractions_Csproj_Exists_AndTargetsNetStandard20()
+    {
+        var csprojPath = Path.Combine(RepoRoot, "src", "Strategos.Identity.Abstractions", "Strategos.Identity.Abstractions.csproj");
+
+        await Assert.That(File.Exists(csprojPath)).IsTrue();
+
+        var content = File.ReadAllText(csprojPath);
+        await Assert.That(content).Contains("<TargetFramework>netstandard2.0</TargetFramework>");
+        await Assert.That(content).Contains("<PackageId>LevelUp.Strategos.Identity.Abstractions</PackageId>");
+    }
+
+    /// <summary>
+    /// Asserts that the PublicAPI tracking files exist so the issue #51 protocol is enforced
+    /// for the new package from the first commit.
+    /// </summary>
+    [Test]
+    public async Task Strategos_Identity_Abstractions_PublicApiFiles_Exist()
+    {
+        var projectDir = Path.Combine(RepoRoot, "src", "Strategos.Identity.Abstractions");
+
+        await Assert.That(File.Exists(Path.Combine(projectDir, "PublicAPI.Shipped.txt"))).IsTrue();
+        await Assert.That(File.Exists(Path.Combine(projectDir, "PublicAPI.Unshipped.txt"))).IsTrue();
+    }
+}

--- a/src/Strategos.Identity.Abstractions.Tests/Build/ReleaseShapeTests.cs
+++ b/src/Strategos.Identity.Abstractions.Tests/Build/ReleaseShapeTests.cs
@@ -56,7 +56,7 @@ public class ReleaseShapeTests
         var changelogPath = Path.Combine(RepoRoot, "CHANGELOG.md");
         var content = await File.ReadAllTextAsync(changelogPath);
 
-        await Assert.That(content).Contains("## [2.7.0-preview.1] - 2026-05-16");
+        await Assert.That(content).Contains("## [2.7.0-preview.1] - 2026-05-17");
         await Assert.That(content).Contains("Strategos.Identity.Abstractions");
         await Assert.That(content).Contains("PropagateIncomingHeaderToOutgoing");
     }

--- a/src/Strategos.Identity.Abstractions.Tests/Build/ReleaseShapeTests.cs
+++ b/src/Strategos.Identity.Abstractions.Tests/Build/ReleaseShapeTests.cs
@@ -1,0 +1,91 @@
+// -----------------------------------------------------------------------
+// <copyright file="ReleaseShapeTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.IO;
+
+namespace Strategos.Identity.Abstractions.Tests.Build;
+
+/// <summary>
+/// T14: release-shape verification anchored against CHANGELOG content.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The release artifact (nupkg files) is produced by <c>dotnet pack</c> at
+/// CI time. This test guards the in-repo state: CHANGELOG carries the
+/// preview.1 section, README documents the identity seam, and the new
+/// abstractions package csproj declares the expected PackageId. The full
+/// pack verification (three nupkgs at exactly <c>2.7.0-preview.1</c>) is
+/// run as a CI gate via:
+/// </para>
+/// <code>
+/// dotnet pack src/Strategos.Identity.Abstractions/Strategos.Identity.Abstractions.csproj /p:MinVerVersionOverride=2.7.0-preview.1
+/// dotnet pack src/Strategos.Generators/Strategos.Generators.csproj             /p:MinVerVersionOverride=2.7.0-preview.1
+/// dotnet pack src/Strategos/Strategos.csproj                                   /p:MinVerVersionOverride=2.7.0-preview.1
+/// </code>
+/// <para>
+/// MinVer is git-tag-driven for releases (v-prefixed tags); the
+/// <c>MinVerVersionOverride</c> property is the supported off-tag-build override.
+/// </para>
+/// </remarks>
+[Property("Category", "Build")]
+public class ReleaseShapeTests
+{
+    private static string RepoRoot
+    {
+        get
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "CHANGELOG.md")))
+            {
+                dir = dir.Parent;
+            }
+
+            return dir?.FullName ?? throw new InvalidOperationException("Could not locate repo root from test assembly base directory.");
+        }
+    }
+
+    /// <summary>
+    /// CHANGELOG.md must carry the 2.7.0-preview.1 release section per the plan.
+    /// </summary>
+    [Test]
+    public async Task Release_Changelog_ContainsPreview1Section()
+    {
+        var changelogPath = Path.Combine(RepoRoot, "CHANGELOG.md");
+        var content = await File.ReadAllTextAsync(changelogPath);
+
+        await Assert.That(content).Contains("## [2.7.0-preview.1] - 2026-05-16");
+        await Assert.That(content).Contains("Strategos.Identity.Abstractions");
+        await Assert.That(content).Contains("PropagateIncomingHeaderToOutgoing");
+    }
+
+    /// <summary>
+    /// README.md must include the Identity Seam subsection so consumers know
+    /// to register the workflow-identity header-propagation policy.
+    /// </summary>
+    [Test]
+    public async Task Release_Readme_ContainsIdentitySeamSubsection()
+    {
+        var readmePath = Path.Combine(RepoRoot, "README.md");
+        var content = await File.ReadAllTextAsync(readmePath);
+
+        await Assert.That(content).Contains("Identity Seam");
+        await Assert.That(content).Contains("PropagateIncomingHeaderToOutgoing");
+        await Assert.That(content).Contains("StrategosHeaders.WorkflowIdentity");
+    }
+
+    /// <summary>
+    /// The new abstractions csproj must declare the expected PackageId so the
+    /// produced nupkg files match the release plan.
+    /// </summary>
+    [Test]
+    public async Task Release_AbstractionsCsproj_DeclaresExpectedPackageId()
+    {
+        var csprojPath = Path.Combine(RepoRoot, "src", "Strategos.Identity.Abstractions", "Strategos.Identity.Abstractions.csproj");
+        var content = await File.ReadAllTextAsync(csprojPath);
+
+        await Assert.That(content).Contains("<PackageId>LevelUp.Strategos.Identity.Abstractions</PackageId>");
+    }
+}

--- a/src/Strategos.Identity.Abstractions.Tests/DR8EdgeCasesIntegrationTests.cs
+++ b/src/Strategos.Identity.Abstractions.Tests/DR8EdgeCasesIntegrationTests.cs
@@ -9,21 +9,56 @@ using Strategos.Identity.Abstractions.Tests.Fakes;
 namespace Strategos.Identity.Abstractions.Tests;
 
 /// <summary>
-/// Consolidated DR-8 traceability anchor. Each test maps to one row of the
-/// design document's "Error handling and edge cases" table:
+/// Consolidated DR-8 traceability anchor. The DR-8 "Error handling and edge
+/// cases" table in the design document has six rows; each is mapped below
+/// to the test (or off-repo enforcement surface) that satisfies it.
 /// </summary>
-/// <list type="bullet">
-///   <item><description>Row 1 — accessor read outside a handler returns null (no throw).</description></item>
-///   <item><description>Row 2 — middleware generates a new identity when none is incoming (basileus contract).</description></item>
-///   <item><description>Row 3 — identity records reject null/empty values at construction.</description></item>
-///   <item><description>Row 4 — provider returns null is a basileus contract; the stub provider's contract is enforced in T6.</description></item>
-///   <item><description>Row 5 — headers ride the envelope natively via Wolverine (documented, not tested here).</description></item>
-///   <item><description>Row 6 — non-ASCII header values are rejected by the record constructor.</description></item>
-/// </list>
 /// <remarks>
-/// Rows 2/4/5 are basileus-middleware contracts; their tests here are
-/// documentation anchors that pass trivially so an explicit grep for
-/// <c>DR8_</c> surfaces the full traceability mapping.
+/// <para>
+/// <b>Strategos-side enforcement (tests live in this class):</b>
+/// </para>
+/// <list type="bullet">
+///   <item><description>
+///     <b>Row 1</b> — accessor read outside a handler returns null (no throw).
+///     Test: <see cref="DR8_AccessorReadOutsideHandler_ReturnsNull_NoThrow"/>.
+///   </description></item>
+///   <item><description>
+///     <b>Row 3</b> — identity records reject null/empty values at construction.
+///     Test: <see cref="DR8_IdentityRecordConstructedWithNullValue_ThrowsArgumentException"/>.
+///     (Additional null/empty/whitespace/non-ASCII coverage in
+///     <see cref="WorkflowIdentityTests"/> and <see cref="AgentIdentityTests"/>.)
+///   </description></item>
+///   <item><description>
+///     <b>Row 6</b> — non-ASCII / control-character header values are rejected by
+///     the record constructor so the transport layer never sees an un-encodable byte.
+///     Test: <see cref="DR8_HeaderValueWithNonAsciiCharacter_RecordConstructorRejects"/>.
+///   </description></item>
+/// </list>
+/// <para>
+/// <b>Basileus-side / Wolverine-side enforcement (no Strategos-side test):</b>
+/// </para>
+/// <list type="bullet">
+///   <item><description>
+///     <b>Row 2</b> — middleware generates a new identity when none is incoming.
+///     This is the basileus <c>StrategosHeaderMiddleware</c> contract; the
+///     reference implementation lives in lvlup-sw/basileus PR #184. See
+///     <c>docs/coordination/2026-05-16-basileus-handoff.md</c> for the cross-repo
+///     handoff and middleware-shape contract.
+///   </description></item>
+///   <item><description>
+///     <b>Row 4</b> — provider returning null from <c>DeriveStepIdentity</c> is a
+///     basileus contract surface. The Strategos-side enforcement is the stub
+///     provider's own throw-on-null behavior verified in
+///     <see cref="IAgentIdentityProviderContractTests"/> (T6).
+///   </description></item>
+///   <item><description>
+///     <b>Row 5</b> — outgoing messages carry the workflow-identity header via
+///     Wolverine's native envelope mechanism plus the
+///     <c>PropagateIncomingHeaderToOutgoing</c> policy. Tested by Wolverine's
+///     own test suite (out of scope for Strategos); documented in CHANGELOG
+///     under the v2.7.0-preview.1 Migration subsection.
+///   </description></item>
+/// </list>
 /// </remarks>
 [Property("Category", "Integration")]
 public class DR8EdgeCasesIntegrationTests
@@ -42,21 +77,6 @@ public class DR8EdgeCasesIntegrationTests
     }
 
     /// <summary>
-    /// DR-8 Row 2 (documentation): when no incoming workflow-identity header is
-    /// present, the basileus middleware is responsible for generating one keyed
-    /// to <c>sagaId</c>. Strategos provides no enforcement.
-    /// </summary>
-    [Test]
-    public async Task DR8_NoIncomingWorkflowHeader_MiddlewareGeneratesNewIdentity_DocumentedAsBasileusContract()
-    {
-        // Documentation test: anchors the DR-8 row 2 contract in this suite so
-        // that a grep for DR8_ surfaces the basileus boundary. The actual
-        // enforcement lives in the basileus middleware (out of scope for
-        // Strategos).
-        await Assert.That(true).IsTrue();
-    }
-
-    /// <summary>
     /// DR-8 Row 3: both <see cref="WorkflowIdentity"/> and <see cref="AgentIdentity"/>
     /// reject null/empty values at construction.
     /// </summary>
@@ -68,29 +88,6 @@ public class DR8EdgeCasesIntegrationTests
 
         await Assert.That(() => new WorkflowIdentity(string.Empty)).Throws<ArgumentException>();
         await Assert.That(() => new AgentIdentity(string.Empty)).Throws<ArgumentException>();
-    }
-
-    /// <summary>
-    /// DR-8 Row 4 (documentation): the basileus provider returning null from
-    /// <c>DeriveStepIdentity</c> is a basileus contract surface. The stub's own
-    /// throw-on-null behavior is the Strategos-side enforcement (T6).
-    /// </summary>
-    [Test]
-    public async Task DR8_ProviderReturnsNull_DocumentedAsBasileusContract_NotEnforcedHere()
-    {
-        await Assert.That(true).IsTrue();
-    }
-
-    /// <summary>
-    /// DR-8 Row 5 (documentation): outgoing messages carry the workflow header
-    /// via Wolverine's native envelope mechanism + the
-    /// <c>PropagateIncomingHeaderToOutgoing</c> policy. Tested by Wolverine's
-    /// own suite; documented here for traceability.
-    /// </summary>
-    [Test]
-    public async Task DR8_HandlerEmitsMessage_HeadersRideOnEnvelope_NativeWolverineMechanism_DocumentedNotTested()
-    {
-        await Assert.That(true).IsTrue();
     }
 
     /// <summary>

--- a/src/Strategos.Identity.Abstractions.Tests/DR8EdgeCasesIntegrationTests.cs
+++ b/src/Strategos.Identity.Abstractions.Tests/DR8EdgeCasesIntegrationTests.cs
@@ -1,0 +1,111 @@
+// -----------------------------------------------------------------------
+// <copyright file="DR8EdgeCasesIntegrationTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Identity.Abstractions.Tests.Fakes;
+
+namespace Strategos.Identity.Abstractions.Tests;
+
+/// <summary>
+/// Consolidated DR-8 traceability anchor. Each test maps to one row of the
+/// design document's "Error handling and edge cases" table:
+/// </summary>
+/// <list type="bullet">
+///   <item><description>Row 1 — accessor read outside a handler returns null (no throw).</description></item>
+///   <item><description>Row 2 — middleware generates a new identity when none is incoming (basileus contract).</description></item>
+///   <item><description>Row 3 — identity records reject null/empty values at construction.</description></item>
+///   <item><description>Row 4 — provider returns null is a basileus contract; the stub provider's contract is enforced in T6.</description></item>
+///   <item><description>Row 5 — headers ride the envelope natively via Wolverine (documented, not tested here).</description></item>
+///   <item><description>Row 6 — non-ASCII header values are rejected by the record constructor.</description></item>
+/// </list>
+/// <remarks>
+/// Rows 2/4/5 are basileus-middleware contracts; their tests here are
+/// documentation anchors that pass trivially so an explicit grep for
+/// <c>DR8_</c> surfaces the full traceability mapping.
+/// </remarks>
+[Property("Category", "Integration")]
+public class DR8EdgeCasesIntegrationTests
+{
+    /// <summary>
+    /// DR-8 Row 1: accessor read outside a Wolverine handler context returns
+    /// null on both properties and does NOT throw.
+    /// </summary>
+    [Test]
+    public async Task DR8_AccessorReadOutsideHandler_ReturnsNull_NoThrow()
+    {
+        var accessor = new FakeAgentIdentityAccessor(envelopeHeaders: null);
+
+        await Assert.That(accessor.CurrentWorkflow).IsNull();
+        await Assert.That(accessor.CurrentAgent).IsNull();
+    }
+
+    /// <summary>
+    /// DR-8 Row 2 (documentation): when no incoming workflow-identity header is
+    /// present, the basileus middleware is responsible for generating one keyed
+    /// to <c>sagaId</c>. Strategos provides no enforcement.
+    /// </summary>
+    [Test]
+    public async Task DR8_NoIncomingWorkflowHeader_MiddlewareGeneratesNewIdentity_DocumentedAsBasileusContract()
+    {
+        // Documentation test: anchors the DR-8 row 2 contract in this suite so
+        // that a grep for DR8_ surfaces the basileus boundary. The actual
+        // enforcement lives in the basileus middleware (out of scope for
+        // Strategos).
+        await Assert.That(true).IsTrue();
+    }
+
+    /// <summary>
+    /// DR-8 Row 3: both <see cref="WorkflowIdentity"/> and <see cref="AgentIdentity"/>
+    /// reject null/empty values at construction.
+    /// </summary>
+    [Test]
+    public async Task DR8_IdentityRecordConstructedWithNullValue_ThrowsArgumentException()
+    {
+        await Assert.That(() => new WorkflowIdentity(null!)).Throws<ArgumentNullException>();
+        await Assert.That(() => new AgentIdentity(null!)).Throws<ArgumentNullException>();
+
+        await Assert.That(() => new WorkflowIdentity(string.Empty)).Throws<ArgumentException>();
+        await Assert.That(() => new AgentIdentity(string.Empty)).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// DR-8 Row 4 (documentation): the basileus provider returning null from
+    /// <c>DeriveStepIdentity</c> is a basileus contract surface. The stub's own
+    /// throw-on-null behavior is the Strategos-side enforcement (T6).
+    /// </summary>
+    [Test]
+    public async Task DR8_ProviderReturnsNull_DocumentedAsBasileusContract_NotEnforcedHere()
+    {
+        await Assert.That(true).IsTrue();
+    }
+
+    /// <summary>
+    /// DR-8 Row 5 (documentation): outgoing messages carry the workflow header
+    /// via Wolverine's native envelope mechanism + the
+    /// <c>PropagateIncomingHeaderToOutgoing</c> policy. Tested by Wolverine's
+    /// own suite; documented here for traceability.
+    /// </summary>
+    [Test]
+    public async Task DR8_HandlerEmitsMessage_HeadersRideOnEnvelope_NativeWolverineMechanism_DocumentedNotTested()
+    {
+        await Assert.That(true).IsTrue();
+    }
+
+    /// <summary>
+    /// DR-8 Row 6: non-ASCII header values are rejected by both record
+    /// constructors so the transport layer never sees an un-encodable byte.
+    /// </summary>
+    [Test]
+    public async Task DR8_HeaderValueWithNonAsciiCharacter_RecordConstructorRejects()
+    {
+        // U+00E9 — printable in UTF-8, but outside the 0x20..0x7E ASCII subset.
+        await Assert.That(() => new WorkflowIdentity("workflow-é")).Throws<ArgumentException>();
+        await Assert.That(() => new AgentIdentity("agent-é")).Throws<ArgumentException>();
+
+        // Control character — outside 0x20..0x7E.
+        await Assert.That(() => new WorkflowIdentity("workflow\n1")).Throws<ArgumentException>();
+        await Assert.That(() => new AgentIdentity("agent\t1")).Throws<ArgumentException>();
+    }
+}

--- a/src/Strategos.Identity.Abstractions.Tests/Fakes/FakeAgentIdentityAccessor.cs
+++ b/src/Strategos.Identity.Abstractions.Tests/Fakes/FakeAgentIdentityAccessor.cs
@@ -21,7 +21,7 @@ namespace Strategos.Identity.Abstractions.Tests.Fakes;
 /// projections, debuggers, or hosted-service inspection paths.
 /// </para>
 /// </remarks>
-public sealed class FakeAgentIdentityAccessor : IAgentIdentityAccessor
+internal sealed class FakeAgentIdentityAccessor : IAgentIdentityAccessor
 {
     private readonly IDictionary<string, string>? envelopeHeaders;
 

--- a/src/Strategos.Identity.Abstractions.Tests/Fakes/FakeAgentIdentityAccessor.cs
+++ b/src/Strategos.Identity.Abstractions.Tests/Fakes/FakeAgentIdentityAccessor.cs
@@ -1,0 +1,71 @@
+// -----------------------------------------------------------------------
+// <copyright file="FakeAgentIdentityAccessor.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Strategos.Identity.Abstractions.Tests.Fakes;
+
+/// <summary>
+/// In-memory <see cref="IAgentIdentityAccessor"/> for tests.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Constructed with an optional <c>IDictionary&lt;string,string&gt;</c> standing in
+/// for the envelope-header bag. Passing <c>null</c> models the "no Wolverine
+/// message context active" case (DR-8 row 1).
+/// </para>
+/// <para>
+/// Per DR-5 contract, invalid header values produce <c>null</c> rather than
+/// throwing — the accessor is read-only and must not be allowed to crash
+/// projections, debuggers, or hosted-service inspection paths.
+/// </para>
+/// </remarks>
+public sealed class FakeAgentIdentityAccessor : IAgentIdentityAccessor
+{
+    private readonly IDictionary<string, string>? envelopeHeaders;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FakeAgentIdentityAccessor"/> class.
+    /// </summary>
+    /// <param name="envelopeHeaders">
+    /// The header bag standing in for the Wolverine envelope, or <c>null</c> to model
+    /// "no message context active".
+    /// </param>
+    public FakeAgentIdentityAccessor(IDictionary<string, string>? envelopeHeaders)
+    {
+        this.envelopeHeaders = envelopeHeaders;
+    }
+
+    /// <inheritdoc/>
+    public WorkflowIdentity? CurrentWorkflow => this.TryGet(StrategosHeaders.WorkflowIdentity, v => new WorkflowIdentity(v));
+
+    /// <inheritdoc/>
+    public AgentIdentity? CurrentAgent => this.TryGet(StrategosHeaders.AgentIdentity, v => new AgentIdentity(v));
+
+    private T? TryGet<T>(string headerKey, Func<string, T> factory)
+        where T : class
+    {
+        if (this.envelopeHeaders is null)
+        {
+            return null;
+        }
+
+        if (!this.envelopeHeaders.TryGetValue(headerKey, out var raw) || raw is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return factory(raw);
+        }
+        catch (ArgumentException)
+        {
+            // DR-5: invalid header value must not crash the accessor — silently
+            // degrade so projections, debuggers, and hosted-service inspection
+            // paths can continue.
+            return null;
+        }
+    }
+}

--- a/src/Strategos.Identity.Abstractions.Tests/Fakes/StubAgentIdentityProvider.cs
+++ b/src/Strategos.Identity.Abstractions.Tests/Fakes/StubAgentIdentityProvider.cs
@@ -16,7 +16,7 @@ namespace Strategos.Identity.Abstractions.Tests.Fakes;
 /// stub is intentionally simpler so tests can assert the contract without
 /// pulling in SPIFFE machinery.
 /// </remarks>
-public sealed class StubAgentIdentityProvider : IAgentIdentityProvider
+internal sealed class StubAgentIdentityProvider : IAgentIdentityProvider
 {
     /// <inheritdoc/>
     public AgentIdentity DeriveStepIdentity(WorkflowIdentity workflow, string phaseName)

--- a/src/Strategos.Identity.Abstractions.Tests/Fakes/StubAgentIdentityProvider.cs
+++ b/src/Strategos.Identity.Abstractions.Tests/Fakes/StubAgentIdentityProvider.cs
@@ -1,0 +1,52 @@
+// -----------------------------------------------------------------------
+// <copyright file="StubAgentIdentityProvider.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Strategos.Identity.Abstractions.Tests.Fakes;
+
+/// <summary>
+/// Minimal in-test implementation of <see cref="IAgentIdentityProvider"/>.
+/// </summary>
+/// <remarks>
+/// Concatenates <c>{workflow.Value}#{phaseName}</c> for derivation; round-trips
+/// the workflow header value verbatim. The production basileus adapter shapes
+/// the value as <c>spiffe://td/workflow/&lt;id&gt;/step/&lt;phase&gt;</c> — the
+/// stub is intentionally simpler so tests can assert the contract without
+/// pulling in SPIFFE machinery.
+/// </remarks>
+public sealed class StubAgentIdentityProvider : IAgentIdentityProvider
+{
+    /// <inheritdoc/>
+    public AgentIdentity DeriveStepIdentity(WorkflowIdentity workflow, string phaseName)
+    {
+        if (workflow is null)
+        {
+            throw new ArgumentNullException(nameof(workflow));
+        }
+
+        if (phaseName is null)
+        {
+            throw new ArgumentNullException(nameof(phaseName));
+        }
+
+        if (string.IsNullOrWhiteSpace(phaseName))
+        {
+            throw new ArgumentException("Phase name must be non-empty.", nameof(phaseName));
+        }
+
+        return new AgentIdentity($"{workflow.Value}#{phaseName}");
+    }
+
+    /// <inheritdoc/>
+    public WorkflowIdentity ParseWorkflowHeader(string headerValue)
+    {
+        if (headerValue is null)
+        {
+            throw new ArgumentNullException(nameof(headerValue));
+        }
+
+        return new WorkflowIdentity(headerValue);
+    }
+}

--- a/src/Strategos.Identity.Abstractions.Tests/GlobalUsings.cs
+++ b/src/Strategos.Identity.Abstractions.Tests/GlobalUsings.cs
@@ -1,0 +1,16 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using System;
+global using System.Collections.Generic;
+global using System.Linq;
+global using System.Threading.Tasks;
+
+global using NSubstitute;
+
+global using TUnit.Assertions;
+global using TUnit.Assertions.Extensions;
+global using TUnit.Core;

--- a/src/Strategos.Identity.Abstractions.Tests/GlobalUsings.cs
+++ b/src/Strategos.Identity.Abstractions.Tests/GlobalUsings.cs
@@ -9,8 +9,6 @@ global using System.Collections.Generic;
 global using System.Linq;
 global using System.Threading.Tasks;
 
-global using NSubstitute;
-
 global using TUnit.Assertions;
 global using TUnit.Assertions.Extensions;
 global using TUnit.Core;

--- a/src/Strategos.Identity.Abstractions.Tests/IAgentIdentityAccessorContractTests.cs
+++ b/src/Strategos.Identity.Abstractions.Tests/IAgentIdentityAccessorContractTests.cs
@@ -74,11 +74,11 @@ public class IAgentIdentityAccessorContractTests
     }
 
     /// <summary>
-    /// DR-5: an invalid header value must not throw — the accessor returns null
-    /// so projections, debuggers, and inspection paths stay reliable.
+    /// DR-5: an invalid workflow header value must not throw — the accessor
+    /// returns null so projections, debuggers, and inspection paths stay reliable.
     /// </summary>
     [Test]
-    public async Task FakeAgentIdentityAccessor_HeaderValueInvalid_ReturnsNullNoThrow()
+    public async Task FakeAgentIdentityAccessor_WorkflowHeaderValueInvalid_ReturnsNullNoThrow()
     {
         var headers = new Dictionary<string, string>
         {
@@ -88,5 +88,26 @@ public class IAgentIdentityAccessorContractTests
         var sut = new FakeAgentIdentityAccessor(headers);
 
         await Assert.That(sut.CurrentWorkflow).IsNull();
+    }
+
+    /// <summary>
+    /// DR-5 symmetric coverage: an invalid agent header value must not throw
+    /// either — the accessor returns null on both properties uniformly. This
+    /// mirrors <see cref="FakeAgentIdentityAccessor_WorkflowHeaderValueInvalid_ReturnsNullNoThrow"/>
+    /// so the agent-side path has the same regression net as the workflow-side path.
+    /// </summary>
+    [Test]
+    public async Task FakeAgentIdentityAccessor_AgentHeaderValueInvalid_ReturnsNullNoThrow()
+    {
+        var headers = new Dictionary<string, string>
+        {
+            [StrategosHeaders.WorkflowIdentity] = "wf-001",
+            // Control character violates the printable-ASCII subset rule on construction.
+            [StrategosHeaders.AgentIdentity] = "wf-001#bad\nphase",
+        };
+        var sut = new FakeAgentIdentityAccessor(headers);
+
+        await Assert.That(sut.CurrentWorkflow).IsNotNull();
+        await Assert.That(sut.CurrentAgent).IsNull();
     }
 }

--- a/src/Strategos.Identity.Abstractions.Tests/IAgentIdentityAccessorContractTests.cs
+++ b/src/Strategos.Identity.Abstractions.Tests/IAgentIdentityAccessorContractTests.cs
@@ -1,0 +1,92 @@
+// -----------------------------------------------------------------------
+// <copyright file="IAgentIdentityAccessorContractTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Identity.Abstractions.Tests.Fakes;
+
+namespace Strategos.Identity.Abstractions.Tests;
+
+/// <summary>
+/// Contract tests for <see cref="IAgentIdentityAccessor"/> exercised via
+/// <see cref="FakeAgentIdentityAccessor"/>. Anchors DR-5 and DR-8 row 1.
+/// </summary>
+[Property("Category", "Unit")]
+public class IAgentIdentityAccessorContractTests
+{
+    /// <summary>
+    /// DR-5: outside a Wolverine handler context, CurrentWorkflow returns null.
+    /// </summary>
+    [Test]
+    public async Task FakeAgentIdentityAccessor_NoEnvelopeContext_CurrentWorkflowReturnsNull()
+    {
+        var sut = new FakeAgentIdentityAccessor(envelopeHeaders: null);
+
+        await Assert.That(sut.CurrentWorkflow).IsNull();
+    }
+
+    /// <summary>
+    /// DR-5: outside a Wolverine handler context, CurrentAgent returns null.
+    /// </summary>
+    [Test]
+    public async Task FakeAgentIdentityAccessor_NoEnvelopeContext_CurrentAgentReturnsNull()
+    {
+        var sut = new FakeAgentIdentityAccessor(envelopeHeaders: null);
+
+        await Assert.That(sut.CurrentAgent).IsNull();
+    }
+
+    /// <summary>
+    /// Both headers present: both properties return populated records.
+    /// </summary>
+    [Test]
+    public async Task FakeAgentIdentityAccessor_BothHeadersPresent_ReturnsParsedRecords()
+    {
+        var headers = new Dictionary<string, string>
+        {
+            [StrategosHeaders.WorkflowIdentity] = "wf-001",
+            [StrategosHeaders.AgentIdentity] = "wf-001#Drafting",
+        };
+        var sut = new FakeAgentIdentityAccessor(headers);
+
+        await Assert.That(sut.CurrentWorkflow).IsNotNull();
+        await Assert.That(sut.CurrentWorkflow!.Value).IsEqualTo("wf-001");
+        await Assert.That(sut.CurrentAgent).IsNotNull();
+        await Assert.That(sut.CurrentAgent!.Value).IsEqualTo("wf-001#Drafting");
+    }
+
+    /// <summary>
+    /// Workflow header only: CurrentAgent must remain null (each handler stamps
+    /// its own agent identity).
+    /// </summary>
+    [Test]
+    public async Task FakeAgentIdentityAccessor_OnlyWorkflowHeader_CurrentAgentReturnsNull()
+    {
+        var headers = new Dictionary<string, string>
+        {
+            [StrategosHeaders.WorkflowIdentity] = "wf-001",
+        };
+        var sut = new FakeAgentIdentityAccessor(headers);
+
+        await Assert.That(sut.CurrentWorkflow).IsNotNull();
+        await Assert.That(sut.CurrentAgent).IsNull();
+    }
+
+    /// <summary>
+    /// DR-5: an invalid header value must not throw — the accessor returns null
+    /// so projections, debuggers, and inspection paths stay reliable.
+    /// </summary>
+    [Test]
+    public async Task FakeAgentIdentityAccessor_HeaderValueInvalid_ReturnsNullNoThrow()
+    {
+        var headers = new Dictionary<string, string>
+        {
+            // U+00E9 (é) violates the ASCII subset rule on construction.
+            [StrategosHeaders.WorkflowIdentity] = "wf-é-001",
+        };
+        var sut = new FakeAgentIdentityAccessor(headers);
+
+        await Assert.That(sut.CurrentWorkflow).IsNull();
+    }
+}

--- a/src/Strategos.Identity.Abstractions.Tests/IAgentIdentityProviderContractTests.cs
+++ b/src/Strategos.Identity.Abstractions.Tests/IAgentIdentityProviderContractTests.cs
@@ -1,0 +1,92 @@
+// -----------------------------------------------------------------------
+// <copyright file="IAgentIdentityProviderContractTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Identity.Abstractions.Tests.Fakes;
+
+namespace Strategos.Identity.Abstractions.Tests;
+
+/// <summary>
+/// Contract tests for <see cref="IAgentIdentityProvider"/> exercised via
+/// <see cref="StubAgentIdentityProvider"/>. Anchors DR-3 and DR-8 row 4.
+/// </summary>
+[Property("Category", "Unit")]
+public class IAgentIdentityProviderContractTests
+{
+    /// <summary>
+    /// Happy path: deriving from a valid workflow and phase produces an AgentIdentity
+    /// containing both inputs.
+    /// </summary>
+    [Test]
+    public async Task StubAgentIdentityProvider_DeriveStepIdentity_ReturnsAgentIdentity_ContainingWorkflowAndPhase()
+    {
+        var sut = new StubAgentIdentityProvider();
+        var workflow = new WorkflowIdentity("wf-001");
+
+        var agent = sut.DeriveStepIdentity(workflow, "Drafting");
+
+        await Assert.That(agent.Value).Contains("wf-001");
+        await Assert.That(agent.Value).Contains("Drafting");
+    }
+
+    /// <summary>
+    /// DR-3 boundary: a null workflow throws ArgumentNullException.
+    /// </summary>
+    [Test]
+    public async Task StubAgentIdentityProvider_DeriveStepIdentity_NullWorkflow_ThrowsArgumentNullException()
+    {
+        var sut = new StubAgentIdentityProvider();
+
+        await Assert.That(() => sut.DeriveStepIdentity(null!, "Drafting")).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>
+    /// DR-3 boundary: a null phaseName throws ArgumentNullException.
+    /// </summary>
+    [Test]
+    public async Task StubAgentIdentityProvider_DeriveStepIdentity_NullPhaseName_ThrowsArgumentNullException()
+    {
+        var sut = new StubAgentIdentityProvider();
+        var workflow = new WorkflowIdentity("wf-001");
+
+        await Assert.That(() => sut.DeriveStepIdentity(workflow, null!)).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>
+    /// DR-3 boundary: an empty phaseName throws ArgumentException.
+    /// </summary>
+    [Test]
+    public async Task StubAgentIdentityProvider_DeriveStepIdentity_EmptyPhaseName_ThrowsArgumentException()
+    {
+        var sut = new StubAgentIdentityProvider();
+        var workflow = new WorkflowIdentity("wf-001");
+
+        await Assert.That(() => sut.DeriveStepIdentity(workflow, string.Empty)).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// DR-3 boundary: ParseWorkflowHeader rejects null inputs.
+    /// </summary>
+    [Test]
+    public async Task StubAgentIdentityProvider_ParseWorkflowHeader_NullValue_ThrowsArgumentNullException()
+    {
+        var sut = new StubAgentIdentityProvider();
+
+        await Assert.That(() => sut.ParseWorkflowHeader(null!)).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>
+    /// Roundtrip: a valid header value parses to a WorkflowIdentity with the same Value.
+    /// </summary>
+    [Test]
+    public async Task StubAgentIdentityProvider_ParseWorkflowHeader_ValidValue_RoundTrips()
+    {
+        var sut = new StubAgentIdentityProvider();
+
+        var parsed = sut.ParseWorkflowHeader("wf-001");
+
+        await Assert.That(parsed.Value).IsEqualTo("wf-001");
+    }
+}

--- a/src/Strategos.Identity.Abstractions.Tests/IPhaseAwareSagaTests.cs
+++ b/src/Strategos.Identity.Abstractions.Tests/IPhaseAwareSagaTests.cs
@@ -1,0 +1,58 @@
+// -----------------------------------------------------------------------
+// <copyright file="IPhaseAwareSagaTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Reflection;
+
+namespace Strategos.Identity.Abstractions.Tests;
+
+/// <summary>
+/// Verifies the public shape of <see cref="IPhaseAwareSaga"/>.
+/// </summary>
+/// <remarks>
+/// Anchors DR-6 (interface portion). The basileus middleware reads
+/// <c>saga.CurrentPhaseName</c> via this interface to derive per-step
+/// agent identities, so the property must be a read-only string getter.
+/// </remarks>
+[Property("Category", "Unit")]
+public class IPhaseAwareSagaTests
+{
+    /// <summary>
+    /// Marker test: ensures the type exists and is a public interface.
+    /// </summary>
+    [Test]
+    public async Task IPhaseAwareSaga_IsPublicInterface_ViaReflection()
+    {
+        var t = typeof(IPhaseAwareSaga);
+
+        await Assert.That(t.IsInterface).IsTrue();
+        await Assert.That(t.IsPublic).IsTrue();
+    }
+
+    /// <summary>
+    /// The middleware contract requires a string CurrentPhaseName getter.
+    /// </summary>
+    [Test]
+    public async Task IPhaseAwareSaga_HasCurrentPhaseNameProperty_AsStringGetter()
+    {
+        var prop = typeof(IPhaseAwareSaga).GetProperty("CurrentPhaseName", BindingFlags.Public | BindingFlags.Instance);
+
+        await Assert.That(prop).IsNotNull();
+        await Assert.That(prop!.PropertyType).IsEqualTo(typeof(string));
+        await Assert.That(prop.GetGetMethod()).IsNotNull();
+    }
+
+    /// <summary>
+    /// INV-7 immutability: CurrentPhaseName must NOT expose a setter through this contract.
+    /// </summary>
+    [Test]
+    public async Task IPhaseAwareSaga_CurrentPhaseName_HasNoSetter()
+    {
+        var prop = typeof(IPhaseAwareSaga).GetProperty("CurrentPhaseName", BindingFlags.Public | BindingFlags.Instance);
+
+        await Assert.That(prop).IsNotNull();
+        await Assert.That(prop!.GetSetMethod()).IsNull();
+    }
+}

--- a/src/Strategos.Identity.Abstractions.Tests/Strategos.Identity.Abstractions.Tests.csproj
+++ b/src/Strategos.Identity.Abstractions.Tests/Strategos.Identity.Abstractions.Tests.csproj
@@ -8,8 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="TUnit" />
-    <PackageReference Include="NSubstitute" />
-    <PackageReference Include="Verify.SourceGenerators" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Strategos.Identity.Abstractions.Tests/Strategos.Identity.Abstractions.Tests.csproj
+++ b/src/Strategos.Identity.Abstractions.Tests/Strategos.Identity.Abstractions.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>Strategos.Identity.Abstractions.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TUnit" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Verify.SourceGenerators" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Strategos.Identity.Abstractions\Strategos.Identity.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Strategos.Identity.Abstractions.Tests/StrategosHeadersTests.cs
+++ b/src/Strategos.Identity.Abstractions.Tests/StrategosHeadersTests.cs
@@ -1,0 +1,84 @@
+// -----------------------------------------------------------------------
+// <copyright file="StrategosHeadersTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Reflection;
+
+namespace Strategos.Identity.Abstractions.Tests;
+
+/// <summary>
+/// Verifies the <see cref="StrategosHeaders"/> constant values.
+/// </summary>
+/// <remarks>
+/// Anchors DR-4. Constant values are part of the wire protocol — drift would
+/// silently break basileus-side header propagation.
+/// </remarks>
+[Property("Category", "Unit")]
+public class StrategosHeadersTests
+{
+    /// <summary>
+    /// The workflow identity header constant is part of the wire protocol.
+    /// </summary>
+    [Test]
+    public async Task StrategosHeaders_WorkflowIdentity_EqualsExpectedConstantValue()
+    {
+        await Assert.That(StrategosHeaders.WorkflowIdentity).IsEqualTo("x-strategos-workflow-identity");
+    }
+
+    /// <summary>
+    /// The agent identity header constant is part of the wire protocol.
+    /// </summary>
+    [Test]
+    public async Task StrategosHeaders_AgentIdentity_EqualsExpectedConstantValue()
+    {
+        await Assert.That(StrategosHeaders.AgentIdentity).IsEqualTo("x-strategos-agent-identity");
+    }
+
+    /// <summary>
+    /// All public string constants must follow the <c>x-strategos-</c> prefix convention.
+    /// </summary>
+    [Test]
+    public async Task StrategosHeaders_AllKeys_FollowXStrategosPrefix()
+    {
+        var fields = typeof(StrategosHeaders)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(f => f.IsLiteral && !f.IsInitOnly && f.FieldType == typeof(string))
+            .ToList();
+
+        await Assert.That(fields.Count).IsGreaterThan(0);
+
+        foreach (var f in fields)
+        {
+            var v = (string?)f.GetRawConstantValue();
+            await Assert.That(v).IsNotNull();
+            await Assert.That(v!.StartsWith("x-strategos-", StringComparison.Ordinal)).IsTrue();
+        }
+    }
+
+    /// <summary>
+    /// All public string constants must be ASCII lower kebab-case so they survive
+    /// case-insensitive HTTP header normalization and every transport's serializer.
+    /// </summary>
+    [Test]
+    public async Task StrategosHeaders_AllKeys_AreAsciiLowerKebabCase()
+    {
+        var fields = typeof(StrategosHeaders)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(f => f.IsLiteral && !f.IsInitOnly && f.FieldType == typeof(string))
+            .ToList();
+
+        foreach (var f in fields)
+        {
+            var v = (string?)f.GetRawConstantValue();
+            await Assert.That(v).IsNotNull();
+
+            foreach (var c in v!)
+            {
+                var isLowerOrDigit = (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-';
+                await Assert.That(isLowerOrDigit).IsTrue();
+            }
+        }
+    }
+}

--- a/src/Strategos.Identity.Abstractions.Tests/WorkflowIdentityTests.cs
+++ b/src/Strategos.Identity.Abstractions.Tests/WorkflowIdentityTests.cs
@@ -1,0 +1,86 @@
+// -----------------------------------------------------------------------
+// <copyright file="WorkflowIdentityTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Strategos.Identity.Abstractions.Tests;
+
+/// <summary>
+/// Behavior tests for <see cref="WorkflowIdentity"/>.
+/// </summary>
+/// <remarks>
+/// Anchors DR-2 (sealed record, ASCII-validated value) and DR-8 rows 3 and 6
+/// (null/empty/non-ASCII inputs rejected at construction time).
+/// </remarks>
+[Property("Category", "Unit")]
+public class WorkflowIdentityTests
+{
+    /// <summary>
+    /// Verifies that the record stores the supplied value byte-for-byte.
+    /// </summary>
+    [Test]
+    public async Task WorkflowIdentity_ConstructedWithValue_StoresValueExactly()
+    {
+        var identity = new WorkflowIdentity("spiffe://td/workflow/abc-123");
+
+        await Assert.That(identity.Value).IsEqualTo("spiffe://td/workflow/abc-123");
+    }
+
+    /// <summary>
+    /// A null value violates DR-2 boundary validation.
+    /// </summary>
+    [Test]
+    public async Task WorkflowIdentity_NullValue_ThrowsArgumentNullException()
+    {
+        await Assert.That(() => new WorkflowIdentity(null!)).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>
+    /// An empty value violates DR-2 boundary validation.
+    /// </summary>
+    [Test]
+    public async Task WorkflowIdentity_EmptyValue_ThrowsArgumentException()
+    {
+        await Assert.That(() => new WorkflowIdentity(string.Empty)).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Whitespace-only is treated as empty per DR-2.
+    /// </summary>
+    [Test]
+    public async Task WorkflowIdentity_WhitespaceValue_ThrowsArgumentException()
+    {
+        await Assert.That(() => new WorkflowIdentity("   ")).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Non-ASCII characters violate the header-safe ASCII subset enforced by DR-8 row 6.
+    /// </summary>
+    [Test]
+    public async Task WorkflowIdentity_NonAsciiValue_ThrowsArgumentException()
+    {
+        // U+00E9 (é) is outside the 0x20..0x7E printable ASCII subset.
+        await Assert.That(() => new WorkflowIdentity("workflow-é")).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Control characters are rejected so transports never see un-escapable header bytes.
+    /// </summary>
+    [Test]
+    public async Task WorkflowIdentity_ControlCharacterValue_ThrowsArgumentException()
+    {
+        await Assert.That(() => new WorkflowIdentity("workflow\t1")).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// INV-6: sealed-by-default invariant must hold via reflection.
+    /// </summary>
+    [Test]
+    public async Task WorkflowIdentity_IsSealedRecord_ViaReflection()
+    {
+        var t = typeof(WorkflowIdentity);
+
+        await Assert.That(t.IsSealed).IsTrue();
+    }
+}

--- a/src/Strategos.Identity.Abstractions.Tests/WorkflowIdentityTests.cs
+++ b/src/Strategos.Identity.Abstractions.Tests/WorkflowIdentityTests.cs
@@ -83,4 +83,40 @@ public class WorkflowIdentityTests
 
         await Assert.That(t.IsSealed).IsTrue();
     }
+
+    /// <summary>
+    /// DR-2 must hold under <c>with</c>-clone too. Body-syntax records expose an
+    /// <c>init</c> setter that bypasses the constructor, so a clone with a bad
+    /// value would silently succeed. Positional-record primary-constructor
+    /// validation runs on every clone via the synthetic copy constructor.
+    /// </summary>
+    [Test]
+    public async Task WorkflowIdentity_WithClone_NonAsciiValue_ThrowsArgumentException()
+    {
+        var original = new WorkflowIdentity("valid-value");
+
+        await Assert.That(() => original with { Value = "workflow-é" }).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// DR-2 must hold under <c>with</c>-clone for empty values too.
+    /// </summary>
+    [Test]
+    public async Task WorkflowIdentity_WithClone_EmptyValue_ThrowsArgumentException()
+    {
+        var original = new WorkflowIdentity("valid-value");
+
+        await Assert.That(() => original with { Value = string.Empty }).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// DR-2 must hold under <c>with</c>-clone for null values too.
+    /// </summary>
+    [Test]
+    public async Task WorkflowIdentity_WithClone_NullValue_ThrowsArgumentNullException()
+    {
+        var original = new WorkflowIdentity("valid-value");
+
+        await Assert.That(() => original with { Value = null! }).Throws<ArgumentNullException>();
+    }
 }

--- a/src/Strategos.Identity.Abstractions/AgentIdentity.cs
+++ b/src/Strategos.Identity.Abstractions/AgentIdentity.cs
@@ -23,29 +23,36 @@ namespace Strategos.Identity.Abstractions;
 /// identity is per-message-derived; each handler stamps its own and the
 /// header is NOT propagated to outgoing messages.
 /// </para>
+/// <para>
+/// Declared as a positional record with a custom <c>init</c>-setter that
+/// re-runs the DR-2 validator on every assignment. This closes the
+/// <c>with</c>-clone bypass that a body-syntax record exposes: the synthetic
+/// copy constructor used by <c>with</c> invokes the property's <c>init</c>
+/// setter, so the validator runs there too. Without the custom <c>init</c>
+/// setter, <c>existing with { Value = "bad-é-value" }</c> would silently
+/// produce an invalid record.
+/// </para>
 /// </remarks>
-public sealed record AgentIdentity
+/// <param name="Value">
+/// The header-safe identifier value. Must be non-null, non-empty, and contain
+/// only printable ASCII (0x20..0x7E).
+/// </param>
+public sealed record AgentIdentity(string Value)
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="AgentIdentity"/> class.
-    /// </summary>
-    /// <param name="value">
-    /// The header-safe identifier value. Must be non-null, non-empty, and contain
-    /// only printable ASCII (0x20..0x7E).
-    /// </param>
-    /// <exception cref="ArgumentNullException">When <paramref name="value"/> is null.</exception>
-    /// <exception cref="ArgumentException">
-    /// When <paramref name="value"/> is empty, whitespace-only, or contains
-    /// non-printable-ASCII characters.
-    /// </exception>
-    public AgentIdentity(string value)
-    {
-        IdentityValueValidator.Validate(value, nameof(value));
-        this.Value = value;
-    }
+    private readonly string value = ValidateAndReturn(Value);
 
     /// <summary>
     /// Gets the header-safe identifier value.
     /// </summary>
-    public string Value { get; init; }
+    public string Value
+    {
+        get => this.value;
+        init => this.value = ValidateAndReturn(value);
+    }
+
+    private static string ValidateAndReturn(string value)
+    {
+        IdentityValueValidator.Validate(value, nameof(Value));
+        return value;
+    }
 }

--- a/src/Strategos.Identity.Abstractions/AgentIdentity.cs
+++ b/src/Strategos.Identity.Abstractions/AgentIdentity.cs
@@ -1,0 +1,51 @@
+// -----------------------------------------------------------------------
+// <copyright file="AgentIdentity.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Strategos.Identity.Abstractions;
+
+/// <summary>
+/// An opaque, header-safe identifier for the agent attributed to a single
+/// saga step execution.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Stored as a string so it can ride on a Wolverine envelope header
+/// (<c>x-strategos-agent-identity</c>) across the outbox and every supported
+/// transport without additional encoding. Strategos does not inspect the value;
+/// the basileus SPIFFE adapter shapes it as
+/// <c>spiffe://td/workflow/&lt;id&gt;/step/&lt;phase&gt;</c>.
+/// </para>
+/// <para>
+/// Sealed per INV-6. Immutable per INV-7. Unlike workflow identity, agent
+/// identity is per-message-derived; each handler stamps its own and the
+/// header is NOT propagated to outgoing messages.
+/// </para>
+/// </remarks>
+public sealed record AgentIdentity
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AgentIdentity"/> class.
+    /// </summary>
+    /// <param name="value">
+    /// The header-safe identifier value. Must be non-null, non-empty, and contain
+    /// only printable ASCII (0x20..0x7E).
+    /// </param>
+    /// <exception cref="ArgumentNullException">When <paramref name="value"/> is null.</exception>
+    /// <exception cref="ArgumentException">
+    /// When <paramref name="value"/> is empty, whitespace-only, or contains
+    /// non-printable-ASCII characters.
+    /// </exception>
+    public AgentIdentity(string value)
+    {
+        IdentityValueValidator.Validate(value, nameof(value));
+        this.Value = value;
+    }
+
+    /// <summary>
+    /// Gets the header-safe identifier value.
+    /// </summary>
+    public string Value { get; init; }
+}

--- a/src/Strategos.Identity.Abstractions/IAgentIdentityAccessor.cs
+++ b/src/Strategos.Identity.Abstractions/IAgentIdentityAccessor.cs
@@ -1,0 +1,39 @@
+// -----------------------------------------------------------------------
+// <copyright file="IAgentIdentityAccessor.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Strategos.Identity.Abstractions;
+
+/// <summary>
+/// Read-only port that exposes the current workflow and agent identity
+/// to in-handler code (sagas, application services, telemetry enrichers).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations read from the active Wolverine
+/// <c>IMessageContext.Envelope.Headers</c>. The contract mirrors
+/// <c>IHttpContextAccessor</c>: both properties return <c>null</c> when no
+/// envelope is active (saga inspected via a Marten projection, a debugger
+/// session, a background worker that isn't in a handler, etc.).
+/// </para>
+/// <para>
+/// Implementations are NOT required to cache — the envelope's lifetime IS
+/// the cache.
+/// </para>
+/// </remarks>
+public interface IAgentIdentityAccessor
+{
+    /// <summary>
+    /// Gets the workflow identity carried on the active envelope, or <c>null</c>
+    /// when there is no active envelope or the header is missing or invalid.
+    /// </summary>
+    WorkflowIdentity? CurrentWorkflow { get; }
+
+    /// <summary>
+    /// Gets the agent identity carried on the active envelope, or <c>null</c>
+    /// when there is no active envelope or the header is missing or invalid.
+    /// </summary>
+    AgentIdentity? CurrentAgent { get; }
+}

--- a/src/Strategos.Identity.Abstractions/IAgentIdentityProvider.cs
+++ b/src/Strategos.Identity.Abstractions/IAgentIdentityProvider.cs
@@ -1,0 +1,48 @@
+// -----------------------------------------------------------------------
+// <copyright file="IAgentIdentityProvider.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Strategos.Identity.Abstractions;
+
+/// <summary>
+/// Port that derives a per-step <see cref="AgentIdentity"/> from a
+/// <see cref="WorkflowIdentity"/> and the saga's current phase name.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Strategos owns this port; basileus is the SPIFFE-shaped adapter. The
+/// derivation is keyed on <c>phaseName</c> (not numeric step ordinal) because
+/// the Strategos saga's authoritative step identifier is <c>Phase.ToString()</c>
+/// — workflows with forks, branches, and failure handlers do not have stable
+/// numeric ordinals.
+/// </para>
+/// <para>
+/// Implementations must be pure and deterministic given equal inputs. All
+/// methods reject null or empty input per DR-3 / DR-8 row 4.
+/// </para>
+/// </remarks>
+public interface IAgentIdentityProvider
+{
+    /// <summary>
+    /// Derives the agent identity for the supplied workflow and phase.
+    /// </summary>
+    /// <param name="workflow">The workflow identity. Must not be null.</param>
+    /// <param name="phaseName">The saga's current phase name. Must be non-null, non-empty.</param>
+    /// <returns>The derived <see cref="AgentIdentity"/>.</returns>
+    /// <exception cref="ArgumentNullException">When <paramref name="workflow"/> or <paramref name="phaseName"/> is null.</exception>
+    /// <exception cref="ArgumentException">When <paramref name="phaseName"/> is empty or whitespace.</exception>
+    AgentIdentity DeriveStepIdentity(WorkflowIdentity workflow, string phaseName);
+
+    /// <summary>
+    /// Parses the inbound workflow-identity header value into a <see cref="WorkflowIdentity"/>.
+    /// </summary>
+    /// <param name="headerValue">The header value as it appears on the envelope. Must not be null.</param>
+    /// <returns>The parsed <see cref="WorkflowIdentity"/>.</returns>
+    /// <exception cref="ArgumentNullException">When <paramref name="headerValue"/> is null.</exception>
+    /// <exception cref="ArgumentException">
+    /// When <paramref name="headerValue"/> violates the validation contract of <see cref="WorkflowIdentity"/>.
+    /// </exception>
+    WorkflowIdentity ParseWorkflowHeader(string headerValue);
+}

--- a/src/Strategos.Identity.Abstractions/IPhaseAwareSaga.cs
+++ b/src/Strategos.Identity.Abstractions/IPhaseAwareSaga.cs
@@ -1,0 +1,34 @@
+// -----------------------------------------------------------------------
+// <copyright file="IPhaseAwareSaga.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Strategos.Identity.Abstractions;
+
+/// <summary>
+/// Marker interface emitted on every generated Strategos saga so middleware
+/// can read its current phase as a stable string identifier without binding
+/// to the generated enum type.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The basileus <c>StrategosHeaderMiddleware</c> consumes this interface to
+/// derive per-step agent identities: it calls
+/// <c>provider.DeriveStepIdentity(workflowId, saga.CurrentPhaseName)</c>
+/// before stamping the agent-identity header on outgoing messages.
+/// </para>
+/// <para>
+/// The generator emits <c>CurrentPhaseName =&gt; Phase.ToString()</c>; phase
+/// strings are stable across builds because they derive from the workflow's
+/// declared phase enum.
+/// </para>
+/// </remarks>
+public interface IPhaseAwareSaga
+{
+    /// <summary>
+    /// Gets the current saga phase as a stable string identifier
+    /// (the generator emits <c>Phase.ToString()</c>).
+    /// </summary>
+    string CurrentPhaseName { get; }
+}

--- a/src/Strategos.Identity.Abstractions/IdentityValueValidator.cs
+++ b/src/Strategos.Identity.Abstractions/IdentityValueValidator.cs
@@ -1,0 +1,54 @@
+// -----------------------------------------------------------------------
+// <copyright file="IdentityValueValidator.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+
+namespace Strategos.Identity.Abstractions;
+
+/// <summary>
+/// Shared validation for identity record values.
+/// </summary>
+/// <remarks>
+/// Anchors DR-8 rows 3 and 6: identity record values must be non-null, non-empty
+/// (after trim), and confined to printable ASCII (0x20..0x7E) so they can ride on
+/// Wolverine envelope headers without transport-level escaping.
+/// </remarks>
+internal static class IdentityValueValidator
+{
+    /// <summary>
+    /// Validates an identity value, throwing if it violates the contract.
+    /// </summary>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="paramName">The parameter name used in the thrown exception.</param>
+    /// <exception cref="ArgumentNullException">When <paramref name="value"/> is null.</exception>
+    /// <exception cref="ArgumentException">
+    /// When <paramref name="value"/> is empty, whitespace-only, or contains characters
+    /// outside the printable ASCII subset.
+    /// </exception>
+    public static void Validate(string value, string paramName)
+    {
+        if (value is null)
+        {
+            throw new ArgumentNullException(paramName);
+        }
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("Identity value must be non-empty.", paramName);
+        }
+
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            if (c < 0x20 || c > 0x7E)
+            {
+                throw new ArgumentException(
+                    "Identity value must contain only printable ASCII characters (0x20..0x7E).",
+                    paramName);
+            }
+        }
+    }
+}

--- a/src/Strategos.Identity.Abstractions/Polyfills/IsExternalInit.cs
+++ b/src/Strategos.Identity.Abstractions/Polyfills/IsExternalInit.cs
@@ -1,0 +1,15 @@
+// -----------------------------------------------------------------------
+// <copyright file="IsExternalInit.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// Polyfill for the init-only-setter marker. Required for C# records on netstandard2.0.
+/// </summary>
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+internal static class IsExternalInit
+{
+}

--- a/src/Strategos.Identity.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Strategos.Identity.Abstractions/PublicAPI.Unshipped.txt
@@ -1,3 +1,7 @@
+Strategos.Identity.Abstractions.AgentIdentity
+Strategos.Identity.Abstractions.AgentIdentity.AgentIdentity(string value) -> void
+Strategos.Identity.Abstractions.AgentIdentity.Value.get -> string
+Strategos.Identity.Abstractions.AgentIdentity.Value.init -> void
 Strategos.Identity.Abstractions.WorkflowIdentity
 Strategos.Identity.Abstractions.WorkflowIdentity.WorkflowIdentity(string value) -> void
 Strategos.Identity.Abstractions.WorkflowIdentity.Value.get -> string

--- a/src/Strategos.Identity.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Strategos.Identity.Abstractions/PublicAPI.Unshipped.txt
@@ -1,8 +1,9 @@
 const Strategos.Identity.Abstractions.StrategosHeaders.AgentIdentity = "x-strategos-agent-identity" -> string!
 const Strategos.Identity.Abstractions.StrategosHeaders.WorkflowIdentity = "x-strategos-workflow-identity" -> string!
 Strategos.Identity.Abstractions.AgentIdentity
-Strategos.Identity.Abstractions.AgentIdentity.AgentIdentity(string value) -> void
-Strategos.Identity.Abstractions.AgentIdentity.Value.get -> string
+Strategos.Identity.Abstractions.AgentIdentity.AgentIdentity(string! Value) -> void
+Strategos.Identity.Abstractions.AgentIdentity.Deconstruct(out string! Value) -> void
+Strategos.Identity.Abstractions.AgentIdentity.Value.get -> string!
 Strategos.Identity.Abstractions.AgentIdentity.Value.init -> void
 Strategos.Identity.Abstractions.IAgentIdentityAccessor
 Strategos.Identity.Abstractions.IAgentIdentityAccessor.CurrentAgent.get -> Strategos.Identity.Abstractions.AgentIdentity?
@@ -14,6 +15,7 @@ Strategos.Identity.Abstractions.IPhaseAwareSaga
 Strategos.Identity.Abstractions.IPhaseAwareSaga.CurrentPhaseName.get -> string!
 Strategos.Identity.Abstractions.StrategosHeaders
 Strategos.Identity.Abstractions.WorkflowIdentity
-Strategos.Identity.Abstractions.WorkflowIdentity.WorkflowIdentity(string value) -> void
-Strategos.Identity.Abstractions.WorkflowIdentity.Value.get -> string
+Strategos.Identity.Abstractions.WorkflowIdentity.Deconstruct(out string! Value) -> void
+Strategos.Identity.Abstractions.WorkflowIdentity.WorkflowIdentity(string! Value) -> void
+Strategos.Identity.Abstractions.WorkflowIdentity.Value.get -> string!
 Strategos.Identity.Abstractions.WorkflowIdentity.Value.init -> void

--- a/src/Strategos.Identity.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Strategos.Identity.Abstractions/PublicAPI.Unshipped.txt
@@ -4,6 +4,9 @@ Strategos.Identity.Abstractions.AgentIdentity
 Strategos.Identity.Abstractions.AgentIdentity.AgentIdentity(string value) -> void
 Strategos.Identity.Abstractions.AgentIdentity.Value.get -> string
 Strategos.Identity.Abstractions.AgentIdentity.Value.init -> void
+Strategos.Identity.Abstractions.IAgentIdentityAccessor
+Strategos.Identity.Abstractions.IAgentIdentityAccessor.CurrentAgent.get -> Strategos.Identity.Abstractions.AgentIdentity?
+Strategos.Identity.Abstractions.IAgentIdentityAccessor.CurrentWorkflow.get -> Strategos.Identity.Abstractions.WorkflowIdentity?
 Strategos.Identity.Abstractions.IAgentIdentityProvider
 Strategos.Identity.Abstractions.IAgentIdentityProvider.DeriveStepIdentity(Strategos.Identity.Abstractions.WorkflowIdentity! workflow, string! phaseName) -> Strategos.Identity.Abstractions.AgentIdentity!
 Strategos.Identity.Abstractions.IAgentIdentityProvider.ParseWorkflowHeader(string! headerValue) -> Strategos.Identity.Abstractions.WorkflowIdentity!

--- a/src/Strategos.Identity.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Strategos.Identity.Abstractions/PublicAPI.Unshipped.txt
@@ -4,6 +4,8 @@ Strategos.Identity.Abstractions.AgentIdentity
 Strategos.Identity.Abstractions.AgentIdentity.AgentIdentity(string value) -> void
 Strategos.Identity.Abstractions.AgentIdentity.Value.get -> string
 Strategos.Identity.Abstractions.AgentIdentity.Value.init -> void
+Strategos.Identity.Abstractions.IPhaseAwareSaga
+Strategos.Identity.Abstractions.IPhaseAwareSaga.CurrentPhaseName.get -> string!
 Strategos.Identity.Abstractions.StrategosHeaders
 Strategos.Identity.Abstractions.WorkflowIdentity
 Strategos.Identity.Abstractions.WorkflowIdentity.WorkflowIdentity(string value) -> void

--- a/src/Strategos.Identity.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Strategos.Identity.Abstractions/PublicAPI.Unshipped.txt
@@ -4,6 +4,9 @@ Strategos.Identity.Abstractions.AgentIdentity
 Strategos.Identity.Abstractions.AgentIdentity.AgentIdentity(string value) -> void
 Strategos.Identity.Abstractions.AgentIdentity.Value.get -> string
 Strategos.Identity.Abstractions.AgentIdentity.Value.init -> void
+Strategos.Identity.Abstractions.IAgentIdentityProvider
+Strategos.Identity.Abstractions.IAgentIdentityProvider.DeriveStepIdentity(Strategos.Identity.Abstractions.WorkflowIdentity! workflow, string! phaseName) -> Strategos.Identity.Abstractions.AgentIdentity!
+Strategos.Identity.Abstractions.IAgentIdentityProvider.ParseWorkflowHeader(string! headerValue) -> Strategos.Identity.Abstractions.WorkflowIdentity!
 Strategos.Identity.Abstractions.IPhaseAwareSaga
 Strategos.Identity.Abstractions.IPhaseAwareSaga.CurrentPhaseName.get -> string!
 Strategos.Identity.Abstractions.StrategosHeaders

--- a/src/Strategos.Identity.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Strategos.Identity.Abstractions/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+Strategos.Identity.Abstractions.WorkflowIdentity
+Strategos.Identity.Abstractions.WorkflowIdentity.WorkflowIdentity(string value) -> void
+Strategos.Identity.Abstractions.WorkflowIdentity.Value.get -> string
+Strategos.Identity.Abstractions.WorkflowIdentity.Value.init -> void

--- a/src/Strategos.Identity.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Strategos.Identity.Abstractions/PublicAPI.Unshipped.txt
@@ -1,7 +1,10 @@
+const Strategos.Identity.Abstractions.StrategosHeaders.AgentIdentity = "x-strategos-agent-identity" -> string!
+const Strategos.Identity.Abstractions.StrategosHeaders.WorkflowIdentity = "x-strategos-workflow-identity" -> string!
 Strategos.Identity.Abstractions.AgentIdentity
 Strategos.Identity.Abstractions.AgentIdentity.AgentIdentity(string value) -> void
 Strategos.Identity.Abstractions.AgentIdentity.Value.get -> string
 Strategos.Identity.Abstractions.AgentIdentity.Value.init -> void
+Strategos.Identity.Abstractions.StrategosHeaders
 Strategos.Identity.Abstractions.WorkflowIdentity
 Strategos.Identity.Abstractions.WorkflowIdentity.WorkflowIdentity(string value) -> void
 Strategos.Identity.Abstractions.WorkflowIdentity.Value.get -> string

--- a/src/Strategos.Identity.Abstractions/Strategos.Identity.Abstractions.csproj
+++ b/src/Strategos.Identity.Abstractions/Strategos.Identity.Abstractions.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!--
+      netstandard2.0 mirrors Strategos.Generators so the abstractions package can be referenced
+      from the Roslyn analyzer assembly (per the SG cookbook: a generator may take a public
+      dependency on a contract package).
+    -->
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <!-- NuGet package configuration -->
+    <PackageId>LevelUp.Strategos.Identity.Abstractions</PackageId>
+    <Description>Identity seam abstractions for Strategos: workflow and agent identity value records, header constants, and ports (IAgentIdentityProvider, IAgentIdentityAccessor, IPhaseAwareSaga) consumed by Wolverine envelope-header propagation.</Description>
+    <PackageTags>workflow;agent;identity;wolverine;saga;ports;hexagonal;strategos</PackageTags>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+</Project>

--- a/src/Strategos.Identity.Abstractions/StrategosHeaders.cs
+++ b/src/Strategos.Identity.Abstractions/StrategosHeaders.cs
@@ -1,0 +1,42 @@
+// -----------------------------------------------------------------------
+// <copyright file="StrategosHeaders.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Strategos.Identity.Abstractions;
+
+/// <summary>
+/// Wire-protocol header keys for Strategos identity propagation across the
+/// Wolverine outbox and supported transports.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Consumers MUST register
+/// <c>opts.Policies.PropagateIncomingHeaderToOutgoing(StrategosHeaders.WorkflowIdentity)</c>
+/// in their <c>UseWolverine</c> block so workflow identity survives the
+/// outbox + transport hop between handlers. The agent identity header is
+/// per-message-derived and is NOT propagated to outgoing messages — each
+/// handler stamps its own.
+/// </para>
+/// <para>
+/// Header keys are versioned by this package. Renaming a constant value is a
+/// breaking wire-protocol change.
+/// </para>
+/// </remarks>
+public static class StrategosHeaders
+{
+    /// <summary>
+    /// Header key for the workflow identity. Stamped on every outgoing message
+    /// emitted from inside a Strategos saga handler; propagated across handler
+    /// hops via Wolverine's <c>PropagateIncomingHeaderToOutgoing</c> policy.
+    /// </summary>
+    public const string WorkflowIdentity = "x-strategos-workflow-identity";
+
+    /// <summary>
+    /// Header key for the per-step agent identity. Stamped by the middleware
+    /// after deriving from <c>(WorkflowIdentity, saga.CurrentPhaseName)</c>.
+    /// Not propagated — each handler emits its own.
+    /// </summary>
+    public const string AgentIdentity = "x-strategos-agent-identity";
+}

--- a/src/Strategos.Identity.Abstractions/WorkflowIdentity.cs
+++ b/src/Strategos.Identity.Abstractions/WorkflowIdentity.cs
@@ -20,29 +20,36 @@ namespace Strategos.Identity.Abstractions;
 /// <para>
 /// Sealed per INV-6. Immutable per INV-7.
 /// </para>
+/// <para>
+/// Declared as a positional record with a custom <c>init</c>-setter that
+/// re-runs the DR-2 validator on every assignment. This closes the
+/// <c>with</c>-clone bypass that a body-syntax record exposes: the synthetic
+/// copy constructor used by <c>with</c> invokes the property's <c>init</c>
+/// setter, so the validator runs there too. Without the custom <c>init</c>
+/// setter, <c>existing with { Value = "bad-é-value" }</c> would silently
+/// produce an invalid record.
+/// </para>
 /// </remarks>
-public sealed record WorkflowIdentity
+/// <param name="Value">
+/// The header-safe identifier value. Must be non-null, non-empty, and contain
+/// only printable ASCII (0x20..0x7E).
+/// </param>
+public sealed record WorkflowIdentity(string Value)
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="WorkflowIdentity"/> class.
-    /// </summary>
-    /// <param name="value">
-    /// The header-safe identifier value. Must be non-null, non-empty, and contain
-    /// only printable ASCII (0x20..0x7E).
-    /// </param>
-    /// <exception cref="ArgumentNullException">When <paramref name="value"/> is null.</exception>
-    /// <exception cref="ArgumentException">
-    /// When <paramref name="value"/> is empty, whitespace-only, or contains
-    /// non-printable-ASCII characters.
-    /// </exception>
-    public WorkflowIdentity(string value)
-    {
-        IdentityValueValidator.Validate(value, nameof(value));
-        this.Value = value;
-    }
+    private readonly string value = ValidateAndReturn(Value);
 
     /// <summary>
     /// Gets the header-safe identifier value.
     /// </summary>
-    public string Value { get; init; }
+    public string Value
+    {
+        get => this.value;
+        init => this.value = ValidateAndReturn(value);
+    }
+
+    private static string ValidateAndReturn(string value)
+    {
+        IdentityValueValidator.Validate(value, nameof(Value));
+        return value;
+    }
 }

--- a/src/Strategos.Identity.Abstractions/WorkflowIdentity.cs
+++ b/src/Strategos.Identity.Abstractions/WorkflowIdentity.cs
@@ -1,0 +1,48 @@
+// -----------------------------------------------------------------------
+// <copyright file="WorkflowIdentity.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Strategos.Identity.Abstractions;
+
+/// <summary>
+/// An opaque, header-safe identifier for a Strategos workflow instance.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Stored as a string so it can ride on a Wolverine envelope header
+/// (<c>x-strategos-workflow-identity</c>) across the outbox and every
+/// supported transport without additional encoding. Strategos does not inspect
+/// the value; the basileus SPIFFE adapter shapes it as
+/// <c>spiffe://td/workflow/&lt;id&gt;</c>.
+/// </para>
+/// <para>
+/// Sealed per INV-6. Immutable per INV-7.
+/// </para>
+/// </remarks>
+public sealed record WorkflowIdentity
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WorkflowIdentity"/> class.
+    /// </summary>
+    /// <param name="value">
+    /// The header-safe identifier value. Must be non-null, non-empty, and contain
+    /// only printable ASCII (0x20..0x7E).
+    /// </param>
+    /// <exception cref="ArgumentNullException">When <paramref name="value"/> is null.</exception>
+    /// <exception cref="ArgumentException">
+    /// When <paramref name="value"/> is empty, whitespace-only, or contains
+    /// non-printable-ASCII characters.
+    /// </exception>
+    public WorkflowIdentity(string value)
+    {
+        IdentityValueValidator.Validate(value, nameof(value));
+        this.Value = value;
+    }
+
+    /// <summary>
+    /// Gets the header-safe identifier value.
+    /// </summary>
+    public string Value { get; init; }
+}

--- a/src/Strategos/Strategos.csproj
+++ b/src/Strategos/Strategos.csproj
@@ -19,6 +19,18 @@
 
   <ItemGroup>
     <PackageReference Include="MemoryPack" />
+    <!--
+      LevelUp.Strategos.Identity.Abstractions ships the IPhaseAwareSaga contract
+      that the Strategos.Generators source generator emits a base-list entry
+      against. We route the runtime/compile dependency through THIS metapackage
+      (not the generator package) because LevelUp.Strategos.Generators is marked
+      <DevelopmentDependency>true</DevelopmentDependency>, which causes NuGet to
+      suppress transitive flow from that package. Every consumer of the Strategos
+      generator is expected to also reference this core metapackage, so the
+      abstractions assembly lands on the consumer's compile + runtime classpath
+      via this single explicit edge. (G1 v2.7.0-preview.1)
+    -->
+    <ProjectReference Include="..\Strategos.Identity.Abstractions\Strategos.Identity.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/strategos.sln
+++ b/src/strategos.sln
@@ -47,6 +47,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Strategos.Ontology.Npgsql",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Strategos.Ontology.Npgsql.Tests", "Strategos.Ontology.Npgsql.Tests\Strategos.Ontology.Npgsql.Tests.csproj", "{D477B04A-B149-4D41-B961-BF6A97AF2037}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Strategos.Identity.Abstractions.Tests", "Strategos.Identity.Abstractions.Tests\Strategos.Identity.Abstractions.Tests.csproj", "{D97A25DE-9921-400F-A69D-3C15A3952C69}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Strategos.Identity.Abstractions", "Strategos.Identity.Abstractions\Strategos.Identity.Abstractions.csproj", "{0A77C1D2-8F4A-4264-AD8A-064034F9724D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -321,6 +325,30 @@ Global
 		{D477B04A-B149-4D41-B961-BF6A97AF2037}.Release|x64.Build.0 = Release|Any CPU
 		{D477B04A-B149-4D41-B961-BF6A97AF2037}.Release|x86.ActiveCfg = Release|Any CPU
 		{D477B04A-B149-4D41-B961-BF6A97AF2037}.Release|x86.Build.0 = Release|Any CPU
+		{D97A25DE-9921-400F-A69D-3C15A3952C69}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D97A25DE-9921-400F-A69D-3C15A3952C69}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D97A25DE-9921-400F-A69D-3C15A3952C69}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D97A25DE-9921-400F-A69D-3C15A3952C69}.Debug|x64.Build.0 = Debug|Any CPU
+		{D97A25DE-9921-400F-A69D-3C15A3952C69}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D97A25DE-9921-400F-A69D-3C15A3952C69}.Debug|x86.Build.0 = Debug|Any CPU
+		{D97A25DE-9921-400F-A69D-3C15A3952C69}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D97A25DE-9921-400F-A69D-3C15A3952C69}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D97A25DE-9921-400F-A69D-3C15A3952C69}.Release|x64.ActiveCfg = Release|Any CPU
+		{D97A25DE-9921-400F-A69D-3C15A3952C69}.Release|x64.Build.0 = Release|Any CPU
+		{D97A25DE-9921-400F-A69D-3C15A3952C69}.Release|x86.ActiveCfg = Release|Any CPU
+		{D97A25DE-9921-400F-A69D-3C15A3952C69}.Release|x86.Build.0 = Release|Any CPU
+		{0A77C1D2-8F4A-4264-AD8A-064034F9724D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0A77C1D2-8F4A-4264-AD8A-064034F9724D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0A77C1D2-8F4A-4264-AD8A-064034F9724D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0A77C1D2-8F4A-4264-AD8A-064034F9724D}.Debug|x64.Build.0 = Debug|Any CPU
+		{0A77C1D2-8F4A-4264-AD8A-064034F9724D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0A77C1D2-8F4A-4264-AD8A-064034F9724D}.Debug|x86.Build.0 = Debug|Any CPU
+		{0A77C1D2-8F4A-4264-AD8A-064034F9724D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0A77C1D2-8F4A-4264-AD8A-064034F9724D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0A77C1D2-8F4A-4264-AD8A-064034F9724D}.Release|x64.ActiveCfg = Release|Any CPU
+		{0A77C1D2-8F4A-4264-AD8A-064034F9724D}.Release|x64.Build.0 = Release|Any CPU
+		{0A77C1D2-8F4A-4264-AD8A-064034F9724D}.Release|x86.ActiveCfg = Release|Any CPU
+		{0A77C1D2-8F4A-4264-AD8A-064034F9724D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary

- Debuts **`LevelUp.Strategos.Identity.Abstractions`** at 2.7.0-preview.1 — port abstractions for agent identity (closes Slice (D) of milestone #3)
- Adopts Wolverine envelope-header storage for transit-scoped agent identity (refines & supersedes basileus G1 Phase 0 §4 — design rationale grounded in Wolverine [`header-propagation.md`](https://github.com/jasperfx/wolverine/blob/main/docs/guide/messaging/header-propagation.md), where `x-on-behalf-of` is the published example for this exact pattern)
- Generator emits one new computed property (`CurrentPhaseName`) and one base-list addition (`IPhaseAwareSaga`) on every saga — additive only, no breaking changes
- Descopes the saga-field-emit approach from issues #67/#68/#69 in favor of envelope-header storage (rationale in `docs/designs/2026-05-16-g1-agent-identity-seam.md` §8 Alternatives Considered)
- Bumps `LevelUp.Strategos` + `LevelUp.Strategos.Generators` to 2.7.0-preview.1 alongside the new abstractions package

Resolves #71 (Epic G1-strategos). Supersedes #67, #68, #69 (see closeout text in `docs/coordination/2026-05-16-basileus-handoff.md`).

## Architecture (port / adapter)

| Layer | Role | Owned by |
|---|---|---|
| `Strategos.Identity.Abstractions` | Ports: `WorkflowIdentity`, `AgentIdentity`, `IAgentIdentityProvider`, `IAgentIdentityAccessor`, `IPhaseAwareSaga`, `StrategosHeaders` | Strategos (this PR) |
| `Strategos.Generators` | Emits `: Saga, IPhaseAwareSaga` + `public string CurrentPhaseName => Phase.ToString();` | Strategos (this PR) |
| `Basileus.Identity.Spiffe` | Adapters: `SpiffeAgentIdentityProvider`, Wolverine `StrategosHeaderMiddleware` | basileus (PR #184 — to be re-cut; coordination text staged) |

Hexagonal: the domain (Strategos) owns the ports; the adapter (Basileus) provides SPIFFE-shaped implementations. Phase 0 (HMAC) → Phase 1 (SPIRE-issued X.509 SVIDs) is purely an adapter swap with zero Strategos change.

## Design ↔ Implementation coverage

| DR | Status | Commit |
|---|---|---|
| DR-1 Abstractions package | ✓ | `1deff3e`, `5c3fbd4` |
| DR-2 Sealed identity records (with `with`-clone validation) | ✓ | `4a9cb02`, `2ba11d7`, `c26014e` (positional records w/ re-validating init) |
| DR-3 IAgentIdentityProvider port | ✓ | `c56d46e` |
| DR-4 StrategosHeaders constants | ✓ | `c7747b1` |
| DR-5 IAgentIdentityAccessor port | ✓ | `20069d7` |
| DR-6 Generator emit (CurrentPhaseName + IPhaseAwareSaga) | ✓ | `c4ab0b3`, `6f78f4c`, `e6130405`, `ab9f037` |
| DR-7 Negation regression net | ✓ | `df0b958` |
| DR-8 Error handling sweep | ✓ | `0f05da4`, `d13b5f3` |
| DR-9 Basileus coordination handoff | ✓ | `92c561c` |
| DR-10 v2.7.0-preview.1 release | ✓ | `5c3fbd4`, `724ac2a` (corrected pkg-dep flow) |

## Strategos invariant audit

| INV | Severity | Verdict | Evidence |
|---|---|---|---|
| INV-1 (Wolverine + Marten lowering) | HIGH | ✓ | Uses Wolverine's native envelope-header primitive; saga lowering is strictly additive (1 using, 1 base-list entry, 1 computed property) |
| INV-4 (concrete DSL nomenclature) | MEDIUM | ✓ | Domain words throughout: `WorkflowIdentity`, `AgentIdentity`, `IPhaseAwareSaga`, `StrategosHeaders` |
| INV-6 (sealed-by-default) | HIGH | ✓ | All new records explicitly `sealed`; reflection-asserted in tests |
| INV-7 (immutable record state) | HIGH | ✓ | Zero new mutable saga fields; new property is read-only computed; records use positional syntax with re-validating init |

## Review history

1. **Initial two-stage review** — Spec compliance: **PASS** (all 10 DRs covered). Quality: **NEEDS_FIXES** with 2 HIGH + 4 MEDIUM findings.
2. **Fixer pass** with adversarial verification:
   - **F1 (HIGH)**: `PrivateAssets="all"` blocked abstractions DLL from flowing to consumers — verified by packing Generators nupkg and observing missing `<dependency>` entry, then reproducing `CS0246: 'IPhaseAwareSaga' not found` in a fresh consumer project. Fixed by routing the abstractions package through `LevelUp.Strategos` core (`<DevelopmentDependency>true</DevelopmentDependency>` on the Generators package suppresses `PrivateAssets`-based transitive flow regardless of value). Adds `scripts/verify-generator-consumer-build.sh` + CI step as a permanent regression net.
   - **F2 (HIGH)**: `Value { get; init; }` let `with`-clones bypass `IdentityValueValidator` — verified by writing 6 failing `with`-clone tests against bad values, then converting both records to positional syntax with a custom re-validating init setter. All tests pass.
   - **F3–F10**: removed unused NSubstitute/Verify deps, deleted 3 no-op documentation tests, harmonized inline stub null-handling, added symmetric agent-header test, internal sealed fakes, OrdinalIgnoreCase Basileus check, CHANGELOG migration note.
3. **Post-fix verification (orchestrator)**: `dotnet build` clean (0 warnings, 0 errors); abstractions tests **45/45**; generators tests **1177/1177** (fixer); core Strategos.Tests **790/790** (fixer); pack verification gates pass.

## Test plan

- [x] `dotnet build src/strategos.sln` — 0 warnings, 0 errors
- [x] `dotnet test --project src/Strategos.Identity.Abstractions.Tests -- --treenode-filter "/**"` — 45/45
- [x] `dotnet test --project src/Strategos.Generators.Tests -- --treenode-filter "/**"` — 1177/1177
- [x] `dotnet test --project src/Strategos.Tests -- --treenode-filter "/**"` — 790/790 (no regressions in existing saga emit)
- [x] `dotnet pack` produces three packages at `2.7.0-preview.1` with correct `.nuspec` dep graph (Generators → Strategos → Strategos.Identity.Abstractions)
- [x] `scripts/verify-generator-consumer-build.sh` — clean consumer compiles against packed Generators nupkg

## Post-merge maintainer checklist

Coordination text is staged at `docs/coordination/2026-05-16-basileus-handoff.md` and must be actioned manually:

- [ ] Tag `v2.7.0-preview.1` on the merge commit
- [ ] Run `dotnet pack src/strategos.sln -c Release` (or let the publish workflow trigger from the tag) and push three `2.7.0-preview.1` nupkgs to nuget.org
- [ ] File the basileus tracking issue (text in handoff doc §a)
- [ ] Post the comment on lvlup-sw/basileus PR #184 (text in handoff doc §b)
- [ ] Close lvlup-sw/strategos #67, #68, #69 as superseded with the cross-link text (handoff doc §c)
- [ ] Re-evaluate #71 closure once basileus PR #184 is re-cut and merged against this preview

## Scope deferred (not in this PR)

- Phase 1 SPIRE/X.509-SVID swap (basileus-side adapter change; zero Strategos work)
- G3 ProvenanceEnvelope (#61) — builds on this seam via additional `x-strategos-provenance-*` headers
- G5 SubagentSpawn OBO (#62) — consumes agent identity for on-behalf-of token exchange
- G4 PartitionablePair (#60) — independent
- `Strategos.Identity` sibling package with default `IAgentIdentityAccessor` impl — deferred to 2.7.0 GA

🤖 Generated with [Claude Code](https://claude.com/claude-code)