### PR TITLE
feat(agents): 2.7.0 GA closeout — tool-source redaction boundary + debt (#85, #84, #92, #83, #86, #87)

### DIFF
--- a/docs/designs/2026-05-17-strategos-agents-meai-10-5.md
+++ b/docs/designs/2026-05-17-strategos-agents-meai-10-5.md
@@ -35,10 +35,10 @@ Alternatives A (keep abstract base, add generic) and B (parallel base classes) a
                     │   .WithUserPrompt(Func<TState, string>)              │
                     │   .WithApplyResult(Func<TState, TResult, CT, Task<StepResult<TState>>>)
                     │   .WithTool(AIFunction)                              │
-                    │   .WithMcpToolSource(IMcpToolSource)                 │
+                    │   .WithToolSource(IToolSource)                       │
                     │   .WithChatOptions(ChatOptions)                      │
                     │   .ConfigureChatClient(Action<ChatClientBuilder>)    │
-                    │   .Build() → IAgentStep<TState, TResult>             │
+                    │   .Build(IChatClient) → IAgentStep<TState, TResult>  │
                     └──────────────────────────────────────────────────────┘
                                             │
                                             ▼

--- a/docs/designs/2026-05-23-strategos-2-7-0-ga-closeout.md
+++ b/docs/designs/2026-05-23-strategos-2-7-0-ga-closeout.md
@@ -1,0 +1,105 @@
+# Strategos 2.7.0 — GA closeout
+
+**Date:** 2026-05-23 · **Milestone:** Strategos 2.7.0 — Agent Capabilities (GA) · **Tracks:** [#85](https://github.com/lvlup-sw/strategos/issues/85), [#92](https://github.com/lvlup-sw/strategos/issues/92), [#84](https://github.com/lvlup-sw/strategos/issues/84), [#83](https://github.com/lvlup-sw/strategos/issues/83), [#86](https://github.com/lvlup-sw/strategos/issues/86), [#87](https://github.com/lvlup-sw/strategos/issues/87), [#70](https://github.com/lvlup-sw/strategos/issues/70); closes-as-superseded [#67](https://github.com/lvlup-sw/strategos/issues/67), [#68](https://github.com/lvlup-sw/strategos/issues/68), [#69](https://github.com/lvlup-sw/strategos/issues/69)
+
+## Problem Statement
+
+The 2.7.0 "agent capabilities" build is complete on `main`: MEAI 10.5 adoption (PR #82, #45), streaming + in-process tool sources (PR #93, #89/#90/#91), and the agent-identity seam shipped at `2.7.0-preview.1` (PR #81). What remains in the open milestone is **closeout debt**, not feature work — and it must be discharged before cutting GA.
+
+Two of the open items carry real design content; the rest are mechanical. This document settles the two design forks and defines the closeout sequence.
+
+| Item | Nature | This doc |
+|---|---|---|
+| **#85** | `IToolSource` redaction port-contract | **Design** — §Fork 1 |
+| **#92** | `AgentToolLoopException` trace payload vs OTel | **Settle** — §Fork 2 |
+| #84 | Remove dead `AgentStepConfiguration.ChatClientConfigurator` field | Mechanical — §Closeout |
+| #83 / #86 / #87 | Design-diagram & docs reconciliation | Mechanical — §Closeout |
+| #67 / #68 / #69 | Close-as-superseded (PR #81 implemented A1–A3 differently) | Mechanical — §Closeout |
+| #70 | CHANGELOG + cut 2.7.0 GA | Release — §Sequence |
+
+## Fork 1 — #85: redaction at the tool-source boundary
+
+### The gap
+
+`StrategosFunctionsChatClient.ResolveToolsAsync` propagates each source's exception **unchanged** — a deliberate contract shipped in PR #93 ("the failing source's own exception propagates UNCHANGED … this middleware does not reclassify"). The two in-tree adapters self-redact:
+
+- `McpToolSource` (`Strategos.Agents.Mcp`) → `AgentMcpException` (AGAG004) with `RedactedEndpoint` stripped of user-info credentials (DR-10).
+- `AgentToolSource` (in-process) → `AgentToolSourceException` (AGAG007).
+
+A **third-party `IToolSource`** is under no type-level obligation to redact. It can throw a raw `HttpRequestException` whose message embeds `https://user:pass@host/…`; the middleware then propagates it verbatim into logs and traces. The issue as filed proposes a doc-only contract ("adapters MUST redact"). A documented-by-convention contract is not a mitigation — it is unenforceable against the exact actor (a foreign adapter author) it targets.
+
+### Chosen approach — redaction boundary (posture B)
+
+Make `ResolveToolsAsync` the single enforcement point. The boundary distinguishes **conforming** from **foreign** failures by type:
+
+- An exception that is already an `AgentException` subtype — the in-tree adapters — has self-redacted by contract. Propagate **unchanged**, preserving #93's behavior and keeping `McpToolSource` a full-fidelity peer per [[INV-3]].
+- Any other (foreign) exception is wrapped in `AgentToolSourceException` (AGAG007, no new diagnostic ID per [[INV-5]]) with a **redaction pass** applied to the surfaced message: URI-shaped substrings have their user-info component (`user:pass@`) stripped before the message is composed. The original foreign exception is retained as `InnerException` for diagnosis, but the *redacted* AGAG007 message is what tooling logs first.
+
+This narrows #93's "propagate unchanged" contract to **`AgentException`-subtypes-only** — a deliberate, documented tightening (CHANGELOG entry). Redaction becomes a property of the seam, not adapter goodwill.
+
+### Technical design
+
+```text
+ StrategosFunctionsChatClient.ResolveToolsAsync
+   foreach (source in _toolSources):
+     try:
+       resolved = await source.GetToolsAsync(ct)
+     catch (OperationCanceledException):  throw            // cancellation unwrapped (unchanged)
+     catch (AgentException):              throw            // conforming adapter self-redacted → unchanged
+     catch (Exception foreign):
+       throw new AgentToolSourceException(
+                 RedactUserInfo(foreign.Message),          // strip user:pass@ from any URI substring
+                 sourceType: source.GetType().FullName,
+                 innerException: foreign)                   // AGAG007; inner kept for diagnosis
+```
+
+`RedactUserInfo` is a small internal helper in `Strategos.Agents` (sibling to `McpToolSource.RedactEndpoint`'s intent, but operating on free-text messages, not a parsed `Uri`): it locates `scheme://…@` spans and elides the user-info segment. **Honest scope:** this redacts the URI user-info credential — the documented DR-10 threat — and does **not** claim to catch arbitrary secrets embedded in non-URI form. That boundary is stated in the XML doc so no false assurance is implied.
+
+The `IToolSource` XML doc gains a `### Failure contract` note: in-tree/conforming adapters should throw an `AgentException` subtype with redaction applied in-adapter (propagated unchanged); foreign adapters that throw anything else are wrapped-and-redacted at the boundary. This is documentation of an **enforced** behavior, not a substitute for it.
+
+### Design rationale — invariants & dimensions applied
+
+This design was audited against `/axiom:design` (DIM-1..8) and `/strategos-design-invariants` (INV-1..8) during ideation.
+
+| Decision | Governing invariant / dimension | Consequence |
+|---|---|---|
+| Foreign exceptions wrapped+redacted at the seam; `AgentException` subtypes propagate unchanged | DIM-2 (observability) · DIM-3 (contracts) | No raw foreign exception escapes the tool-source boundary; the contract is enforced, not asserted. Satisfies the no-handwavy-mitigations rule. |
+| MCP adapter keeps self-redaction + unchanged propagation | [[INV-3]] (MEDIUM) | MCP stays a full-fidelity peer adapter, not a downgraded special case. |
+| Reuse `AgentToolSourceException` / AGAG007 for the wrap | [[INV-5]] (HIGH) | No new diagnostic ID minted for an existing failure class; ID stability preserved. |
+| `RedactUserInfo` scoped to URI user-info only, scope stated in doc | DIM-8 (prose) · DIM-2 | Documentation names the exact threat covered and the limit; avoids over-claiming. |
+| No new public type; helper is `internal` | DIM-5 (hygiene) · [[INV-6]] | Smallest surface; the port interface is unchanged. |
+
+## Fork 2 — #92: `AgentToolLoopException` trace payload
+
+OpenTelemetry gen-ai semantic conventions model tool invocations as **span events** (`gen_ai.tool.name`, `gen_ai.tool.call.id`, `gen_ai.tool.type`) on the inference span — they are orthogonal to an in-exception diagnostic payload, not a replacement for it. The current `AgentToolLoopException` payload is `IReadOnlyList<ChatMessage>` (stored as a defensive copy after PR #82's fix-cycle), which is a faithful, already-immutable capture of the partial loop.
+
+**Settled:** keep `IReadOnlyList<ChatMessage>`. Add an XML-doc note mapping the payload to the OTel gen-ai event model (so an exporter author knows how to project it), and **defer** a structured `ToolCallTrace` record until a concrete consumer needs the narrower shape (YAGNI / DIM-5 — do not mint a type with no caller). This is a settle-and-document, not a code change to the payload type. [[INV-5]] is unaffected (AGAG005 unchanged).
+
+## Closeout — mechanical items
+
+- **#84** — Remove `AgentStepConfiguration<TState, TResult>.ChatClientConfigurator`. It is populated by the builder but never read by `AgentStepBase.ExecuteAsync` (the configurator is applied at compose-time inside `AgentStepBuilder.ComposeChatClient`). Dead data on an immutable record (DIM-5 / [[INV-6]]). Audit tests for references before deletion.
+- **#83** — Reconcile the DR-1/DR-2 diagram in `docs/designs/2026-05-17-strategos-agents-meai-10-5.md`: the shipped surface is `AgentStepBuilder.Build(IChatClient)`, not a no-arg `Build()` with `IChatClient` on the orchestrator ctor. Update the diagram to match code (DIM-8).
+- **#86** — Document the `AgentStepBuilder` tool-list bound expectation.
+- **#87** — Document direct `ChatClientBuilder` use in `AgentStepBuilder.ComposeChatClient`.
+- **#67 / #68 / #69** — Close as **superseded**: these were the original A1–A3 generator subtasks (emit `CurrentAgentIdentity`, `InitializeIdentity` helper, e2e compile test). PR #81 implemented the identity seam differently — the generator emits `CurrentPhaseName` + the `IPhaseAwareSaga` base-list addition, validated by the shipped generator tests. Close each with a comment pointing to PR #81 as the superseding implementation.
+
+## Sequence
+
+1. **PR α — agent closeout** (one PR): #85 redaction boundary + tests; #84 dead-field removal; #92 doc note; #83/#86/#87 docs. Audited by `/exarchos:review` + `/strategos-design-invariants`.
+2. **Issue housekeeping** (no PR): close #67/#68/#69 as superseded with PR #81 references.
+3. **PR β — release (#70)**: CHANGELOG (incl. the #85 "propagate-unchanged narrowed to `AgentException`-subtypes" note), bump to 2.7.0 GA per [[MinVer version override gotcha]] discipline, cut artifacts.
+
+PR α before PR β so the CHANGELOG reflects the final shipped surface.
+
+## Non-goals
+
+- No new feature pulled forward from 2.8.0 (Contracts 0.2.0, Workflow Builder convergence stay in 2.8.0).
+- #78 (Ontology 2.6.0 polish) is off the agent-capabilities theme; remains "opportunistic," not part of this unit.
+- No structured `ToolCallTrace` record (deferred, §Fork 2).
+- `RedactUserInfo` does not attempt to scrub arbitrary (non-URI) secrets.
+
+## Alternatives considered (Fork 1)
+
+- **A — doc-only port contract** (the issue as filed): rejected. Unenforceable against the foreign-adapter author it targets; conflicts with the no-handwavy-mitigations rule.
+- **C — accept the violation**: viable fallback (declare third-party adapters unsupported for GA). Rejected in favor of B because the enforcement chokepoint already exists (`ResolveToolsAsync`) and the cost is ~15 LOC + tests — cheap enough that explicit non-support is not worth the security-relevant gap.
+- **Type-level enforcement** (abstract `ToolSourceBase` template-method with a redacting `catch`): rejected. Forces inheritance over the clean hexagonal `IToolSource` interface (tension with [[INV-6]] composition-over-inheritance) and breaks the just-shipped port signature for a LOW-severity, third-party-only gap. Over-engineered.

--- a/docs/plans/2026-05-23-strategos-2-7-0-ga-closeout.md
+++ b/docs/plans/2026-05-23-strategos-2-7-0-ga-closeout.md
@@ -1,0 +1,166 @@
+# Implementation Plan — Strategos 2.7.0 GA closeout
+
+**Design:** `docs/designs/2026-05-23-strategos-2-7-0-ga-closeout.md`
+**Date:** 2026-05-23 · **Milestone:** Strategos 2.7.0 — Agent Capabilities (GA)
+**Iron Law:** no production code without a failing test first.
+
+## Test invocation
+
+Per project convention, TUnit runs via tree-node filter, **not** `--filter`:
+
+```bash
+dotnet test src/Strategos.Agents.Tests -- --treenode-filter "/*/*/*/<TestName>"
+```
+
+## Behaviors / scope
+
+| Source | Behavior | Code? | TDD shape |
+|---|---|---|---|
+| #85 | Foreign (non-`AgentException`) tool-source throw is wrapped in `AgentToolSourceException` (AGAG007) with URI user-info redacted; `AgentException` subtypes propagate unchanged | Yes | RED→GREEN→REFACTOR (T1–T4) |
+| #84 | Remove dead `AgentStepConfiguration.ChatClientConfigurator` record property | Yes | Refactor under green suite (T5) |
+| #92 | Settle `AgentToolLoopException` payload; XML-doc the OTel mapping | Docs | T6 (prose-gated) |
+| #83/#86/#87 | Design-diagram + XML-doc reconciliation | Docs | T7 (prose-gated) |
+| #67/#68/#69 | Close as superseded by PR #81 | None | T8 (issue housekeeping) |
+| #70 | CHANGELOG + cut 2.7.0 GA | Release | T9 (prose-gated, MinVer discipline) |
+
+## Key files
+
+- Port: `src/Strategos.Agents.Abstractions/IToolSource.cs`
+- Seam (impl): `src/Strategos.Agents/Configuration/StrategosFunctionsChatClient.cs` → `ResolveToolsAsync`
+- Exception: `src/Strategos.Agents/Exceptions/AgentToolSourceException.cs` (AGAG007, reused)
+- #84 record: `src/Strategos.Agents/Configuration/AgentStepConfiguration.cs`; builder pass-site `src/Strategos.Agents/AgentStepBuilder.cs:196`
+- Redaction tests: `src/Strategos.Agents.Tests/Unit/Configuration/StrategosFunctionsChatClientToolSourceInjectionTests.cs`
+- New fixtures: `src/Strategos.Agents.Tests/Fixtures/` (sibling to `InProcessTestToolSource.cs`, `ThrowingStreamingChatClient.cs`)
+- Prose gate: `src/Strategos.Agents.Tests/Unit/DocumentationAndProseGateTests.cs` (scans `.cs`/`.md`/`.csproj` under Strategos.Agents + `src/Strategos.Agents/README.md` + `CHANGELOG.md`)
+
+---
+
+## PR α — agent closeout (T1–T7)
+
+### Task 1: Foreign tool-source throw is wrapped and redacted
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Add fixture `ForeignThrowingToolSource` (a bare `IToolSource` whose `GetToolsAsync` throws a non-`AgentException` — e.g. `InvalidOperationException` — with a message containing `https://alice:s3cr3t@mcp.example/tools`).
+   - File: `src/Strategos.Agents.Tests/Fixtures/ForeignThrowingToolSource.cs`
+2. [RED] Write test: `ResolveTools_ForeignSourceThrows_WrapsInAgentToolSourceExceptionWithRedactedMessage`
+   - File: `src/Strategos.Agents.Tests/Unit/Configuration/StrategosFunctionsChatClientToolSourceInjectionTests.cs`
+   - Asserts: thrown type is `AgentToolSourceException`; `Diagnostic == AGAG007`; message contains `mcp.example` but **not** `s3cr3t` nor `alice:s3cr3t`; `InnerException` is the original `InvalidOperationException`.
+   - Expected failure: today the seam propagates the raw `InvalidOperationException` unchanged.
+3. [GREEN] In `ResolveToolsAsync`, wrap the `source.GetToolsAsync` call: rethrow `OperationCanceledException` and `AgentException` unchanged; wrap any other exception in `AgentToolSourceException(RedactUserInfo(ex.Message), source.GetType().FullName, ex)`.
+   - File: `src/Strategos.Agents/Configuration/StrategosFunctionsChatClient.cs`
+4. [REFACTOR] Extract `RedactUserInfo(string)` as an `internal static` helper (regex/Uri-span elision of `scheme://user:pass@` → `scheme://`). Keep it private/internal to `Strategos.Agents`.
+
+**Dependencies:** None
+**Parallelizable:** No (shares file with T2/T3)
+
+### Task 2: AgentException subtypes propagate unchanged
+**Phase:** RED → GREEN
+
+1. [RED] Add fixture `AgentExceptionThrowingToolSource` whose `GetToolsAsync` throws `AgentToolSourceException("boom", "Custom")` (already-redacted, conforming).
+   - File: `src/Strategos.Agents.Tests/Fixtures/AgentExceptionThrowingToolSource.cs`
+2. [RED] Write test: `ResolveTools_AgentExceptionSource_PropagatesUnchanged`
+   - File: same injection test file as T1
+   - Asserts: the exact thrown instance is rethrown (reference-equal / not re-wrapped, no nested `AgentToolSourceException` of an `AgentToolSourceException`).
+   - Expected failure: only after T1's catch exists, to pin that the `catch (AgentException) { throw; }` arm precedes the foreign-wrap arm.
+3. [GREEN] Satisfied by T1's `catch (AgentException) throw;` ordering; add the arm if T1 was written wrap-first.
+
+**Dependencies:** T1
+**Parallelizable:** No
+
+### Task 3: Cancellation propagates unwrapped
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `ResolveTools_SourceThrowsOperationCanceled_PropagatesUnwrapped`
+   - File: same injection test file
+   - Asserts: a cancelled token surfacing `OperationCanceledException` from a source is **not** wrapped in `AgentToolSourceException`.
+   - Expected failure: a naive `catch (Exception)` would swallow/wrap cancellation.
+2. [GREEN] Ensure `catch (OperationCanceledException) throw;` precedes the foreign-wrap arm.
+   - File: `src/Strategos.Agents/Configuration/StrategosFunctionsChatClient.cs`
+
+**Dependencies:** T1
+**Parallelizable:** No
+
+### Task 4: IToolSource failure-contract doc
+**Phase:** GREEN (docs) — prose-gated
+
+1. [GREEN] Add a `### Failure contract` paragraph to the `IToolSource` XML doc: conforming adapters throw an `AgentException` subtype with redaction applied in-adapter (propagated unchanged); foreign exceptions are wrapped-and-redacted at the `ResolveToolsAsync` boundary; redaction covers URI user-info only (the DR-10 threat), not arbitrary secrets.
+   - File: `src/Strategos.Agents.Abstractions/IToolSource.cs`
+2. Verify `DocumentationAndProseGateTests` still passes (no AI-writing tells).
+
+**Dependencies:** T1
+**Parallelizable:** Yes (doc-only, separate file)
+
+### Task 5: Remove dead `ChatClientConfigurator` property (#84)
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] In `AgentStepConfigurationTests`, delete the `config.ChatClientConfigurator` `IsNull` assertion and the `ChatClientConfigurator:` named arg from its construction sites. Suite no longer compiles → the failing state.
+   - File: `src/Strategos.Agents.Tests/Unit/Configuration/AgentStepConfigurationTests.cs`
+2. [GREEN] Remove the property (decl + ctor param + assignment) from the record; drop the `ChatClientConfigurator: _chatClientConfigurator` pass-site in the builder (the configurator stays applied at compose-time in `ComposeChatClient`; only the unread record field is removed).
+   - Files: `src/Strategos.Agents/Configuration/AgentStepConfiguration.cs`, `src/Strategos.Agents/AgentStepBuilder.cs`
+3. [REFACTOR] Remove the now-orphaned `ChatClientConfigurator: null,` named args from all remaining construction sites:
+   - `src/Strategos.Agents.Tests/Integration/AgentStepBaseExecuteTests.cs` (5×), `AgentStepBaseStreamingTests.cs` (3×), `AgentStepBaseToolLoopTests.cs` (1×)
+   - Confirm `dotnet build` clean + full Agents.Tests suite green.
+
+**Dependencies:** None
+**Parallelizable:** No (touches builder + many test files)
+
+### Task 6: Settle #92 — AgentToolLoopException payload doc
+**Phase:** GREEN (docs) — prose-gated
+
+1. [GREEN] Keep payload as `IReadOnlyList<ChatMessage>` (no type change). Add XML-doc note mapping it to OTel gen-ai span events (`gen_ai.tool.name`, `gen_ai.tool.call.id`) and stating the structured `ToolCallTrace` record is deferred (no consumer).
+   - File: `src/Strategos.Agents/Exceptions/AgentToolLoopException.cs`
+2. Verify prose gate passes.
+
+**Dependencies:** None
+**Parallelizable:** Yes
+
+### Task 7: Docs reconciliation #83/#86/#87
+**Phase:** GREEN (docs) — prose-gated
+
+1. [GREEN] #83 — update the DR-1/DR-2 diagram in `docs/designs/2026-05-17-strategos-agents-meai-10-5.md` to show `AgentStepBuilder.Build(IChatClient)` (matches shipped code).
+2. [GREEN] #86 — document the `AgentStepBuilder` tool-list bound expectation (XML doc on the relevant `WithTool`/`Build` member).
+   - File: `src/Strategos.Agents/AgentStepBuilder.cs`
+3. [GREEN] #87 — document direct `ChatClientBuilder` use in `AgentStepBuilder.ComposeChatClient`.
+   - File: `src/Strategos.Agents/AgentStepBuilder.cs`
+4. Verify prose gate passes.
+
+**Dependencies:** None
+**Parallelizable:** Partially (T7.1 is a different file from T7.2/T7.3)
+
+---
+
+## Issue housekeeping (no PR)
+
+### Task 8: Close #67/#68/#69 as superseded
+1. `gh issue close 67 68 69` each with a comment: superseded by PR #81 (identity seam emits `CurrentPhaseName` + `IPhaseAwareSaga` base-list addition; validated by shipped generator tests) — original A1–A3 subtask shape not implemented.
+
+**Dependencies:** None · **Parallelizable:** Yes · **No test** (administrative)
+
+---
+
+## PR β — release (T9)
+
+### Task 9: CHANGELOG + cut 2.7.0 GA (#70)
+**Phase:** GREEN (release) — prose-gated
+
+1. [GREEN] CHANGELOG.md: add 2.7.0 GA section. Include the #85 entry noting the tool-source seam now **wraps+redacts foreign exceptions** and narrows the prior "propagate unchanged" contract to `AgentException`-subtypes-only.
+2. Version bump per MinVer discipline — explicit `<Version>` is silently overwritten unless paired with `<MinVerSkip>true</MinVerSkip>` + `<PackageVersion>` (see `project_minver_version_override`). Verify via `dotnet pack` / `nbgv`-equivalent that the produced nupkg version is `2.7.0`.
+3. Verify prose gate passes on CHANGELOG.md.
+
+**Dependencies:** T1–T7 merged (CHANGELOG reflects final surface)
+**Parallelizable:** No · **Sequence:** after PR α merges
+
+---
+
+## Parallelization summary
+
+- **Sequential chain (PR α core):** T1 → T2, T1 → T3 (same file, same seam).
+- **Parallel-safe within PR α:** T4 (doc), T5 (#84, different files), T6 (#92 doc), T7 (docs) can proceed alongside the T1 chain; only T5 touches many files so run it on its own pass to avoid churn.
+- **Independent:** T8 (housekeeping, no code).
+- **Gated last:** T9 (release) after PR α merges.
+
+## Risks
+
+- **Prose gate (DIM-8):** T4/T6/T7/T9 all add prose under gated paths — write in domain voice, no AI tells, or `DocumentationAndProseGateTests` fails.
+- **#84 blast radius:** 12 construction sites; a missed site breaks compilation (caught by build). Pure refactor — no behavior change.
+- **#85 redaction scope:** `RedactUserInfo` covers URI user-info only; the XML doc must state this limit so no false assurance is implied (design §Fork 1).

--- a/src/Strategos.Agents.Tests/Fixtures/AgentExceptionThrowingToolSource.cs
+++ b/src/Strategos.Agents.Tests/Fixtures/AgentExceptionThrowingToolSource.cs
@@ -1,0 +1,37 @@
+// =============================================================================
+// <copyright file="AgentExceptionThrowingToolSource.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// =============================================================================
+
+using Microsoft.Extensions.AI;
+using Strategos.Agents.Abstractions;
+using Strategos.Agents.Exceptions;
+
+namespace Strategos.Agents.Tests.Fixtures;
+
+/// <summary>
+/// <see cref="IToolSource"/> fixture that throws a conforming <see cref="AgentToolSourceException"/>
+/// (AGAG007) from <see cref="GetToolsAsync"/>. Used to assert the propagation-unchanged
+/// arm of the boundary catch: a source that already wraps its own failure must not be
+/// re-wrapped in a second <see cref="AgentToolSourceException"/> (#85 / T2).
+/// </summary>
+internal sealed class AgentExceptionThrowingToolSource : IToolSource
+{
+    private readonly AgentToolSourceException _exception;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AgentExceptionThrowingToolSource"/> class.
+    /// </summary>
+    /// <param name="exception">The <see cref="AgentToolSourceException"/> to throw on resolve.</param>
+    public AgentExceptionThrowingToolSource(AgentToolSourceException exception)
+    {
+        _exception = exception ?? throw new ArgumentNullException(nameof(exception));
+    }
+
+    /// <inheritdoc/>
+    public Task<IReadOnlyList<AIFunction>> GetToolsAsync(CancellationToken cancellationToken)
+    {
+        throw _exception;
+    }
+}

--- a/src/Strategos.Agents.Tests/Fixtures/ForeignThrowingToolSource.cs
+++ b/src/Strategos.Agents.Tests/Fixtures/ForeignThrowingToolSource.cs
@@ -1,0 +1,25 @@
+// =============================================================================
+// <copyright file="ForeignThrowingToolSource.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// =============================================================================
+
+using Microsoft.Extensions.AI;
+using Strategos.Agents.Abstractions;
+
+namespace Strategos.Agents.Tests.Fixtures;
+
+/// <summary>
+/// Bare <see cref="IToolSource"/> fixture that does NOT throw an <c>AgentException</c>
+/// subtype. Its <see cref="GetToolsAsync"/> throws a raw <see cref="InvalidOperationException"/>
+/// whose message embeds a URI with credentials, simulating a third-party adapter that
+/// has not applied any redaction. Used to drive the credential-leak test (DR-10 / #85).
+/// </summary>
+internal sealed class ForeignThrowingToolSource : IToolSource
+{
+    /// <inheritdoc/>
+    public Task<IReadOnlyList<AIFunction>> GetToolsAsync(CancellationToken cancellationToken)
+    {
+        throw new InvalidOperationException("connect failed to https://alice:s3cr3t@mcp.example/tools");
+    }
+}

--- a/src/Strategos.Agents.Tests/Integration/AgentStepBaseExecuteTests.cs
+++ b/src/Strategos.Agents.Tests/Integration/AgentStepBaseExecuteTests.cs
@@ -62,7 +62,6 @@ public sealed class AgentStepBaseExecuteTests
             Tools: Array.Empty<AIFunction>(),
             ToolSources: Array.Empty<IToolSource>(),
             ChatOptions: null,
-            ChatClientConfigurator: null,
             MaxToolIterations: null);
 
         var orchestrator = new AgentStepBase<TestState, TestDto>(chatClient, configuration);
@@ -119,7 +118,6 @@ public sealed class AgentStepBaseExecuteTests
             Tools: Array.Empty<AIFunction>(),
             ToolSources: Array.Empty<IToolSource>(),
             ChatOptions: null,
-            ChatClientConfigurator: null,
             MaxToolIterations: null);
 
         var orchestrator = new AgentStepBase<TestState, TestDto>(chatClient, configuration);
@@ -177,7 +175,6 @@ public sealed class AgentStepBaseExecuteTests
             Tools: Array.Empty<AIFunction>(),
             ToolSources: Array.Empty<IToolSource>(),
             ChatOptions: null,
-            ChatClientConfigurator: null,
             MaxToolIterations: null);
 
         var orchestrator = new AgentStepBase<TestState, TestDto>(chatClient, configuration);
@@ -243,7 +240,6 @@ public sealed class AgentStepBaseExecuteTests
             Tools: Array.Empty<AIFunction>(),
             ToolSources: Array.Empty<IToolSource>(),
             ChatOptions: null,
-            ChatClientConfigurator: null,
             MaxToolIterations: null);
 
         var orchestrator = new AgentStepBase<TestState, TestDto>(chatClient, configuration);
@@ -296,7 +292,6 @@ public sealed class AgentStepBaseExecuteTests
             Tools: Array.Empty<AIFunction>(),
             ToolSources: Array.Empty<IToolSource>(),
             ChatOptions: null,
-            ChatClientConfigurator: null,
             MaxToolIterations: null);
 
         var orchestrator = new AgentStepBase<TestState, TestDto>(chatClient, configuration);

--- a/src/Strategos.Agents.Tests/Integration/AgentStepBaseStreamingTests.cs
+++ b/src/Strategos.Agents.Tests/Integration/AgentStepBaseStreamingTests.cs
@@ -80,7 +80,6 @@ public sealed class AgentStepBaseStreamingTests
             Tools: Array.Empty<AIFunction>(),
             ToolSources: Array.Empty<IToolSource>(),
             ChatOptions: null,
-            ChatClientConfigurator: null,
             MaxToolIterations: null,
             StreamingHandler: handler);
 
@@ -164,7 +163,6 @@ public sealed class AgentStepBaseStreamingTests
             Tools: Array.Empty<AIFunction>(),
             ToolSources: Array.Empty<IToolSource>(),
             ChatOptions: null,
-            ChatClientConfigurator: null,
             MaxToolIterations: null,
             StreamingHandler: handler);
 
@@ -210,7 +208,6 @@ public sealed class AgentStepBaseStreamingTests
             Tools: Array.Empty<AIFunction>(),
             ToolSources: Array.Empty<IToolSource>(),
             ChatOptions: null,
-            ChatClientConfigurator: null,
             MaxToolIterations: null,
             StreamingHandler: handler);
 

--- a/src/Strategos.Agents.Tests/Integration/AgentStepBaseToolLoopTests.cs
+++ b/src/Strategos.Agents.Tests/Integration/AgentStepBaseToolLoopTests.cs
@@ -94,7 +94,6 @@ public sealed class AgentStepBaseToolLoopTests
             Tools: new[] { fakeTool },
             ToolSources: Array.Empty<IToolSource>(),
             ChatOptions: chatOptions,
-            ChatClientConfigurator: null,
             MaxToolIterations: 8);
 
         var orchestrator = new AgentStepBase<TestState, TestDto>(composedClient, configuration);

--- a/src/Strategos.Agents.Tests/Unit/Configuration/AgentStepConfigurationTests.cs
+++ b/src/Strategos.Agents.Tests/Unit/Configuration/AgentStepConfigurationTests.cs
@@ -40,7 +40,6 @@ public sealed class AgentStepConfigurationTests
             Tools: Array.Empty<AIFunction>(),
             ToolSources: Array.Empty<IToolSource>(),
             ChatOptions: null,
-            ChatClientConfigurator: null,
             MaxToolIterations: null);
 
         await Assert.That(config.SystemPrompt).IsEqualTo(systemPrompt);
@@ -49,7 +48,6 @@ public sealed class AgentStepConfigurationTests
         await Assert.That(config.Tools.Count).IsEqualTo(0);
         await Assert.That(config.ToolSources.Count).IsEqualTo(0);
         await Assert.That(config.ChatOptions).IsNull();
-        await Assert.That(config.ChatClientConfigurator).IsNull();
         await Assert.That(config.MaxToolIterations).IsNull();
 
         // Constructor accessibility — internal (the builder is the only sanctioned creator)
@@ -75,7 +73,6 @@ public sealed class AgentStepConfigurationTests
             Tools: Array.Empty<AIFunction>(),
             ToolSources: new IToolSource[] { null! },
             ChatOptions: null,
-            ChatClientConfigurator: null,
             MaxToolIterations: null));
 
         await Assert.That(ex!.ParamName).IsEqualTo("ToolSources");
@@ -97,7 +94,6 @@ public sealed class AgentStepConfigurationTests
             Tools: Array.Empty<AIFunction>(),
             ToolSources: Array.Empty<IToolSource>(),
             ChatOptions: null,
-            ChatClientConfigurator: null,
             MaxToolIterations: null);
 
         await Assert.That(defaultConfig.StreamingHandler).IsNull();
@@ -110,7 +106,6 @@ public sealed class AgentStepConfigurationTests
             Tools: Array.Empty<AIFunction>(),
             ToolSources: Array.Empty<IToolSource>(),
             ChatOptions: null,
-            ChatClientConfigurator: null,
             MaxToolIterations: null,
             StreamingHandler: handler);
 
@@ -124,6 +119,19 @@ public sealed class AgentStepConfigurationTests
         var openGeneric = typeof(AgentStepConfiguration<,>);
         var legacy = openGeneric.GetProperty("McpToolSource", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
         await Assert.That(legacy).IsNull();
+    }
+
+    [Test]
+    public async Task Configuration_NoChatClientConfiguratorMember()
+    {
+        // T5 / #84: the dead ChatClientConfigurator property is removed; the
+        // configurator is applied at compose-time in AgentStepBuilder.ComposeChatClient
+        // and does not need to be stored on the configuration record.
+        var openGeneric = typeof(AgentStepConfiguration<,>);
+        var dead = openGeneric.GetProperty(
+            "ChatClientConfigurator",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        await Assert.That(dead).IsNull();
     }
 
     private sealed record DummyState : IWorkflowState

--- a/src/Strategos.Agents.Tests/Unit/Configuration/StrategosFunctionsChatClientToolSourceInjectionTests.cs
+++ b/src/Strategos.Agents.Tests/Unit/Configuration/StrategosFunctionsChatClientToolSourceInjectionTests.cs
@@ -195,8 +195,19 @@ public sealed class StrategosFunctionsChatClientToolSourceInjectionTests
         await Assert.That(caught.Message).Contains("mcp.example");
         await Assert.That(caught.Message).DoesNotContain("s3cr3t");
         await Assert.That(caught.Message).DoesNotContain("alice:s3cr3t");
+
+        // #85 leak guard (CodeRabbit, PR #94): redacting only the outer Message is
+        // insufficient — Exception.ToString() recurses into InnerException, so a raw
+        // foreign exception retained as the inner re-surfaces the credential. The full
+        // string projection must therefore stay clean.
+        await Assert.That(caught.ToString()).DoesNotContain("s3cr3t");
+        await Assert.That(caught.ToString()).DoesNotContain("alice:s3cr3t");
+
+        // A non-null inner is retained for diagnosis, but redacted and carrying only the
+        // original exception type name (no secret).
         await Assert.That(caught.InnerException).IsNotNull();
-        await Assert.That(caught.InnerException).IsTypeOf<InvalidOperationException>();
+        await Assert.That(caught.InnerException!.Message).DoesNotContain("s3cr3t");
+        await Assert.That(caught.InnerException.Message).Contains(nameof(InvalidOperationException));
     }
 
     [Test]

--- a/src/Strategos.Agents.Tests/Unit/Configuration/StrategosFunctionsChatClientToolSourceInjectionTests.cs
+++ b/src/Strategos.Agents.Tests/Unit/Configuration/StrategosFunctionsChatClientToolSourceInjectionTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.AI;
 using NSubstitute;
 using Strategos.Agents.Abstractions;
 using Strategos.Agents.Configuration;
+using Strategos.Agents.Diagnostics;
 using Strategos.Agents.Exceptions;
 using Strategos.Agents.Tests.Fixtures;
 
@@ -171,6 +172,73 @@ public sealed class StrategosFunctionsChatClientToolSourceInjectionTests
                 cancellationToken: CancellationToken.None));
 
         await Assert.That(caught).IsSameReferenceAs(innerEx);
+    }
+
+    [Test]
+    public async Task ResolveTools_ForeignSourceThrows_WrapsInAgentToolSourceExceptionWithRedactedMessage()
+    {
+        // T1 / #85: a foreign IToolSource (not an AgentException thrower) whose message
+        // embeds credentials must NOT leak them. The boundary must wrap in
+        // AgentToolSourceException (AGAG007) and redact URI user-info.
+        var inner = OkClient();
+        var source = new ForeignThrowingToolSource();
+        var client = new StrategosFunctionsChatClient(inner, Array.Empty<AIFunction>(), new IToolSource[] { source });
+
+        var caught = await Assert.ThrowsAsync<AgentToolSourceException>(async () =>
+            await client.GetResponseAsync(
+                new[] { new ChatMessage(ChatRole.User, "hi") },
+                options: null,
+                cancellationToken: CancellationToken.None));
+
+        await Assert.That(caught).IsNotNull();
+        await Assert.That(caught!.Diagnostic).IsEqualTo(AgentDiagnostics.AGAG007);
+        await Assert.That(caught.Message).Contains("mcp.example");
+        await Assert.That(caught.Message).DoesNotContain("s3cr3t");
+        await Assert.That(caught.Message).DoesNotContain("alice:s3cr3t");
+        await Assert.That(caught.InnerException).IsNotNull();
+        await Assert.That(caught.InnerException).IsTypeOf<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task ResolveTools_AgentExceptionSource_PropagatesUnchanged()
+    {
+        // T2 / #85: a conforming source that already throws an AgentToolSourceException
+        // must be propagated UNCHANGED — not wrapped in a second AGAG007 layer.
+        var inner = OkClient();
+        var originalEx = new AgentToolSourceException("boom", "CustomSource");
+        var source = new AgentExceptionThrowingToolSource(originalEx);
+        var client = new StrategosFunctionsChatClient(inner, Array.Empty<AIFunction>(), new IToolSource[] { source });
+
+        var caught = await Assert.ThrowsAsync<AgentToolSourceException>(async () =>
+            await client.GetResponseAsync(
+                new[] { new ChatMessage(ChatRole.User, "hi") },
+                options: null,
+                cancellationToken: CancellationToken.None));
+
+        // Must be the exact same instance — not a re-wrapper.
+        await Assert.That(caught).IsSameReferenceAs(originalEx);
+        // Must not have an outer AGAG007-wrapping-AGAG007 nesting.
+        await Assert.That(caught!.InnerException).IsNull();
+    }
+
+    [Test]
+    public async Task ResolveTools_SourceThrowsOperationCanceled_PropagatesUnwrapped()
+    {
+        // T3 / #85: cancellation propagates through the boundary unwrapped —
+        // NOT wrapped in AgentToolSourceException.
+        var inner = OkClient();
+        var source = new InProcessTestToolSource(new OperationCanceledException("cancelled"));
+        var client = new StrategosFunctionsChatClient(inner, Array.Empty<AIFunction>(), new IToolSource[] { source });
+
+        var caught = await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await client.GetResponseAsync(
+                new[] { new ChatMessage(ChatRole.User, "hi") },
+                options: null,
+                cancellationToken: CancellationToken.None));
+
+        await Assert.That(caught).IsNotNull();
+        // Cancellation must escape as-is — not wrapped in AgentToolSourceException.
+        await Assert.That(caught!.Message).IsEqualTo("cancelled");
     }
 
     private static IChatClient OkClient()

--- a/src/Strategos.Agents/Abstractions/IToolSource.cs
+++ b/src/Strategos.Agents/Abstractions/IToolSource.cs
@@ -17,6 +17,22 @@ namespace Strategos.Agents.Abstractions;
 /// reflection adapter (<c>AgentToolSource</c>) ships here — so the
 /// <c>LevelUp.Strategos.Agents</c> assembly stays free of any MCP dependency.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Failure contract.</strong> Conforming adapters throw an
+/// <c>AgentException</c> subtype (e.g. <c>AgentToolSourceException</c> / AGAG007,
+/// or <c>AgentMcpException</c> / AGAG004) and apply credential redaction before
+/// constructing the exception message. The <c>ResolveToolsAsync</c> boundary in
+/// <c>StrategosFunctionsChatClient</c> propagates those exceptions unchanged.
+/// Any other exception thrown by an adapter is treated as foreign: the boundary
+/// wraps it in <c>AgentToolSourceException</c> (AGAG007) and applies URI
+/// user-info redaction to the message (<c>scheme://user:pass@host</c> →
+/// <c>scheme://host</c>) before propagating. That redaction covers only URI
+/// user-info — it does not claim to scrub arbitrary secrets from foreign message
+/// text. Cancellation (<see cref="OperationCanceledException"/>) is always
+/// propagated unwrapped regardless of adapter type.
+/// </para>
+/// </remarks>
 public interface IToolSource
 {
     /// <summary>

--- a/src/Strategos.Agents/AgentStepBuilder.cs
+++ b/src/Strategos.Agents/AgentStepBuilder.cs
@@ -155,7 +155,14 @@ public sealed class AgentStepBuilder<TState, TResult>
     /// Construct the configured <see cref="IAgentStep{TState, TResult}"/>. Throws
     /// <see cref="AgentBuilderValidationException"/> (AGAG001) if any required hook is missing.
     /// </summary>
-    /// <param name="chatClient">The MEAI chat client to invoke.</param>
+    /// <param name="chatClient">
+    /// The MEAI chat client placed at the bottom of the composed pipeline. The builder
+    /// wraps it with <c>UseStrategosFunctions</c> (tool-list injection) and
+    /// <c>UseFunctionInvocation</c> (bounded tool-call loop) in that fixed order, then
+    /// applies the optional host configurator outermost. Tool names registered via
+    /// <see cref="WithTool"/> must be unique at this point — duplicate names cause
+    /// <see cref="AgentDuplicateToolException"/> (AGAG003) before the pipeline is built.
+    /// </param>
     /// <returns>The configured agent step.</returns>
     public IAgentStep<TState, TResult> Build(IChatClient chatClient)
     {
@@ -193,7 +200,6 @@ public sealed class AgentStepBuilder<TState, TResult>
             Tools: toolList,
             ToolSources: toolSources,
             ChatOptions: _chatOptions,
-            ChatClientConfigurator: _chatClientConfigurator,
             MaxToolIterations: _maxToolIterations,
             StreamingHandler: _streamingHandler);
 
@@ -205,6 +211,25 @@ public sealed class AgentStepBuilder<TState, TResult>
     /// Composes the IChatClient pipeline in fixed order (DR-6):
     /// host configurator → <c>UseStrategosFunctions</c> → <c>UseFunctionInvocation</c>.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Uses <see cref="ChatClientBuilder"/> directly rather than a DI container so
+    /// that the builder remains dependency-injection-agnostic (DR-6 escape hatch).
+    /// The host supplies the outermost middleware via <see cref="ConfigureChatClient"/>
+    /// and the <paramref name="innerClient"/> at the bottom via <see cref="Build"/>;
+    /// everything in between is Strategos-owned and applied here in a fixed sequence.
+    /// </para>
+    /// <para>
+    /// Pipeline order (outermost → innermost, matching call order on the builder):
+    /// <list type="number">
+    /// <item><description>Host configurator (logging, OTel, distributed cache, etc.).</description></item>
+    /// <item><description><c>UseStrategosFunctions</c> — injects the accumulated tool list and
+    /// resolves tool sources into <c>ChatOptions.Tools</c> on each request.</description></item>
+    /// <item><description><c>UseFunctionInvocation</c> — runs the tool-call loop bounded by
+    /// <c>MaxToolIterations</c> (default: <see cref="AgentStepBase{TState, TResult}.DefaultMaxToolIterations"/>).</description></item>
+    /// </list>
+    /// </para>
+    /// </remarks>
     private IChatClient ComposeChatClient(
         IChatClient innerClient,
         IReadOnlyList<AIFunction> tools,

--- a/src/Strategos.Agents/Configuration/AgentStepConfiguration.cs
+++ b/src/Strategos.Agents/Configuration/AgentStepConfiguration.cs
@@ -38,9 +38,6 @@ public sealed record AgentStepConfiguration<TState, TResult>
     /// <summary>Optional explicit ChatOptions. The builder still applies defaults if null.</summary>
     public ChatOptions? ChatOptions { get; }
 
-    /// <summary>Optional host-side ChatClientBuilder configurator (logging, OTel, distributed cache, etc.).</summary>
-    public Action<ChatClientBuilder>? ChatClientConfigurator { get; }
-
     /// <summary>Optional override for the tool-iteration bound (default 8; see AgentStepBase.DefaultMaxToolIterations).</summary>
     public int? MaxToolIterations { get; }
 
@@ -59,7 +56,6 @@ public sealed record AgentStepConfiguration<TState, TResult>
         IReadOnlyList<AIFunction> Tools,
         IReadOnlyList<IToolSource> ToolSources,
         ChatOptions? ChatOptions,
-        Action<ChatClientBuilder>? ChatClientConfigurator,
         int? MaxToolIterations,
         IStreamingHandler? StreamingHandler = null)
     {
@@ -95,7 +91,6 @@ public sealed record AgentStepConfiguration<TState, TResult>
         this.Tools = Tools;
         this.ToolSources = ToolSources;
         this.ChatOptions = ChatOptions;
-        this.ChatClientConfigurator = ChatClientConfigurator;
         this.MaxToolIterations = MaxToolIterations;
         this.StreamingHandler = StreamingHandler;
     }

--- a/src/Strategos.Agents/Configuration/StrategosFunctionsChatClient.cs
+++ b/src/Strategos.Agents/Configuration/StrategosFunctionsChatClient.cs
@@ -252,9 +252,10 @@ internal sealed class StrategosFunctionsChatClient : DelegatingChatClient
                 }
                 catch (Exception ex)
                 {
-                    // Foreign (non-conforming) adapter: redact URI user-info and wrap.
+                    // Foreign adapter: redact, and never retain the raw ex as inner — it re-leaks the credential via ToString(). (PR #94)
                     var redacted = UriRedaction.RedactUserInfo(ex.Message);
-                    throw new AgentToolSourceException(redacted, source.GetType().FullName, ex);
+                    var safeInner = redacted == ex.Message ? ex : new Exception($"{ex.GetType().Name}: {redacted}");
+                    throw new AgentToolSourceException(redacted, source.GetType().FullName, safeInner);
                 }
 
                 if (resolved is not null)

--- a/src/Strategos.Agents/Configuration/StrategosFunctionsChatClient.cs
+++ b/src/Strategos.Agents/Configuration/StrategosFunctionsChatClient.cs
@@ -7,6 +7,7 @@
 using Microsoft.Extensions.AI;
 using Strategos.Agents.Abstractions;
 using Strategos.Agents.Exceptions;
+using Strategos.Agents.Extensions;
 
 namespace Strategos.Agents.Configuration;
 
@@ -34,10 +35,10 @@ namespace Strategos.Agents.Configuration;
 /// aggregated <see cref="AIFunction"/>s are cached for the lifetime of this
 /// middleware instance, then merged into <see cref="ChatOptions.Tools"/> after the
 /// host-supplied and Strategos-registered tools. If resolution fails, the cache
-/// stays empty and the next request retries; the source's own exception propagates
-/// unchanged (the MCP adapter raises <see cref="AgentMcpException"/>/AGAG004; the
-/// in-process adapter raises <c>AgentToolSourceException</c>/AGAG007) — the
-/// middleware does NOT reclassify. Cancellation flows through unwrapped.
+/// stays empty and the next request retries. Conforming adapters (those that throw
+/// an <see cref="AgentException"/> subtype) propagate unchanged; foreign exceptions
+/// are wrapped in <see cref="AgentToolSourceException"/> (AGAG007) after URI
+/// user-info redaction (DR-10 / #85). Cancellation flows through unwrapped.
 /// </para>
 /// <para>
 /// Name-collision precedence (host &gt; Strategos &gt; tool-sources): the host's
@@ -189,11 +190,28 @@ internal sealed class StrategosFunctionsChatClient : DelegatingChatClient
     /// Resolves every registered tool source lazily on first call, each at most once,
     /// aggregating their <see cref="AIFunction"/>s in registration order. Subsequent
     /// successful calls reuse the cached list. On failure the cache stays empty so the
-    /// next call retries; the failing source's own exception propagates UNCHANGED — the
-    /// MCP adapter raises <see cref="AgentMcpException"/> (AGAG004) and the in-process
-    /// adapter raises <c>AgentToolSourceException</c> (AGAG007); this middleware does
-    /// not reclassify. Cancellation is propagated unwrapped.
+    /// next call retries.
     /// </summary>
+    /// <remarks>
+    /// Exception-propagation contract at this boundary (catch order is significant):
+    /// <list type="number">
+    /// <item><description>
+    /// <see cref="OperationCanceledException"/> — propagated unwrapped. Cancellation is not a
+    /// domain failure and must never be classified as <see cref="AgentToolSourceException"/>.
+    /// </description></item>
+    /// <item><description>
+    /// <see cref="AgentException"/> subtypes — propagated unchanged. Conforming adapters
+    /// (e.g. <see cref="AgentMcpException"/> AGAG004, <see cref="AgentToolSourceException"/>
+    /// AGAG007) have already applied their own redaction; re-wrapping them would produce
+    /// nested AGAG007 payloads.
+    /// </description></item>
+    /// <item><description>
+    /// Any other exception — wrapped in <see cref="AgentToolSourceException"/> (AGAG007) with
+    /// <see cref="UriRedaction.RedactUserInfo"/> applied to the message. This guards against
+    /// third-party adapters that embed raw credentials in exception messages (DR-10 / #85).
+    /// </description></item>
+    /// </list>
+    /// </remarks>
     private async Task<IReadOnlyList<AIFunction>> ResolveToolsAsync(CancellationToken cancellationToken)
     {
         if (_toolSources.Count == 0)
@@ -217,8 +235,28 @@ internal sealed class StrategosFunctionsChatClient : DelegatingChatClient
             var aggregated = new List<AIFunction>();
             foreach (var source in _toolSources)
             {
-                // Each source surfaces its own diagnostic; propagate unchanged.
-                var resolved = await source.GetToolsAsync(cancellationToken).ConfigureAwait(false);
+                IReadOnlyList<AIFunction>? resolved;
+                try
+                {
+                    resolved = await source.GetToolsAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Cancellation is not a domain failure — propagate unwrapped.
+                    throw;
+                }
+                catch (AgentException)
+                {
+                    // Conforming adapter: already self-redacted; propagate unchanged.
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    // Foreign (non-conforming) adapter: redact URI user-info and wrap.
+                    var redacted = UriRedaction.RedactUserInfo(ex.Message);
+                    throw new AgentToolSourceException(redacted, source.GetType().FullName, ex);
+                }
+
                 if (resolved is not null)
                 {
                     aggregated.AddRange(resolved);

--- a/src/Strategos.Agents/Exceptions/AgentToolLoopException.cs
+++ b/src/Strategos.Agents/Exceptions/AgentToolLoopException.cs
@@ -20,7 +20,17 @@ public sealed class AgentToolLoopException : AgentException
     /// <summary>Maximum iterations that was hit.</summary>
     public int MaxIterations { get; }
 
-    /// <summary>Partial trace of tool-call messages observed before the limit fired.</summary>
+    /// <summary>
+    /// Partial trace of tool-call messages observed before the limit fired.
+    /// </summary>
+    /// <remarks>
+    /// The payload is <see cref="IReadOnlyList{ChatMessage}"/>. Each entry maps to
+    /// OpenTelemetry gen-ai span event fields (<c>gen_ai.tool.name</c>,
+    /// <c>gen_ai.tool.call.id</c>) for exporters that want to surface partial
+    /// call history as span events. A structured <c>ToolCallTrace</c> record
+    /// is deferred until a consumer with concrete projection requirements emerges;
+    /// the raw message list is sufficient for current diagnostic and OTel use (#92).
+    /// </remarks>
     public IReadOnlyList<ChatMessage> PartialTrace { get; }
 
     /// <summary>

--- a/src/Strategos.Agents/Extensions/UriRedaction.cs
+++ b/src/Strategos.Agents/Extensions/UriRedaction.cs
@@ -1,0 +1,43 @@
+// =============================================================================
+// <copyright file="UriRedaction.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// =============================================================================
+
+using System.Text.RegularExpressions;
+
+namespace Strategos.Agents.Extensions;
+
+/// <summary>
+/// URI user-info redaction helper (DR-10 / #85). Removes the user-info segment
+/// (<c>user:pass@</c>) from any <c>scheme://user:pass@host/…</c> substrings in
+/// a message string. Scope is intentionally narrow: URI user-info only.
+/// Arbitrary secret scrubbing is outside the contract.
+/// </summary>
+internal static partial class UriRedaction
+{
+    // Matches: scheme "://" followed by one or more non-whitespace characters
+    // that contain "@", up to and including the "@". Captures the scheme prefix
+    // so the replacement keeps it intact.
+    // Pattern: (scheme://) <user-info> @
+    //   where <user-info> is any sequence of non-whitespace chars with no "@"
+    //   before the final "@".
+    [GeneratedRegex(@"([a-zA-Z][a-zA-Z0-9+.\-]*://)[^/@\s]*@", RegexOptions.CultureInvariant)]
+    private static partial Regex UserInfoPattern();
+
+    /// <summary>
+    /// Replaces every <c>scheme://user:pass@</c> substring in <paramref name="message"/>
+    /// with <c>scheme://</c>, eliding the user-info segment.
+    /// </summary>
+    /// <param name="message">The message to redact.</param>
+    /// <returns>The redacted message.</returns>
+    internal static string RedactUserInfo(string message)
+    {
+        if (string.IsNullOrEmpty(message))
+        {
+            return message;
+        }
+
+        return UserInfoPattern().Replace(message, "$1");
+    }
+}


### PR DESCRIPTION
## Strategos 2.7.0 — GA closeout (PR α)

Closes the open agent-capabilities debt for 2.7.0 GA. The feature build (MEAI 10.5 #82, streaming + tool sources #93, identity seam #81) is already on `main`; this discharges the post-merge debt.

Design: `docs/designs/2026-05-23-strategos-2-7-0-ga-closeout.md` · Plan: `docs/plans/2026-05-23-strategos-2-7-0-ga-closeout.md`

### #85 — redaction at the tool-source boundary (the one design decision)
`StrategosFunctionsChatClient.ResolveToolsAsync` now enforces redaction mechanically instead of by documented convention. Catch order: `OperationCanceledException` → unwrapped; `AgentException` subtypes (the in-tree MCP/in-process adapters, which self-redact) → propagate **unchanged** (preserves #93's contract); any **foreign** exception → wrapped in `AgentToolSourceException` (AGAG007, no new diagnostic ID) with URI user-info elided via the new `internal UriRedaction.RedactUserInfo`.

This narrows #93's "propagate unchanged" to `AgentException`-subtypes-only — a deliberate tightening. Redaction scope is URI user-info only (the DR-10 threat), documented honestly on `IToolSource`; it does not claim to scrub arbitrary secrets.

### Also in this PR
- **#84** — remove dead `AgentStepConfiguration.ChatClientConfigurator` (12 callsites; reflection guard test asserts the member is gone).
- **#92** — settle `AgentToolLoopException` payload: keep `IReadOnlyList<ChatMessage>`, document the OTel gen-ai event mapping, defer a structured `ToolCallTrace` (no consumer).
- **#83/#86/#87** — design-diagram + XML-doc reconciliation.

### Verification
- `dotnet build` clean; `Strategos.Agents.Tests` **229 passed**, `Strategos.Agents.Mcp.Tests` **6 passed** (0 failed / 0 skipped).
- 3 new behavior tests drive the live `ResolveToolsAsync` seam; credential-leak test asserts the secret is absent and host preserved.
- Two-stage review: **SPEC PASS**, **QUALITY PASS** (0 HIGH / 0 MEDIUM / 2 LOW, both non-actionable).

### Not in this PR (follow-ups)
- Close #67/#68/#69 as superseded by #81.
- CHANGELOG + cut 2.7.0 GA (PR β).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
