### PR TITLE
refactor(ontology): close Ontology 2.6.0 post-merge polish (closes #78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed — Ontology hybrid retrieval polish (#78)
+
+- **`HybridMeta.Degraded` gains `"sparse-empty"`** (#78 item 1). When the sparse
+  keyword leg runs cleanly but returns zero candidates, `OntologyQueryTool` now
+  surfaces `HybridMeta { Hybrid = false, Degraded = "sparse-empty" }` instead of a
+  `Hybrid = true` envelope with a null `sparseTopScore`. This makes the wire honor
+  the documented invariant that `Hybrid = true` ⇔ the sparse leg actually
+  contributed to fusion (design §6.6, DIM-7). An empty sparse result is not a
+  fault, so — unlike `"sparse-failed"` — it is not logged.
+- **Missing-provider warn-once is now per-process** (#78 item 4). The
+  "`HybridQueryOptions` supplied but no `IKeywordSearchProvider` registered"
+  warning is latched on a process-wide `static` flag (moved off `OntologyQueryTool`
+  onto the new `HybridQueryCoordinator`), so hosts that construct multiple tool
+  instances no longer emit one warning per instance. Public API unchanged.
+
 ## [2.7.0] - 2026-05-18
 
 ### Changed (BREAKING) — Agent step contract
@@ -159,6 +174,10 @@ design rationale.
   Supporting records: `RankedCandidate`, `ScoredCandidate`, `FusedResult`.
 - **`HybridQueryOptions`** + **`FusionMethod`** enum (PR-C) — additive optional
   per-call configuration for `OntologyQueryTool.QueryAsync`.
+- **`HybridQueryOptions.Validate()`** (PR-C) — public validation method invoked at
+  `QueryAsync` entry. Throws `ArgumentOutOfRangeException` for a negative
+  `SparseTopK` / `DenseTopK`, a non-positive `RrfK`, or an undefined `FusionMethod`;
+  throws `ArgumentException` for `SourceWeights` with length ≠ 2 or a negative weight.
 - **`HybridMeta`** typed sub-record (PR-C) — attached to `ResponseMeta.Hybrid`
   whenever the hybrid path was engaged. Omitted from JSON when null, preserving
   byte-for-byte 2.5.0 `_meta` snapshots.

--- a/docs/designs/2026-05-15-ontology-2-6-0-hybrid-retrieval.md
+++ b/docs/designs/2026-05-15-ontology-2-6-0-hybrid-retrieval.md
@@ -465,7 +465,9 @@ hybridOptions non-null AND semanticQuery non-null
       │   ├─ dense throws → propagate (baseline)
       │   └─ sparse throws → catch, log with stack, fall back to dense-only.
       │       └─ HybridMeta { Hybrid = false, Degraded = "sparse-failed" }
-      ├─ both complete → fuse:
+      ├─ sparse succeeds but returns zero rows → dense-only (fusion is a no-op).
+      │       └─ HybridMeta { Hybrid = false, Degraded = "sparse-empty" }
+      ├─ both complete with sparse rows → fuse:
       │   ├─ Reciprocal → RankFusion.Reciprocal(rankedLists, SourceWeights, RrfK, topK)
       │   └─ DistributionBased → RankFusion.DistributionBased(scoredLists, SourceWeights, topK)
       └─ HybridMeta {
@@ -476,6 +478,24 @@ hybridOptions non-null AND semanticQuery non-null
             Degraded = null
         }
 ```
+
+> **2.7.0 reconciliation (#78, item 1).** The `sparse-empty` leaf was added so the
+> `Hybrid = true` ⇔ "sparse contributed" invariant (§6.6, DIM-7) holds literally: a
+> sparse leg that runs cleanly but returns no candidates cannot reorder the dense
+> ranking, so it degrades to dense-only with the distinct `Degraded = "sparse-empty"`
+> reason rather than emitting a `Hybrid = true` envelope carrying a null
+> `sparseTopScore`. Empty is not a fault, so unlike `sparse-failed` it logs nothing.
+
+**Sparse-only document drop policy (#78, item 3).** When fusion runs, a document
+that appears *only* on the sparse leg — i.e. its `DocumentId` has no matching dense
+item with a reflection-extractable `Id` — is **dropped from the projected result**.
+The 2.5.0 `SemanticQueryResult` wire shape is `items` + `scores` over ontology
+objects, and Strategos cannot synthesize an ontology object from a bare sparse
+`DocumentId`. Such a document still influences fusion *ranking* (it occupies a rank
+slot and shifts reciprocal/score contributions for the documents around it) but is
+absent from the returned `items`. Consequently the projected item count can be less
+than the fused candidate count. Materializing sparse-only documents is out of scope
+for 2.6.0/2.7.0 and belongs to a future reranker/hydration layer (§9.3).
 
 ### 6.5 Extended ResponseMeta
 
@@ -534,15 +554,15 @@ Wire shape:
 |---|---|
 | Backward compat (DIM-3) | 2.5.0 `OntologyQueryTool` test suite passes unmodified. **Hard gate.** |
 | Default fusion | `FusionMethod.Reciprocal` (production default). |
-| `HybridMeta.Hybrid` | `true` only when sparse path actually contributed results. |
+| `HybridMeta.Hybrid` | `true` only when the sparse leg actually contributed results to fusion. A sparse leg that returns zero rows does not contribute (see `"sparse-empty"`, #78 item 1). |
 | `HybridMeta.FusionMethod` | Present when `Hybrid = true`. Values: `"reciprocal"` or `"distribution_based"`. |
-| `HybridMeta.Degraded` | Present only on degraded paths (`"no-keyword-provider"`, `"sparse-failed"`). Null on healthy. |
+| `HybridMeta.Degraded` | Present only on degraded paths (`"no-keyword-provider"`, `"sparse-failed"`, `"sparse-empty"`). Null on healthy. (`"sparse-empty"` added 2.7.0, #78 item 1.) |
 | Cancellation | Single `ct` propagated to both legs via `Task.WhenAll`. |
 | Parallelism | `Task.WhenAll(denseTask, sparseTask)` — both await before fusion. |
 | Argument validation | `SparseTopK >= 0`, `DenseTopK >= 0`, `RrfK > 0`, `SourceWeights` (when non-null) length = 2, all weights ≥ 0. Otherwise `ArgumentOutOfRangeException` / `ArgumentException`. |
 | `SourceWeights` order | `[denseWeight, sparseWeight]`. Documented in XML. |
 | `BmSaturationThreshold` | Surfaces in `HybridMeta.BmSaturationThreshold`. **Does not affect fusion math in 2.6.0.** |
-| Warning-once | Missing provider warning emitted exactly once per process via `Interlocked.CompareExchange` flag on the tool. |
+| Warning-once | Missing-provider warning emitted exactly once **per process** via a `static` `Interlocked.CompareExchange` latch on `HybridQueryCoordinator`. (2.7.0, #78 item 4: promoted from a per-instance field on `OntologyQueryTool`, which relied on the unenforced singleton-DI convention; a test-only `ResetWarnOnceLatch()` seam restores per-test isolation under the parallel runner.) |
 
 ### 6.7 Test strategy
 

--- a/src/Strategos.Ontology.MCP.Tests/OntologyQueryToolHybridMetaSnapshotTests.cs
+++ b/src/Strategos.Ontology.MCP.Tests/OntologyQueryToolHybridMetaSnapshotTests.cs
@@ -24,6 +24,9 @@ public sealed class OntologyQueryToolHybridMetaSnapshotTests
     [Before(Test)]
     public void Setup()
     {
+        // Reset the process-wide warn-once latch (issue #78 item 4) so the
+        // no-provider snapshot does not consume the warning another suite asserts on.
+        HybridQueryCoordinator.ResetWarnOnceLatch();
         _graph = TestOntologyGraphFactory.CreateTradingGraph();
         _objectSetProvider = Substitute.For<IObjectSetProvider>();
         _eventStreamProvider = Substitute.For<IEventStreamProvider>();
@@ -133,7 +136,10 @@ public sealed class OntologyQueryToolHybridMetaSnapshotTests
 
     // ---- Snapshot 4: degraded no-keyword-provider ----
 
+    // Trips the process-wide warn-once latch (item 4); serialized with the
+    // warn-count assertions in OntologyQueryToolHybridTests via the shared key.
     [Test]
+    [NotInParallel("HybridWarnOnceLatch")]
     public async Task Snapshot_HybridDegradedNoKeywordProvider()
     {
         var items = new List<object> { new TestItem("doc-a", "AAPL") };
@@ -181,6 +187,36 @@ public sealed class OntologyQueryToolHybridMetaSnapshotTests
         var json = SerializeMeta(result.Meta);
         await Assert.That(json).Contains("\"hybrid\":false");
         await Assert.That(json).Contains("\"degraded\":\"sparse-failed\"");
+        await Assert.That(json).DoesNotContain("\"fusionMethod\"");
+        await Assert.That(json).DoesNotContain("\"denseTopScore\"");
+        await Assert.That(json).DoesNotContain("\"sparseTopScore\"");
+        await Assert.That(json).DoesNotContain("\"bmSaturationThreshold\"");
+    }
+
+    // ---- Snapshot 6: degraded sparse-empty (issue #78 item 1) ----
+
+    [Test]
+    public async Task Snapshot_HybridDegradedSparseEmpty()
+    {
+        var items = new List<object> { new TestItem("doc-a", "AAPL") };
+        var scores = new List<double> { 0.91 };
+        _objectSetProvider
+            .ExecuteSimilarityAsync<object>(Arg.Any<SimilarityExpression>(), Arg.Any<CancellationToken>())
+            .Returns(new ScoredObjectSetResult<object>(items, items.Count, ObjectSetInclusion.Properties, scores));
+
+        var keywordProvider = Substitute.For<IKeywordSearchProvider>();
+        keywordProvider
+            .SearchAsync(Arg.Any<KeywordSearchRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<KeywordSearchResult>>(Array.Empty<KeywordSearchResult>()));
+
+        var tool = BuildTool(keywordProvider);
+        var result = (SemanticQueryResult)await tool.QueryAsync(
+            objectType: "TestPosition", domain: "trading",
+            semanticQuery: "q", hybridOptions: new HybridQueryOptions());
+
+        var json = SerializeMeta(result.Meta);
+        await Assert.That(json).Contains("\"hybrid\":false");
+        await Assert.That(json).Contains("\"degraded\":\"sparse-empty\"");
         await Assert.That(json).DoesNotContain("\"fusionMethod\"");
         await Assert.That(json).DoesNotContain("\"denseTopScore\"");
         await Assert.That(json).DoesNotContain("\"sparseTopScore\"");

--- a/src/Strategos.Ontology.MCP.Tests/OntologyQueryToolHybridTests.cs
+++ b/src/Strategos.Ontology.MCP.Tests/OntologyQueryToolHybridTests.cs
@@ -21,6 +21,10 @@ public sealed class OntologyQueryToolHybridTests
     [Before(Test)]
     public void Setup()
     {
+        // The missing-provider warn-once latch is process-wide static (issue #78
+        // item 4), so reset it per test to keep the "warns exactly once" assertion
+        // independent of test execution order.
+        HybridQueryCoordinator.ResetWarnOnceLatch();
         _graph = TestOntologyGraphFactory.CreateTradingGraph();
         _objectSetProvider = Substitute.For<IObjectSetProvider>();
         _eventStreamProvider = Substitute.For<IEventStreamProvider>();
@@ -102,7 +106,10 @@ public sealed class OntologyQueryToolHybridTests
 
     // ---- Task 31: semantic + hybridOptions + no provider → degraded ----
 
+    // Serialized against every other test that trips the process-wide warn-once
+    // latch (item 4) so the warning-count assertions are not raced by parallel tests.
     [Test]
+    [NotInParallel("HybridWarnOnceLatch")]
     public async Task QueryAsync_SemanticWithHybridOptions_NoProviderRegistered_DenseOnly_DegradedNoKeywordProvider_WarnsOnce()
     {
         var items = new List<object> { new { Id = "p1" } };
@@ -461,6 +468,79 @@ public sealed class OntologyQueryToolHybridTests
         var errors = logger.Entries.Where(e => e.Level == LogLevel.Error).ToList();
         await Assert.That(errors.Count).IsEqualTo(1);
         await Assert.That(errors[0].Exception).IsSameReferenceAs(sparseFault);
+    }
+
+    // ---- Issue #78 item 1: Sparse empty (non-null, zero rows) → dense-only, Degraded="sparse-empty" ----
+
+    [Test]
+    public async Task QueryAsync_HybridSparseReturnsEmpty_DenseOnly_DegradedSparseEmpty_NoWarnOrError()
+    {
+        // The sparse leg succeeds but contributes no candidates. Per design §6.6 /
+        // DIM-7, HybridMeta.Hybrid is true only when sparse actually contributed,
+        // so this surfaces as dense-only with Degraded="sparse-empty" — NOT a
+        // Hybrid=true envelope with a null sparseTopScore. Empty is not a failure,
+        // so nothing is logged.
+        var denseItems = new List<object> { new TestItem("doc-a", "AAPL") };
+        var denseScores = new List<double> { 0.91 };
+        _objectSetProvider
+            .ExecuteSimilarityAsync<object>(Arg.Any<SimilarityExpression>(), Arg.Any<CancellationToken>())
+            .Returns(new ScoredObjectSetResult<object>(denseItems, denseItems.Count, ObjectSetInclusion.Properties, denseScores));
+
+        var keywordProvider = Substitute.For<IKeywordSearchProvider>();
+        keywordProvider
+            .SearchAsync(Arg.Any<KeywordSearchRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<KeywordSearchResult>>(Array.Empty<KeywordSearchResult>()));
+
+        var logger = new CapturingLogger<OntologyQueryTool>();
+        var tool = BuildTool(logger, keywordProvider: keywordProvider);
+
+        var union = await tool.QueryAsync(
+            objectType: "TestPosition",
+            domain: "trading",
+            semanticQuery: "tech stocks",
+            hybridOptions: new HybridQueryOptions());
+
+        var result = (SemanticQueryResult)union;
+        await Assert.That(result.Items.Cast<TestItem>().Select(i => i.Id).ToList())
+            .IsEquivalentTo(new[] { "doc-a" });
+        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Scores).IsEquivalentTo(new[] { 0.91 });
+        await Assert.That(result.Meta.Hybrid).IsNotNull();
+        await Assert.That(result.Meta.Hybrid!.Hybrid).IsFalse();
+        await Assert.That(result.Meta.Hybrid.Degraded).IsEqualTo("sparse-empty");
+        await Assert.That(result.Meta.Hybrid.FusionMethod).IsNull();
+        await Assert.That(result.Meta.Hybrid.SparseTopScore).IsNull();
+        // Empty is a legitimate result, not a fault — no warning, no error.
+        await Assert.That(logger.Entries.Count).IsEqualTo(0);
+    }
+
+    // ---- Issue #78 item 4: warn-once is per-process (static), not per-instance ----
+
+    [Test]
+    [NotInParallel("HybridWarnOnceLatch")]
+    public async Task QueryAsync_NoProvider_AcrossTwoToolInstances_WarnsOncePerProcess()
+    {
+        // Item 4: the missing-provider warning is latched per process (static), so a
+        // second OntologyQueryTool instance sharing the process does NOT re-warn.
+        // Setup() reset the latch, so the first instance owns the single warning.
+        var items = new List<object> { new { Id = "p1" } };
+        var scores = new List<double> { 0.9 };
+        _objectSetProvider
+            .ExecuteSimilarityAsync<object>(Arg.Any<SimilarityExpression>(), Arg.Any<CancellationToken>())
+            .Returns(new ScoredObjectSetResult<object>(items, items.Count, ObjectSetInclusion.Properties, scores));
+
+        var loggerA = new CapturingLogger<OntologyQueryTool>();
+        var loggerB = new CapturingLogger<OntologyQueryTool>();
+        var toolA = BuildTool(loggerA, keywordProvider: null);
+        var toolB = BuildTool(loggerB, keywordProvider: null);
+
+        await toolA.QueryAsync(objectType: "TestPosition", domain: "trading",
+            semanticQuery: "q", hybridOptions: new HybridQueryOptions());
+        await toolB.QueryAsync(objectType: "TestPosition", domain: "trading",
+            semanticQuery: "q", hybridOptions: new HybridQueryOptions());
+
+        await Assert.That(loggerA.Entries.Count(e => e.Level == LogLevel.Warning)).IsEqualTo(1);
+        await Assert.That(loggerB.Entries.Count(e => e.Level == LogLevel.Warning)).IsEqualTo(0);
     }
 
     // ---- Task 38: Dense failure → propagates (no fallback to sparse-only) ----

--- a/src/Strategos.Ontology.MCP/HybridMeta.cs
+++ b/src/Strategos.Ontology.MCP/HybridMeta.cs
@@ -19,8 +19,10 @@ namespace Strategos.Ontology.MCP;
 /// </param>
 /// <param name="Degraded">
 /// Degradation reason tag when the hybrid path declined to its dense-only
-/// fallback. Values: <c>"no-keyword-provider"</c> or <c>"sparse-failed"</c>.
-/// Null on healthy paths; omitted from the wire when null.
+/// fallback. Values: <c>"no-keyword-provider"</c> (no provider registered),
+/// <c>"sparse-failed"</c> (sparse leg threw), or <c>"sparse-empty"</c> (sparse
+/// leg succeeded but returned no candidates, so it could not contribute to
+/// fusion). Null on healthy paths; omitted from the wire when null.
 /// </param>
 /// <param name="DenseTopScore">
 /// Highest dense-leg similarity score observed for this query. Null on degraded

--- a/src/Strategos.Ontology.MCP/HybridQueryCoordinator.cs
+++ b/src/Strategos.Ontology.MCP/HybridQueryCoordinator.cs
@@ -1,0 +1,333 @@
+using Microsoft.Extensions.Logging;
+
+using Strategos.Ontology.ObjectSets;
+using Strategos.Ontology.Retrieval;
+
+namespace Strategos.Ontology.MCP;
+
+/// <summary>
+/// Drives the hybrid (dense + sparse) retrieval path for
+/// <see cref="OntologyQueryTool"/>: the <c>EnableKeyword</c> ablation gate, the
+/// missing-provider and sparse-failure degradations, the parallel two-leg fan-out,
+/// and rank fusion (design §6.4 decision tree). <see cref="OntologyQueryTool"/>
+/// retains structural and dense-only-semantic orchestration; everything that only
+/// matters when <c>hybridOptions</c> is supplied lives here (issue #78, item 5).
+/// </summary>
+internal sealed class HybridQueryCoordinator
+{
+    private readonly IObjectSetProvider _objectSetProvider;
+    private readonly IKeywordSearchProvider? _keywordProvider;
+    private readonly OntologyGraph _graph;
+    private readonly ILogger _logger;
+
+    // Warn-once latch for the "hybrid requested but no IKeywordSearchProvider
+    // registered" degraded path. Static so the warning fires exactly once per
+    // process (design §6.6, DIM-5/DIM-8) regardless of how many OntologyQueryTool /
+    // HybridQueryCoordinator instances a host constructs — issue #78 item 4
+    // replaced the prior per-instance field, which relied on the unenforced
+    // "DI registers a singleton" convention. Reset for test isolation via
+    // ResetWarnOnceLatch.
+    private static int s_noProviderWarnedOnce;
+
+    public HybridQueryCoordinator(
+        IObjectSetProvider objectSetProvider,
+        IKeywordSearchProvider? keywordProvider,
+        OntologyGraph graph,
+        ILogger logger)
+    {
+        _objectSetProvider = objectSetProvider;
+        _keywordProvider = keywordProvider;
+        _graph = graph;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Resets the process-wide warn-once latch. Test-only seam: the static latch
+    /// (item 4) makes the "warns exactly once" assertion order-dependent across
+    /// tests in a shared process, so suites that exercise the missing-provider path
+    /// call this in their per-test setup.
+    /// </summary>
+    internal static void ResetWarnOnceLatch() => Interlocked.Exchange(ref s_noProviderWarnedOnce, 0);
+
+    /// <summary>
+    /// Executes the hybrid path for a semantic query with non-null
+    /// <paramref name="hybridOptions"/>. Returns a dense-only
+    /// <see cref="SemanticQueryResult"/> on every degraded leaf and a fused result
+    /// when both legs contribute.
+    /// </summary>
+    public async Task<SemanticQueryResult> ExecuteAsync(
+        SimilarityExpression similarityExpression,
+        SemanticQueryRequest request,
+        HybridQueryOptions hybridOptions,
+        CancellationToken ct)
+    {
+        // EnableKeyword=false: explicit-ablation path takes precedence over
+        // provider-missing degradation so callers who explicitly opted out of
+        // sparse never see Degraded="no-keyword-provider" even when no
+        // IKeywordSearchProvider is registered (CodeRabbit PR #77 finding).
+        if (!hybridOptions.EnableKeyword)
+        {
+            return await DenseOnlyAsync(
+                similarityExpression, request, new HybridMeta(Hybrid: false), ct).ConfigureAwait(false);
+        }
+
+        // Hybrid requested but no provider registered → degraded dense-only
+        // with warn-once. The warning carries enough context for operators
+        // to discover the missing DI registration.
+        if (_keywordProvider is null)
+        {
+            if (Interlocked.CompareExchange(ref s_noProviderWarnedOnce, 1, 0) == 0)
+            {
+                _logger.LogWarning(
+                    "HybridQueryOptions supplied but no IKeywordSearchProvider is registered; falling back to dense-only retrieval for this and subsequent calls.");
+            }
+
+            var degradedMeta = new HybridMeta(Hybrid: false, Degraded: "no-keyword-provider");
+            return await DenseOnlyAsync(similarityExpression, request, degradedMeta, ct).ConfigureAwait(false);
+        }
+
+        return await ExecuteHybridAsync(similarityExpression, request, hybridOptions, ct).ConfigureAwait(false);
+    }
+
+    private async Task<SemanticQueryResult> DenseOnlyAsync(
+        SimilarityExpression similarityExpression,
+        SemanticQueryRequest request,
+        HybridMeta hybridMeta,
+        CancellationToken ct)
+    {
+        var dense = await _objectSetProvider
+            .ExecuteSimilarityAsync<object>(similarityExpression, ct)
+            .ConfigureAwait(false);
+
+        return SemanticQueryResult.FromRequest(
+            request, dense.Items, dense.Scores, hybridMeta, ResponseMeta.ForGraph(_graph));
+    }
+
+    private async Task<SemanticQueryResult> ExecuteHybridAsync(
+        SimilarityExpression similarityExpression,
+        SemanticQueryRequest request,
+        HybridQueryOptions hybridOptions,
+        CancellationToken ct)
+    {
+        // Fan out dense + sparse legs in parallel. Both Tasks start before either
+        // is awaited so we get true overlap (design §6.6 parallelism contract).
+        // The sparse leg uses HybridQueryOptions.SparseTopK and the descriptor
+        // name (objectType) as the collection key.
+        //
+        // The dense leg uses a candidate pool of max(outer topK, DenseTopK) so
+        // fusion sees the full DenseTopK pool the caller requested while still
+        // returning at least the outer topK results the caller asked for. The
+        // final projection in FuseHybrid trims back to outer topK.
+        var denseSimilarityExpression = hybridOptions.DenseTopK > similarityExpression.TopK
+            ? new SimilarityExpression(
+                similarityExpression.Source,
+                similarityExpression.QueryText,
+                hybridOptions.DenseTopK,
+                similarityExpression.MinRelevance,
+                similarityExpression.Metric,
+                similarityExpression.EmbeddingPropertyName,
+                similarityExpression.QueryVector,
+                similarityExpression.Filters)
+            : similarityExpression;
+        var denseTask = _objectSetProvider.ExecuteSimilarityAsync<object>(denseSimilarityExpression, ct);
+        var sparseTask = InvokeSparseLegAsync(request.SemanticQuery, request.ObjectType, hybridOptions.SparseTopK, ct);
+
+        // Await both. Dense throws propagate (baseline — design §6.6, Task 38).
+        // Sparse-fault is caught inside InvokeSparseLegAsync and surfaced as null
+        // so that Task.WhenAll cannot raise just-the-sparse failure here. We
+        // still await Task.WhenAll for cancellation-token propagation symmetry.
+        try
+        {
+            await Task.WhenAll(denseTask, sparseTask).ConfigureAwait(false);
+        }
+        catch when (denseTask.IsFaulted)
+        {
+            // Re-throw the dense exception below by awaiting the task directly.
+        }
+
+        var dense = await denseTask.ConfigureAwait(false);
+        var sparseOrNull = await sparseTask.ConfigureAwait(false);
+
+        if (sparseOrNull is null)
+        {
+            // Sparse-failed degraded path: return dense-only items with
+            // HybridMeta { Hybrid = false, Degraded = "sparse-failed" }.
+            return SemanticQueryResult.FromRequest(
+                request, dense.Items, dense.Scores,
+                new HybridMeta(Hybrid: false, Degraded: "sparse-failed"),
+                ResponseMeta.ForGraph(_graph));
+        }
+
+        if (sparseOrNull.Count == 0)
+        {
+            // Sparse-empty path (issue #78 item 1): the sparse leg ran and
+            // succeeded but contributed no candidates, so fusion is a no-op over
+            // the dense order. HybridMeta.Hybrid is true only when sparse actually
+            // contributed (design §6.6, DIM-7), so this surfaces as dense-only with
+            // a distinct Degraded="sparse-empty" reason rather than a misleading
+            // Hybrid=true envelope carrying a null sparseTopScore.
+            return SemanticQueryResult.FromRequest(
+                request, dense.Items, dense.Scores,
+                new HybridMeta(Hybrid: false, Degraded: "sparse-empty"),
+                ResponseMeta.ForGraph(_graph));
+        }
+
+        return FuseHybrid(dense, sparseOrNull, hybridOptions, request);
+    }
+
+    /// <summary>
+    /// Invokes the sparse keyword leg, returning <c>null</c> on caught fault
+    /// (logged at Error with the exception + stack) and rethrowing on cancel
+    /// so caller-driven cancellation does not silently mutate into a
+    /// sparse-failed degraded result.
+    /// </summary>
+    private async Task<IReadOnlyList<KeywordSearchResult>?> InvokeSparseLegAsync(
+        string query, string collection, int sparseTopK, CancellationToken ct)
+    {
+        try
+        {
+            return await _keywordProvider!
+                .SearchAsync(new KeywordSearchRequest(query, collection, sparseTopK), ct)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Caller-driven cancellation: surface naturally so QueryAsync
+            // rethrows OperationCanceledException (design §6.6 cancellation).
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Hybrid sparse leg threw {ExceptionType}; falling back to dense-only retrieval for this call.",
+                ex.GetType().Name);
+            return null;
+        }
+    }
+
+    private SemanticQueryResult FuseHybrid(
+        ScoredObjectSetResult<object> dense,
+        IReadOnlyList<KeywordSearchResult> sparse,
+        HybridQueryOptions hybridOptions,
+        SemanticQueryRequest request)
+    {
+        // Build (id → item, score) lookup for the dense leg, preserving original
+        // item order so that DBSF's tie-break (input-order stability inside
+        // RankFusion) matches an oracle that iterates dense.Items in order.
+        var denseByDocId = new Dictionary<string, (object Item, double Score, int Rank)>(StringComparer.Ordinal);
+        var denseRanked = new List<RankedCandidate>(dense.Items.Count);
+        var denseScored = new List<ScoredCandidate>(dense.Items.Count);
+        for (int i = 0; i < dense.Items.Count; i++)
+        {
+            var id = ExtractDocumentId(dense.Items[i]);
+            if (id is null)
+            {
+                continue;
+            }
+
+            // Tie behavior: first occurrence wins for the dense projection map.
+            if (!denseByDocId.ContainsKey(id))
+            {
+                denseByDocId[id] = (dense.Items[i], dense.Scores[i], i + 1);
+                denseRanked.Add(new RankedCandidate(id, i + 1));
+                denseScored.Add(new ScoredCandidate(id, dense.Scores[i]));
+            }
+        }
+
+        var sparseRanked = sparse.Select(r => new RankedCandidate(r.DocumentId, r.Rank)).ToList();
+
+        // Run fusion. Dispatch on FusionMethod.
+        IReadOnlyList<FusedResult> fused;
+        if (hybridOptions.FusionMethod == FusionMethod.Reciprocal)
+        {
+            fused = RankFusion.Reciprocal(
+                new IReadOnlyList<RankedCandidate>[] { denseRanked, sparseRanked },
+                weights: hybridOptions.SourceWeights,
+                k: hybridOptions.RrfK,
+                topK: request.TopK);
+        }
+        else
+        {
+            // DistributionBased uses raw scores rather than ranks. denseScored
+            // was built above in dense.Items order so DBSF's stability matches
+            // an oracle that iterates dense.Items left-to-right.
+            var sparseScored = sparse.Select(r => new ScoredCandidate(r.DocumentId, r.Score)).ToList();
+
+            fused = RankFusion.DistributionBased(
+                new IReadOnlyList<ScoredCandidate>[] { denseScored, sparseScored },
+                weights: hybridOptions.SourceWeights,
+                topK: request.TopK);
+        }
+
+        // Project the fused order back to dense items. Documents that exist only
+        // on the sparse leg (no matching dense item with extractable Id) are
+        // dropped — the 2.5.0 SemanticQueryResult shape is items+scores, and
+        // we cannot synthesize an object for a sparse-only DocumentId. See
+        // design §6.4 for the documented sparse-only drop policy.
+        var projectedItems = new List<object>(fused.Count);
+        var projectedScores = new List<double>(fused.Count);
+        foreach (var f in fused)
+        {
+            if (denseByDocId.TryGetValue(f.DocumentId, out var hit))
+            {
+                projectedItems.Add(hit.Item);
+                projectedScores.Add(hit.Score);
+            }
+        }
+
+        var sparseTopScore = sparse.Count > 0 ? sparse[0].Score : (double?)null;
+        var denseTopScore = dense.Scores.Count > 0 ? dense.Scores[0] : (double?)null;
+        var fusionTag = hybridOptions.FusionMethod switch
+        {
+            FusionMethod.Reciprocal => "reciprocal",
+            FusionMethod.DistributionBased => "distribution_based",
+            _ => null,
+        };
+
+        var hybridMeta = new HybridMeta(
+            Hybrid: true,
+            FusionMethod: fusionTag,
+            Degraded: null,
+            DenseTopScore: denseTopScore,
+            SparseTopScore: sparseTopScore,
+            BmSaturationThreshold: hybridOptions.BmSaturationThreshold);
+
+        return SemanticQueryResult.FromRequest(
+            request, projectedItems, projectedScores, hybridMeta, ResponseMeta.ForGraph(_graph));
+    }
+
+    /// <summary>
+    /// Reads the <c>Id</c> property from a dense-leg item via reflection. The
+    /// hybrid coordinator needs a stable string identifier to align dense items
+    /// with sparse <see cref="KeywordSearchResult.DocumentId"/>; the ontology's
+    /// existing convention is a public <c>Id</c> property. Returns <c>null</c>
+    /// when no such property exists or its string projection is null.
+    /// </summary>
+    /// <remarks>
+    /// The trim-warning is suppressed because dense items are produced by
+    /// <see cref="IObjectSetProvider.ExecuteSimilarityAsync"/> which already
+    /// requires the underlying CLR types to be preserved end-to-end; the
+    /// ontology graph machinery keeps those types referenced.
+    /// </remarks>
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2075:'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method",
+        Justification = "Dense items' CLR types are retained by the ontology graph (see IObjectSetProvider). The 'Id' property is part of every ontology object descriptor that participates in similarity search.")]
+    private static string? ExtractDocumentId(object item)
+    {
+        if (item is null)
+        {
+            return null;
+        }
+
+        var prop = item.GetType().GetProperty("Id");
+        if (prop is null)
+        {
+            return null;
+        }
+
+        var value = prop.GetValue(item);
+        return value?.ToString();
+    }
+}

--- a/src/Strategos.Ontology.MCP/OntologyQueryTool.cs
+++ b/src/Strategos.Ontology.MCP/OntologyQueryTool.cs
@@ -16,13 +16,7 @@ public sealed class OntologyQueryTool
     private readonly IObjectSetProvider _objectSetProvider;
     private readonly IEventStreamProvider _eventStreamProvider;
     private readonly ILogger<OntologyQueryTool> _logger;
-    private readonly IKeywordSearchProvider? _keywordProvider;
-
-    // Warn-once latch for the "hybrid requested but no IKeywordSearchProvider
-    // registered" degraded path. Scoped per OntologyQueryTool instance per design
-    // §6.6 ("Warning-once: ... per process" — DI typically registers the tool as a
-    // singleton, making per-instance equivalent to per-process for production hosts).
-    private int _noProviderWarnedOnce;
+    private readonly HybridQueryCoordinator _hybridCoordinator;
 
     public OntologyQueryTool(
         OntologyGraph graph,
@@ -36,7 +30,11 @@ public sealed class OntologyQueryTool
         _objectSetProvider = objectSetProvider;
         _eventStreamProvider = eventStreamProvider;
         _logger = logger;
-        _keywordProvider = keywordProvider;
+
+        // The coordinator owns the hybrid (dense + sparse) path; it is constructed
+        // even when no keyword provider is registered so the missing-provider
+        // degradation (with its process-wide warn-once) routes through one place.
+        _hybridCoordinator = new HybridQueryCoordinator(objectSetProvider, keywordProvider, graph, logger);
     }
 
     /// <summary>
@@ -75,9 +73,10 @@ public sealed class OntologyQueryTool
 
         if (semanticQuery is not null)
         {
-            return await ExecuteSemanticQueryAsync(
-                expression, objectType, semanticQuery, topK, minRelevance, distanceMetric,
-                filter, traverseLink, interfaceName, include, hybridOptions, ct).ConfigureAwait(false);
+            var request = new SemanticQueryRequest(
+                objectType, semanticQuery, topK, minRelevance, distanceMetric,
+                filter, traverseLink, interfaceName, include);
+            return await ExecuteSemanticQueryAsync(expression, request, hybridOptions, ct).ConfigureAwait(false);
         }
 
         var result = await _objectSetProvider.ExecuteAsync<object>(expression, ct).ConfigureAwait(false);
@@ -117,338 +116,32 @@ public sealed class OntologyQueryTool
 
     private async Task<SemanticQueryResult> ExecuteSemanticQueryAsync(
         ObjectSetExpression baseExpression,
-        string objectType,
-        string semanticQuery,
-        int topK,
-        double minRelevance,
-        string? distanceMetric,
-        string? filter,
-        string? traverseLink,
-        string? interfaceName,
-        string? include,
+        SemanticQueryRequest request,
         HybridQueryOptions? hybridOptions,
         CancellationToken ct)
     {
-        var metric = ParseDistanceMetric(distanceMetric);
+        var metric = ParseDistanceMetric(request.DistanceMetric);
 
         var similarityExpression = new SimilarityExpression(
-            baseExpression, semanticQuery, topK, minRelevance, metric);
+            baseExpression, request.SemanticQuery, request.TopK, request.MinRelevance, metric);
 
         // Hybrid dispatch lives entirely on the semantic branch; structural
         // queries return 2.5.0 QueryResult untouched. See design §6.4 decision tree.
+        // When no hybridOptions are supplied this is the byte-for-byte 2.5.0
+        // dense-only path; otherwise the coordinator owns the hybrid decision tree.
         if (hybridOptions is null)
         {
             var dense = await _objectSetProvider
                 .ExecuteSimilarityAsync<object>(similarityExpression, ct)
                 .ConfigureAwait(false);
 
-            return BuildSemanticResult(objectType, dense.Items, dense.Scores,
-                hybridMeta: null, semanticQuery, topK, minRelevance,
-                filter, traverseLink, interfaceName, include);
+            return SemanticQueryResult.FromRequest(
+                request, dense.Items, dense.Scores, hybridMeta: null, CurrentMeta());
         }
 
-        // EnableKeyword=false: explicit-ablation path takes precedence over
-        // provider-missing degradation so callers who explicitly opted out of
-        // sparse never see Degraded="no-keyword-provider" even when no
-        // IKeywordSearchProvider is registered (CodeRabbit PR #77 finding).
-        if (!hybridOptions.EnableKeyword)
-        {
-            var dense = await _objectSetProvider
-                .ExecuteSimilarityAsync<object>(similarityExpression, ct)
-                .ConfigureAwait(false);
-
-            var enabledFalseMeta = new HybridMeta(Hybrid: false);
-            return BuildSemanticResult(objectType, dense.Items, dense.Scores,
-                hybridMeta: enabledFalseMeta, semanticQuery, topK, minRelevance,
-                filter, traverseLink, interfaceName, include);
-        }
-
-        // Hybrid requested but no provider registered → degraded dense-only
-        // with warn-once. The warning carries enough context for operators
-        // to discover the missing DI registration.
-        if (_keywordProvider is null)
-        {
-            if (Interlocked.CompareExchange(ref _noProviderWarnedOnce, 1, 0) == 0)
-            {
-                _logger.LogWarning(
-                    "HybridQueryOptions supplied but no IKeywordSearchProvider is registered; falling back to dense-only retrieval for this and subsequent calls.");
-            }
-
-            var dense = await _objectSetProvider
-                .ExecuteSimilarityAsync<object>(similarityExpression, ct)
-                .ConfigureAwait(false);
-
-            var degradedMeta = new HybridMeta(Hybrid: false, Degraded: "no-keyword-provider");
-            return BuildSemanticResult(objectType, dense.Items, dense.Scores,
-                hybridMeta: degradedMeta, semanticQuery, topK, minRelevance,
-                filter, traverseLink, interfaceName, include);
-        }
-
-        return await ExecuteHybridSemanticAsync(
-            similarityExpression, objectType, semanticQuery, topK, minRelevance,
-            filter, traverseLink, interfaceName, include, hybridOptions, ct).ConfigureAwait(false);
-    }
-
-    private async Task<SemanticQueryResult> ExecuteHybridSemanticAsync(
-        SimilarityExpression similarityExpression,
-        string objectType,
-        string semanticQuery,
-        int topK,
-        double minRelevance,
-        string? filter,
-        string? traverseLink,
-        string? interfaceName,
-        string? include,
-        HybridQueryOptions hybridOptions,
-        CancellationToken ct)
-    {
-        // Fan out dense + sparse legs in parallel. Both Tasks start before either
-        // is awaited so we get true overlap (design §6.6 parallelism contract).
-        // The sparse leg uses HybridQueryOptions.SparseTopK and the descriptor
-        // name (objectType) as the collection key.
-        //
-        // The dense leg uses a candidate pool of max(outer topK, DenseTopK) so
-        // fusion sees the full DenseTopK pool the caller requested while still
-        // returning at least the outer topK results the caller asked for. The
-        // final projection in FuseHybrid trims back to outer topK.
-        var denseSimilarityExpression = hybridOptions.DenseTopK > similarityExpression.TopK
-            ? new SimilarityExpression(
-                similarityExpression.Source,
-                similarityExpression.QueryText,
-                hybridOptions.DenseTopK,
-                similarityExpression.MinRelevance,
-                similarityExpression.Metric,
-                similarityExpression.EmbeddingPropertyName,
-                similarityExpression.QueryVector,
-                similarityExpression.Filters)
-            : similarityExpression;
-        var denseTask = _objectSetProvider.ExecuteSimilarityAsync<object>(denseSimilarityExpression, ct);
-        var sparseTask = InvokeSparseLegAsync(semanticQuery, objectType, hybridOptions.SparseTopK, ct);
-
-        // Await both. Dense throws propagate (baseline — design §6.6, Task 38).
-        // Sparse-fault is caught inside InvokeSparseLegAsync and surfaced as null
-        // so that Task.WhenAll cannot raise just-the-sparse failure here. We
-        // still await Task.WhenAll for cancellation-token propagation symmetry.
-        try
-        {
-            await Task.WhenAll(denseTask, sparseTask).ConfigureAwait(false);
-        }
-        catch when (denseTask.IsFaulted)
-        {
-            // Re-throw the dense exception below by awaiting the task directly.
-        }
-
-        var dense = await denseTask.ConfigureAwait(false);
-        var sparseOrNull = await sparseTask.ConfigureAwait(false);
-
-        if (sparseOrNull is null)
-        {
-            // Sparse-failed degraded path: return dense-only items with
-            // HybridMeta { Hybrid = false, Degraded = "sparse-failed" }.
-            var degradedMeta = new HybridMeta(Hybrid: false, Degraded: "sparse-failed");
-            return BuildSemanticResult(objectType, dense.Items, dense.Scores,
-                degradedMeta, semanticQuery, topK, minRelevance,
-                filter, traverseLink, interfaceName, include);
-        }
-
-        return FuseHybrid(
-            dense, sparseOrNull, hybridOptions, objectType, semanticQuery, topK, minRelevance,
-            filter, traverseLink, interfaceName, include);
-    }
-
-    /// <summary>
-    /// Invokes the sparse keyword leg, returning <c>null</c> on caught fault
-    /// (logged at Error with the exception + stack) and rethrowing on cancel
-    /// so caller-driven cancellation does not silently mutate into a
-    /// sparse-failed degraded result.
-    /// </summary>
-    private async Task<IReadOnlyList<KeywordSearchResult>?> InvokeSparseLegAsync(
-        string query, string collection, int sparseTopK, CancellationToken ct)
-    {
-        try
-        {
-            return await _keywordProvider!
-                .SearchAsync(new KeywordSearchRequest(query, collection, sparseTopK), ct)
-                .ConfigureAwait(false);
-        }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
-        {
-            // Caller-driven cancellation: surface naturally so QueryAsync
-            // rethrows OperationCanceledException (design §6.6 cancellation).
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(
-                ex,
-                "Hybrid sparse leg threw {ExceptionType}; falling back to dense-only retrieval for this call.",
-                ex.GetType().Name);
-            return null;
-        }
-    }
-
-    private SemanticQueryResult FuseHybrid(
-        ScoredObjectSetResult<object> dense,
-        IReadOnlyList<KeywordSearchResult> sparse,
-        HybridQueryOptions hybridOptions,
-        string objectType,
-        string semanticQuery,
-        int topK,
-        double minRelevance,
-        string? filter,
-        string? traverseLink,
-        string? interfaceName,
-        string? include)
-    {
-        // Build (id → item, score) lookup for the dense leg, preserving original
-        // item order so that DBSF's tie-break (input-order stability inside
-        // RankFusion) matches an oracle that iterates dense.Items in order.
-        var denseByDocId = new Dictionary<string, (object Item, double Score, int Rank)>(StringComparer.Ordinal);
-        var denseRanked = new List<RankedCandidate>(dense.Items.Count);
-        var denseScored = new List<ScoredCandidate>(dense.Items.Count);
-        for (int i = 0; i < dense.Items.Count; i++)
-        {
-            var id = ExtractDocumentId(dense.Items[i]);
-            if (id is null)
-            {
-                continue;
-            }
-
-            // Tie behavior: first occurrence wins for the dense projection map.
-            if (!denseByDocId.ContainsKey(id))
-            {
-                denseByDocId[id] = (dense.Items[i], dense.Scores[i], i + 1);
-                denseRanked.Add(new RankedCandidate(id, i + 1));
-                denseScored.Add(new ScoredCandidate(id, dense.Scores[i]));
-            }
-        }
-
-        var sparseRanked = sparse.Select(r => new RankedCandidate(r.DocumentId, r.Rank)).ToList();
-
-        // Run fusion. Dispatch on FusionMethod.
-        IReadOnlyList<FusedResult> fused;
-        if (hybridOptions.FusionMethod == FusionMethod.Reciprocal)
-        {
-            fused = RankFusion.Reciprocal(
-                new IReadOnlyList<RankedCandidate>[] { denseRanked, sparseRanked },
-                weights: hybridOptions.SourceWeights,
-                k: hybridOptions.RrfK,
-                topK: topK);
-        }
-        else
-        {
-            // DistributionBased uses raw scores rather than ranks. denseScored
-            // was built above in dense.Items order so DBSF's stability matches
-            // an oracle that iterates dense.Items left-to-right.
-            var sparseScored = sparse.Select(r => new ScoredCandidate(r.DocumentId, r.Score)).ToList();
-
-            fused = RankFusion.DistributionBased(
-                new IReadOnlyList<ScoredCandidate>[] { denseScored, sparseScored },
-                weights: hybridOptions.SourceWeights,
-                topK: topK);
-        }
-
-        // Project the fused order back to dense items. Documents that exist only
-        // on the sparse leg (no matching dense item with extractable Id) are
-        // dropped — the 2.5.0 SemanticQueryResult shape is items+scores, and
-        // we cannot synthesize an object for a sparse-only DocumentId.
-        var projectedItems = new List<object>(fused.Count);
-        var projectedScores = new List<double>(fused.Count);
-        foreach (var f in fused)
-        {
-            if (denseByDocId.TryGetValue(f.DocumentId, out var hit))
-            {
-                projectedItems.Add(hit.Item);
-                projectedScores.Add(hit.Score);
-            }
-        }
-
-        var sparseTopScore = sparse.Count > 0 ? sparse[0].Score : (double?)null;
-        var denseTopScore = dense.Scores.Count > 0 ? dense.Scores[0] : (double?)null;
-        var fusionTag = hybridOptions.FusionMethod switch
-        {
-            FusionMethod.Reciprocal => "reciprocal",
-            FusionMethod.DistributionBased => "distribution_based",
-            _ => null,
-        };
-
-        var hybridMeta = new HybridMeta(
-            Hybrid: true,
-            FusionMethod: fusionTag,
-            Degraded: null,
-            DenseTopScore: denseTopScore,
-            SparseTopScore: sparseTopScore,
-            BmSaturationThreshold: hybridOptions.BmSaturationThreshold);
-
-        return BuildSemanticResult(objectType, projectedItems, projectedScores,
-            hybridMeta, semanticQuery, topK, minRelevance,
-            filter, traverseLink, interfaceName, include);
-    }
-
-    /// <summary>
-    /// Reads the <c>Id</c> property from a dense-leg item via reflection. The
-    /// hybrid coordinator needs a stable string identifier to align dense items
-    /// with sparse <see cref="KeywordSearchResult.DocumentId"/>; the ontology's
-    /// existing convention is a public <c>Id</c> property. Returns <c>null</c>
-    /// when no such property exists or its string projection is null.
-    /// </summary>
-    /// <remarks>
-    /// The trim-warning is suppressed because dense items are produced by
-    /// <see cref="IObjectSetProvider.ExecuteSimilarityAsync"/> which already
-    /// requires the underlying CLR types to be preserved end-to-end; the
-    /// ontology graph machinery keeps those types referenced.
-    /// </remarks>
-    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(
-        "Trimming",
-        "IL2075:'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method",
-        Justification = "Dense items' CLR types are retained by the ontology graph (see IObjectSetProvider). The 'Id' property is part of every ontology object descriptor that participates in similarity search.")]
-    private static string? ExtractDocumentId(object item)
-    {
-        if (item is null)
-        {
-            return null;
-        }
-
-        var prop = item.GetType().GetProperty("Id");
-        if (prop is null)
-        {
-            return null;
-        }
-
-        var value = prop.GetValue(item);
-        return value?.ToString();
-    }
-
-    private SemanticQueryResult BuildSemanticResult(
-        string objectType,
-        IReadOnlyList<object> items,
-        IReadOnlyList<double> scores,
-        HybridMeta? hybridMeta,
-        string semanticQuery,
-        int topK,
-        double minRelevance,
-        string? filter,
-        string? traverseLink,
-        string? interfaceName,
-        string? include)
-    {
-        var meta = CurrentMeta();
-        if (hybridMeta is not null)
-        {
-            meta = meta with { Hybrid = hybridMeta };
-        }
-
-        return new SemanticQueryResult(objectType, items, meta)
-        {
-            Scores = scores,
-            SemanticQuery = semanticQuery,
-            TopK = topK,
-            MinRelevance = minRelevance,
-            Filter = filter,
-            TraverseLink = traverseLink,
-            InterfaceName = interfaceName,
-            Include = include,
-        };
+        return await _hybridCoordinator
+            .ExecuteAsync(similarityExpression, request, hybridOptions, ct)
+            .ConfigureAwait(false);
     }
 
     private ObjectSetExpression BuildExpression(

--- a/src/Strategos.Ontology.MCP/SemanticQueryRequest.cs
+++ b/src/Strategos.Ontology.MCP/SemanticQueryRequest.cs
@@ -1,0 +1,26 @@
+namespace Strategos.Ontology.MCP;
+
+/// <summary>
+/// Internal parameter object bundling the per-call shape of a semantic
+/// (<c>semanticQuery is not null</c>) query as it flows through
+/// <see cref="OntologyQueryTool"/> and <see cref="HybridQueryCoordinator"/>.
+/// </summary>
+/// <remarks>
+/// This collapses the 11–12-argument private-helper signatures that the additive
+/// 2.6.0 hybrid surface grew (issue #78). It is deliberately <c>internal</c>: the
+/// public <see cref="OntologyQueryTool.QueryAsync"/> signature stays flat and
+/// positional so the 2.5.0 backward-compatibility gate (design §6.2/§6.3, DIM-3)
+/// is untouched. Every field mirrors a <c>QueryAsync</c> parameter that the
+/// semantic branch consumes; <see cref="DistanceMetric"/> is the raw caller string,
+/// parsed once when the <c>SimilarityExpression</c> is built.
+/// </remarks>
+internal sealed record SemanticQueryRequest(
+    string ObjectType,
+    string SemanticQuery,
+    int TopK,
+    double MinRelevance,
+    string? DistanceMetric,
+    string? Filter,
+    string? TraverseLink,
+    string? InterfaceName,
+    string? Include);

--- a/src/Strategos.Ontology.MCP/SemanticQueryResult.cs
+++ b/src/Strategos.Ontology.MCP/SemanticQueryResult.cs
@@ -20,4 +20,30 @@ public sealed record SemanticQueryResult(
 
     /// <summary>Minimum relevance threshold applied to filter results.</summary>
     public double MinRelevance { get; init; }
+
+    /// <summary>
+    /// Assembles a <see cref="SemanticQueryResult"/> from a
+    /// <see cref="SemanticQueryRequest"/>, the projected items/scores, an optional
+    /// <see cref="HybridMeta"/>, and the base <see cref="ResponseMeta"/>. Single
+    /// construction site shared by <see cref="OntologyQueryTool"/>'s dense-only
+    /// semantic path and <see cref="HybridQueryCoordinator"/>'s hybrid/degraded
+    /// paths so the wire shape cannot diverge between them (DIM-5).
+    /// </summary>
+    internal static SemanticQueryResult FromRequest(
+        SemanticQueryRequest request,
+        IReadOnlyList<object> items,
+        IReadOnlyList<double> scores,
+        HybridMeta? hybridMeta,
+        ResponseMeta baseMeta) =>
+        new(request.ObjectType, items, hybridMeta is null ? baseMeta : baseMeta with { Hybrid = hybridMeta })
+        {
+            Scores = scores,
+            SemanticQuery = request.SemanticQuery,
+            TopK = request.TopK,
+            MinRelevance = request.MinRelevance,
+            Filter = request.Filter,
+            TraverseLink = request.TraverseLink,
+            InterfaceName = request.InterfaceName,
+            Include = request.Include,
+        };
 }


### PR DESCRIPTION
Resolves all six LOW-severity follow-ups from the PR #77 two-stage review (issue #78), applying `/axiom:design` and `/strategos-design-invariants` to the two behavior/design forks.

## Items

| # | Item | Resolution |
|---|------|-----------|
| 1 | `HybridMeta.Hybrid` on empty-sparse path | **Tightened** → `Hybrid=false, Degraded="sparse-empty"`. Honors the design §6.6 / DIM-7 invariant that `Hybrid=true` ⇔ the sparse leg actually contributed to fusion. The empty path was *not* pinned by any existing snapshot, so this is additive, not breaking. Empty ≠ fault, so it logs nothing. |
| 2 | `HybridQueryOptions.Validate()` absent from CHANGELOG | Added an explicit bullet under `[2.6.0]`. |
| 3 | Sparse-only drop policy undocumented | Documented in design §6.4 — sparse-only documents influence fusion *ranking* but are dropped from the projected `items` (no ontology object to synthesize from a bare `DocumentId`). |
| 4 | `_noProviderWarnedOnce` per-instance vs per-process | **Promoted to a process-wide `static` latch** on the new `HybridQueryCoordinator` (replaces the unenforced "singleton DI" convention). Added an internal `ResetWarnOnceLatch()` test seam; the three latch-touching tests are serialized via `[NotInParallel]` so warn-count assertions stay deterministic under the parallel runner. |
| 5 | `OntologyQueryTool.cs` > SC-3 500-LOC bar | Extracted `HybridQueryCoordinator` (sealed). **526 → 219 LOC.** |
| 6 | 11–12-param private helpers | Introduced `internal sealed record SemanticQueryRequest`. Public `QueryAsync` signature unchanged — DIM-3 backward-compat gate held. |

## Design conformance

- **`/strategos-design-invariants`** → **pass**. INV-3 (MCP wire shape) preserved — `HybridMeta` stays an omittable typed sub-record; INV-6/INV-7 (sealed, immutable) honored by both new types.
- **`/axiom:design`** → both forks resolved toward the DIM-7/DIM-5 honest-failure-mode reading. The static-latch test-isolation cost (DIM-4) surfaced as a real parallel-runner race during implementation and was fixed deterministically. Result construction single-sourced via `SemanticQueryResult.FromRequest` (DIM-5).

## Verification

- `Strategos.Ontology.MCP.Tests`: **158/158** (155 prior unmodified + 3 new), deterministic across 3 repeat runs.
- `Strategos.Ontology.Tests`: **839/839**.
- Full solution build: **0 warnings**.

New tests: `QueryAsync_HybridSparseReturnsEmpty_DenseOnly_DegradedSparseEmpty_NoWarnOrError`, `QueryAsync_NoProvider_AcrossTwoToolInstances_WarnsOncePerProcess`, `Snapshot_HybridDegradedSparseEmpty`.

Closes #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)