### PR TITLE
chore(release): prep v2.8.0 — CHANGELOG + Contracts 0.3.0 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,42 @@ the change here so the downstream exarchos mirror can re-baseline deliberately.
 
 _(none this release)_
 
+## [2.8.0] - 2026-05-25
+
+The **cross-product schema substrate** release. TypeSpec remains the single
+canonical source; the build emits JSON Schema (exarchos derives Zod) and C#
+records (basileus consumes the DLL).
+
+### Cross-product breaking changes
+
+_(none this release)_ — the 7 `Strategos.Builders` interfaces are now baselined
+in `PublicAPI.Shipped.txt` and frozen by `PublicApiAnalyzers` (#51); this
+release establishes the baseline without changing any signature.
+
+### Added
+
+- **Ontology MCP registration bridge** (#104) — new
+  `LevelUp.Strategos.Ontology.MCP.Hosting` package adapts ontology tool
+  descriptors into `ModelContextProtocol` server tools and registers them on an
+  MCP server builder, preserving `OutputSchema` + `ToolAnnotations`.
+- **Builder API-stability gate** (#51) — `Microsoft.CodeAnalysis.PublicApiAnalyzers`
+  wired from zero with a populated baseline; a CI gate fails closed on builder
+  signature drift and opens a re-baseline issue against exarchos's
+  `strategos-api-mirror.test.ts`.
+- **AGWF single-source catalog** (#52) — the 10 `AGWF*` diagnostic codes are
+  now generated from a single TypeSpec-sourced catalog (`agwf-catalog.json` +
+  `AgwfCode` enum), giving exarchos (#1256) a 1:1 mapping target. Drift
+  hardening across the #51/#52 follow-ups (#105, #106, #107).
+
+### Cross-product schemas (`LevelUp.Strategos.Contracts` 0.3.0, published separately)
+
+- **Semantic-merge-queue surface** (#63–#66) — `MergeGateDecision`,
+  `JourneyResult`, the `WorkflowRef` discriminated union, and `WorkflowCatalog`,
+  all extending a shared response envelope carrying `_meta.degraded` +
+  `DegradedReason` (fallback is always visible, never silent).
+- Contracts is independently versioned (`contracts-v*` tag); 0.3.0 is an
+  additive minor over 0.2.0 (events + workflow IR).
+
 ## [2.7.0] - 2026-05-24
 
 ### Changed (BREAKING) — Agent step contract

--- a/src/Strategos.Contracts.Tests/PackagingTests.cs
+++ b/src/Strategos.Contracts.Tests/PackagingTests.cs
@@ -69,23 +69,25 @@ public class PackagingTests
     }
 
     /// <summary>
-    /// T32 — the 0.2.0 release package. Packs the project and asserts:
-    /// the version is 0.2.0; all three schema families (events / workflow /
+    /// T32 — the 0.3.0 release package. Packs the project and asserts:
+    /// the version is 0.3.0; all three schema families (events / workflow /
     /// diagnostics) are embedded under <c>contentFiles/any/any/schemas/</c>; the
     /// #53 builder fixtures are embedded under
     /// <c>contentFiles/any/any/fixtures/</c> (so Exarchos can extract them); and
     /// the compiled contracts assembly ships under <c>lib/</c>.
+    /// (0.3.0 adds the semantic-merge-queue surface over 0.2.0's events + IR;
+    /// see <see cref="Packaging_SmqSchemas_EmbeddedAsContent"/> for content.)
     /// </summary>
     [Test]
     [Property("Category", "Pack")]
-    public async Task Package_Version_Is_0_2_0_WithEventsIrAndDiagnosticsContent()
+    public async Task Package_Version_Is_0_3_0_WithEventsIrAndDiagnosticsContent()
     {
         // The fixtures are content (T32): ensure they exist on disk first — the
         // #53 export writes them under artifacts/builder-fixtures/.
         await EnsureFixturesExportedAsync();
 
         var projectDir = RepoLayout.ContractsProjectDir;
-        var outputDir = Directory.CreateTempSubdirectory("contracts-pack-020-").FullName;
+        var outputDir = Directory.CreateTempSubdirectory("contracts-pack-030-").FullName;
 
         try
         {
@@ -99,21 +101,21 @@ public class PackagingTests
                 .FirstOrDefault(p => !p.EndsWith(".symbols.nupkg", StringComparison.Ordinal));
             await Assert.That(nupkg).IsNotNull();
 
-            // Version 0.2.0 — read from the file name (the canonical packed version).
+            // Version 0.3.0 — read from the file name (the canonical packed version).
             var fileName = Path.GetFileName(nupkg!);
-            await Assert.That(fileName).IsEqualTo("LevelUp.Strategos.Contracts.0.2.0.nupkg")
-                .Because($"the package must version at exactly 0.2.0; got {fileName}");
+            await Assert.That(fileName).IsEqualTo("LevelUp.Strategos.Contracts.0.3.0.nupkg")
+                .Because($"the package must version at exactly 0.3.0; got {fileName}");
 
             using var archive = ZipFile.OpenRead(nupkg!);
 
-            // The .nuspec also pins 0.2.0.
+            // The .nuspec also pins 0.3.0.
             var nuspec = archive.Entries.First(e =>
                 e.FullName.EndsWith(".nuspec", StringComparison.Ordinal));
             using (var reader = new StreamReader(nuspec.Open()))
             {
                 var nuspecXml = await reader.ReadToEndAsync();
-                await Assert.That(nuspecXml).Contains("<version>0.2.0</version>")
-                    .Because("the .nuspec must declare version 0.2.0.");
+                await Assert.That(nuspecXml).Contains("<version>0.3.0</version>")
+                    .Because("the .nuspec must declare version 0.3.0.");
             }
 
             string[] entries = [.. archive.Entries.Select(e => e.FullName)];

--- a/src/Strategos.Contracts/README.md
+++ b/src/Strategos.Contracts/README.md
@@ -144,14 +144,18 @@ over the schema file set.
 
 ## Versioning & publishing (T32)
 
-This package versions at **0.2.0** (see `Strategos.Contracts.csproj`). Per the
-repo convention, MinVer derives versions from the `v*` release tag; to pin
-0.2.0 explicitly we set `<MinVerSkip>true</MinVerSkip>` + `<Version>` +
-`<PackageVersion>` (MinVer silently overwrites a bare `<Version>` otherwise).
+This package versions at **0.3.0** (see `Strategos.Contracts.csproj`). Per the
+repo convention, MinVer derives versions from the `v*` release tag; to pin the
+contracts version explicitly — independent of the product line — we set
+`<MinVerSkip>true</MinVerSkip>` + `<Version>` + `<PackageVersion>` (MinVer
+silently overwrites a bare `<Version>` otherwise), driven by the single
+`<ContractsVersion>` property and the `contracts-v*` publish tag.
 
-**Do not publish 0.2.0 until both the events and workflow-IR families have
-landed** (they have, in this milestone — there is intentionally no 0.1.0). The
-package embeds all three schema families under
+**Version history:** 0.2.0 debuted events + workflow IR (no 0.1.0); 0.3.0 adds
+the semantic-merge-queue surface (`MergeGateDecision` / `JourneyResult` /
+`WorkflowRef` / `WorkflowCatalog`, the `_meta.degraded` response envelope) and
+the AGWF catalog — an additive minor. The package embeds all three schema
+families under
 `contentFiles/any/any/schemas/` and the builder-fixture corpus under
 `contentFiles/any/any/fixtures/` so Exarchos can extract both. See `CHANGELOG.md`
 → "Cross-product breaking changes".

--- a/src/Strategos.Contracts/Strategos.Contracts.csproj
+++ b/src/Strategos.Contracts/Strategos.Contracts.csproj
@@ -11,18 +11,21 @@
     <ContractsGeneratedDir>$(MSBuildProjectDirectory)/Generated</ContractsGeneratedDir>
   </PropertyGroup>
 
-  <!-- T32: pin the package to 0.2.0. MinVer otherwise derives the version from
-       the repo's `v*` release tag (which currently floats at 2.7.x for the
-       Strategos core line). The contracts substrate is a NEW, independently
-       versioned cross-product artifact whose first published release is 0.2.0
-       (no 0.1.0 — see CHANGELOG: it must not publish until events + IR both
-       land, which they have). MinVer silently overwrites a bare <Version>, so
-       per repo convention (cf. Strategos.Agents smoke-pin) we also set
-       <MinVerSkip>true</MinVerSkip> + <PackageVersion>. The CONTRACTS_VERSION
-       property keeps the three in lockstep and lets the release pipeline bump
-       in one place. -->
+  <!-- T32: pin the package version independently of the `v*` product tag.
+       MinVer otherwise derives the version from the repo's `v*` release tag
+       (which floats at 2.x for the Strategos core line). The contracts
+       substrate is an independently versioned cross-product artifact: 0.2.0
+       shipped events + workflow IR; 0.3.0 adds the semantic-merge-queue
+       surface (MergeGateDecision / JourneyResult / WorkflowRef /
+       WorkflowCatalog, the response `_meta.degraded` envelope) and the AGWF
+       catalog — all additive (minor bump). MinVer silently overwrites a bare
+       <Version>, so per repo convention (cf. Strategos.Agents smoke-pin) we
+       also set <MinVerSkip>true</MinVerSkip> + <PackageVersion>. The
+       ContractsVersion property keeps the three in lockstep and lets the
+       release pipeline bump in one place; the `contracts-v<version>` publish
+       workflow fails closed if the tag disagrees with it. -->
   <PropertyGroup>
-    <ContractsVersion>0.2.0</ContractsVersion>
+    <ContractsVersion>0.3.0</ContractsVersion>
     <MinVerSkip>true</MinVerSkip>
     <Version>$(ContractsVersion)</Version>
     <PackageVersion>$(ContractsVersion)</PackageVersion>


### PR DESCRIPTION
Release-prep for **v2.8.0** (cross-product schema substrate). Splits into the dated CHANGELOG section + the Contracts version bump that lets the milestone's namesake schemas reach NuGet.

## Why the Contracts bump

`LevelUp.Strategos.Contracts 0.2.0` (NuGet, immutable) was tagged at #101 — **before** the S1–S4 semantic-merge-queue surface (#108) and AGWF catalog (#102) landed in `Strategos.Contracts`. The package is version-pinned (`<ContractsVersion>`), so the `v2.8.0` product tag would pack Contracts as 0.2.0 and `--skip-duplicate` would skip it. Bumping to **0.3.0** (additive minor: +2812/−2, all new schema files) publishes the substrate. The `contracts-v*` workflow's "tag must match pinned version" guard passes (0.3.0 == 0.3.0).

## Changes

- `CHANGELOG.md`: dated `## [2.8.0] - 2026-05-25` section.
- `Strategos.Contracts.csproj`: `<ContractsVersion>` 0.2.0 → 0.3.0 + refreshed comment.

## Cut sequence after merge

1. tag `contracts-v0.3.0` → `publish-contracts.yml` publishes Contracts 0.3.0.
2. tag `v2.8.0` (annotated) → `publish.yml` publishes the 14 product packages (incl. new `Ontology.MCP.Hosting`) at 2.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)