### PR TITLE
fix(release): drop Strategos.Agents 2.7.0-preview.2 pin for GA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
   basileus-smoke:
     # DR-11 / T-022 release-readiness gate.
     #
-    # Packs LevelUp.Strategos.Agents at the pinned 2.7.0
+    # Packs LevelUp.Strategos.Agents at a synthetic 2.7.0-smoke version
     # version into a directory-based local feed, then restores + builds
     # + runs the smoke project at tests/basileus-smoke/. The smoke
     # project's BasileusConsumedSurfaceTests asserts (a) the basileus-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
   basileus-smoke:
     # DR-11 / T-022 release-readiness gate.
     #
-    # Packs LevelUp.Strategos.Agents at the pinned v2.7.0-preview.2
+    # Packs LevelUp.Strategos.Agents at the pinned 2.7.0
     # version into a directory-based local feed, then restores + builds
     # + runs the smoke project at tests/basileus-smoke/. The smoke
     # project's BasileusConsumedSurfaceTests asserts (a) the basileus-

--- a/scripts/pack-to-local-feed.sh
+++ b/scripts/pack-to-local-feed.sh
@@ -65,10 +65,19 @@ echo "Expecting: $EXPECTED_NUPKG_NAME"
 rm -f "$FEED_DIR_ABS"/LevelUp.Strategos.Agents.*.nupkg \
       "$FEED_DIR_ABS"/LevelUp.Strategos.Agents.*.snupkg
 
+# NoWarn NU5104: this smoke gate packs Strategos.Agents *in isolation* in a
+# tagless CI checkout (--no-tags --depth=1), so MinVer resolves the core
+# LevelUp.Strategos dependency to a prerelease (0.0.0-alpha.0). A stable Agents
+# 2.7.0 depending on that prerelease trips NU5104, but here it is a false
+# positive — the smoke only validates the basileus-consumed surface against the
+# packed artifact. Real release dependency hygiene is enforced by the publish
+# job (which checks out the v-tag → core is stable 2.7.0) and the Pack (verify)
+# CI gate.
 if ! dotnet pack "$AGENTS_CSPROJ" \
        -c Release \
        -o "$FEED_DIR_ABS" \
        --nologo \
+       -p:NoWarn=NU5104 \
        -v:m; then
   echo "FAIL: dotnet pack of $AGENTS_CSPROJ failed." >&2
   exit 2

--- a/scripts/pack-to-local-feed.sh
+++ b/scripts/pack-to-local-feed.sh
@@ -37,7 +37,7 @@
 set -euo pipefail
 
 FEED_DIR="${1:-./local-feed}"
-EXPECTED_VERSION="2.7.0-preview.2"
+EXPECTED_VERSION="2.7.0"
 EXPECTED_NUPKG_NAME="LevelUp.Strategos.Agents.${EXPECTED_VERSION}.nupkg"
 
 # Resolve to absolute path so downstream messages are unambiguous, even

--- a/scripts/pack-to-local-feed.sh
+++ b/scripts/pack-to-local-feed.sh
@@ -31,14 +31,23 @@
 #   0  pack succeeded and the expected nupkg is present
 #   1  invalid arguments / setup error
 #   2  pack failed (regression in Strategos.Agents.csproj)
-#   3  pack succeeded but produced an unexpected version (likely
-#      <Version> override drifted off 2.7.0-preview.2)
+#   3  pack succeeded but produced an unexpected version
+#
+# Versioning note: Strategos.Agents.csproj is MinVer-derived (no explicit
+# <Version> pin) so it ships 2.7.0 at the release tag and 0.0.0-alpha.0 on
+# tagless CI, uniform with every sibling. The smoke gate does not care about the
+# real shipping version — it validates the basileus-consumed surface against a
+# packed artifact — so we pack at a deterministic SYNTHETIC prerelease version
+# here (overriding MinVer for this pack only). It is prerelease, so it may depend
+# on the prerelease core MinVer produces on tagless CI without tripping NU5104;
+# and nuget.org will never carry it, so the smoke project's PackageReference
+# resolves it unambiguously from the local feed.
 # -----------------------------------------------------------------------
 set -euo pipefail
 
 FEED_DIR="${1:-./local-feed}"
-EXPECTED_VERSION="2.7.0"
-EXPECTED_NUPKG_NAME="LevelUp.Strategos.Agents.${EXPECTED_VERSION}.nupkg"
+SMOKE_VERSION="2.7.0-smoke"
+EXPECTED_NUPKG_NAME="LevelUp.Strategos.Agents.${SMOKE_VERSION}.nupkg"
 
 # Resolve to absolute path so downstream messages are unambiguous, even
 # if the script is invoked from a deeper cwd.
@@ -65,19 +74,16 @@ echo "Expecting: $EXPECTED_NUPKG_NAME"
 rm -f "$FEED_DIR_ABS"/LevelUp.Strategos.Agents.*.nupkg \
       "$FEED_DIR_ABS"/LevelUp.Strategos.Agents.*.snupkg
 
-# NoWarn NU5104: this smoke gate packs Strategos.Agents *in isolation* in a
-# tagless CI checkout (--no-tags --depth=1), so MinVer resolves the core
-# LevelUp.Strategos dependency to a prerelease (0.0.0-alpha.0). A stable Agents
-# 2.7.0 depending on that prerelease trips NU5104, but here it is a false
-# positive — the smoke only validates the basileus-consumed surface against the
-# packed artifact. Real release dependency hygiene is enforced by the publish
-# job (which checks out the v-tag → core is stable 2.7.0) and the Pack (verify)
-# CI gate.
+# Pack at the synthetic prerelease SMOKE_VERSION. AgentsSmokeVersion is consumed
+# only by Strategos.Agents.csproj (a guarded PropertyGroup), so the override does
+# NOT propagate to the core LevelUp.Strategos ProjectReference — core stays
+# MinVer-derived and the stamped dependency floats low (prerelease on tagless CI),
+# which is why a prerelease SMOKE_VERSION avoids NU5104.
 if ! dotnet pack "$AGENTS_CSPROJ" \
        -c Release \
        -o "$FEED_DIR_ABS" \
        --nologo \
-       -p:NoWarn=NU5104 \
+       -p:AgentsSmokeVersion="$SMOKE_VERSION" \
        -v:m; then
   echo "FAIL: dotnet pack of $AGENTS_CSPROJ failed." >&2
   exit 2
@@ -87,7 +93,7 @@ if [[ ! -f "$FEED_DIR_ABS/$EXPECTED_NUPKG_NAME" ]]; then
   echo "FAIL: expected nupkg $EXPECTED_NUPKG_NAME not produced in $FEED_DIR_ABS." >&2
   echo "Produced packages:" >&2
   ls -1 "$FEED_DIR_ABS" >&2 || true
-  echo "Hint: check <Version> in src/Strategos.Agents/Strategos.Agents.csproj." >&2
+  echo "Hint: SMOKE_VERSION ($SMOKE_VERSION) must match the smoke project's PackageReference." >&2
   exit 3
 fi
 

--- a/src/Strategos.Agents/Strategos.Agents.csproj
+++ b/src/Strategos.Agents/Strategos.Agents.csproj
@@ -5,10 +5,6 @@
     <PackageId>LevelUp.Strategos.Agents</PackageId>
     <Description>Microsoft Agent Framework integration for Strategos. Provides abstractions for LLM-powered workflow steps with conversation continuity, streaming responses, and agent selection.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <!-- Explicit override of MinVer-derived version for DR-11 migration smoke (T-022). MinVer takes over after v2.7.0-preview.2 release tag lands. -->
-    <MinVerSkip>true</MinVerSkip>
-    <Version>2.7.0-preview.2</Version>
-    <PackageVersion>2.7.0-preview.2</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Strategos.Agents/Strategos.Agents.csproj
+++ b/src/Strategos.Agents/Strategos.Agents.csproj
@@ -5,6 +5,14 @@
     <PackageId>LevelUp.Strategos.Agents</PackageId>
     <Description>Microsoft Agent Framework integration for Strategos. Provides abstractions for LLM-powered workflow steps with conversation continuity, streaming responses, and agent selection.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <!-- Explicit, deterministic package version for the basileus release-readiness
+         smoke gate (scripts/pack-to-local-feed.sh + tests/basileus-smoke), which
+         pins to this exact version to fail loudly if it drifts. Bumped to the
+         2.7.0 GA. Keep this, the script's EXPECTED_VERSION, and the smoke
+         project's PackageReference in lockstep. -->
+    <MinVerSkip>true</MinVerSkip>
+    <Version>2.7.0</Version>
+    <PackageVersion>2.7.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Strategos.Agents/Strategos.Agents.csproj
+++ b/src/Strategos.Agents/Strategos.Agents.csproj
@@ -5,14 +5,24 @@
     <PackageId>LevelUp.Strategos.Agents</PackageId>
     <Description>Microsoft Agent Framework integration for Strategos. Provides abstractions for LLM-powered workflow steps with conversation continuity, streaming responses, and agent selection.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <!-- Explicit, deterministic package version for the basileus release-readiness
-         smoke gate (scripts/pack-to-local-feed.sh + tests/basileus-smoke), which
-         pins to this exact version to fail loudly if it drifts. Bumped to the
-         2.7.0 GA. Keep this, the script's EXPECTED_VERSION, and the smoke
-         project's PackageReference in lockstep. -->
+    <!-- Version is MinVer-derived from the release tag, uniform with every sibling
+         package (2.7.0 at v2.7.0; 0.0.0-alpha.0 on tagless CI). The earlier
+         explicit 2.7.0-preview.2 / 2.7.0 pin was removed at GA: a stable pin made
+         tagless pack gates (Pack verify) emit NU5104, since a stable package
+         cannot depend on the prerelease (0.0.0-alpha.0) core that MinVer produces
+         without a tag. -->
+  </PropertyGroup>
+
+  <!-- Basileus release-readiness smoke gate (scripts/pack-to-local-feed.sh) packs
+       THIS project at a deterministic synthetic prerelease version by passing
+       -p:AgentsSmokeVersion=…. The property is consumed only here, so it does not
+       leak onto the core LevelUp.Strategos ProjectReference dependency (which stays
+       MinVer-derived and floats low on tagless CI). Empty in every normal build,
+       so MinVer governs the real shipped version. -->
+  <PropertyGroup Condition="'$(AgentsSmokeVersion)' != ''">
     <MinVerSkip>true</MinVerSkip>
-    <Version>2.7.0</Version>
-    <PackageVersion>2.7.0</PackageVersion>
+    <Version>$(AgentsSmokeVersion)</Version>
+    <PackageVersion>$(AgentsSmokeVersion)</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/basileus-smoke/Basileus.Smoke.Tests/Basileus.Smoke.Tests.csproj
+++ b/tests/basileus-smoke/Basileus.Smoke.Tests/Basileus.Smoke.Tests.csproj
@@ -36,11 +36,13 @@
   <ItemGroup>
     <!--
       Pulled from sibling local-feed/ via nuget.config in this directory.
-      Pin to 2.7.0 explicitly: this project's job is to fail restore
-      loudly the moment the production csproj's <Version> drifts off the
-      version basileus expects.
+      Pinned to the synthetic 2.7.0-smoke version that
+      scripts/pack-to-local-feed.sh stamps onto the packed artifact. That
+      version exists only in the local feed (nuget.org will never carry it), so
+      this resolves the freshly-packed Agents unambiguously and fails restore
+      loudly if the pack step did not run.
     -->
-    <PackageReference Include="LevelUp.Strategos.Agents" Version="2.7.0" />
+    <PackageReference Include="LevelUp.Strategos.Agents" Version="2.7.0-smoke" />
     <PackageReference Include="TUnit" Version="1.2.11" />
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.5.2" />
   </ItemGroup>

--- a/tests/basileus-smoke/Basileus.Smoke.Tests/Basileus.Smoke.Tests.csproj
+++ b/tests/basileus-smoke/Basileus.Smoke.Tests/Basileus.Smoke.Tests.csproj
@@ -36,11 +36,11 @@
   <ItemGroup>
     <!--
       Pulled from sibling local-feed/ via nuget.config in this directory.
-      Pin to 2.7.0-preview.2 explicitly: this project's job is to fail
-      restore loudly the moment the production csproj's <Version> drifts
-      off the version basileus expects.
+      Pin to 2.7.0 explicitly: this project's job is to fail restore
+      loudly the moment the production csproj's <Version> drifts off the
+      version basileus expects.
     -->
-    <PackageReference Include="LevelUp.Strategos.Agents" Version="2.7.0-preview.2" />
+    <PackageReference Include="LevelUp.Strategos.Agents" Version="2.7.0" />
     <PackageReference Include="TUnit" Version="1.2.11" />
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.5.2" />
   </ItemGroup>

--- a/tests/basileus-smoke/Basileus.Smoke.Tests/BasileusConsumedSurfaceTests.cs
+++ b/tests/basileus-smoke/Basileus.Smoke.Tests/BasileusConsumedSurfaceTests.cs
@@ -11,7 +11,7 @@
 // src/strategos.sln. Two reasons:
 //
 //   1) Chicken-and-egg with CI: the smoke project's <PackageReference>
-//      to LevelUp.Strategos.Agents 2.7.0-preview.2 only resolves AFTER
+//      to LevelUp.Strategos.Agents 2.7.0 only resolves AFTER
 //      `dotnet pack` populates the sibling local-feed/. The main
 //      build-test job restores src/strategos.sln before any pack step,
 //      so including this csproj there would break that job.

--- a/tests/basileus-smoke/Basileus.Smoke.Tests/BasileusConsumedSurfaceTests.cs
+++ b/tests/basileus-smoke/Basileus.Smoke.Tests/BasileusConsumedSurfaceTests.cs
@@ -11,7 +11,7 @@
 // src/strategos.sln. Two reasons:
 //
 //   1) Chicken-and-egg with CI: the smoke project's <PackageReference>
-//      to LevelUp.Strategos.Agents 2.7.0 only resolves AFTER
+//      to LevelUp.Strategos.Agents 2.7.0-smoke only resolves AFTER
 //      `dotnet pack` populates the sibling local-feed/. The main
 //      build-test job restores src/strategos.sln before any pack step,
 //      so including this csproj there would break that job.


### PR DESCRIPTION
The first `v2.7.0` publish run failed at **Pack** (before any NuGet push — nothing shipped):

```
error NU5104: A stable release of a package should not have a prerelease dependency.
  "LevelUp.Strategos.Agents [2.7.0-preview.2, )"
```

`Strategos.Agents` carried a `MinVerSkip` + `<Version>2.7.0-preview.2</Version>` override (a temporary DR-11 migration-smoke pin). At GA that forced `Strategos.Rag` and `Strategos.Agents.Mcp` (stable `2.7.0`) to depend on a prerelease. Removing the override hands versioning back to MinVer, which stamps `2.7.0` from the release tag — matching every sibling package.

**Validated locally:** `dotnet pack -c Release` with the `v2.7.0` tag now produces `LevelUp.Strategos.Agents.2.7.0`, `.Agents.Mcp.2.7.0`, `.Rag.2.7.0` — all stable, pack exit 0, no NU5104.

After merge, `v2.7.0` is re-tagged on main and pushed to re-run the publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)