### PR TITLE
feat(ontology-mcp): descriptor → McpServerTool registration bridge (#104)

### DIFF
--- a/src/Strategos.Ontology.MCP.Hosting.Tests/AddOntologyToolsTests.cs
+++ b/src/Strategos.Ontology.MCP.Hosting.Tests/AddOntologyToolsTests.cs
@@ -1,0 +1,78 @@
+using System.IO.Pipelines;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+using Strategos.Ontology.MCP.Hosting;
+
+namespace Strategos.Ontology.MCP.Hosting.Tests;
+
+public sealed class AddOntologyToolsTests
+{
+    private static readonly string[] ExpectedToolNames =
+    [
+        "ontology_explore",
+        "ontology_query",
+        "ontology_action",
+        "ontology_validate",
+    ];
+
+    [Test]
+    public async Task AddOntologyTools_RegistersFourCallableTools()
+    {
+        // Arrange — register ontology tools on an MCP server builder.
+        var graph = TestOntologyGraphFactory.CreateTradingGraph();
+        var services = new ServiceCollection();
+        services.AddMcpServer().AddOntologyTools(graph);
+        await using var provider = services.BuildServiceProvider();
+        var serverOptions = provider.GetRequiredService<IOptions<McpServerOptions>>().Value;
+
+        // In-memory duplex transport pair (no process, no network).
+        var clientToServer = new Pipe();
+        var serverToClient = new Pipe();
+
+        await using var serverTransport = new StreamServerTransport(
+            clientToServer.Reader.AsStream(),
+            serverToClient.Writer.AsStream(),
+            serverName: "ontology-test-server",
+            loggerFactory: null);
+
+        await using var server = McpServer.Create(
+            serverTransport,
+            serverOptions,
+            loggerFactory: null,
+            serviceProvider: provider);
+
+        var serverRun = server.RunAsync();
+
+        var clientTransport = new StreamClientTransport(
+            serverInput: clientToServer.Writer.AsStream(),
+            serverOutput: serverToClient.Reader.AsStream(),
+            loggerFactory: null);
+
+        await using var client = await McpClient.CreateAsync(clientTransport);
+
+        // Act — tools/list advertises the four ontology tools.
+        var tools = await client.ListToolsAsync();
+        var names = tools.Select(t => t.Name).ToList();
+
+        // Assert
+        foreach (var expected in ExpectedToolNames)
+        {
+            await Assert.That(names).Contains(expected);
+        }
+
+        // Act — tools/call on ontology_query routes to the registered tool.
+        var result = await client.CallToolAsync(
+            "ontology_query",
+            new Dictionary<string, object?> { ["input"] = "{}" });
+
+        // Assert — the call routed and returned content (no protocol error).
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result.IsError ?? false).IsFalse();
+    }
+}

--- a/src/Strategos.Ontology.MCP.Hosting.Tests/GlobalUsings.cs
+++ b/src/Strategos.Ontology.MCP.Hosting.Tests/GlobalUsings.cs
@@ -1,0 +1,5 @@
+global using NSubstitute;
+
+global using TUnit.Assertions;
+global using TUnit.Assertions.Extensions;
+global using TUnit.Core;

--- a/src/Strategos.Ontology.MCP.Hosting.Tests/OntologyServerToolFactoryTests.cs
+++ b/src/Strategos.Ontology.MCP.Hosting.Tests/OntologyServerToolFactoryTests.cs
@@ -1,0 +1,97 @@
+using System.Text.Json;
+
+using Strategos.Ontology.MCP.Hosting;
+
+namespace Strategos.Ontology.MCP.Hosting.Tests;
+
+public sealed class OntologyServerToolFactoryTests
+{
+    [Test]
+    public async Task CreateServerTools_PreservesOutputSchemaAndAnnotations()
+    {
+        // Arrange
+        var graph = TestOntologyGraphFactory.CreateTradingGraph();
+        var descriptors = new Strategos.Ontology.MCP.OntologyToolDiscovery(graph)
+            .Discover()
+            .ToDictionary(d => d.Name);
+
+        // Act
+        var serverTools = OntologyServerToolFactory.CreateServerTools(graph).ToList();
+
+        // Assert — one tool per descriptor.
+        await Assert.That(serverTools).HasCount().EqualTo(descriptors.Count);
+
+        foreach (var tool in serverTools)
+        {
+            var protocolTool = tool.ProtocolTool;
+            await Assert.That(descriptors.ContainsKey(protocolTool.Name)).IsTrue();
+            var descriptor = descriptors[protocolTool.Name];
+
+            // OutputSchema survives the adapter. The SDK re-emits the schema in its own
+            // canonical form (notably it widens the root "type":"object" to admit null),
+            // so the load-bearing content to compare is the untouched "properties" subtree.
+            await Assert.That(protocolTool.OutputSchema.HasValue).IsEqualTo(descriptor.OutputSchema.HasValue);
+            if (descriptor.OutputSchema.HasValue)
+            {
+                var expectedProps = PropertiesJson(descriptor.OutputSchema.Value);
+                var actualProps = PropertiesJson(protocolTool.OutputSchema!.Value);
+                await Assert.That(actualProps).IsEqualTo(expectedProps);
+            }
+
+            // Annotations map field-by-field.
+            var annotations = protocolTool.Annotations;
+            await Assert.That(annotations).IsNotNull();
+            await Assert.That(annotations!.ReadOnlyHint).IsEqualTo(descriptor.Annotations.ReadOnlyHint);
+            await Assert.That(annotations.DestructiveHint).IsEqualTo(descriptor.Annotations.DestructiveHint);
+            await Assert.That(annotations.IdempotentHint).IsEqualTo(descriptor.Annotations.IdempotentHint);
+            await Assert.That(annotations.OpenWorldHint).IsEqualTo(descriptor.Annotations.OpenWorldHint);
+
+            await Assert.That(protocolTool.Title).IsEqualTo(descriptor.Title);
+            await Assert.That(protocolTool.Description).IsEqualTo(descriptor.Description);
+        }
+    }
+
+    [Test]
+    public async Task CreateServerTools_PreservesConstraintSummaries()
+    {
+        // Arrange
+        var graph = TestOntologyGraphFactory.CreateConstrainedGraph();
+        var actionDescriptor = new Strategos.Ontology.MCP.OntologyToolDiscovery(graph)
+            .Discover()
+            .Single(d => d.Name == "ontology_action");
+
+        // Precondition: the fixture yields at least one constraint summary to preserve.
+        await Assert.That(actionDescriptor.ConstraintSummaries.Count).IsGreaterThan(0);
+
+        // Act
+        var actionTool = OntologyServerToolFactory.CreateServerTools(graph)
+            .Single(t => t.ProtocolTool.Name == "ontology_action");
+
+        // Assert — constraint summaries survive via the tool's _meta carrier.
+        var meta = actionTool.ProtocolTool.Meta;
+        await Assert.That(meta).IsNotNull();
+        await Assert.That(meta!.ContainsKey("constraintSummaries")).IsTrue();
+
+        var carried = JsonSerializer.Deserialize<List<Strategos.Ontology.MCP.ActionConstraintSummary>>(
+            meta["constraintSummaries"]!.ToJsonString());
+        await Assert.That(carried).IsNotNull();
+        await Assert.That(carried!.Count).IsEqualTo(actionDescriptor.ConstraintSummaries.Count);
+
+        var expectedFirst = actionDescriptor.ConstraintSummaries[0];
+        var actualFirst = carried[0];
+        await Assert.That(actualFirst.ObjectTypeName).IsEqualTo(expectedFirst.ObjectTypeName);
+        await Assert.That(actualFirst.ActionName).IsEqualTo(expectedFirst.ActionName);
+        await Assert.That(actualFirst.HardConstraintCount).IsEqualTo(expectedFirst.HardConstraintCount);
+        await Assert.That(actualFirst.SoftConstraintCount).IsEqualTo(expectedFirst.SoftConstraintCount);
+    }
+
+    private static string PropertiesJson(JsonElement schema)
+    {
+        // Re-serialize the "properties" subtree to a canonical string. This is the part
+        // of the JSON schema the SDK preserves verbatim, independent of its root-type
+        // nullability normalization.
+        return schema.TryGetProperty("properties", out var props)
+            ? JsonSerializer.Serialize(JsonSerializer.Deserialize<JsonElement>(props.GetRawText()))
+            : "<no-properties>";
+    }
+}

--- a/src/Strategos.Ontology.MCP.Hosting.Tests/PackagingTests.cs
+++ b/src/Strategos.Ontology.MCP.Hosting.Tests/PackagingTests.cs
@@ -1,0 +1,46 @@
+using System.Reflection;
+
+using Strategos.Ontology.MCP.Hosting;
+
+namespace Strategos.Ontology.MCP.Hosting.Tests;
+
+/// <summary>
+/// The .Hosting package is the SDK-bound companion to the SDK-free core. It must ship
+/// the descriptor->tool adapter and the builder extension, and its assembly must
+/// reference BOTH the ModelContextProtocol SDK AND the core Strategos.Ontology.MCP
+/// package (the bridge depends on both ends).
+/// </summary>
+public sealed class PackagingTests
+{
+    [Test]
+    public async Task Packaging_HostingPackage_ShipsAdapterAndExtension()
+    {
+        var hostingAssembly = typeof(OntologyServerToolFactory).Assembly;
+
+        // Ships the public adapter factory.
+        var factory = hostingAssembly.GetType("Strategos.Ontology.MCP.Hosting.OntologyServerToolFactory");
+        await Assert.That(factory).IsNotNull();
+        await Assert.That(factory!.IsPublic).IsTrue();
+        await Assert.That(factory.GetMethod("CreateServerTools", BindingFlags.Public | BindingFlags.Static)).IsNotNull();
+
+        // Ships the public IMcpServerBuilder extension.
+        var extensions = hostingAssembly.GetType(
+            "Microsoft.Extensions.DependencyInjection.OntologyMcpServerBuilderExtensions");
+        await Assert.That(extensions).IsNotNull();
+        await Assert.That(extensions!.IsPublic).IsTrue();
+        await Assert.That(extensions.GetMethod("AddOntologyTools", BindingFlags.Public | BindingFlags.Static)).IsNotNull();
+
+        // The bridge references both ends: the SDK and the core MCP package.
+        var referencedNames = hostingAssembly.GetReferencedAssemblies()
+            .Select(a => a.Name ?? string.Empty)
+            .ToList();
+
+        var referencesSdk = referencedNames.Any(
+            n => n.Contains("ModelContextProtocol", StringComparison.OrdinalIgnoreCase));
+        await Assert.That(referencesSdk).IsTrue();
+
+        var referencesCore = referencedNames.Any(
+            n => string.Equals(n, "Strategos.Ontology.MCP", StringComparison.Ordinal));
+        await Assert.That(referencesCore).IsTrue();
+    }
+}

--- a/src/Strategos.Ontology.MCP.Hosting.Tests/Strategos.Ontology.MCP.Hosting.Tests.csproj
+++ b/src/Strategos.Ontology.MCP.Hosting.Tests/Strategos.Ontology.MCP.Hosting.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="ModelContextProtocol" />
+    <PackageReference Include="TUnit" />
+    <PackageReference Include="NSubstitute" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Strategos.Ontology.MCP.Hosting\Strategos.Ontology.MCP.Hosting.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Strategos.Ontology.MCP.Hosting.Tests/TestOntologyGraphFactory.cs
+++ b/src/Strategos.Ontology.MCP.Hosting.Tests/TestOntologyGraphFactory.cs
@@ -5,36 +5,39 @@ using Strategos.Ontology.Descriptors;
 namespace Strategos.Ontology.MCP.Hosting.Tests;
 
 // Test domain types mirroring the rich fixture used by Strategos.Ontology.MCP.Tests.
-public class TestPosition
+// Colocated in one fixture file (matching the sibling test project's
+// TestOntologyGraphFactory.cs); DTO-like types are immutable records, the
+// ontology classes are sealed.
+public sealed record TestPosition
 {
-    public string Id { get; set; } = "";
-    public string Symbol { get; set; } = "";
-    public decimal Quantity { get; set; }
+    public string Id { get; init; } = "";
+    public string Symbol { get; init; } = "";
+    public decimal Quantity { get; init; }
 }
 
-public class TestOrder
+public sealed record TestOrder
 {
-    public string OrderId { get; set; } = "";
-    public string PositionId { get; set; } = "";
-    public decimal Amount { get; set; }
+    public string OrderId { get; init; } = "";
+    public string PositionId { get; init; } = "";
+    public decimal Amount { get; init; }
 }
 
-public class TestTradeExecutionRequest
+public sealed record TestTradeExecutionRequest
 {
-    public string Symbol { get; set; } = "";
-    public decimal Quantity { get; set; }
+    public string Symbol { get; init; } = "";
+    public decimal Quantity { get; init; }
 }
 
-public class TestTradeExecutionResult
+public sealed record TestTradeExecutionResult
 {
-    public bool Success { get; set; }
-    public string TradeId { get; set; } = "";
+    public bool Success { get; init; }
+    public string TradeId { get; init; } = "";
 }
 
-public class TestTradeExecutedEvent
+public sealed record TestTradeExecutedEvent
 {
-    public string TradeId { get; set; } = "";
-    public string OrderId { get; set; } = "";
+    public string TradeId { get; init; } = "";
+    public string OrderId { get; init; } = "";
 }
 
 public interface ISearchable
@@ -45,7 +48,7 @@ public interface ISearchable
 /// <summary>
 /// A rich test domain ontology that exercises properties, links, actions, events, interfaces.
 /// </summary>
-public class TestTradingDomainOntology : DomainOntology
+public sealed class TestTradingDomainOntology : DomainOntology
 {
     public override string DomainName => "trading";
 
@@ -110,35 +113,35 @@ public static class TestOntologyGraphFactory
 
 // Test domain types for constrained action tests.
 
-public class TestAccount
+public sealed record TestAccount
 {
-    public string Id { get; set; } = "";
-    public string Status { get; set; } = "active";
-    public decimal Balance { get; set; }
+    public string Id { get; init; } = "";
+    public string Status { get; init; } = "active";
+    public decimal Balance { get; init; }
 }
 
-public class TestTransaction
+public sealed record TestTransaction
 {
-    public string TransactionId { get; set; } = "";
-    public string AccountId { get; set; } = "";
-    public decimal Amount { get; set; }
+    public string TransactionId { get; init; } = "";
+    public string AccountId { get; init; } = "";
+    public decimal Amount { get; init; }
 }
 
-public class TestCloseAccountRequest
+public sealed record TestCloseAccountRequest
 {
-    public string Reason { get; set; } = "";
+    public string Reason { get; init; } = "";
 }
 
-public class TestCloseAccountResult
+public sealed record TestCloseAccountResult
 {
-    public bool Success { get; set; }
+    public bool Success { get; init; }
 }
 
 /// <summary>
 /// A test domain ontology with actions that carry preconditions, used to verify
 /// constraint summaries survive the server-tool adapter.
 /// </summary>
-public class ConstrainedDomainOntology : DomainOntology
+public sealed class ConstrainedDomainOntology : DomainOntology
 {
     public override string DomainName => "banking";
 

--- a/src/Strategos.Ontology.MCP.Hosting.Tests/TestOntologyGraphFactory.cs
+++ b/src/Strategos.Ontology.MCP.Hosting.Tests/TestOntologyGraphFactory.cs
@@ -1,0 +1,170 @@
+using Strategos.Ontology;
+using Strategos.Ontology.Builder;
+using Strategos.Ontology.Descriptors;
+
+namespace Strategos.Ontology.MCP.Hosting.Tests;
+
+// Test domain types mirroring the rich fixture used by Strategos.Ontology.MCP.Tests.
+public class TestPosition
+{
+    public string Id { get; set; } = "";
+    public string Symbol { get; set; } = "";
+    public decimal Quantity { get; set; }
+}
+
+public class TestOrder
+{
+    public string OrderId { get; set; } = "";
+    public string PositionId { get; set; } = "";
+    public decimal Amount { get; set; }
+}
+
+public class TestTradeExecutionRequest
+{
+    public string Symbol { get; set; } = "";
+    public decimal Quantity { get; set; }
+}
+
+public class TestTradeExecutionResult
+{
+    public bool Success { get; set; }
+    public string TradeId { get; set; } = "";
+}
+
+public class TestTradeExecutedEvent
+{
+    public string TradeId { get; set; } = "";
+    public string OrderId { get; set; } = "";
+}
+
+public interface ISearchable
+{
+    string Id { get; }
+}
+
+/// <summary>
+/// A rich test domain ontology that exercises properties, links, actions, events, interfaces.
+/// </summary>
+public class TestTradingDomainOntology : DomainOntology
+{
+    public override string DomainName => "trading";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Interface<ISearchable>("Searchable", intf =>
+        {
+            intf.Property(s => s.Id);
+        });
+
+        builder.Object<TestPosition>(obj =>
+        {
+            obj.Key(p => p.Id);
+            obj.Property(p => p.Symbol).Required();
+            obj.Property(p => p.Quantity);
+            obj.HasMany<TestOrder>("Orders")
+                .Description("Orders placed against this position");
+            obj.Action("execute_trade")
+                .Description("Execute a trade on the position")
+                .Accepts<TestTradeExecutionRequest>()
+                .Returns<TestTradeExecutionResult>();
+            obj.Event<TestTradeExecutedEvent>(evt =>
+            {
+                evt.Description("Trade was executed");
+                evt.MaterializesLink<TestPosition>("Orders", e => e.OrderId);
+                evt.Severity(EventSeverity.Info);
+            });
+            obj.Implements<ISearchable>(map =>
+            {
+                map.Via(p => p.Id, s => s.Id);
+            });
+        });
+
+        builder.Object<TestOrder>(obj =>
+        {
+            obj.Key(o => o.OrderId);
+            obj.Property(o => o.Amount).Required();
+            obj.HasOne<TestPosition>("Position");
+        });
+    }
+}
+
+/// <summary>
+/// Factory to build test OntologyGraph instances using the builder.
+/// </summary>
+public static class TestOntologyGraphFactory
+{
+    public static OntologyGraph CreateTradingGraph()
+    {
+        var builder = new OntologyGraphBuilder();
+        builder.AddDomain<TestTradingDomainOntology>();
+        return builder.Build();
+    }
+
+    public static OntologyGraph CreateConstrainedGraph()
+    {
+        var builder = new OntologyGraphBuilder();
+        builder.AddDomain<ConstrainedDomainOntology>();
+        return builder.Build();
+    }
+}
+
+// Test domain types for constrained action tests.
+
+public class TestAccount
+{
+    public string Id { get; set; } = "";
+    public string Status { get; set; } = "active";
+    public decimal Balance { get; set; }
+}
+
+public class TestTransaction
+{
+    public string TransactionId { get; set; } = "";
+    public string AccountId { get; set; } = "";
+    public decimal Amount { get; set; }
+}
+
+public class TestCloseAccountRequest
+{
+    public string Reason { get; set; } = "";
+}
+
+public class TestCloseAccountResult
+{
+    public bool Success { get; set; }
+}
+
+/// <summary>
+/// A test domain ontology with actions that carry preconditions, used to verify
+/// constraint summaries survive the server-tool adapter.
+/// </summary>
+public class ConstrainedDomainOntology : DomainOntology
+{
+    public override string DomainName => "banking";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TestAccount>(obj =>
+        {
+            obj.Key(a => a.Id);
+            obj.Property(a => a.Status).Required();
+            obj.Property(a => a.Balance);
+            obj.HasMany<TestTransaction>("Transactions");
+
+            obj.Action("close_account")
+                .Description("Close the account permanently")
+                .Accepts<TestCloseAccountRequest>()
+                .Returns<TestCloseAccountResult>()
+                .Requires(a => a.Status == "active")
+                .RequiresLink("Transactions")
+                .RequiresSoft(a => a.Balance == 0);
+        });
+
+        builder.Object<TestTransaction>(obj =>
+        {
+            obj.Key(t => t.TransactionId);
+            obj.Property(t => t.Amount).Required();
+            obj.HasOne<TestAccount>("Account");
+        });
+    }
+}

--- a/src/Strategos.Ontology.MCP.Hosting/OntologyMcpServerBuilderExtensions.cs
+++ b/src/Strategos.Ontology.MCP.Hosting/OntologyMcpServerBuilderExtensions.cs
@@ -1,0 +1,35 @@
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Strategos.Ontology;
+using Strategos.Ontology.MCP.Hosting;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Registration extensions that bridge the Strategos ontology onto an MCP server builder.
+/// </summary>
+public static class OntologyMcpServerBuilderExtensions
+{
+    /// <summary>
+    /// Discovers the four ontology tools from <paramref name="graph"/> and registers them
+    /// as callable MCP server tools on <paramref name="builder"/>.
+    /// </summary>
+    /// <param name="builder">The MCP server builder (from <c>services.AddMcpServer()</c>).</param>
+    /// <param name="graph">The ontology graph to derive tools from.</param>
+    /// <returns>The same <paramref name="builder"/> for chaining.</returns>
+    /// <remarks>
+    /// Tool discovery reflects over result-record types to build output schemas, so this
+    /// method inherits the same trim/AOT constraints as <see cref="OntologyServerToolFactory.CreateServerTools"/>.
+    /// </remarks>
+    [RequiresUnreferencedCode("Ontology tool discovery reflects over result-record types; not safe under trimming.")]
+    [RequiresDynamicCode("Ontology tool discovery may require runtime code generation.")]
+    public static IMcpServerBuilder AddOntologyTools(this IMcpServerBuilder builder, OntologyGraph graph)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(graph);
+
+        return builder.WithTools(OntologyServerToolFactory.CreateServerTools(graph));
+    }
+}

--- a/src/Strategos.Ontology.MCP.Hosting/OntologyServerToolFactory.cs
+++ b/src/Strategos.Ontology.MCP.Hosting/OntologyServerToolFactory.cs
@@ -4,8 +4,6 @@ using System.Text.Json.Nodes;
 
 using ModelContextProtocol.Server;
 
-using Strategos.Ontology.Descriptors;
-
 namespace Strategos.Ontology.MCP.Hosting;
 
 /// <summary>

--- a/src/Strategos.Ontology.MCP.Hosting/OntologyServerToolFactory.cs
+++ b/src/Strategos.Ontology.MCP.Hosting/OntologyServerToolFactory.cs
@@ -1,0 +1,99 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+using ModelContextProtocol.Server;
+
+using Strategos.Ontology.Descriptors;
+
+namespace Strategos.Ontology.MCP.Hosting;
+
+/// <summary>
+/// Adapts ontology <see cref="OntologyToolDescriptor"/>s into ModelContextProtocol
+/// <see cref="McpServerTool"/>s. This is the SDK-bound bridge: all ModelContextProtocol
+/// types live here, never in the core <c>Strategos.Ontology.MCP</c> assembly (INV-2).
+/// </summary>
+public static class OntologyServerToolFactory
+{
+    /// <summary>
+    /// JSON property under the tool's <c>_meta</c> that carries the action constraint
+    /// summaries. The MCP <c>Tool</c> shape has no native descriptor slot for them, so
+    /// they ride along in <c>_meta</c> where MCP clients are permitted to surface
+    /// implementation-defined metadata.
+    /// </summary>
+    internal const string ConstraintSummariesMetaKey = "constraintSummaries";
+
+    /// <summary>
+    /// Discovers the four ontology tools from <paramref name="graph"/> and adapts each
+    /// into an <see cref="McpServerTool"/>, preserving the descriptor's output schema,
+    /// annotations, title, and (for the action tool) its constraint summaries.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="OntologyToolDiscovery.Discover"/> reflects over result-record types to
+    /// build output schemas, so this method inherits the same trim/AOT constraints.
+    /// </remarks>
+    [RequiresUnreferencedCode("OntologyToolDiscovery.Discover() reflects over result-record types; not safe under trimming.")]
+    [RequiresDynamicCode("OntologyToolDiscovery.Discover() may require runtime code generation.")]
+    public static IEnumerable<McpServerTool> CreateServerTools(OntologyGraph graph)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+
+        var descriptors = new OntologyToolDiscovery(graph).Discover();
+        var tools = new List<McpServerTool>(descriptors.Count);
+
+        foreach (var descriptor in descriptors)
+        {
+            tools.Add(CreateServerTool(descriptor));
+        }
+
+        return tools;
+    }
+
+    private static McpServerTool CreateServerTool(OntologyToolDescriptor descriptor)
+    {
+        var toolName = descriptor.Name;
+
+        // Minimal handler: the ontology tools are discovered declaratively here; the
+        // concrete dispatch is wired by the host. The handler keeps the tool callable so
+        // tools/call routes deterministically by name.
+        var handler = (string? input) => $"{{\"tool\":\"{toolName}\"}}";
+
+        var options = new McpServerToolCreateOptions
+        {
+            Name = descriptor.Name,
+            Description = descriptor.Description,
+            Title = descriptor.Title,
+            OutputSchema = descriptor.OutputSchema,
+            // The SDK only surfaces an explicitly provided OutputSchema on the protocol
+            // Tool when structured content is opted in; otherwise it is silently dropped.
+            UseStructuredContent = descriptor.OutputSchema.HasValue,
+            Meta = BuildMeta(descriptor),
+        };
+
+        ApplyAnnotations(options, descriptor.Annotations);
+
+        return McpServerTool.Create(handler, options);
+    }
+
+    private static void ApplyAnnotations(McpServerToolCreateOptions options, ToolAnnotations annotations)
+    {
+        options.ReadOnly = annotations.ReadOnlyHint;
+        options.Destructive = annotations.DestructiveHint;
+        options.Idempotent = annotations.IdempotentHint;
+        options.OpenWorld = annotations.OpenWorldHint;
+    }
+
+    private static JsonObject? BuildMeta(OntologyToolDescriptor descriptor)
+    {
+        if (descriptor.ConstraintSummaries.Count == 0)
+        {
+            return null;
+        }
+
+        var summariesJson = JsonSerializer.SerializeToNode(descriptor.ConstraintSummaries);
+        return new JsonObject
+        {
+            [ConstraintSummariesMetaKey] = summariesJson,
+        };
+    }
+}

--- a/src/Strategos.Ontology.MCP.Hosting/README.md
+++ b/src/Strategos.Ontology.MCP.Hosting/README.md
@@ -1,0 +1,40 @@
+# Strategos.Ontology.MCP.Hosting
+
+MCP server hosting bridge for Strategos ontology. Adapts ontology tool descriptors into [ModelContextProtocol](https://www.nuget.org/packages/ModelContextProtocol) server tools and registers them on an MCP server builder.
+
+## Installation
+
+```bash
+dotnet add package LevelUp.Strategos.Ontology.MCP.Hosting
+```
+
+Brings in `LevelUp.Strategos.Ontology.MCP` (the SDK-free core) and the `ModelContextProtocol` server SDK.
+
+## Why a separate package
+
+The core `Strategos.Ontology.MCP` package stays free of any `ModelContextProtocol` dependency so it can be referenced by AOT-published and SDK-agnostic consumers. This companion package carries the server-SDK bridge.
+
+## Usage
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Strategos.Ontology.MCP.Hosting;
+
+builder.Services
+    .AddMcpServer()
+    .AddOntologyTools(ontologyGraph);
+```
+
+`AddOntologyTools` discovers the four ontology tools (`ontology_explore`, `ontology_query`, `ontology_action`, `ontology_validate`) and registers them as callable MCP server tools.
+
+To obtain the adapted tools directly:
+
+```csharp
+IEnumerable<McpServerTool> tools = OntologyServerToolFactory.CreateServerTools(ontologyGraph);
+```
+
+Each tool preserves the originating descriptor's `OutputSchema`, annotations, and action constraint summaries (carried in the tool's `_meta`).
+
+## License
+
+MIT

--- a/src/Strategos.Ontology.MCP.Hosting/Strategos.Ontology.MCP.Hosting.csproj
+++ b/src/Strategos.Ontology.MCP.Hosting/Strategos.Ontology.MCP.Hosting.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>LevelUp.Strategos.Ontology.MCP.Hosting</PackageId>
+    <Description>MCP server hosting bridge for Strategos ontology. Adapts ontology tool descriptors into ModelContextProtocol server tools and registers them on an MCP server builder.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="$(AssemblyName).Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Strategos.Ontology.MCP\Strategos.Ontology.MCP.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Strategos.Ontology.MCP.Tests/AssemblyDependencyTests.cs
+++ b/src/Strategos.Ontology.MCP.Tests/AssemblyDependencyTests.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+
+namespace Strategos.Ontology.MCP.Tests;
+
+/// <summary>
+/// INV-2: the core <c>Strategos.Ontology.MCP</c> assembly must stay free of any
+/// ModelContextProtocol SDK dependency. All SDK-typed code lives in the companion
+/// <c>Strategos.Ontology.MCP.Hosting</c> package, preserving the core as an
+/// SDK-agnostic, AOT-friendly surface.
+/// </summary>
+public sealed class AssemblyDependencyTests
+{
+    [Test]
+    public async Task CoreMcpAssembly_HasNoModelContextProtocolDependency()
+    {
+        // typeof a core type forces the assembly to load; GetReferencedAssemblies
+        // reports the SDK only if a ModelContextProtocol type leaked into core.
+        var coreAssembly = typeof(OntologyToolDiscovery).Assembly;
+
+        var referenced = coreAssembly.GetReferencedAssemblies();
+
+        foreach (AssemblyName refName in referenced)
+        {
+            var leaks = refName.Name?.Contains("ModelContextProtocol", StringComparison.OrdinalIgnoreCase) ?? false;
+            await Assert.That(leaks).IsFalse();
+        }
+    }
+}

--- a/src/strategos.sln
+++ b/src/strategos.sln
@@ -61,6 +61,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Strategos.Contracts.Tests",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Strategos.Contracts.Codegen", "Strategos.Contracts.Codegen\Strategos.Contracts.Codegen.csproj", "{EE8A43EA-3868-4000-89F9-83C34B753ADF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Strategos.Ontology.MCP.Hosting", "Strategos.Ontology.MCP.Hosting\Strategos.Ontology.MCP.Hosting.csproj", "{D84889D9-9BA0-46BB-B4C8-004236C29638}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Strategos.Ontology.MCP.Hosting.Tests", "Strategos.Ontology.MCP.Hosting.Tests\Strategos.Ontology.MCP.Hosting.Tests.csproj", "{5ED77069-6A17-417C-8BCA-27AACA0EFBE0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -419,6 +423,30 @@ Global
 		{EE8A43EA-3868-4000-89F9-83C34B753ADF}.Release|x64.Build.0 = Release|Any CPU
 		{EE8A43EA-3868-4000-89F9-83C34B753ADF}.Release|x86.ActiveCfg = Release|Any CPU
 		{EE8A43EA-3868-4000-89F9-83C34B753ADF}.Release|x86.Build.0 = Release|Any CPU
+		{D84889D9-9BA0-46BB-B4C8-004236C29638}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D84889D9-9BA0-46BB-B4C8-004236C29638}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D84889D9-9BA0-46BB-B4C8-004236C29638}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D84889D9-9BA0-46BB-B4C8-004236C29638}.Debug|x64.Build.0 = Debug|Any CPU
+		{D84889D9-9BA0-46BB-B4C8-004236C29638}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D84889D9-9BA0-46BB-B4C8-004236C29638}.Debug|x86.Build.0 = Debug|Any CPU
+		{D84889D9-9BA0-46BB-B4C8-004236C29638}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D84889D9-9BA0-46BB-B4C8-004236C29638}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D84889D9-9BA0-46BB-B4C8-004236C29638}.Release|x64.ActiveCfg = Release|Any CPU
+		{D84889D9-9BA0-46BB-B4C8-004236C29638}.Release|x64.Build.0 = Release|Any CPU
+		{D84889D9-9BA0-46BB-B4C8-004236C29638}.Release|x86.ActiveCfg = Release|Any CPU
+		{D84889D9-9BA0-46BB-B4C8-004236C29638}.Release|x86.Build.0 = Release|Any CPU
+		{5ED77069-6A17-417C-8BCA-27AACA0EFBE0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5ED77069-6A17-417C-8BCA-27AACA0EFBE0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5ED77069-6A17-417C-8BCA-27AACA0EFBE0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5ED77069-6A17-417C-8BCA-27AACA0EFBE0}.Debug|x64.Build.0 = Debug|Any CPU
+		{5ED77069-6A17-417C-8BCA-27AACA0EFBE0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5ED77069-6A17-417C-8BCA-27AACA0EFBE0}.Debug|x86.Build.0 = Debug|Any CPU
+		{5ED77069-6A17-417C-8BCA-27AACA0EFBE0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5ED77069-6A17-417C-8BCA-27AACA0EFBE0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5ED77069-6A17-417C-8BCA-27AACA0EFBE0}.Release|x64.ActiveCfg = Release|Any CPU
+		{5ED77069-6A17-417C-8BCA-27AACA0EFBE0}.Release|x64.Build.0 = Release|Any CPU
+		{5ED77069-6A17-417C-8BCA-27AACA0EFBE0}.Release|x86.ActiveCfg = Release|Any CPU
+		{5ED77069-6A17-417C-8BCA-27AACA0EFBE0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## What

Ships the official **descriptor → `McpServerTool`** registration bridge requested in #104, as a thin companion package `Strategos.Ontology.MCP.Hosting` so the core `Strategos.Ontology.MCP` stays SDK-free ("library, not a server").

- `OntologyServerToolFactory.CreateServerTools(graph)` → `IEnumerable<McpServerTool>` via `OntologyToolDiscovery(graph).Discover()` + `McpServerTool.Create(...)`, preserving each descriptor's `OutputSchema`, `ToolAnnotations`, and `ConstraintSummaries`.
- `IMcpServerBuilder.AddOntologyTools(graph)` extension wrapping `WithTools(IEnumerable<McpServerTool>)` — registers `ontology_explore/query/action/validate` in one call.
- INV-2 (core stays SDK-free) is mechanically enforced by a load-bearing assembly-dependency test.

This puts the descriptor→SDK mapping (and its schema/annotation fidelity) in one tested place, so downstream consumers (valkyrie, ex-occidente) stop re-rolling the adapter.

## How (per task, strict TDD)

| Task | Surface | Test |
|------|---------|------|
| T15 | `OntologyServerToolFactory.CreateServerTools` | `CreateServerTools_PreservesOutputSchemaAndAnnotations`, `CreateServerTools_PreservesConstraintSummaries` |
| T16 | `IMcpServerBuilder.AddOntologyTools` extension | `AddOntologyTools_RegistersFourCallableTools` (real in-memory MCP client/server) |
| T17 | core stays SDK-free (INV-2) | `CoreMcpAssembly_HasNoModelContextProtocolDependency` |
| T18 | package wiring + packaging | `Packaging_HostingPackage_ShipsAdapterAndExtension` |

Implementation notes confirmed against the real `ModelContextProtocol` 1.3.0 assembly:
- `McpServerTool.Create` drops a provided `OutputSchema` unless `UseStructuredContent = true`; set conditionally on `OutputSchema.HasValue`.
- The SDK widens the schema root (`"type":"object"` → `["object","null"]`), so the preservation test compares the untouched `properties` subtree.
- `ConstraintSummaries` has no native MCP slot → carried in the tool's `_meta` under `constraintSummaries`.
- `[RequiresUnreferencedCode]`/`[RequiresDynamicCode]` are propagated from `Discover()`; `<IsAotCompatible>` deliberately **not** set on `.Hosting`.

## Scope boundary (please note)

The registered tools **advertise** their schemas/annotations for discovery; their handlers are **routing placeholders**. Concrete query dispatch is wired by the host (as valkyrie does via its own seam) and is out of scope here — consistent with the plan's deferral of execution/`FromContract` (#100). A follow-up can let the factory accept a dispatch delegate so the advertised structured-content contract is also functionally satisfied.

## Verification

- Build: `dotnet build src/strategos.sln` — clean, 0 warnings, 0 errors.
- `Strategos.Ontology.MCP.Hosting.Tests`: **4/4** pass.
- `Strategos.Ontology.MCP.Tests`: **159/159** pass (incl. new INV-2 test; no regressions).

## Review

Two-stage review APPROVED — spec PASS, quality PASS (0 HIGH; 1 MEDIUM + 4 LOW, all in-scope/non-blocking; see scope boundary above).

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)
