### PR TITLE
ci(contracts): contracts-only publish workflow

### DIFF
--- a/.github/workflows/publish-contracts.yml
+++ b/.github/workflows/publish-contracts.yml
@@ -1,0 +1,122 @@
+name: Publish Contracts
+
+# Publishes ONLY LevelUp.Strategos.Contracts, decoupled from the product-line
+# release. The contracts package is independently versioned (MinVerSkip + a
+# pinned <ContractsVersion>; see Strategos.Contracts.csproj T32), so its cadence
+# must not be tied to the `v*` product tag that MinVer-versions every sibling.
+#
+# Trigger: a dedicated `contracts-v<version>` tag (e.g. contracts-v0.2.0). This
+# does NOT match the product publish workflow's `v*` trigger, and MinVer ignores
+# it (tag prefix is `v`), so cutting it touches no other package.
+
+on:
+  push:
+    tags:
+      - 'contracts-v*'
+
+env:
+  DOTNET_VERSION: '10.0.x'
+  DOTNET_QUALITY: 'preview'
+  CONTRACTS_PROJECT: 'src/Strategos.Contracts/Strategos.Contracts.csproj'
+  TESTS_PROJECT: 'src/Strategos.Tests/Strategos.Tests.csproj'
+
+# Mirrors the product publish workflow's trusted-publishing setup.
+permissions:
+  id-token: write   # OIDC token for NuGet trusted publishing
+  contents: write   # Create the GitHub Release
+  packages: write   # Push packages
+
+jobs:
+  publish-contracts:
+    name: Publish LevelUp.Strategos.Contracts to NuGet
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    environment: nuget-publish
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-quality: ${{ env.DOTNET_QUALITY }}
+
+      - name: Verify tag matches pinned ContractsVersion
+        # The package version is pinned in the csproj, not derived from the tag.
+        # Fail loudly if the tag and the pinned version disagree, so a mistyped
+        # tag can never publish a mislabeled release.
+        run: |
+          tag_version="${GITHUB_REF_NAME#contracts-v}"
+          pinned="$(grep -oP '(?<=<ContractsVersion>)[^<]+' "$CONTRACTS_PROJECT")"
+          echo "tag=$tag_version pinned=$pinned"
+          if [[ "$tag_version" != "$pinned" ]]; then
+            echo "::error::Tag contracts-v$tag_version does not match pinned <ContractsVersion>$pinned. Update the csproj or retag."
+            exit 1
+          fi
+
+      - name: Restore
+        run: dotnet restore "$CONTRACTS_PROJECT"
+
+      - name: Generate builder-fixture corpus (T24/#53)
+        # The package embeds the >=100-case WorkflowDefinitionV1 fixture corpus
+        # under contentFiles/ for downstream (Exarchos) consumption. The corpus
+        # lives in artifacts/builder-fixtures/ (gitignored) and is produced by
+        # the fixture-export test; it must exist before pack, or the csproj's
+        # Exists()-guarded Content glob silently ships a corpus-less package.
+        run: |
+          dotnet run --project "$TESTS_PROJECT" --configuration Release \
+            -- --treenode-filter "/*/*/FixtureExportTests/*"
+
+      - name: Verify corpus is present and complete
+        run: |
+          index="artifacts/builder-fixtures/index.json"
+          if [[ ! -f "$index" ]]; then
+            echo "::error::Fixture corpus missing ($index); aborting before pack."
+            exit 1
+          fi
+          count="$(grep -oP '(?<="count":\s)\d+' "$index" | head -1)"
+          echo "fixture count=$count"
+          if [[ -z "$count" || "$count" -lt 100 ]]; then
+            echo "::error::Fixture corpus has <100 cases ($count); aborting before pack."
+            exit 1
+          fi
+
+      - name: Pack
+        # No --no-build: pack builds the contracts project (committed Generated/
+        # records + schemas; no TypeSpec/Node needed) and globs the now-present
+        # fixture corpus into the package.
+        run: dotnet pack "$CONTRACTS_PROJECT" --configuration Release --output ./packages
+
+      - name: List packages
+        run: ls -la ./packages/
+
+      - name: Push to NuGet
+        run: |
+          for package in ./packages/*.nupkg; do
+            echo "Pushing $package..."
+            dotnet nuget push "$package" \
+              --api-key ${{ secrets.NUGET_API_KEY }} \
+              --source https://api.nuget.org/v3/index.json \
+              --skip-duplicate
+          done
+
+      - name: Push symbols
+        run: |
+          for package in ./packages/*.snupkg; do
+            if [ -f "$package" ]; then
+              echo "Pushing symbols $package..."
+              dotnet nuget push "$package" \
+                --api-key ${{ secrets.NUGET_API_KEY }} \
+                --source https://api.nuget.org/v3/index.json \
+                --skip-duplicate
+            fi
+          done
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ./packages/*
+          generate_release_notes: true


### PR DESCRIPTION
## What

Adds `.github/workflows/publish-contracts.yml` — a publish path for **`LevelUp.Strategos.Contracts` only**, decoupled from the product-line release.

## Why

`Strategos.Contracts` is independently versioned (`MinVerSkip` + pinned `<ContractsVersion>0.2.0</ContractsVersion>`, csproj T32). But the existing `publish.yml` triggers on the shared `v*` tag and `dotnet pack`s the whole solution — every sibling package takes its version from that tag via MinVer. There was no way to ship contracts `0.2.0` without GA-releasing the entire product line (and cutting `v0.2.0` would regress `LevelUp.Strategos` from its published 2.7.0).

## How

Triggered by a dedicated **`contracts-v<version>`** tag (e.g. `contracts-v0.2.0`). This does not match the product `v*` trigger, and MinVer ignores it (tag prefix is `v`), so cutting it touches no other package. The job packs and pushes only the contracts package, mirroring `publish.yml`'s trusted-publishing setup (`environment: nuget-publish`, OIDC `id-token: write`).

**Guards:**
- Tag version must equal the pinned `<ContractsVersion>` — a mistyped tag can't publish a mislabeled release.
- The ≥100-case builder-fixture corpus (#53) — generated by the fixture-export test into the gitignored `artifacts/builder-fixtures/` — must exist and be complete **before pack**, or the csproj's `Exists()`-guarded content glob would silently ship a corpus-less package.

## Verified locally

- tag→version guard logic
- corpus generation: **210 cases**, `index.json` count parses
- `dotnet pack` → `LevelUp.Strategos.Contracts.0.2.0.nupkg` containing **66 schema files + 211 fixture files** (210 + index)

## After merge

Cutting `contracts-v0.2.0` publishes the package. No product-line release is implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)