### PR TITLE
fix(ci): skip Node-toolchain + benchmark tests in publish verify

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,9 +41,21 @@ jobs:
         run: dotnet build ${{ env.SOLUTION_PATH }} --no-restore --configuration Release
 
       - name: Test (verify before publish)
+        # Mirror ci.yml's skip-patterns. This .NET-only publish runner does not
+        # provision Node, so *Contracts.Tests* (which shell out to `npx tsp
+        # compile` — @typespec/compiler needs Node 22+) false-fail here; they are
+        # already gated in ci.yml's Node-provisioned job and re-run by the
+        # contracts-v* publish workflow, and this workflow does not publish the
+        # version-pinned Contracts package anyway. *Benchmarks.Tests* are perf,
+        # not a release gate (skipped in ci.yml too).
         run: |
           for proj in src/*Tests/*.csproj; do
-            echo "Testing $(basename $proj)..."
+            case "$proj" in
+              *Benchmarks.Tests*|*Contracts.Tests*)
+                echo "Skipping $(basename "$proj") (verified elsewhere; see step comment)"
+                continue ;;
+            esac
+            echo "Testing $(basename "$proj")..."
             dotnet run --project "$proj" --configuration Release --no-build
           done
 


### PR DESCRIPTION
## Problem

The `v2.8.0` product publish (`publish.yml`) **false-failed at "Test (verify before publish)"** — 17 failures in `Strategos.Contracts.Tests` with:

> `SyntaxError: The requested module 'fs/promises' does not provide an export named 'glob'` — Node.js v20.20.0

Those tests shell out to `npx tsp compile`; `@typespec/compiler` needs **Node 22+**, but the publish runner is .NET-only (Node 20). This surfaced now because Contracts tests didn't exist at 2.7.0. The publish aborted cleanly **before Pack/Push** — nothing was published.

## Fix

Mirror `ci.yml`'s `skip-patterns` (`*Benchmarks.Tests*`, `*Contracts.Tests*`) in the publish verify loop. Rationale:
- `Contracts.Tests` are already gated by `ci.yml`'s Node-24 job and re-run by `publish-contracts.yml`; this workflow doesn't publish the version-pinned Contracts package anyway.
- `Benchmarks.Tests` are perf, not a release gate (skipped in `ci.yml`).

## After merge

Move the `v2.8.0` tag onto this commit and re-push to re-trigger the (now fixed) product publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)