### PR TITLE
feat(ontology): edge foundation — instance identity, relate-store, associations, instance-anchored traversal (v2.9.0)

### DIFF
--- a/docs/designs/2026-06-03-ontology-edge-foundation.md
+++ b/docs/designs/2026-06-03-ontology-edge-foundation.md
@@ -1,0 +1,111 @@
+# Design: Ontology Edge Foundation — instance identity + in-memory relationship layer (v2.9.0)
+
+- **Date:** 2026-06-03
+- **Milestone:** v2.9.0
+- **Design input:** [`docs/designs/2026-06-02-ontology-edge-layer.md`](2026-06-02-ontology-edge-layer.md) (parent epic), [`docs/research/2026-06-02-optimal-edge-api.md`](../research/2026-06-02-optimal-edge-api.md) (discovery)
+- **Realizes:** DR-1, DR-2, DR-3, DR-4 and the in-memory slice of DR-8 from the parent epic. **Coordinates:** #114, #115.
+- **Scope:** the *foundation* bundle — core + in-memory provider only. No second provider, no analyzer rules.
+- **Status:** approved for TDD planning via `/exarchos:plan`.
+
+## Problem
+
+The parent epic establishes the defect: the ontology advertises a property-graph affordance it does not back, and has no instance-level relationship layer at all. `ObjectSet.TraverseLink` resolves by target *type* — `InMemoryExpressionEvaluator.EvaluateTraverseLink` calls `itemResolver(link.TargetTypeName)` (`InMemoryExpressionEvaluator.cs:139`) and returns every object of that type with no source-instance filter. You cannot express "instance A relates to instance B" through any provider.
+
+The code map surfaced a sharper sub-problem the parent doc only implied: **there is no object-instance id today.** `ObjectTypeDescriptor` carries `KeyProperty` (a `PropertyDescriptor` — name + type), but nothing reads its *value* off an instance; instance identity is `item?.ToString()` (`ObjectSet.ApplyAsync:134`), and `OntologyEvent.ObjectId` / `ActionContext.ObjectId` are ad-hoc strings produced the same way. An association row cannot reference endpoints it cannot name.
+
+This foundation builds the smallest self-demonstrating core: a deterministic instance id, an in-memory relationship store with relate/unrelate, instance-anchored traversal that closes the #114 regression, and the `Association<T>` authoring surface — end-to-end in-memory, with nothing that requires a second provider or a new analyzer.
+
+## Decisions (locked at ideation)
+
+1. **Substrate = unified association-row store (Approach A).** One row shape `(srcId, linkName, tgtId, associationObjectId?)`. A pure link is a bare row; an attributed relationship promotes the row by storing an `ObjectKind.Association` object and back-referencing its id. Chosen over object-uniform (B — over-objectifies pure links, diverges from DR-7's junction-table target) and adjacency-index-primary (C — a derived structure that can drift). A is the parent design's own spectrum and pre-images the DR-7 Postgres lowering, so the in-memory and Npgsql providers converge rather than diverge.
+2. **Identity is reflection-free on both paths.** CLR descriptors carry a captured key-selector delegate; `SymbolKey`-only descriptors get their accessor from the contributing `IOntologySource`. No per-call reflection anywhere (INV-8). Rejected: reflecting on `KeyProperty.Name` — it is structurally impossible on the polyglot path and is INV-8's worked-example failure verbatim.
+3. **Foundation defers DR-5/DR-6/DR-7/DR-9.** Footgun removal + AONT diagnostic (DR-5), cardinality analyzer rule (DR-6), Npgsql/pgvector tables (DR-7), and rationale/CLR-free validation (DR-9) land in follow-on passes. This bundle touches **no analyzer**, so INV-5 stays dormant here — but see *Deferred* for the diagnostic-id correction it must carry.
+
+## Approach (chosen): row substrate + reflection-free identity projector
+
+**Identity (DR-1).** A core `IObjectIdentityProjector` with `string ProjectId(ObjectTypeDescriptor descriptor, object instance)`. The descriptor gains a reflection-free id accessor: for a CLR descriptor it is a `Func<object, object?>` captured at the key-declaration site (the lambda *is* the accessor — no reflection); for a `SymbolKey`-only descriptor it is supplied by the `IOntologySource` that contributed the descriptor, operating on that source's instance representation. Composite keys format deterministically with a reserved separator; the single-key case is the norm. The projector lives in `Strategos.Ontology` core and reaches no Marten/Wolverine (INV-2). New surface is typed on the descriptor + an identity discriminator, never `Type` (INV-8).
+
+**Storage (DR-2).** The in-memory provider keeps the existing `_items` (`ConcurrentDictionary<string, List<object>>`) for vertices and association objects, and adds a provider-local **relate-store** keyed `(srcDescriptorName, srcId, linkName)` → an ordered list of rows `(tgtDescriptorName, tgtId, associationObjectId?)`. Rows are read in ordinal-by-id order so replay and tests are deterministic (`ConcurrentDictionary` enumeration is not — INV-7's determinism concern). `RelateAsync(srcDesc, srcId, linkName, tgtDesc, tgtId, ct)` is an idempotent row insert; `UnrelateAsync(...)` removes a matching row and is a no-op when absent. Both live on the provider's write surface alongside `StoreAsync` (`IObjectSetWriter`), keeping storage in the provider (INV-2).
+
+**Traversal (DR-3).** `EvaluateTraverseLink` stops calling `itemResolver(link.TargetTypeName)`. Instead it materializes the upstream set to instances, projects their ids, looks up rows by `(srcId, linkName)`, collects `tgtId`s, and resolves the target objects by id. `GetObjectSet<T>().Where(t => t.Id == x).TraverseLink<U>("link")` returns only the `U`s related to `x`. When a link is backed by association objects, the traversal step can yield the association objects for attribute filtering (`.Where(c => c.Status == Active)`) before the further hop resolves the far endpoint via the row's other side.
+
+**Authoring (DR-4).** `ObjectKind` gains `Association` (today `{ Entity, Process }`). A top-level `ontology.Association<TRel>(name, a => { a.Between<L>(lSel).And<R>(rSel); a.Property(...); a.Lifecycle(...); a.Event<…>(...); })` declares an association as an `ObjectTypeDescriptor` with `Kind = Association`, two typed endpoints, and its own properties — distinct from `ManyToMany`, which hangs off a single source type. The graph builder recognizes association objects and exposes their endpoints as edge source/destination. The descriptor, endpoint, and builder types are `sealed` (INV-6); the association object is an immutable record with no mutation surface (INV-7); endpoints carry identity via descriptors, not `typeof` (INV-8).
+
+## Requirements
+
+### DR-1 — Object-identity contract
+A deterministic, polyglot-safe string id per object instance, resolvable by the in-memory provider from the declared key.
+
+**Acceptance criteria:**
+- Given an instance and its descriptor, `IObjectIdentityProjector.ProjectId` returns a deterministic string id from the declared key.
+- A `SymbolKey`-only (CLR-free) descriptor resolves an id with **no reflection** (accessor supplied by its `IOntologySource`).
+- Identical key values yield identical ids; the contract is written so the future Npgsql provider produces the same id (round-trip test seam reserved).
+- No public API in this contract accepts or returns a `System.Type` to denote identity.
+
+### DR-2 — Instance-level relationship primitive (in-memory)
+A relate-store plus relate/unrelate verbs for pure links.
+
+**Acceptance criteria:**
+- `RelateAsync(srcDescriptor, srcId, linkName, tgtDescriptor, tgtId, ct)` and `UnrelateAsync(...)` create/remove an instance link on the in-memory provider.
+- Rows are stored separately from object items; read order is deterministic (ordinal by id) for replay/test fidelity.
+- `RelateAsync` is idempotent on a duplicate `(src, link, tgt)`; `UnrelateAsync` on a missing row is a no-op (no throw).
+
+### DR-3 — Instance-anchored traversal
+`TraverseLink` resolves by source instance, not target type.
+
+**Acceptance criteria:**
+- `GetObjectSet<T>().Where(t => t.Id == x).TraverseLink<U>("link")` returns only `U` instances related to `x` via relate-store rows.
+- Traversal over an association-backed link exposes the association object's attributes for filtering before traversing to the far endpoint.
+- `EvaluateTraverseLink` no longer calls `itemResolver(link.TargetTypeName)` to fetch all target-type items (the line-139 path is removed).
+
+### DR-4 — `Association<T>` authoring + `ObjectKind.Association`
+A first-class reified-relation affordance on the builder + descriptor model.
+
+**Acceptance criteria:**
+- `ontology.Association<TRel>(name, a => { a.Between<L>(…).And<R>(…); a.Property(…); … })` declares a relation object with two typed endpoints and its own properties.
+- `ObjectKind` gains `Association`; the graph builder recognizes association objects and exposes their endpoints as the edge source/destination.
+- An association object is an immutable, `sealed` record; no mutation surface is introduced (INV-6, INV-7).
+- Relating *with attributes* stores the association object via `StoreAsync` and writes a row whose `associationObjectId` references it.
+
+### DR-8 (in-memory slice) — Error handling and edge cases (MANDATORY)
+The relationship layer fails safely in-memory; the contract fixes a posture both backends will honor.
+
+**Acceptance criteria:**
+- Relating to a non-existent endpoint id surfaces a **typed error** (not a silent dangling row). The in-memory provider validates endpoints **eagerly**; the contract documents this as the posture Npgsql's FK constraints will mirror.
+- Self-loops `(x, link, x)` are permitted only when the link opts in; otherwise a typed runtime error, never a silent drop. (Promotion to an analyzer diagnostic is DR-6, deferred.)
+- Traversal from an instance with zero relations returns an **empty set**, never all target-type items — the regression guard for the #114 defect.
+- A `SymbolKey`-only descriptor exercises the full relate → traverse path with no reflection (polyglot regression test, INV-8).
+
+## Invariant conformance
+
+| Invariant | How this design satisfies it |
+|---|---|
+| INV-2 (ontology self-contained) | Relate-store lives in the in-memory provider; the projector lives in core. No Wolverine/Marten reference enters `Strategos.Ontology*`. |
+| INV-6 (sealed by default) | New `Association<T>` descriptor, endpoint, and builder types are `sealed`; extension via `IOntologySource`, not subclassing. |
+| INV-7 (immutable state) | Association objects are immutable records; relate/unrelate append/remove rows rather than mutate stored vertices; relate-store rows are read in a deterministic order for replay fidelity. |
+| INV-8 (polyglot identity) | Identity via captured selector (CLR) or source-provided accessor (`SymbolKey`-only); zero per-call reflection; no `Type`-typed identity API. |
+| INV-5 (stable diagnostic ids) | Dormant — this bundle adds no analyzer rule. The diagnostic-id correction is carried to the deferred DR-5/DR-6 (see below). |
+
+## Design-dimension review (axiom DIM-1..DIM-8)
+
+Approach A was selected after evaluating three substrates against the dimensions. Discriminators: **DIM-4** (A pre-images DR-7's junction-table lowering, minimizing in-memory↔Npgsql divergence), **DIM-1/DIM-5** (A's two stores hold *different* truths — edges vs vertices/attributes — so there is no divergent-implementation hazard, only one consistency seam at relate/unrelate). Parity items the plan must honor: **DIM-2** typed errors for the DR-8 failure modes; **DIM-7** deterministic ordered reads (the relate-store is authoritative state, not an eviction cache, so size bounds do not apply but ordering does); **DIM-8** concrete prose in the new XML docs.
+
+## Decomposition → tasks
+
+| Task | DR anchors | Notes |
+|---|---|---|
+| Object-identity projector + descriptor accessor | DR-1 | Dependency root. Reflection-free CLR + polyglot paths. |
+| In-memory relate-store + `Relate/UnrelateAsync` | DR-2, DR-8 | Eager endpoint validation, idempotent insert, deterministic read order. |
+| Instance-anchored `TraverseLink` | DR-3, DR-8 | Replaces the line-139 type-resolve; zero-relations empty-set regression guard. |
+| `Association<T>` + `ObjectKind.Association` | DR-4 | Top-level authoring; graph builder endpoint exposure; attributed-relate seam to DR-2. |
+
+**Dependency order:** DR-1 → DR-2 → {DR-3, DR-4}; the DR-8 criteria fold into DR-2 (relate validation) and DR-3 (traversal regression guard).
+
+## Deferred (out of scope for this foundation)
+
+- **DR-5** footgun removal (`IEdgeBuilder`, `ManyToMany(name, edgeConfig)`, `LinkDescriptor.EdgeProperties`, `EdgeBuilder.Property<TProp>`'s `typeof`) + AONT diagnostic.
+- **DR-6** association endpoint-cardinality analyzer rule.
+- **DR-7** Npgsql/pgvector junction tables + join-lowered traversal.
+- **DR-9** rationale / CLR-free edge validation (coordinates #115).
+
+**Diagnostic-id correction (carry forward to DR-5/DR-6):** the parent doc cites "next free id after AONT037" and `AONT041`. Neither matches source: `OntologyDiagnosticIds.cs` runs the standard sequence to **AONT037**, then a 200-series block to **AONT208** (polyglot graph-freeze). `AONT041` does not exist. When DR-5/DR-6 assign new ids, take the genuine next-free id against the real maximum — monotonic, never reused (INV-5).

--- a/docs/plans/2026-06-03-ontology-edge-foundation.md
+++ b/docs/plans/2026-06-03-ontology-edge-foundation.md
@@ -1,0 +1,240 @@
+# Plan: Ontology Edge Foundation (v2.9.0)
+
+- **Design:** [`docs/designs/2026-06-03-ontology-edge-foundation.md`](../designs/2026-06-03-ontology-edge-foundation.md)
+- **Iron law:** no production code without a failing test first.
+- **Test framework:** TUnit. Conventions from existing suites: `[Test]`, `await Assert.That(x).IsEqualTo(...)` / `.IsNotNull()` / `.IsTypeOf<T>()` / `.Throws<T>()`; names `Type_Scenario_Outcome`.
+- **Run a single test:** `dotnet test src/Strategos.Ontology.Tests -- --treenode-filter "/*/*/*/<TestName>"` (the `--filter` form does not work in this repo).
+- **Dependency order:** DR-1 → DR-2 → {DR-3, DR-4}. DR-8 criteria fold into DR-2 and DR-3.
+
+## Grounding facts (from code map)
+
+- `IObjectTypeBuilder.Key(Expression<Func<T, object>> keySelector)` (`IObjectTypeBuilder.cs:9`) already captures the key selector; `ObjectTypeBuilder.Key` (`ObjectTypeBuilder.cs:53`) derives only `_keyProperty` (name) today and drops the expression. **DR-1 retains `keySelector.Compile()` as the reflection-free CLR id accessor.**
+- `InMemoryObjectSetProvider` (`ObjectSets/InMemoryObjectSetProvider.cs:19`) is `sealed`, implements `IObjectSetProvider, IObjectSetWriter`; vertices live in `_items: ConcurrentDictionary<string, List<object>>` (line 30). **DR-2 adds a sibling relate-store field.**
+- `IObjectSetWriter` (`ObjectSets/IObjectSetWriter.cs:12`) has four `Store*` methods. **DR-2 adds `RelateAsync` / `UnrelateAsync`.**
+- `InMemoryExpressionEvaluator.EvaluateTraverseLink` resolves by type at `itemResolver(link.TargetTypeName)` (`InMemoryExpressionEvaluator.cs:139`). **DR-3 replaces that path.**
+- `ObjectKind` (`Descriptors/ObjectKind.cs`) = `{ Entity, Process }`. **DR-4 adds `Association`.** No `Association` symbol exists anywhere yet — greenfield.
+
+---
+
+## Group 1 — DR-1: Object-identity projector (dependency root)
+
+**Branch:** `feat/edge-foundation-dr1-identity`
+
+### Task 1: Compile the existing `Key` selector into a descriptor id accessor
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Write test: `Key_Selector_RetainsCompiledIdAccessor`
+   - File: `src/Strategos.Ontology.Tests/Builder/ObjectTypeBuilderTests.cs`
+   - Expected failure: `ObjectTypeDescriptor` has no id-accessor member; only `KeyProperty` (name) is retained.
+2. [GREEN] Add `Func<object, object?>? IdAccessor { get; init; }` to `ObjectTypeDescriptor`; in `ObjectTypeBuilder.Key`, store `keySelector.Compile()` (boxed to `Func<object, object?>`) alongside `_keyProperty`; assign at `ObjectTypeBuilder.cs:169`.
+   - Files: `src/Strategos.Ontology/Descriptors/ObjectTypeDescriptor.cs`, `src/Strategos.Ontology/Builder/ObjectTypeBuilder.cs`
+3. [REFACTOR] Accessor cached on the descriptor instance (not a static) — avoids the TUnit static-state/parallelism hazard.
+
+**Dependencies:** None · **Parallelizable:** No (root)
+
+### Task 2: `IObjectIdentityProjector.ProjectId` — CLR path
+1. [RED] `ProjectId_ClrDescriptorWithKey_ReturnsDeterministicId` and `ProjectId_SameKeyValue_ReturnsSameId`
+   - File: `src/Strategos.Ontology.Tests/Identity/ObjectIdentityProjectorTests.cs` (new dir)
+   - Expected failure: type does not exist.
+2. [GREEN] `IObjectIdentityProjector` + `ObjectIdentityProjector` in `src/Strategos.Ontology/Identity/`; `string ProjectId(ObjectTypeDescriptor descriptor, object instance)` invokes `descriptor.IdAccessor` and `ToString()`s the result.
+3. [REFACTOR] Null-key → typed `InvalidOperationException` with descriptor name in the message (DIM-2 context).
+
+**Dependencies:** Task 1 · **Parallelizable:** No
+
+### Task 3: Polyglot path — `SymbolKey`-only accessor with no reflection
+1. [RED] `ProjectId_SymbolKeyOnlyDescriptor_ResolvesWithoutReflection`
+   - File: `src/Strategos.Ontology.Tests/Identity/ObjectIdentityProjectorTests.cs`
+   - Build a descriptor with `ClrType = null, SymbolKey = "py::Foo"` and a source-supplied accessor over a dictionary-shaped instance; assert no reflection (accessor invoked, deterministic id).
+2. [GREEN] Allow the id accessor to be supplied by `IOntologySource` for `SymbolKey`-only descriptors; projector resolves CLR accessor or source accessor, never `GetType().GetProperty(...)`.
+   - Files: `src/Strategos.Ontology/Identity/ObjectIdentityProjector.cs`, `src/Strategos.Ontology/Sources/IOntologySource.cs`
+3. [REFACTOR] Neither-accessor case → typed error ("descriptor has no id accessor"), never silent.
+
+**Dependencies:** Task 2 · **Parallelizable:** No
+
+### Task 4: Composite-key formatting + no `Type`-typed identity API
+1. [RED] `ProjectId_CompositeKey_FormatsDeterministicallyWithSeparator`
+   - File: `src/Strategos.Ontology.Tests/Identity/ObjectIdentityProjectorTests.cs`
+2. [GREEN] Deterministic composite formatting (reserved separator); single-key path unchanged.
+3. [REFACTOR] Assert (compile-time review) no public member in `Identity/` accepts/returns `System.Type` (INV-8).
+
+**Dependencies:** Task 2 · **Parallelizable:** with Task 3
+
+---
+
+## Group 2 — DR-2 + DR-8(relate): in-memory relate-store
+
+**Branch:** `feat/edge-foundation-dr2-relate-store` (stacked on DR-1)
+
+### Task 5: `RelateAsync` / `UnrelateAsync` create and remove a row
+1. [RED] `RelateAsync_TwoInstances_CreatesRow`, `UnrelateAsync_ExistingRow_RemovesIt`
+   - File: `src/Strategos.Ontology.Tests/ObjectSets/InMemoryRelateStoreTests.cs` (new)
+   - Expected failure: methods do not exist on `IObjectSetWriter`.
+2. [GREEN] Add `RelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default)` and `UnrelateAsync(...)` to `IObjectSetWriter`; implement in `InMemoryObjectSetProvider` with `_relations: ConcurrentDictionary<(string,string,string), List<(string tgtDescriptor,string tgtId,string? assocId)>>`.
+   - Files: `src/Strategos.Ontology/ObjectSets/IObjectSetWriter.cs`, `src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs`
+3. [REFACTOR] Row tuple → a small `sealed record RelationRow` for readability.
+
+**Dependencies:** Task 2 · **Parallelizable:** No
+
+### Task 6: Idempotency + unrelate no-op
+1. [RED] `RelateAsync_DuplicateTriple_IsIdempotent`, `UnrelateAsync_MissingRow_IsNoOp`
+   - File: `InMemoryRelateStoreTests.cs`
+2. [GREEN] Guard duplicate `(src, link, tgt)` insert; `UnrelateAsync` of absent row returns without throwing.
+3. [REFACTOR] —
+
+**Dependencies:** Task 5 · **Parallelizable:** No
+
+### Task 7: Deterministic ordinal-by-id read order (INV-7 / replay)
+1. [RED] `Relations_ReadOrder_IsOrdinalByTargetId`
+   - File: `InMemoryRelateStoreTests.cs` — insert out of order, assert sorted read.
+2. [GREEN] Read path returns rows ordered by `tgtId` (stable); `ConcurrentDictionary` enumeration never exposed raw.
+3. [REFACTOR] —
+
+**Dependencies:** Task 5 · **Parallelizable:** with Task 6
+
+### Task 8 (DR-8): Eager endpoint validation → typed error
+1. [RED] `RelateAsync_NonExistentEndpoint_ThrowsTypedError`
+   - File: `InMemoryRelateStoreTests.cs` — relate to an unstored `tgtId`; assert a typed exception, no dangling row.
+2. [GREEN] Validate both endpoint ids exist in `_items` before writing; throw a typed `RelationEndpointNotFoundException` naming the missing endpoint (DIM-2). Document this as the eager posture Npgsql FKs mirror.
+3. [REFACTOR] —
+
+**Dependencies:** Task 5 · **Parallelizable:** No
+
+### Task 9 (DR-8): Self-loop policy
+1. [RED] `RelateAsync_SelfLoop_WhenDisallowed_ThrowsTypedError`, `RelateAsync_SelfLoop_WhenAllowed_CreatesRow`
+   - File: `InMemoryRelateStoreTests.cs`
+2. [GREEN] Link-level `AllowsSelfLoop` flag (default false); self-loop `(x, link, x)` throws typed error unless opted in. (Analyzer promotion is DR-6, deferred.)
+   - Files: `src/Strategos.Ontology/Descriptors/LinkDescriptor.cs`, `InMemoryObjectSetProvider.cs`
+3. [REFACTOR] —
+
+**Dependencies:** Task 8 · **Parallelizable:** No
+
+---
+
+## Group 3 — DR-3 + DR-8(traverse): instance-anchored traversal
+
+**Branch:** `feat/edge-foundation-dr3-traversal` (stacked on DR-2)
+
+### Task 10: Traverse resolves by source instance, not target type
+1. [RED] `TraverseLink_FromInstance_ReturnsOnlyRelatedTargets`
+   - File: `src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTraversalTests.cs`
+   - Relate `x→{a,b}`, store unrelated `c`; assert traverse from `x` yields `{a,b}` only.
+2. [GREEN] Rewrite `EvaluateTraverseLink`: materialize upstream instances, project ids (DR-1 projector), look up `_relations` by `(srcId, linkName)`, resolve targets by id. Remove the `itemResolver(link.TargetTypeName)` call at line 139.
+   - File: `src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs`
+3. [REFACTOR] Extract target-by-id resolution helper.
+
+**Dependencies:** Task 5, Task 2 · **Parallelizable:** No
+
+### Task 11 (DR-8): Zero-relations empty-set regression guard for #114
+1. [RED] `TraverseLink_InstanceWithNoRelations_ReturnsEmptySet`
+   - File: `ObjectSetTraversalTests.cs` — the explicit #114 guard: an instance with no rows must NOT return all target-type items.
+2. [GREEN] Covered by Task 10's rewrite; this test pins the regression.
+3. [REFACTOR] —
+
+**Dependencies:** Task 10 · **Parallelizable:** with Task 12
+
+### Task 12: Association-backed traversal exposes edge attributes before far hop
+1. [RED] `TraverseLink_OverAssociation_ExposesEdgeAttributesForFilter`
+   - File: `ObjectSetTraversalTests.cs` — relate via an association carrying `Status`; assert `.Where(a => a.Status == Active)` filters before the far-endpoint hop.
+2. [GREEN] When a row carries `assocId`, the traversal step yields the association object (filterable); a further hop resolves the far endpoint via the row's other side.
+   - File: `InMemoryExpressionEvaluator.cs`
+3. [REFACTOR] —
+
+**Dependencies:** Task 10, Task 17 · **Parallelizable:** No
+
+### Task 13 (DR-8): `SymbolKey`-only relate→traverse, no reflection
+1. [RED] `RelateThenTraverse_SymbolKeyOnlyDescriptor_NoReflection`
+   - File: `ObjectSetTraversalTests.cs` — full path on a CLR-free descriptor; INV-8 regression.
+2. [GREEN] Covered by DR-1 + DR-3; this test pins the polyglot path end-to-end.
+3. [REFACTOR] —
+
+**Dependencies:** Task 10, Task 3 · **Parallelizable:** No
+
+---
+
+## Group 4 — DR-4: `Association<T>` + `ObjectKind.Association`
+
+**Branch:** `feat/edge-foundation-dr4-association` (stacked on DR-1; attributed-relate seam needs DR-2)
+
+### Task 14: `ObjectKind.Association`
+1. [RED] `ObjectKind_DefinesAssociationMember`
+   - File: `src/Strategos.Ontology.Tests/Builder/ObjectTypeBuilderTests.cs`
+2. [GREEN] Add `Association` to `ObjectKind` (additive enum — backward compatible, DIM-3).
+   - File: `src/Strategos.Ontology/Descriptors/ObjectKind.cs`
+3. [REFACTOR] —
+
+**Dependencies:** None · **Parallelizable:** with Group 1
+
+### Task 15: `ontology.Association<TRel>(name, cfg)` authoring with typed endpoints
+1. [RED] `Association_DeclaresRelationWithTwoTypedEndpoints`, `Association_WithProperty_CapturesEdgeAttribute`
+   - File: `src/Strategos.Ontology.Tests/Builder/AssociationBuilderTests.cs` (new)
+2. [GREEN] `IAssociationBuilder` / `sealed AssociationBuilder` with `Between<L>(sel).And<R>(sel)`, `Property(...)`; `Association<TRel>(string name, Action<IAssociationBuilder> cfg)` on `IOntologyBuilder` / `OntologyBuilder` producing an `ObjectTypeDescriptor` with `Kind = Association` + two endpoint refs.
+   - Files: `src/Strategos.Ontology/Builder/IAssociationBuilder.cs`, `AssociationBuilder.cs`, `IOntologyBuilder.cs`, `OntologyBuilder.cs`; descriptor endpoint fields in `ObjectTypeDescriptor.cs`
+3. [REFACTOR] All new builder/descriptor types `sealed` (INV-6); association object immutable record (INV-7); endpoints typed via descriptors, not `typeof` (INV-8).
+
+**Dependencies:** Task 14 · **Parallelizable:** with Group 2/3 authoring
+
+### Task 16: Graph builder recognizes associations and exposes endpoints as edges
+1. [RED] `OntologyGraph_AssociationObject_ExposesEndpointsAsEdge`
+   - File: `src/Strategos.Ontology.Tests/OntologyGraphBuilderTests.cs` (exists — extend)
+2. [GREEN] `OntologyGraphBuilder` treats `Kind == Association` objects as edges whose source/destination are the two endpoints.
+   - File: `src/Strategos.Ontology/OntologyGraphBuilder.cs`
+3. [REFACTOR] —
+
+**Dependencies:** Task 15 · **Parallelizable:** No
+
+### Task 17: Attributed-relate seam (store association object + row with `assocId`)
+1. [RED] `RelateWithAssociation_StoresObjectAndRowReferencingIt`
+   - File: `src/Strategos.Ontology.Tests/ObjectSets/InMemoryRelateStoreTests.cs`
+2. [GREEN] Overload/path that `StoreAsync`-es the association object then writes a row whose `assocId` is the association object's projected id.
+   - Files: `IObjectSetWriter.cs`, `InMemoryObjectSetProvider.cs`
+3. [REFACTOR] —
+
+**Dependencies:** Task 5, Task 15 · **Parallelizable:** No
+
+---
+
+## Group 5 — Invariant guards (mechanical enforcement, not review-by-convention)
+
+**Branch:** folds into the DR-1 / DR-4 branches that introduce the surfaces being guarded.
+
+> Added in plan-review: the design asserts INV-2 / INV-6 / INV-8 conformance "by construction." That is a hand-wavy mitigation. Each is converted here into a failing-test-first mechanical guard. No new test package required — plain reflection over the loaded assembly.
+
+### Task 18 (INV-2): assembly-reference self-containment guard
+1. [RED] `Ontology_Assembly_ReferencesNoWolverineOrMarten`
+   - File: `src/Strategos.Ontology.Tests/InvariantGuardTests.cs` (new)
+   - Assert `typeof(ObjectTypeDescriptor).Assembly.GetReferencedAssemblies()` contains no name starting with `Wolverine` or `Marten`. Fails the moment the relate-store or projector pulls in an event-store dependency.
+2. [GREEN] Passes at baseline; the test is the standing regression guard for the DR-2 relate-store work.
+3. [REFACTOR] —
+
+**Dependencies:** Task 5 (lands with the relate-store, the most likely place to violate) · **Parallelizable:** No
+
+### Task 19 (INV-6 + INV-8): sealed + no `Type`-typed identity, as tests
+1. [RED] `NewEdgeTypes_AreSealed`, `IdentityApi_ExposesNoSystemTypeMembers`
+   - File: `src/Strategos.Ontology.Tests/InvariantGuardTests.cs`
+   - Reflect over the new `Identity/` + association types: assert each is `sealed`; assert no public member in the `Identity` namespace has a `System.Type` parameter or return (INV-8 "typed on identity, not `Type`").
+2. [GREEN] Covered by the DR-1 / DR-4 type shapes; this pins the structural invariants so a later edit can't silently unseal or reintroduce a `Type`-typed identity API.
+3. [REFACTOR] —
+
+**Dependencies:** Task 4, Task 15 · **Parallelizable:** with Task 18
+
+---
+
+## Parallelization summary
+
+- **Sequential spine:** Task 1 → 2 → 5 → 10. (identity accessor → projector → relate-store → traversal)
+- **Parallel-safe within a branch:** {Task 3, Task 4}; {Task 6, Task 7}; {Task 11, Task 13}.
+- **Group 4 (DR-4)** can begin from Task 14 in parallel with Group 1 once `ObjectKind` lands; Task 17 joins after both Task 5 and Task 15; Task 12 (assoc traversal) is the last join (needs Task 10 + Task 17).
+- **Stacked branches:** DR-2 stacks on DR-1; DR-3 stacks on DR-2; DR-4 stacks on DR-1. Rebase DR-3/DR-4 onto merged main as parents land (per the stacked-branch gate discipline).
+
+## Coverage map (design DR → tasks)
+
+| Design requirement | Tasks |
+|---|---|
+| DR-1 object-identity contract | 1, 2, 3, 4 |
+| DR-2 relate-store + relate/unrelate | 5, 6, 7 |
+| DR-3 instance-anchored traversal | 10, 12 |
+| DR-4 `Association<T>` + `ObjectKind.Association` | 14, 15, 16, 17 |
+| DR-8 (in-memory slice) failure modes | 8 (dangling), 9 (self-loop), 11 (zero-relations #114 guard), 13 (polyglot no-reflection) |
+| INV-2 self-containment (mechanical) | 18 |
+| INV-6 sealed + INV-8 no-`Type` identity (mechanical) | 19 |
+| INV-7 immutable / replay-deterministic | 7, 15 |

--- a/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
+++ b/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
@@ -369,6 +369,22 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
             + "The DR-2 relate-store ships on InMemoryObjectSetProvider; the Npgsql relation-table "
             + "materialization is a later increment.");
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// DR-4 (Ontology Edge Foundation): attributed relate (storing a reified
+    /// association object alongside the relation row) ships on
+    /// <c>InMemoryObjectSetProvider</c>. The Npgsql materialization — an
+    /// association object table whose endpoint columns are foreign keys —
+    /// is the same later increment as <see cref="RelateAsync"/>; until then this
+    /// surface throws rather than silently dropping a write.
+    /// </remarks>
+    public Task RelateAsync<TRel>(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, string associationDescriptor, TRel association, CancellationToken ct = default)
+        where TRel : class =>
+        throw new NotSupportedException(
+            "Attributed RelateAsync<TRel> is not yet implemented by PgVectorObjectSetProvider. "
+            + "The DR-4 association relate-store ships on InMemoryObjectSetProvider; the Npgsql "
+            + "association-table materialization is a later increment.");
+
     /// <summary>
     /// Core single-item write helper. Takes a pre-resolved <paramref name="tableName"/>
     /// so both the default <see cref="StoreAsync{T}(T, CancellationToken)"/> overload

--- a/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
+++ b/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
@@ -344,6 +344,31 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
         return StoreBatchAsyncCore<T>(tableName, items, ct);
     }
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// DR-2 (Ontology Edge Foundation) implements the relate-store only for the
+    /// in-memory provider. The Npgsql relation-table materialization (with the
+    /// foreign-key constraints that mirror the in-memory provider's eager
+    /// endpoint validation) is a later increment; until then this surface
+    /// throws rather than silently dropping a write.
+    /// </remarks>
+    public Task RelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default) =>
+        throw new NotSupportedException(
+            "RelateAsync is not yet implemented by PgVectorObjectSetProvider. "
+            + "The DR-2 relate-store ships on InMemoryObjectSetProvider; the Npgsql relation-table "
+            + "materialization is a later increment.");
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// DR-2 (Ontology Edge Foundation): see <see cref="RelateAsync"/>. Not yet
+    /// implemented by the Npgsql provider.
+    /// </remarks>
+    public Task UnrelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default) =>
+        throw new NotSupportedException(
+            "UnrelateAsync is not yet implemented by PgVectorObjectSetProvider. "
+            + "The DR-2 relate-store ships on InMemoryObjectSetProvider; the Npgsql relation-table "
+            + "materialization is a later increment.");
+
     /// <summary>
     /// Core single-item write helper. Takes a pre-resolved <paramref name="tableName"/>
     /// so both the default <see cref="StoreAsync{T}(T, CancellationToken)"/> overload

--- a/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
+++ b/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
@@ -371,6 +371,20 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
 
     /// <inheritdoc />
     /// <remarks>
+    /// DR-4 (Ontology Edge Foundation): attributed unrelate (removing the
+    /// relation row and its orphaned association object) ships on
+    /// <c>InMemoryObjectSetProvider</c>. The Npgsql materialization is the same
+    /// later increment as <see cref="RelateAsync"/>; until then this surface
+    /// throws rather than silently dropping a write.
+    /// </remarks>
+    public Task UnrelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, string associationDescriptor, string associationId, CancellationToken ct = default) =>
+        throw new NotSupportedException(
+            "Attributed UnrelateAsync is not yet implemented by PgVectorObjectSetProvider. "
+            + "The DR-4 association relate-store ships on InMemoryObjectSetProvider; the Npgsql "
+            + "association-table materialization is a later increment.");
+
+    /// <inheritdoc />
+    /// <remarks>
     /// DR-4 (Ontology Edge Foundation): attributed relate (storing a reified
     /// association object alongside the relation row) ships on
     /// <c>InMemoryObjectSetProvider</c>. The Npgsql materialization — an

--- a/src/Strategos.Ontology.Tests/Builder/AssociationBuilderTests.cs
+++ b/src/Strategos.Ontology.Tests/Builder/AssociationBuilderTests.cs
@@ -1,0 +1,87 @@
+using Strategos.Ontology.Builder;
+using Strategos.Ontology.Descriptors;
+
+namespace Strategos.Ontology.Tests.Builder;
+
+// ---------------------------------------------------------------------------
+// Test domain types for the association builder (DR-4)
+// ---------------------------------------------------------------------------
+
+public sealed record AssocPerson(string Id);
+
+public sealed record AssocCompany(string Id);
+
+// Reified association: Employment links a Person (left) to a Company (right)
+// and carries its own edge attribute (Title) plus its own key.
+public sealed record Employment(string Id, AssocPerson Employee, AssocCompany Employer, string Title);
+
+public sealed class AssociationTestOntology : DomainOntology
+{
+    public override string DomainName => "assoc";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<AssocPerson>(obj => obj.Key(p => p.Id));
+        builder.Object<AssocCompany>(obj => obj.Key(c => c.Id));
+
+        builder.Association<Employment>("Employment", a =>
+        {
+            a.Key(e => e.Id);
+            a.Between(e => e.Employee).And(e => e.Employer);
+            a.Property(e => e.Title).Required();
+        });
+    }
+}
+
+public class AssociationBuilderTests
+{
+    private static ObjectTypeDescriptor BuildAssociationDescriptor()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain<AssociationTestOntology>();
+        var graph = graphBuilder.Build();
+        return graph.ObjectTypes.First(ot => ot.Name == "Employment");
+    }
+
+    [Test]
+    public async Task Association_DeclaresRelationWithTwoTypedEndpoints()
+    {
+        var descriptor = BuildAssociationDescriptor();
+
+        // The association is a standalone object type tagged with the Association kind.
+        await Assert.That(descriptor.Kind).IsEqualTo(ObjectKind.Association);
+
+        // It exposes exactly two endpoints, referenced by descriptor name — never
+        // by a bare System.Type (INV-8).
+        await Assert.That(descriptor.AssociationEndpoints).HasCount().EqualTo(2);
+
+        var left = descriptor.AssociationEndpoints[0];
+        var right = descriptor.AssociationEndpoints[1];
+
+        await Assert.That(left.DescriptorName).IsEqualTo(nameof(AssocPerson));
+        await Assert.That(right.DescriptorName).IsEqualTo(nameof(AssocCompany));
+
+        // The role records which property on the association object carries the endpoint.
+        await Assert.That(left.Role).IsEqualTo(nameof(Employment.Employee));
+        await Assert.That(right.Role).IsEqualTo(nameof(Employment.Employer));
+    }
+
+    [Test]
+    public async Task Association_WithProperty_CapturesEdgeAttribute()
+    {
+        var descriptor = BuildAssociationDescriptor();
+
+        // The association carries its own properties (edge attributes), like any object type.
+        await Assert.That(descriptor.Properties.Count).IsEqualTo(1);
+        await Assert.That(descriptor.Properties[0].Name).IsEqualTo(nameof(Employment.Title));
+        await Assert.That(descriptor.Properties[0].IsRequired).IsTrue();
+
+        // Its own key/id flows through the DR-1 IdAccessor path like any object type.
+        await Assert.That(descriptor.KeyProperty).IsNotNull();
+        await Assert.That(descriptor.KeyProperty!.Name).IsEqualTo(nameof(Employment.Id));
+        await Assert.That(descriptor.IdAccessor).IsNotNull();
+
+        var instance = new Employment("e1", new AssocPerson("p1"), new AssocCompany("c1"), "Engineer");
+        await Assert.That(descriptor.IdAccessor!(instance)).IsEqualTo("e1");
+    }
+}

--- a/src/Strategos.Ontology.Tests/Builder/AssociationBuilderTests.cs
+++ b/src/Strategos.Ontology.Tests/Builder/AssociationBuilderTests.cs
@@ -84,4 +84,65 @@ public class AssociationBuilderTests
         var instance = new Employment("e1", new AssocPerson("p1"), new AssocCompany("c1"), "Engineer");
         await Assert.That(descriptor.IdAccessor!(instance)).IsEqualTo("e1");
     }
+
+    // -----------------------------------------------------------------------
+    // FIX-F — upfront guard clauses on the fluent entry points, matching the
+    // other builders' convention so null/blank inputs fail with actionable
+    // errors at the call site rather than later as a NullReferenceException.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task Property_ByName_Blank_ThrowsArgumentException()
+    {
+        IAssociationBuilder<Employment> builder = new AssociationBuilder<Employment>("assoc", "Employment");
+
+        await Assert.That(() => builder.Property<string>("   "))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task Property_ByName_Null_ThrowsArgumentNullException()
+    {
+        IAssociationBuilder<Employment> builder = new AssociationBuilder<Employment>("assoc", "Employment");
+
+        await Assert.That(() => builder.Property<string>(null!))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Key_NullSelector_ThrowsArgumentNullException()
+    {
+        IAssociationBuilder<Employment> builder = new AssociationBuilder<Employment>("assoc", "Employment");
+
+        await Assert.That(() => builder.Key(null!))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task PropertyBySelector_Null_ThrowsArgumentNullException()
+    {
+        IAssociationBuilder<Employment> builder = new AssociationBuilder<Employment>("assoc", "Employment");
+
+        await Assert.That(() => builder.Property(null!))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Between_NullSelector_ThrowsArgumentNullException()
+    {
+        IAssociationBuilder<Employment> builder = new AssociationBuilder<Employment>("assoc", "Employment");
+
+        await Assert.That(() => builder.Between<AssocPerson>(null!))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task And_NullSelector_ThrowsArgumentNullException()
+    {
+        IAssociationEndpointBuilder<Employment> builder =
+            new AssociationBuilder<Employment>("assoc", "Employment");
+
+        await Assert.That(() => builder.And<AssocCompany>(null!))
+            .Throws<ArgumentNullException>();
+    }
 }

--- a/src/Strategos.Ontology.Tests/Builder/ObjectTypeBuilderTests.cs
+++ b/src/Strategos.Ontology.Tests/Builder/ObjectTypeBuilderTests.cs
@@ -18,6 +18,21 @@ public class ObjectTypeBuilderTests
     }
 
     [Test]
+    public async Task Key_Selector_RetainsCompiledIdAccessor()
+    {
+        var builder = new ObjectTypeBuilder<TestPosition>("Trading");
+
+        builder.Key(p => p.Id);
+        var descriptor = builder.Build();
+
+        await Assert.That(descriptor.IdAccessor).IsNotNull();
+
+        var id = Guid.NewGuid();
+        var instance = new TestPosition(id, "AAPL", 1m, 0m, "");
+        await Assert.That(descriptor.IdAccessor!(instance)).IsEqualTo(id);
+    }
+
+    [Test]
     public async Task ObjectTypeBuilder_Property_AddsPropertyDescriptor()
     {
         var builder = new ObjectTypeBuilder<TestPosition>("Trading");

--- a/src/Strategos.Ontology.Tests/Configuration/EmbeddingProviderRegistrationTests.cs
+++ b/src/Strategos.Ontology.Tests/Configuration/EmbeddingProviderRegistrationTests.cs
@@ -43,6 +43,10 @@ public class StubObjectSetWriterForDI : IObjectSetWriter
 
     public Task UnrelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default) =>
         Task.CompletedTask;
+
+    // Attributed unrelate added for DR-4; this DI test double does not need unrelate behavior.
+    public Task UnrelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, string associationDescriptor, string associationId, CancellationToken ct = default) =>
+        Task.CompletedTask;
 }
 
 public class DualProvider : IObjectSetProvider, IObjectSetWriter
@@ -83,6 +87,10 @@ public class DualProvider : IObjectSetProvider, IObjectSetWriter
         Task.CompletedTask;
 
     public Task UnrelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default) =>
+        Task.CompletedTask;
+
+    // Attributed unrelate added for DR-4; this DI test double does not need unrelate behavior.
+    public Task UnrelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, string associationDescriptor, string associationId, CancellationToken ct = default) =>
         Task.CompletedTask;
 }
 

--- a/src/Strategos.Ontology.Tests/Configuration/EmbeddingProviderRegistrationTests.cs
+++ b/src/Strategos.Ontology.Tests/Configuration/EmbeddingProviderRegistrationTests.cs
@@ -31,6 +31,13 @@ public class StubObjectSetWriterForDI : IObjectSetWriter
 
     public Task StoreBatchAsync<T>(string descriptorName, IReadOnlyList<T> items, CancellationToken ct = default) where T : class =>
         Task.CompletedTask;
+
+    // Relate-store methods added for DR-2; this DI test double does not need relate behavior.
+    public Task RelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default) =>
+        Task.CompletedTask;
+
+    public Task UnrelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default) =>
+        Task.CompletedTask;
 }
 
 public class DualProvider : IObjectSetProvider, IObjectSetWriter
@@ -59,6 +66,13 @@ public class DualProvider : IObjectSetProvider, IObjectSetWriter
         Task.CompletedTask;
 
     public Task StoreBatchAsync<T>(string descriptorName, IReadOnlyList<T> items, CancellationToken ct = default) where T : class =>
+        Task.CompletedTask;
+
+    // Relate-store methods added for DR-2; this DI test double does not need relate behavior.
+    public Task RelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default) =>
+        Task.CompletedTask;
+
+    public Task UnrelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default) =>
         Task.CompletedTask;
 }
 

--- a/src/Strategos.Ontology.Tests/Configuration/EmbeddingProviderRegistrationTests.cs
+++ b/src/Strategos.Ontology.Tests/Configuration/EmbeddingProviderRegistrationTests.cs
@@ -36,6 +36,11 @@ public class StubObjectSetWriterForDI : IObjectSetWriter
     public Task RelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default) =>
         Task.CompletedTask;
 
+    // Attributed relate added for DR-4; this DI test double does not need relate behavior.
+    public Task RelateAsync<TRel>(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, string associationDescriptor, TRel association, CancellationToken ct = default)
+        where TRel : class =>
+        Task.CompletedTask;
+
     public Task UnrelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default) =>
         Task.CompletedTask;
 }
@@ -70,6 +75,11 @@ public class DualProvider : IObjectSetProvider, IObjectSetWriter
 
     // Relate-store methods added for DR-2; this DI test double does not need relate behavior.
     public Task RelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default) =>
+        Task.CompletedTask;
+
+    // Attributed relate added for DR-4; this DI test double does not need relate behavior.
+    public Task RelateAsync<TRel>(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, string associationDescriptor, TRel association, CancellationToken ct = default)
+        where TRel : class =>
         Task.CompletedTask;
 
     public Task UnrelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default) =>

--- a/src/Strategos.Ontology.Tests/Descriptors/ObjectKindTests.cs
+++ b/src/Strategos.Ontology.Tests/Descriptors/ObjectKindTests.cs
@@ -69,4 +69,12 @@ public class ObjectKindTests
 
         await Assert.That(descriptor.Kind).IsEqualTo(ObjectKind.Entity);
     }
+
+    [Test]
+    public async Task ObjectKind_DefinesAssociationMember()
+    {
+        // DR-4 (Task 14): an association is a standalone object-with-two-endpoints,
+        // so the kind enum gains an Association member (additive, backward compatible).
+        await Assert.That(Enum.IsDefined(ObjectKind.Association)).IsTrue();
+    }
 }

--- a/src/Strategos.Ontology.Tests/Identity/ObjectIdentityProjectorTests.cs
+++ b/src/Strategos.Ontology.Tests/Identity/ObjectIdentityProjectorTests.cs
@@ -39,7 +39,7 @@ public class ObjectIdentityProjectorTests
     }
 
     [Test]
-    public async Task ProjectId_NullKeyValue_ThrowsNamingDescriptor()
+    public async Task ProjectId_NullKeyValue_ThrowsNullKeyValueException()
     {
         var projector = new ObjectIdentityProjector();
         var descriptor = new ObjectTypeDescriptor("NullableThing", typeof(NullableThing), "test")
@@ -47,9 +47,12 @@ public class ObjectIdentityProjectorTests
             IdAccessor = o => ((NullableThing)o).Id,
         };
 
+        // A null key value is a DATA error (distinct from a missing-accessor
+        // CONFIG error), so it surfaces as NullKeyValueException — not the
+        // shared InvalidOperationException of old.
         await Assert.That(() => projector.ProjectId(descriptor, new NullableThing(null)))
             .ThrowsException()
-            .WithExceptionType(typeof(InvalidOperationException));
+            .WithExceptionType(typeof(NullKeyValueException));
 
         await Assert.That(() => projector.ProjectId(descriptor, new NullableThing(null)))
             .ThrowsException()
@@ -182,7 +185,7 @@ public class ObjectIdentityProjectorTests
     }
 
     [Test]
-    public async Task ProjectId_DescriptorWithoutIdAccessor_ThrowsNamingDescriptor()
+    public async Task ProjectId_DescriptorWithoutIdAccessor_ThrowsMissingIdAccessorException()
     {
         var projector = new ObjectIdentityProjector();
         var descriptor = new ObjectTypeDescriptor
@@ -193,9 +196,12 @@ public class ObjectIdentityProjectorTests
             IdAccessor = null,
         };
 
+        // A missing accessor is a CONFIG error (descriptor misconfiguration),
+        // distinct from a null key VALUE (a data error). It surfaces as
+        // MissingIdAccessorException so callers can tell the two apart.
         await Assert.That(() => projector.ProjectId(descriptor, new object()))
             .ThrowsException()
-            .WithExceptionType(typeof(InvalidOperationException));
+            .WithExceptionType(typeof(MissingIdAccessorException));
 
         await Assert.That(() => projector.ProjectId(descriptor, new object()))
             .ThrowsException()

--- a/src/Strategos.Ontology.Tests/Identity/ObjectIdentityProjectorTests.cs
+++ b/src/Strategos.Ontology.Tests/Identity/ObjectIdentityProjectorTests.cs
@@ -90,6 +90,46 @@ public class ObjectIdentityProjectorTests
     }
 
     [Test]
+    public async Task ProjectId_CompositeKey_FormatsDeterministicallyWithSeparator()
+    {
+        var projector = new ObjectIdentityProjector();
+
+        // Composite key whose accessor yields a ValueTuple (ITuple). The id is
+        // its elements joined by the reserved Unit Separator; single-value keys
+        // are plain ToString(). Determinism: same elements => same id.
+        var descriptor = new ObjectTypeDescriptor
+        {
+            Name = "CompositeThing",
+            DomainName = "test",
+            SymbolKey = "py::CompositeThing",
+            IdAccessor = o => ((IReadOnlyDictionary<string, object>)o)["key"],
+        };
+
+        var instance = new Dictionary<string, object> { ["key"] = (tenant: "acme", id: 7) };
+
+        var projected = projector.ProjectId(descriptor, instance);
+        var again = projector.ProjectId(
+            descriptor,
+            new Dictionary<string, object> { ["key"] = (tenant: "acme", id: 7) });
+
+        var expected = $"acme{ObjectIdentityProjector.CompositeKeySeparator}7";
+        await Assert.That(projected).IsEqualTo(expected);
+        await Assert.That(projected).IsEqualTo(again);
+    }
+
+    [Test]
+    public async Task ProjectId_SingleValueKey_IsPlainToString()
+    {
+        var projector = new ObjectIdentityProjector();
+        var descriptor = ClrDescriptor();
+        var id = Guid.NewGuid();
+
+        var projected = projector.ProjectId(descriptor, new ClrThing(id, "x"));
+
+        await Assert.That(projected).IsEqualTo(id.ToString());
+    }
+
+    [Test]
     public async Task ProjectId_DescriptorWithoutIdAccessor_ThrowsNamingDescriptor()
     {
         var projector = new ObjectIdentityProjector();

--- a/src/Strategos.Ontology.Tests/Identity/ObjectIdentityProjectorTests.cs
+++ b/src/Strategos.Ontology.Tests/Identity/ObjectIdentityProjectorTests.cs
@@ -94,9 +94,10 @@ public class ObjectIdentityProjectorTests
     {
         var projector = new ObjectIdentityProjector();
 
-        // Composite key whose accessor yields a ValueTuple (ITuple). The id is
-        // its elements joined by the reserved Unit Separator; single-value keys
-        // are plain ToString(). Determinism: same elements => same id.
+        // Composite key whose accessor yields a ValueTuple (ITuple). Each element
+        // is length-prefixed (V<len>:<text>) and joined by the reserved Unit
+        // Separator so the encoding is injective; single-value keys are plain
+        // ToString(). Determinism: same elements => same id.
         var descriptor = new ObjectTypeDescriptor
         {
             Name = "CompositeThing",
@@ -112,9 +113,60 @@ public class ObjectIdentityProjectorTests
             descriptor,
             new Dictionary<string, object> { ["key"] = (tenant: "acme", id: 7) });
 
-        var expected = $"acme{ObjectIdentityProjector.CompositeKeySeparator}7";
+        var expected = $"V4:acme{ObjectIdentityProjector.CompositeKeySeparator}V1:7";
         await Assert.That(projected).IsEqualTo(expected);
         await Assert.That(projected).IsEqualTo(again);
+    }
+
+    [Test]
+    public async Task ProjectId_CompositeKey_IsCollisionFreeAcrossSeparatorBoundaries()
+    {
+        var projector = new ObjectIdentityProjector();
+        var descriptor = new ObjectTypeDescriptor
+        {
+            Name = "CompositeThing",
+            DomainName = "test",
+            SymbolKey = "py::CompositeThing",
+            IdAccessor = o => ((IReadOnlyDictionary<string, object>)o)["key"],
+        };
+
+        // Both tuples join to "a<US>b<US>c" under the naive join-on-separator
+        // encoding: the first sneaks the separator INTO a component, the second
+        // splits it ACROSS components. A collision-free (injective) encoding must
+        // keep them distinct so the relate-store never merges two instances.
+        var sep = ObjectIdentityProjector.CompositeKeySeparator;
+        var leftHasSeparator = new Dictionary<string, object> { ["key"] = ($"a{sep}b", "c") };
+        var rightSplitAcross = new Dictionary<string, object> { ["key"] = ("a", $"b{sep}c") };
+
+        var left = projector.ProjectId(descriptor, leftHasSeparator);
+        var right = projector.ProjectId(descriptor, rightSplitAcross);
+
+        await Assert.That(left).IsNotEqualTo(right);
+    }
+
+    [Test]
+    public async Task ProjectId_CompositeKey_NullElement_DistinctFromEmpty()
+    {
+        var projector = new ObjectIdentityProjector();
+        var descriptor = new ObjectTypeDescriptor
+        {
+            Name = "CompositeThing",
+            DomainName = "test",
+            SymbolKey = "py::CompositeThing",
+            IdAccessor = o => ((IReadOnlyDictionary<string, object>)o)["key"],
+        };
+
+        // ("a", null) and ("a", "") must project to DIFFERENT ids: a null element
+        // is semantically distinct from the empty string and the two tuples are
+        // distinct instances. The naive encoding collapses null to string.Empty,
+        // merging them.
+        var withNull = new Dictionary<string, object> { ["key"] = ("a", (string?)null) };
+        var withEmpty = new Dictionary<string, object> { ["key"] = ("a", string.Empty) };
+
+        var nullId = projector.ProjectId(descriptor, withNull);
+        var emptyId = projector.ProjectId(descriptor, withEmpty);
+
+        await Assert.That(nullId).IsNotEqualTo(emptyId);
     }
 
     [Test]

--- a/src/Strategos.Ontology.Tests/Identity/ObjectIdentityProjectorTests.cs
+++ b/src/Strategos.Ontology.Tests/Identity/ObjectIdentityProjectorTests.cs
@@ -57,4 +57,56 @@ public class ObjectIdentityProjectorTests
     }
 
     private sealed record NullableThing(string? Id);
+
+    [Test]
+    public async Task ProjectId_SymbolKeyOnlyDescriptor_ResolvesWithoutReflection()
+    {
+        var projector = new ObjectIdentityProjector();
+
+        // Polyglot descriptor: no CLR type at all, only a SCIP moniker. The
+        // IdAccessor is supplied externally (as an IOntologySource would),
+        // reading a dictionary-shaped instance by key. The instance has no
+        // CLR property named "Id", so any reflection fallback would fail —
+        // proving the accessor is the only resolution path (INV-8).
+        var descriptor = new ObjectTypeDescriptor
+        {
+            Name = "Foo",
+            DomainName = "py",
+            ClrType = null,
+            SymbolKey = "py::Foo",
+            LanguageId = "python",
+            IdAccessor = o => ((IReadOnlyDictionary<string, object>)o)["pk"],
+        };
+
+        var instance = new Dictionary<string, object> { ["pk"] = "row-42", ["other"] = 99 };
+
+        var first = projector.ProjectId(descriptor, instance);
+        var second = projector.ProjectId(
+            descriptor,
+            new Dictionary<string, object> { ["pk"] = "row-42", ["other"] = 7 });
+
+        await Assert.That(first).IsEqualTo("row-42");
+        await Assert.That(first).IsEqualTo(second);
+    }
+
+    [Test]
+    public async Task ProjectId_DescriptorWithoutIdAccessor_ThrowsNamingDescriptor()
+    {
+        var projector = new ObjectIdentityProjector();
+        var descriptor = new ObjectTypeDescriptor
+        {
+            Name = "Bar",
+            DomainName = "py",
+            SymbolKey = "py::Bar",
+            IdAccessor = null,
+        };
+
+        await Assert.That(() => projector.ProjectId(descriptor, new object()))
+            .ThrowsException()
+            .WithExceptionType(typeof(InvalidOperationException));
+
+        await Assert.That(() => projector.ProjectId(descriptor, new object()))
+            .ThrowsException()
+            .WithMessageContaining("Bar");
+    }
 }

--- a/src/Strategos.Ontology.Tests/Identity/ObjectIdentityProjectorTests.cs
+++ b/src/Strategos.Ontology.Tests/Identity/ObjectIdentityProjectorTests.cs
@@ -1,0 +1,60 @@
+using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Identity;
+
+namespace Strategos.Ontology.Tests.Identity;
+
+public class ObjectIdentityProjectorTests
+{
+    private sealed record ClrThing(Guid Id, string Name);
+
+    private static ObjectTypeDescriptor ClrDescriptor() =>
+        new("ClrThing", typeof(ClrThing), "test")
+        {
+            IdAccessor = o => ((ClrThing)o).Id,
+        };
+
+    [Test]
+    public async Task ProjectId_ClrDescriptorWithKey_ReturnsDeterministicId()
+    {
+        var projector = new ObjectIdentityProjector();
+        var id = Guid.NewGuid();
+        var instance = new ClrThing(id, "alpha");
+
+        var projected = projector.ProjectId(ClrDescriptor(), instance);
+
+        await Assert.That(projected).IsEqualTo(id.ToString());
+    }
+
+    [Test]
+    public async Task ProjectId_SameKeyValue_ReturnsSameId()
+    {
+        var projector = new ObjectIdentityProjector();
+        var id = Guid.NewGuid();
+        var descriptor = ClrDescriptor();
+
+        var first = projector.ProjectId(descriptor, new ClrThing(id, "alpha"));
+        var second = projector.ProjectId(descriptor, new ClrThing(id, "beta-different-name"));
+
+        await Assert.That(first).IsEqualTo(second);
+    }
+
+    [Test]
+    public async Task ProjectId_NullKeyValue_ThrowsNamingDescriptor()
+    {
+        var projector = new ObjectIdentityProjector();
+        var descriptor = new ObjectTypeDescriptor("NullableThing", typeof(NullableThing), "test")
+        {
+            IdAccessor = o => ((NullableThing)o).Id,
+        };
+
+        await Assert.That(() => projector.ProjectId(descriptor, new NullableThing(null)))
+            .ThrowsException()
+            .WithExceptionType(typeof(InvalidOperationException));
+
+        await Assert.That(() => projector.ProjectId(descriptor, new NullableThing(null)))
+            .ThrowsException()
+            .WithMessageContaining("NullableThing");
+    }
+
+    private sealed record NullableThing(string? Id);
+}

--- a/src/Strategos.Ontology.Tests/InvariantGuardTests.cs
+++ b/src/Strategos.Ontology.Tests/InvariantGuardTests.cs
@@ -1,0 +1,118 @@
+using System.Reflection;
+
+using Strategos.Ontology.Descriptors;
+
+namespace Strategos.Ontology.Tests;
+
+/// <summary>
+/// Standing structural regression guards for the Ontology Edge Foundation
+/// load-bearing invariants. These execute by reflecting over the shipped
+/// <c>Strategos.Ontology</c> assembly, so they fail the build the moment a
+/// future change erodes an invariant rather than at some distant integration
+/// point.
+/// </summary>
+public class InvariantGuardTests
+{
+    private static Assembly OntologyAssembly => typeof(ObjectTypeDescriptor).Assembly;
+
+    /// <summary>
+    /// INV-2 (self-contained): the ontology core must not take a dependency
+    /// on Wolverine or Marten. The whole point of the projector living in
+    /// <c>Strategos.Ontology</c> is that identity resolution carries no
+    /// messaging/persistence baggage.
+    /// </summary>
+    [Test]
+    public async Task Ontology_Assembly_ReferencesNoWolverineOrMarten()
+    {
+        var offenders = OntologyAssembly.GetReferencedAssemblies()
+            .Where(a => a.Name is not null
+                && (a.Name.StartsWith("Wolverine", StringComparison.OrdinalIgnoreCase)
+                    || a.Name.StartsWith("Marten", StringComparison.OrdinalIgnoreCase)))
+            .Select(a => a.Name)
+            .ToList();
+
+        await Assert.That(offenders).IsEmpty();
+    }
+
+    /// <summary>
+    /// INV-6 (sealed): every public concrete type in the
+    /// <c>Strategos.Ontology.Identity</c> namespace must be sealed. Interfaces
+    /// are exempt — they are non-instantiable and sealing is inapplicable to
+    /// them — but no open class/struct is permitted in the identity surface.
+    /// </summary>
+    [Test]
+    public async Task IdentityTypes_AreSealed()
+    {
+        var unsealed = IdentityPublicTypes()
+            .Where(t => !t.IsInterface)
+            .Where(t => !t.IsSealed)
+            .Select(t => t.FullName)
+            .ToList();
+
+        await Assert.That(unsealed).IsEmpty();
+    }
+
+    /// <summary>
+    /// INV-8 (polyglot identity, structural half): no public member of any
+    /// identity type may traffic in <see cref="System.Type"/>. Surfacing a
+    /// <see cref="System.Type"/> would invite a reflection-based key lookup,
+    /// which is exactly the per-call reflection INV-8 forbids.
+    /// </summary>
+    [Test]
+    public async Task IdentityApi_ExposesNoSystemTypeMembers()
+    {
+        var offenders = new List<string>();
+
+        foreach (var type in IdentityPublicTypes())
+        {
+            const BindingFlags flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static;
+
+            foreach (var method in type.GetMethods(flags))
+            {
+                // Skip inherited Object members (ToString/Equals/GetHashCode/GetType).
+                if (method.DeclaringType != type)
+                {
+                    continue;
+                }
+
+                if (method.ReturnType == typeof(Type))
+                {
+                    offenders.Add($"{type.FullName}.{method.Name} returns System.Type");
+                }
+
+                foreach (var p in method.GetParameters())
+                {
+                    if (p.ParameterType == typeof(Type))
+                    {
+                        offenders.Add($"{type.FullName}.{method.Name}({p.Name}) takes System.Type");
+                    }
+                }
+            }
+
+            foreach (var prop in type.GetProperties(flags).Where(p => p.DeclaringType == type))
+            {
+                if (prop.PropertyType == typeof(Type))
+                {
+                    offenders.Add($"{type.FullName}.{prop.Name} is System.Type");
+                }
+            }
+
+            foreach (var ctor in type.GetConstructors(flags))
+            {
+                foreach (var p in ctor.GetParameters())
+                {
+                    if (p.ParameterType == typeof(Type))
+                    {
+                        offenders.Add($"{type.FullName} ctor({p.Name}) takes System.Type");
+                    }
+                }
+            }
+        }
+
+        await Assert.That(offenders).IsEmpty();
+    }
+
+    private static IEnumerable<Type> IdentityPublicTypes() =>
+        OntologyAssembly.GetTypes()
+            .Where(t => t.IsPublic && t.Namespace == "Strategos.Ontology.Identity");
+}

--- a/src/Strategos.Ontology.Tests/InvariantGuardTests.cs
+++ b/src/Strategos.Ontology.Tests/InvariantGuardTests.cs
@@ -112,6 +112,80 @@ public class InvariantGuardTests
         await Assert.That(offenders).IsEmpty();
     }
 
+    /// <summary>
+    /// INV-6 (sealed), DR-4 association surface: the new edge-authoring and
+    /// edge-descriptor types must be sealed. Covers the
+    /// <c>AssociationEndpoint</c> / <c>AssociationEdge</c> descriptor records and
+    /// the concrete <c>AssociationBuilder&lt;&gt;</c> (resolved by name so the
+    /// internal builder is included). Interfaces (<c>IAssociationBuilder</c>,
+    /// <c>IAssociationEndpointBuilder</c>) are exempt — sealing is inapplicable.
+    /// </summary>
+    [Test]
+    public async Task AssociationTypes_AreSealed()
+    {
+        // Resolved by name so the internal AssociationBuilder<> is covered too —
+        // a guard limited to public types would miss it.
+        var names = new[]
+        {
+            "Strategos.Ontology.Descriptors.AssociationEndpoint",
+            "Strategos.Ontology.AssociationEdge",
+            "Strategos.Ontology.Builder.AssociationBuilder`1",
+        };
+
+        var offenders = new List<string>();
+        foreach (var name in names)
+        {
+            var type = OntologyAssembly.GetType(name);
+            if (type is null)
+            {
+                offenders.Add($"{name} (type not found)");
+                continue;
+            }
+
+            if (!type.IsInterface && !type.IsSealed)
+            {
+                offenders.Add($"{type.FullName} is not sealed");
+            }
+        }
+
+        await Assert.That(offenders).IsEmpty();
+    }
+
+    /// <summary>
+    /// INV-6 (sealed), DR-2 edge surface: the relate-store edge types
+    /// introduced for the Ontology Edge Foundation must be sealed. DR-2 left
+    /// them sealed but uncovered by a guard; this closes that net mechanically
+    /// so a future edit that unseals one fails the build.
+    /// </summary>
+    [Test]
+    public async Task EdgeStoreTypes_AreSealed()
+    {
+        var names = new[]
+        {
+            "Strategos.Ontology.ObjectSets.RelationRow",
+            "Strategos.Ontology.ObjectSets.RelationEndpointNotFoundException",
+            "Strategos.Ontology.ObjectSets.SelfLoopNotAllowedException",
+        };
+
+        var offenders = new List<string>();
+        foreach (var name in names)
+        {
+            var type = OntologyAssembly.GetType(name);
+            if (type is null)
+            {
+                offenders.Add($"{name} (type not found)");
+                continue;
+            }
+
+            if (!type.IsSealed)
+            {
+                offenders.Add($"{type.FullName} is not sealed");
+            }
+        }
+
+        await Assert.That(offenders).IsEmpty();
+    }
+
     private static IEnumerable<Type> IdentityPublicTypes() =>
         OntologyAssembly.GetTypes()
             .Where(t => t.IsPublic && t.Namespace == "Strategos.Ontology.Identity");

--- a/src/Strategos.Ontology.Tests/InvariantGuardTests.cs
+++ b/src/Strategos.Ontology.Tests/InvariantGuardTests.cs
@@ -186,6 +186,41 @@ public class InvariantGuardTests
         await Assert.That(offenders).IsEmpty();
     }
 
+    /// <summary>
+    /// INV-6 (sealed), DR-1 identity-failure surface (FIX-E): the two distinct
+    /// projection-failure exception types must be sealed. They split the former
+    /// shared <c>InvalidOperationException</c> into a misconfiguration error
+    /// (missing accessor) and a data error (null key value); a future edit that
+    /// unseals one fails the build.
+    /// </summary>
+    [Test]
+    public async Task IdentityExceptionTypes_AreSealed()
+    {
+        var names = new[]
+        {
+            "Strategos.Ontology.Identity.MissingIdAccessorException",
+            "Strategos.Ontology.Identity.NullKeyValueException",
+        };
+
+        var offenders = new List<string>();
+        foreach (var name in names)
+        {
+            var type = OntologyAssembly.GetType(name);
+            if (type is null)
+            {
+                offenders.Add($"{name} (type not found)");
+                continue;
+            }
+
+            if (!type.IsSealed)
+            {
+                offenders.Add($"{type.FullName} is not sealed");
+            }
+        }
+
+        await Assert.That(offenders).IsEmpty();
+    }
+
     private static IEnumerable<Type> IdentityPublicTypes() =>
         OntologyAssembly.GetTypes()
             .Where(t => t.IsPublic && t.Namespace == "Strategos.Ontology.Identity");

--- a/src/Strategos.Ontology.Tests/InvariantGuardTests.cs
+++ b/src/Strategos.Ontology.Tests/InvariantGuardTests.cs
@@ -177,7 +177,7 @@ public class InvariantGuardTests
                 continue;
             }
 
-            if (!type.IsSealed)
+            if (!type.IsInterface && !type.IsSealed)
             {
                 offenders.Add($"{type.FullName} is not sealed");
             }
@@ -212,7 +212,7 @@ public class InvariantGuardTests
                 continue;
             }
 
-            if (!type.IsSealed)
+            if (!type.IsInterface && !type.IsSealed)
             {
                 offenders.Add($"{type.FullName} is not sealed");
             }

--- a/src/Strategos.Ontology.Tests/Merge/MergeTwoAssociationTests.cs
+++ b/src/Strategos.Ontology.Tests/Merge/MergeTwoAssociationTests.cs
@@ -1,0 +1,95 @@
+using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Merge;
+
+namespace Strategos.Ontology.Tests.Merge;
+
+/// <summary>
+/// MergeTwo lattice coverage for the DR-4 association surface. The reconstructed
+/// descriptor must carry <see cref="ObjectTypeDescriptor.AssociationEndpoints"/>
+/// through the fold (hand wins; fall back to ingested when hand's is empty),
+/// mirroring the other identity-field lattice rules. Dropping it would leave a
+/// merged association descriptor with no endpoints.
+/// </summary>
+public class MergeTwoAssociationTests
+{
+    private sealed class HandModel
+    {
+        public Guid Id { get; set; }
+    }
+
+    [Test]
+    public async Task MergeTwo_AssociationEndpoints_PreservedFromHand()
+    {
+        var endpoints = new[]
+        {
+            new AssociationEndpoint("From", "Person"),
+            new AssociationEndpoint("To", "Company"),
+        };
+
+        var hand = new ObjectTypeDescriptor
+        {
+            Name = "Employment",
+            DomainName = "assoc",
+            ClrType = typeof(HandModel),
+            LanguageId = "dotnet",
+            Source = DescriptorSource.HandAuthored,
+            Kind = ObjectKind.Association,
+            AssociationEndpoints = endpoints,
+        };
+
+        var ingested = new ObjectTypeDescriptor
+        {
+            Name = "Employment",
+            DomainName = "assoc",
+            SymbolKey = "scip-typescript ./mod#Employment",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+        };
+
+        var merged = MergeTwo.Merge(hand, ingested);
+
+        await Assert.That(merged.AssociationEndpoints).HasCount().EqualTo(2);
+        await Assert.That(merged.AssociationEndpoints[0].Role).IsEqualTo("From");
+        await Assert.That(merged.AssociationEndpoints[0].DescriptorName).IsEqualTo("Person");
+        await Assert.That(merged.AssociationEndpoints[1].Role).IsEqualTo("To");
+        await Assert.That(merged.AssociationEndpoints[1].DescriptorName).IsEqualTo("Company");
+    }
+
+    [Test]
+    public async Task MergeTwo_AssociationEndpoints_FallsBackToIngestedWhenHandEmpty()
+    {
+        var ingestedEndpoints = new[]
+        {
+            new AssociationEndpoint("Src", "Node"),
+            new AssociationEndpoint("Tgt", "Node"),
+        };
+
+        // Hand contributes no endpoints (e.g. a symbol-only hand registration);
+        // the ingested side supplied them. Mirrors the ClrType lattice: hand
+        // wins, fall back to ingested.
+        var hand = new ObjectTypeDescriptor
+        {
+            Name = "Link",
+            DomainName = "assoc",
+            ClrType = typeof(HandModel),
+            Source = DescriptorSource.HandAuthored,
+            Kind = ObjectKind.Association,
+        };
+
+        var ingested = new ObjectTypeDescriptor
+        {
+            Name = "Link",
+            DomainName = "assoc",
+            SymbolKey = "scip-typescript ./mod#Link",
+            Source = DescriptorSource.Ingested,
+            Kind = ObjectKind.Association,
+            AssociationEndpoints = ingestedEndpoints,
+        };
+
+        var merged = MergeTwo.Merge(hand, ingested);
+
+        await Assert.That(merged.AssociationEndpoints).HasCount().EqualTo(2);
+        await Assert.That(merged.AssociationEndpoints[0].Role).IsEqualTo("Src");
+        await Assert.That(merged.AssociationEndpoints[1].Role).IsEqualTo("Tgt");
+    }
+}

--- a/src/Strategos.Ontology.Tests/Merge/MergeTwoIdentityTests.cs
+++ b/src/Strategos.Ontology.Tests/Merge/MergeTwoIdentityTests.cs
@@ -144,4 +144,41 @@ public class MergeTwoIdentityTests
         await Assert.That(merged.Name).IsEqualTo("TradeOrder");
         await Assert.That(merged.DomainName).IsEqualTo("trading");
     }
+
+    [Test]
+    public async Task MergeTwo_IdAccessor_HandWinsOverIngested()
+    {
+        Func<object, object?> handAccessor = _ => "hand";
+        Func<object, object?> ingestedAccessor = _ => "ingested";
+        var hand = HandDescriptor() with { IdAccessor = handAccessor };
+        var ingested = IngestedDescriptor() with { IdAccessor = ingestedAccessor };
+
+        var merged = MergeTwo.Merge(hand, ingested);
+
+        await Assert.That(merged.IdAccessor).IsNotNull();
+        await Assert.That(merged.IdAccessor!(new object())).IsEqualTo("hand");
+    }
+
+    [Test]
+    public async Task MergeTwo_IdAccessor_FallsBackToIngestedWhenHandNull()
+    {
+        // Hand-authored descriptor with no compiled accessor (e.g. symbol-only
+        // hand registration); the ingested source supplied the accessor. Mirrors
+        // the ClrType lattice rule: hand wins, fallback to ingested (INV-8 — the
+        // merged descriptor must retain a reflection-free id path).
+        Func<object, object?> ingestedAccessor = _ => "ingested";
+        var hand = new ObjectTypeDescriptor
+        {
+            Name = "TradeOrder",
+            DomainName = "trading",
+            SymbolKey = "hand-only-symbol",
+            Source = DescriptorSource.HandAuthored,
+        };
+        var ingested = IngestedDescriptor() with { IdAccessor = ingestedAccessor };
+
+        var merged = MergeTwo.Merge(hand, ingested);
+
+        await Assert.That(merged.IdAccessor).IsNotNull();
+        await Assert.That(merged.IdAccessor!(new object())).IsEqualTo("ingested");
+    }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/IObjectSetWriterTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/IObjectSetWriterTests.cs
@@ -47,6 +47,12 @@ public class StubObjectSetWriter : IObjectSetWriter
     public Task RelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default)
         => Task.CompletedTask;
 
+    // Attributed relate added for DR-4 (Ontology Edge Foundation). Real behavior
+    // is exercised by InMemoryObjectSetProvider; this stub only satisfies the interface.
+    public Task RelateAsync<TRel>(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, string associationDescriptor, TRel association, CancellationToken ct = default)
+        where TRel : class
+        => Task.CompletedTask;
+
     public Task UnrelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default)
         => Task.CompletedTask;
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/IObjectSetWriterTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/IObjectSetWriterTests.cs
@@ -41,6 +41,14 @@ public class StubObjectSetWriter : IObjectSetWriter
         StoredItems.AddRange(items);
         return Task.CompletedTask;
     }
+
+    // Relate-store methods added for DR-2 (Ontology Edge Foundation). Real behavior
+    // is exercised by InMemoryObjectSetProvider; this stub only satisfies the interface.
+    public Task RelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default)
+        => Task.CompletedTask;
+
+    public Task UnrelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default)
+        => Task.CompletedTask;
 }
 
 public class IObjectSetWriterTests

--- a/src/Strategos.Ontology.Tests/ObjectSets/IObjectSetWriterTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/IObjectSetWriterTests.cs
@@ -55,6 +55,10 @@ public class StubObjectSetWriter : IObjectSetWriter
 
     public Task UnrelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default)
         => Task.CompletedTask;
+
+    // Attributed unrelate added for DR-4; this stub only satisfies the interface.
+    public Task UnrelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, string associationDescriptor, string associationId, CancellationToken ct = default)
+        => Task.CompletedTask;
 }
 
 public class IObjectSetWriterTests

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryExpressionEvaluatorTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryExpressionEvaluatorTests.cs
@@ -166,32 +166,65 @@ public class InMemoryExpressionEvaluatorTests
 
     // -----------------------------------------------------------------------
     // Task 8 tests — TraverseLinkExpression
+    //
+    // DR-3 (Task 10): these were rewritten from the OLD type-based traversal
+    // (which returned ALL target-type items) to the new INSTANCE-ANCHORED
+    // semantics. The evaluator is now constructed with a RelationResolver and
+    // follows only the materialized rows for the source instance.
     // -----------------------------------------------------------------------
+
+    // Builds a relation resolver that returns the given rows for the
+    // (srcDescriptor, srcId, linkName) triple, empty for everything else.
+    private static RelationResolver BuildRelationResolver(
+        string srcDescriptor,
+        string srcId,
+        string linkName,
+        params RelationRow[] rows)
+        => (sd, si, ln) =>
+            sd == srcDescriptor && si == srcId && ln == linkName
+                ? rows
+                : [];
 
     [Test]
     public async Task Evaluate_TraverseLink_ReturnsTargetTypeItems()
     {
-        var evaluator = new InMemoryExpressionEvaluator(_graph);
-        var root = new RootExpression(typeof(EvalSource), "EvalSource");
-        var traverse = new TraverseLinkExpression(root, "targets", typeof(EvalTarget));
+        // Instance-anchored: source "A" is related to target "X" only; the
+        // unrelated "Y" is NOT returned even though it is the same target type.
         var resolver = BuildTestResolver();
+        var relations = BuildRelationResolver(
+            "EvalSource", "A", "targets",
+            new RelationRow("EvalTarget", "X"));
+        var evaluator = new InMemoryExpressionEvaluator(_graph, relations, idProjector: null);
+
+        var root = new RootExpression(typeof(EvalSource), "EvalSource");
+        Expression<Func<EvalSource, bool>> only = s => s.Name == "A";
+        var filter = new FilterExpression(root, only);
+        var traverse = new TraverseLinkExpression(filter, "targets", typeof(EvalTarget));
 
         var result = evaluator.Evaluate<EvalTarget>(traverse, resolver);
 
-        await Assert.That(result).HasCount().EqualTo(2);
+        await Assert.That(result).HasCount().EqualTo(1);
         await Assert.That(result[0].Label).IsEqualTo("X");
-        await Assert.That(result[1].Label).IsEqualTo("Y");
     }
 
     [Test]
     public async Task Evaluate_TraverseLink_ThenFilter_FiltersTargetItems()
     {
-        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        // Instance-anchored: source "A" relates to both "X" and "Y"; the
+        // post-traversal filter narrows the related targets to "X".
+        var resolver = BuildTestResolver();
+        var relations = BuildRelationResolver(
+            "EvalSource", "A", "targets",
+            new RelationRow("EvalTarget", "X"),
+            new RelationRow("EvalTarget", "Y"));
+        var evaluator = new InMemoryExpressionEvaluator(_graph, relations, idProjector: null);
+
         var root = new RootExpression(typeof(EvalSource), "EvalSource");
-        var traverse = new TraverseLinkExpression(root, "targets", typeof(EvalTarget));
+        Expression<Func<EvalSource, bool>> only = s => s.Name == "A";
+        var sourceFilter = new FilterExpression(root, only);
+        var traverse = new TraverseLinkExpression(sourceFilter, "targets", typeof(EvalTarget));
         Expression<Func<EvalTarget, bool>> predicate = t => t.Label == "X";
         var filter = new FilterExpression(traverse, predicate);
-        var resolver = BuildTestResolver();
 
         var result = evaluator.Evaluate<EvalTarget>(filter, resolver);
 
@@ -255,22 +288,29 @@ public class InMemoryExpressionEvaluatorTests
     }
 
     [Test]
-    public async Task Evaluate_TraverseLink_WithFilterOnSource_IgnoresSourceFilter()
+    public async Task Evaluate_TraverseLink_WithFilterOnSource_HonorsSourceFilter()
     {
-        // Schema-level traversal: source filters don't affect target items.
-        // Even with a filter that eliminates all source items, traversal
-        // returns ALL target items because it follows the link schema.
-        var evaluator = new InMemoryExpressionEvaluator(_graph);
+        // DR-3 (Task 10): instance-anchored traversal HONORS the source filter —
+        // it is anchored to exactly the source instances the upstream query
+        // selected. A filter that eliminates every source instance therefore
+        // yields an EMPTY traversal (the old schema-level behavior, which ignored
+        // the filter and returned all target-type items, was the #114 bug).
+        var resolver = BuildTestResolver();
+        var relations = BuildRelationResolver(
+            "EvalSource", "A", "targets",
+            new RelationRow("EvalTarget", "X"),
+            new RelationRow("EvalTarget", "Y"));
+        var evaluator = new InMemoryExpressionEvaluator(_graph, relations, idProjector: null);
+
         var root = new RootExpression(typeof(EvalSource), "EvalSource");
         Expression<Func<EvalSource, bool>> predicate = s => s.Value > 9999; // matches nothing
         var filter = new FilterExpression(root, predicate);
         var traverse = new TraverseLinkExpression(filter, "targets", typeof(EvalTarget));
-        var resolver = BuildTestResolver();
 
         var result = evaluator.Evaluate<EvalTarget>(traverse, resolver);
 
-        // All target items returned despite source filter — schema-level traversal
-        await Assert.That(result).HasCount().EqualTo(2);
+        // No source instance survived the filter, so no rows are followed.
+        await Assert.That(result).HasCount().EqualTo(0);
     }
 
     [Test]

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryObjectSetProviderTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryObjectSetProviderTests.cs
@@ -244,15 +244,23 @@ public class InMemoryObjectSetProviderTests
     [Test]
     public async Task ExecuteAsync_WithGraph_TraverseLink_Works()
     {
-        // Arrange — build a graph with ProvSource -> "targets" -> ProvTarget
+        // Arrange — build a graph with ProvSource -> "targets" -> ProvTarget.
+        // DR-3: traversal is INSTANCE-ANCHORED. Seed an UNRELATED T3 of the same
+        // target type and relate S1 only to T1, T2 — the traversal must return
+        // exactly the related targets, never all ProvTarget items (#114).
         var graph = new OntologyGraphBuilder()
             .AddDomain<ProviderTestOntology>()
             .Build();
 
         var provider = new InMemoryObjectSetProvider(graph);
-        provider.Seed(new ProvSource("S1", 10), "source 1");
+        provider.Seed(new ProvSource("S1", 10), "source 1", descriptorName: nameof(ProvSource));
         provider.Seed(new ProvTarget("T1"), "target 1", descriptorName: nameof(ProvTarget));
         provider.Seed(new ProvTarget("T2"), "target 2", descriptorName: nameof(ProvTarget));
+        provider.Seed(new ProvTarget("T3"), "target 3", descriptorName: nameof(ProvTarget));
+
+        IObjectSetWriter writer = provider;
+        await writer.RelateAsync(nameof(ProvSource), "S1", "targets", nameof(ProvTarget), "T1");
+        await writer.RelateAsync(nameof(ProvSource), "S1", "targets", nameof(ProvTarget), "T2");
 
         var root = new RootExpression(typeof(ProvSource), nameof(ProvSource));
         var traverse = new TraverseLinkExpression(root, "targets", typeof(ProvTarget));
@@ -260,7 +268,7 @@ public class InMemoryObjectSetProviderTests
         // Act
         var result = await provider.ExecuteAsync<ProvTarget>(traverse);
 
-        // Assert
+        // Assert — only the related targets, ordered ordinal-by-id (INV-7).
         await Assert.That(result.Items).HasCount().EqualTo(2);
         await Assert.That(result.Items[0].Label).IsEqualTo("T1");
         await Assert.That(result.Items[1].Label).IsEqualTo("T2");
@@ -311,15 +319,20 @@ public class InMemoryObjectSetProviderTests
     [Test]
     public async Task StreamAsync_WithGraph_DelegatesToEvaluator()
     {
-        // Arrange
+        // Arrange — DR-3: StreamAsync routes through the same instance-anchored
+        // evaluator, so seed + relate then stream the related targets.
         var graph = new OntologyGraphBuilder()
             .AddDomain<ProviderTestOntology>()
             .Build();
 
         var provider = new InMemoryObjectSetProvider(graph);
-        provider.Seed(new ProvSource("S1", 10), "source 1");
+        provider.Seed(new ProvSource("S1", 10), "source 1", descriptorName: nameof(ProvSource));
         provider.Seed(new ProvTarget("T1"), "target 1", descriptorName: nameof(ProvTarget));
         provider.Seed(new ProvTarget("T2"), "target 2", descriptorName: nameof(ProvTarget));
+
+        IObjectSetWriter writer = provider;
+        await writer.RelateAsync(nameof(ProvSource), "S1", "targets", nameof(ProvTarget), "T1");
+        await writer.RelateAsync(nameof(ProvSource), "S1", "targets", nameof(ProvTarget), "T2");
 
         var root = new RootExpression(typeof(ProvSource), nameof(ProvSource));
         var traverse = new TraverseLinkExpression(root, "targets", typeof(ProvTarget));
@@ -419,7 +432,7 @@ public class ProviderTestOntology : DomainOntology
 
         builder.Object<ProvSource>(obj =>
         {
-            obj.Property(s => s.Name).Required();
+            obj.Key(s => s.Name);
             obj.Property(s => s.Value);
             obj.HasMany<ProvTarget>("targets");
             obj.Implements<IProvInterface>(map => { });
@@ -427,7 +440,7 @@ public class ProviderTestOntology : DomainOntology
 
         builder.Object<ProvTarget>(obj =>
         {
-            obj.Property(t => t.Label).Required();
+            obj.Key(t => t.Label);
         });
     }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryRelateStoreTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryRelateStoreTests.cs
@@ -10,6 +10,10 @@ namespace Strategos.Ontology.Tests.ObjectSets;
 
 public sealed record RelateNode(string Id);
 
+// DR-4 (Task 17): a reified association linking two RelateNode endpoints with
+// its own key + edge attribute, for the attributed-relate seam.
+public sealed record RelateAssociation(string Id, RelateNode From, RelateNode To, string Label);
+
 public sealed class RelateTestOntology : DomainOntology
 {
     public override string DomainName => "relate";
@@ -20,6 +24,13 @@ public sealed class RelateTestOntology : DomainOntology
         {
             obj.Key(n => n.Id);
             obj.HasMany<RelateNode>("links_to");
+        });
+
+        builder.Association<RelateAssociation>("RelateAssociation", a =>
+        {
+            a.Key(r => r.Id);
+            a.Between(r => r.From).And(r => r.To);
+            a.Property(r => r.Label).Required();
         });
     }
 }
@@ -198,6 +209,38 @@ public class InMemoryRelateStoreTests
         var rows = provider.GetRelations(nameof(RelateNode), "a", "links_to");
         await Assert.That(rows).HasCount().EqualTo(1);
         await Assert.That(rows[0].TargetId).IsEqualTo("a");
+    }
+
+    // -----------------------------------------------------------------------
+    // Task 17 (DR-4) — attributed relate stores the association object and a
+    // row referencing it via AssociationObjectId.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task RelateWithAssociation_StoresObjectAndRowReferencingIt()
+    {
+        // Arrange — both endpoints stored; the association object carries its own id.
+        var provider = SeededProvider("a", "b");
+        IObjectSetWriter writer = provider;
+        var association = new RelateAssociation("emp-1", new RelateNode("a"), new RelateNode("b"), "manages");
+
+        // Act — attributed relate stores the association AND writes a row that points at it.
+        await writer.RelateAsync(
+            nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b",
+            "RelateAssociation", association);
+
+        // Assert — the row references the association object's projected id.
+        var rows = provider.GetRelations(nameof(RelateNode), "a", "links_to");
+        await Assert.That(rows).HasCount().EqualTo(1);
+        await Assert.That(rows[0].TargetDescriptor).IsEqualTo(nameof(RelateNode));
+        await Assert.That(rows[0].TargetId).IsEqualTo("b");
+        await Assert.That(rows[0].AssociationObjectId).IsEqualTo("emp-1");
+
+        // Assert — the association object itself was stored under its descriptor.
+        var stored = await provider.ExecuteAsync<RelateAssociation>(
+            new RootExpression(typeof(RelateAssociation), "RelateAssociation"));
+        await Assert.That(stored.Items).HasCount().EqualTo(1);
+        await Assert.That(stored.Items[0].Id).IsEqualTo("emp-1");
     }
 
     private static InMemoryObjectSetProvider SelfLoopAllowedProvider(params string[] ids)

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryRelateStoreTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryRelateStoreTests.cs
@@ -141,4 +141,25 @@ public class InMemoryRelateStoreTests
         await Assert.That(targetIds)
             .IsEquivalentTo(new[] { "alpha", "bravo", "charlie", "delta" }, CollectionOrdering.Matching);
     }
+
+    // -----------------------------------------------------------------------
+    // Task 8 (DR-8) — eager endpoint validation
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task RelateAsync_NonExistentEndpoint_ThrowsTypedError()
+    {
+        // Arrange — only the source is stored; the target id has no stored instance
+        var provider = SeededProvider("a");
+        IObjectSetWriter writer = provider;
+
+        // Act & Assert — eager validation throws a typed error
+        await Assert.That(async () =>
+                await writer.RelateAsync(nameof(RelateNode), "a", "links_to", nameof(RelateNode), "ghost"))
+            .Throws<RelationEndpointNotFoundException>();
+
+        // Assert — no dangling row was created
+        var rows = provider.GetRelations(nameof(RelateNode), "a", "links_to");
+        await Assert.That(rows).IsEmpty();
+    }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryRelateStoreTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryRelateStoreTests.cs
@@ -243,6 +243,109 @@ public class InMemoryRelateStoreTests
         await Assert.That(stored.Items[0].Id).IsEqualTo("emp-1");
     }
 
+    // -----------------------------------------------------------------------
+    // F-HIGH-1 (DR-4) — write/remove key symmetry + orphaned-association cleanup.
+    //
+    // The relate-store write key is (TargetDescriptor, TargetId, AssociationObjectId).
+    // Unrelate must remove on the SAME key: a plain unrelate removes ONLY the plain
+    // row (association id == null); an attributed unrelate removes the single row
+    // for its association id AND deletes the now-orphaned association object so it
+    // is no longer queryable or traversable.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task UnrelateAsync_Plain_LeavesAttributedRowAndObject()
+    {
+        // Arrange — relate plain x->y AND attributed x->y over the same endpoints.
+        var provider = SeededProvider("a", "b");
+        IObjectSetWriter writer = provider;
+        var association = new RelateAssociation("emp-1", new RelateNode("a"), new RelateNode("b"), "manages");
+
+        await writer.RelateAsync(nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b");
+        await writer.RelateAsync(
+            nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b",
+            "RelateAssociation", association);
+
+        // Act — plain unrelate removes ONLY the plain row.
+        await writer.UnrelateAsync(nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b");
+
+        // Assert — the attributed row survives intact.
+        var rows = provider.GetRelations(nameof(RelateNode), "a", "links_to");
+        await Assert.That(rows).HasCount().EqualTo(1);
+        await Assert.That(rows[0].AssociationObjectId).IsEqualTo("emp-1");
+
+        // Assert — the association object is still queryable and traversable.
+        var stored = await provider.ExecuteAsync<RelateAssociation>(
+            new RootExpression(typeof(RelateAssociation), "RelateAssociation"));
+        await Assert.That(stored.Items).HasCount().EqualTo(1);
+        await Assert.That(stored.Items[0].Id).IsEqualTo("emp-1");
+    }
+
+    [Test]
+    public async Task UnrelateAsync_Attributed_RemovesRowAndAssociationObject()
+    {
+        // Arrange — a single attributed relate.
+        var provider = SeededProvider("a", "b");
+        IObjectSetWriter writer = provider;
+        var association = new RelateAssociation("emp-1", new RelateNode("a"), new RelateNode("b"), "manages");
+
+        await writer.RelateAsync(
+            nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b",
+            "RelateAssociation", association);
+
+        // Act — attributed unrelate removes the row AND the orphaned association object.
+        await writer.UnrelateAsync(
+            nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b",
+            "RelateAssociation", "emp-1");
+
+        // Assert — no row remains.
+        var rows = provider.GetRelations(nameof(RelateNode), "a", "links_to");
+        await Assert.That(rows).IsEmpty();
+
+        // Assert — the association object is no longer queryable.
+        var stored = await provider.ExecuteAsync<RelateAssociation>(
+            new RootExpression(typeof(RelateAssociation), "RelateAssociation"));
+        await Assert.That(stored.Items).IsEmpty();
+    }
+
+    [Test]
+    public async Task UnrelateAsync_Attributed_LeavesPlainAndSiblingAttributed()
+    {
+        // Arrange — a plain row + two attributed rows (distinct association ids)
+        // over the same endpoint pair.
+        var provider = SeededProvider("a", "b");
+        IObjectSetWriter writer = provider;
+        var first = new RelateAssociation("emp-1", new RelateNode("a"), new RelateNode("b"), "manages");
+        var second = new RelateAssociation("emp-2", new RelateNode("a"), new RelateNode("b"), "mentors");
+
+        await writer.RelateAsync(nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b");
+        await writer.RelateAsync(
+            nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b",
+            "RelateAssociation", first);
+        await writer.RelateAsync(
+            nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b",
+            "RelateAssociation", second);
+
+        // Act — attributed-unrelate of emp-1 removes ONLY that row + its object.
+        await writer.UnrelateAsync(
+            nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b",
+            "RelateAssociation", "emp-1");
+
+        // Assert — the plain row and the emp-2 attributed row survive.
+        var rows = provider.GetRelations(nameof(RelateNode), "a", "links_to");
+        await Assert.That(rows).HasCount().EqualTo(2);
+        var associationIds = rows.Select(r => r.AssociationObjectId).ToList();
+        await Assert.That(associationIds).Contains((string?)null);
+        await Assert.That(associationIds).Contains("emp-2");
+        await Assert.That(associationIds).DoesNotContain("emp-1");
+
+        // Assert — emp-2 survives as a stored object, emp-1 is gone.
+        var stored = await provider.ExecuteAsync<RelateAssociation>(
+            new RootExpression(typeof(RelateAssociation), "RelateAssociation"));
+        var storedIds = stored.Items.Select(r => r.Id).ToList();
+        await Assert.That(storedIds).IsEquivalentTo(new[] { "emp-2" });
+    }
+
     private static InMemoryObjectSetProvider SelfLoopAllowedProvider(params string[] ids)
     {
         var baseGraph = BuildGraph();

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryRelateStoreTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryRelateStoreTests.cs
@@ -1,5 +1,6 @@
 using Strategos.Ontology.Builder;
 using Strategos.Ontology.ObjectSets;
+using TUnit.Assertions.Enums;
 
 namespace Strategos.Ontology.Tests.ObjectSets;
 
@@ -114,5 +115,30 @@ public class InMemoryRelateStoreTests
         var rows = provider.GetRelations(nameof(RelateNode), "a", "links_to");
 
         await Assert.That(rows).IsEmpty();
+    }
+
+    // -----------------------------------------------------------------------
+    // Task 7 — deterministic ordinal-by-id read order (INV-7 / replay)
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task Relations_ReadOrder_IsOrdinalByTargetId()
+    {
+        // Arrange — seed targets and relate them in a deliberately non-sorted order
+        var provider = SeededProvider("src", "delta", "alpha", "charlie", "bravo");
+        IObjectSetWriter writer = provider;
+
+        await writer.RelateAsync(nameof(RelateNode), "src", "links_to", nameof(RelateNode), "delta");
+        await writer.RelateAsync(nameof(RelateNode), "src", "links_to", nameof(RelateNode), "alpha");
+        await writer.RelateAsync(nameof(RelateNode), "src", "links_to", nameof(RelateNode), "charlie");
+        await writer.RelateAsync(nameof(RelateNode), "src", "links_to", nameof(RelateNode), "bravo");
+
+        // Act
+        var rows = provider.GetRelations(nameof(RelateNode), "src", "links_to");
+
+        // Assert — read order is ordinal by TargetId, regardless of insert order
+        var targetIds = rows.Select(r => r.TargetId).ToList();
+        await Assert.That(targetIds)
+            .IsEquivalentTo(new[] { "alpha", "bravo", "charlie", "delta" }, CollectionOrdering.Matching);
     }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryRelateStoreTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryRelateStoreTests.cs
@@ -1,0 +1,83 @@
+using Strategos.Ontology.Builder;
+using Strategos.Ontology.ObjectSets;
+
+namespace Strategos.Ontology.Tests.ObjectSets;
+
+// ---------------------------------------------------------------------------
+// Test domain types for the relate-store (DR-2)
+// ---------------------------------------------------------------------------
+
+public sealed record RelateNode(string Id);
+
+public sealed class RelateTestOntology : DomainOntology
+{
+    public override string DomainName => "relate";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<RelateNode>(obj =>
+        {
+            obj.Key(n => n.Id);
+            obj.HasMany<RelateNode>("links_to");
+        });
+    }
+}
+
+public class InMemoryRelateStoreTests
+{
+    private static OntologyGraph BuildGraph()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain<RelateTestOntology>();
+        return graphBuilder.Build();
+    }
+
+    private static InMemoryObjectSetProvider SeededProvider(params string[] ids)
+    {
+        var provider = new InMemoryObjectSetProvider(BuildGraph());
+        foreach (var id in ids)
+        {
+            provider.Seed(new RelateNode(id), id, nameof(RelateNode));
+        }
+
+        return provider;
+    }
+
+    // -----------------------------------------------------------------------
+    // Task 5
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task RelateAsync_TwoInstances_CreatesRow()
+    {
+        // Arrange
+        var provider = SeededProvider("a", "b");
+        IObjectSetWriter writer = provider;
+
+        // Act
+        await writer.RelateAsync(nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b");
+        var rows = provider.GetRelations(nameof(RelateNode), "a", "links_to");
+
+        // Assert
+        await Assert.That(rows).HasCount().EqualTo(1);
+        await Assert.That(rows[0].TargetDescriptor).IsEqualTo(nameof(RelateNode));
+        await Assert.That(rows[0].TargetId).IsEqualTo("b");
+        await Assert.That(rows[0].AssociationObjectId).IsNull();
+    }
+
+    [Test]
+    public async Task UnrelateAsync_ExistingRow_RemovesIt()
+    {
+        // Arrange
+        var provider = SeededProvider("a", "b");
+        IObjectSetWriter writer = provider;
+        await writer.RelateAsync(nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b");
+
+        // Act
+        await writer.UnrelateAsync(nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b");
+        var rows = provider.GetRelations(nameof(RelateNode), "a", "links_to");
+
+        // Assert
+        await Assert.That(rows).IsEmpty();
+    }
+}

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryRelateStoreTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryRelateStoreTests.cs
@@ -346,6 +346,94 @@ public class InMemoryRelateStoreTests
         await Assert.That(storedIds).IsEquivalentTo(new[] { "emp-2" });
     }
 
+    // -----------------------------------------------------------------------
+    // F-MED-4 — cancellation is observed at entry of every relate-store write,
+    // matching StoreBatchAsync / StreamAsync.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task RelateAsync_Plain_CanceledToken_Throws()
+    {
+        var provider = SeededProvider("a", "b");
+        IObjectSetWriter writer = provider;
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.That(async () =>
+                await writer.RelateAsync(nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b", cts.Token))
+            .Throws<OperationCanceledException>();
+
+        // No row was written under the canceled call.
+        var rows = provider.GetRelations(nameof(RelateNode), "a", "links_to");
+        await Assert.That(rows).IsEmpty();
+    }
+
+    [Test]
+    public async Task RelateAsync_Attributed_CanceledToken_Throws()
+    {
+        var provider = SeededProvider("a", "b");
+        IObjectSetWriter writer = provider;
+        var association = new RelateAssociation("emp-1", new RelateNode("a"), new RelateNode("b"), "manages");
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.That(async () =>
+                await writer.RelateAsync(
+                    nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b",
+                    "RelateAssociation", association, cts.Token))
+            .Throws<OperationCanceledException>();
+
+        // Neither the row nor the association object was written.
+        var rows = provider.GetRelations(nameof(RelateNode), "a", "links_to");
+        await Assert.That(rows).IsEmpty();
+        var stored = await provider.ExecuteAsync<RelateAssociation>(
+            new RootExpression(typeof(RelateAssociation), "RelateAssociation"));
+        await Assert.That(stored.Items).IsEmpty();
+    }
+
+    [Test]
+    public async Task UnrelateAsync_Plain_CanceledToken_Throws()
+    {
+        var provider = SeededProvider("a", "b");
+        IObjectSetWriter writer = provider;
+        await writer.RelateAsync(nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b");
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.That(async () =>
+                await writer.UnrelateAsync(nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b", cts.Token))
+            .Throws<OperationCanceledException>();
+
+        // The row survives the canceled unrelate.
+        var rows = provider.GetRelations(nameof(RelateNode), "a", "links_to");
+        await Assert.That(rows).HasCount().EqualTo(1);
+    }
+
+    [Test]
+    public async Task UnrelateAsync_Attributed_CanceledToken_Throws()
+    {
+        var provider = SeededProvider("a", "b");
+        IObjectSetWriter writer = provider;
+        await writer.RelateAsync(
+            nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b",
+            "RelateAssociation", new RelateAssociation("emp-1", new RelateNode("a"), new RelateNode("b"), "manages"));
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.That(async () =>
+                await writer.UnrelateAsync(
+                    nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b",
+                    "RelateAssociation", "emp-1", cts.Token))
+            .Throws<OperationCanceledException>();
+
+        // The row and the association object both survive the canceled unrelate.
+        var rows = provider.GetRelations(nameof(RelateNode), "a", "links_to");
+        await Assert.That(rows).HasCount().EqualTo(1);
+        var stored = await provider.ExecuteAsync<RelateAssociation>(
+            new RootExpression(typeof(RelateAssociation), "RelateAssociation"));
+        await Assert.That(stored.Items).HasCount().EqualTo(1);
+    }
+
     private static InMemoryObjectSetProvider SelfLoopAllowedProvider(params string[] ids)
     {
         var baseGraph = BuildGraph();

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryRelateStoreTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryRelateStoreTests.cs
@@ -80,4 +80,39 @@ public class InMemoryRelateStoreTests
         // Assert
         await Assert.That(rows).IsEmpty();
     }
+
+    // -----------------------------------------------------------------------
+    // Task 6
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task RelateAsync_DuplicateTriple_IsIdempotent()
+    {
+        // Arrange
+        var provider = SeededProvider("a", "b");
+        IObjectSetWriter writer = provider;
+
+        // Act — relate the same (src, link, tgt) twice
+        await writer.RelateAsync(nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b");
+        await writer.RelateAsync(nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b");
+        var rows = provider.GetRelations(nameof(RelateNode), "a", "links_to");
+
+        // Assert — only one row exists
+        await Assert.That(rows).HasCount().EqualTo(1);
+        await Assert.That(rows[0].TargetId).IsEqualTo("b");
+    }
+
+    [Test]
+    public async Task UnrelateAsync_MissingRow_IsNoOp()
+    {
+        // Arrange
+        var provider = SeededProvider("a", "b");
+        IObjectSetWriter writer = provider;
+
+        // Act & Assert — unrelating an absent row does not throw
+        await writer.UnrelateAsync(nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b");
+        var rows = provider.GetRelations(nameof(RelateNode), "a", "links_to");
+
+        await Assert.That(rows).IsEmpty();
+    }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryRelateStoreTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryRelateStoreTests.cs
@@ -244,6 +244,42 @@ public class InMemoryRelateStoreTests
     }
 
     // -----------------------------------------------------------------------
+    // FIX-C (DR-4) — attributed relate is idempotent for the association OBJECT,
+    // not just the row. Repeating the same attributed triple must store exactly
+    // one association object (the object store must be deduped on the same key as
+    // the row), so a later unrelate that removes one row + one object cannot leave
+    // a stale duplicate behind.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task RelateAsync_AttributedDuplicate_StoresSingleObjectAndRow()
+    {
+        // Arrange — both endpoints stored; the same attributed triple is related twice.
+        var provider = SeededProvider("a", "b");
+        IObjectSetWriter writer = provider;
+        var association = new RelateAssociation("emp-1", new RelateNode("a"), new RelateNode("b"), "manages");
+
+        // Act — relate the SAME attributed (src, link, tgt, association) twice.
+        await writer.RelateAsync(
+            nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b",
+            "RelateAssociation", association);
+        await writer.RelateAsync(
+            nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b",
+            "RelateAssociation", association);
+
+        // Assert — exactly one row.
+        var rows = provider.GetRelations(nameof(RelateNode), "a", "links_to");
+        await Assert.That(rows).HasCount().EqualTo(1);
+        await Assert.That(rows[0].AssociationObjectId).IsEqualTo("emp-1");
+
+        // Assert — exactly one association object stored (not two).
+        var stored = await provider.ExecuteAsync<RelateAssociation>(
+            new RootExpression(typeof(RelateAssociation), "RelateAssociation"));
+        await Assert.That(stored.Items).HasCount().EqualTo(1);
+        await Assert.That(stored.Items[0].Id).IsEqualTo("emp-1");
+    }
+
+    // -----------------------------------------------------------------------
     // F-HIGH-1 (DR-4) — write/remove key symmetry + orphaned-association cleanup.
     //
     // The relate-store write key is (TargetDescriptor, TargetId, AssociationObjectId).

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryRelateStoreTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryRelateStoreTests.cs
@@ -162,4 +162,69 @@ public class InMemoryRelateStoreTests
         var rows = provider.GetRelations(nameof(RelateNode), "a", "links_to");
         await Assert.That(rows).IsEmpty();
     }
+
+    // -----------------------------------------------------------------------
+    // Task 9 (DR-8) — self-loop policy
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task RelateAsync_SelfLoop_WhenDisallowed_ThrowsTypedError()
+    {
+        // Arrange — default "links_to" link has AllowsSelfLoop = false
+        var provider = SeededProvider("a");
+        IObjectSetWriter writer = provider;
+
+        // Act & Assert — relating an instance to itself is rejected
+        await Assert.That(async () =>
+                await writer.RelateAsync(nameof(RelateNode), "a", "links_to", nameof(RelateNode), "a"))
+            .Throws<SelfLoopNotAllowedException>();
+
+        // Assert — no row was created
+        var rows = provider.GetRelations(nameof(RelateNode), "a", "links_to");
+        await Assert.That(rows).IsEmpty();
+    }
+
+    [Test]
+    public async Task RelateAsync_SelfLoop_WhenAllowed_CreatesRow()
+    {
+        // Arrange — rewrite the "links_to" link to allow self-loops
+        var provider = SelfLoopAllowedProvider("a");
+        IObjectSetWriter writer = provider;
+
+        // Act
+        await writer.RelateAsync(nameof(RelateNode), "a", "links_to", nameof(RelateNode), "a");
+
+        // Assert — the self-loop row exists
+        var rows = provider.GetRelations(nameof(RelateNode), "a", "links_to");
+        await Assert.That(rows).HasCount().EqualTo(1);
+        await Assert.That(rows[0].TargetId).IsEqualTo("a");
+    }
+
+    private static InMemoryObjectSetProvider SelfLoopAllowedProvider(params string[] ids)
+    {
+        var baseGraph = BuildGraph();
+        var rewritten = baseGraph.ObjectTypes
+            .Select(ot => ot with
+            {
+                Links = ot.Links
+                    .Select(l => l with { AllowsSelfLoop = true })
+                    .ToList(),
+            })
+            .ToList();
+
+        var graph = new OntologyGraph(
+            domains: baseGraph.Domains,
+            objectTypes: rewritten,
+            interfaces: baseGraph.Interfaces,
+            crossDomainLinks: baseGraph.CrossDomainLinks,
+            workflowChains: baseGraph.WorkflowChains);
+
+        var provider = new InMemoryObjectSetProvider(graph);
+        foreach (var id in ids)
+        {
+            provider.Seed(new RelateNode(id), id, nameof(RelateNode));
+        }
+
+        return provider;
+    }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryRelateStoreTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryRelateStoreTests.cs
@@ -383,6 +383,72 @@ public class InMemoryRelateStoreTests
     }
 
     // -----------------------------------------------------------------------
+    // FIX-D (DR-4) — attributed unrelate cleanup is CONDITIONAL on the row
+    // removal actually matching. An unrelate naming a wrong (src, link, tgt)
+    // tuple removes no row, so it must NOT delete the stored association object
+    // (which would dangle the surviving correct row). The correct-tuple path
+    // still removes both row and object.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task UnrelateAsync_AttributedWrongTuple_DoesNotDeleteAssociationObject()
+    {
+        // Arrange — a single attributed relate a->b with association emp-1.
+        var provider = SeededProvider("a", "b", "c");
+        IObjectSetWriter writer = provider;
+        var association = new RelateAssociation("emp-1", new RelateNode("a"), new RelateNode("b"), "manages");
+
+        await writer.RelateAsync(
+            nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b",
+            "RelateAssociation", association);
+
+        // Act — unrelate names the WRONG target ("c"): no row matches that triple.
+        await writer.UnrelateAsync(
+            nameof(RelateNode), "a", "links_to", nameof(RelateNode), "c",
+            "RelateAssociation", "emp-1");
+
+        // Assert — the correct row survives intact (no row was removed).
+        var rows = provider.GetRelations(nameof(RelateNode), "a", "links_to");
+        await Assert.That(rows).HasCount().EqualTo(1);
+        await Assert.That(rows[0].TargetId).IsEqualTo("b");
+        await Assert.That(rows[0].AssociationObjectId).IsEqualTo("emp-1");
+
+        // Assert — the association object is NOT deleted (no dangling reference):
+        // the surviving row still resolves to a stored object.
+        var stored = await provider.ExecuteAsync<RelateAssociation>(
+            new RootExpression(typeof(RelateAssociation), "RelateAssociation"));
+        await Assert.That(stored.Items).HasCount().EqualTo(1);
+        await Assert.That(stored.Items[0].Id).IsEqualTo("emp-1");
+    }
+
+    [Test]
+    public async Task UnrelateAsync_AttributedCorrectTuple_RemovesBothRowAndObject()
+    {
+        // Arrange — a single attributed relate a->b with association emp-1.
+        var provider = SeededProvider("a", "b");
+        IObjectSetWriter writer = provider;
+        var association = new RelateAssociation("emp-1", new RelateNode("a"), new RelateNode("b"), "manages");
+
+        await writer.RelateAsync(
+            nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b",
+            "RelateAssociation", association);
+
+        // Act — unrelate names the CORRECT triple.
+        await writer.UnrelateAsync(
+            nameof(RelateNode), "a", "links_to", nameof(RelateNode), "b",
+            "RelateAssociation", "emp-1");
+
+        // Assert — the row is gone.
+        var rows = provider.GetRelations(nameof(RelateNode), "a", "links_to");
+        await Assert.That(rows).IsEmpty();
+
+        // Assert — and so is the now-orphaned association object.
+        var stored = await provider.ExecuteAsync<RelateAssociation>(
+            new RootExpression(typeof(RelateAssociation), "RelateAssociation"));
+        await Assert.That(stored.Items).IsEmpty();
+    }
+
+    // -----------------------------------------------------------------------
     // F-MED-4 — cancellation is observed at entry of every relate-store write,
     // matching StoreBatchAsync / StreamAsync.
     // -----------------------------------------------------------------------

--- a/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTraversalTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTraversalTests.cs
@@ -93,6 +93,11 @@ public class ObjectSetTraversalTests
 
 public sealed record TravNode(string Id, int Weight = 0);
 
+// DR-4 reified association carrying a Status edge attribute, used by the
+// association-backed traversal test (Task 12). Endpoints From (source role,
+// index 0) and To (destination role, index 1).
+public sealed record TravEdge(string Id, TravNode From, TravNode To, string Status);
+
 public sealed class TravNodeOntology : DomainOntology
 {
     public override string DomainName => "trav";
@@ -104,6 +109,13 @@ public sealed class TravNodeOntology : DomainOntology
             obj.Key(n => n.Id);
             obj.Property(n => n.Weight);
             obj.HasMany<TravNode>("link");
+        });
+
+        builder.Association<TravEdge>("TravEdge", a =>
+        {
+            a.Key(e => e.Id);
+            a.Between(e => e.From).And(e => e.To);
+            a.Property(e => e.Status).Required();
         });
     }
 }
@@ -179,5 +191,58 @@ public class InstanceAnchoredTraversalTests
 
         // Assert — empty, NOT {a, b} (which the old type-based traversal returned).
         await Assert.That(result.Items).IsEmpty();
+    }
+
+    [Test]
+    public async Task TraverseLink_OverAssociation_ExposesEdgeAttributesForFilter()
+    {
+        // Arrange — x is related to y1 via an "active" edge and to y2 via an
+        // "inactive" edge. The association objects carry the Status edge attribute.
+        var graph = BuildGraph();
+        var (provider, query) = BuildQuery(graph);
+        provider.Seed(new TravNode("x"), "x", nameof(TravNode));
+        provider.Seed(new TravNode("y1"), "y1", nameof(TravNode));
+        provider.Seed(new TravNode("y2"), "y2", nameof(TravNode));
+
+        IObjectSetWriter writer = provider;
+        await writer.RelateAsync(
+            nameof(TravNode), "x", "link", nameof(TravNode), "y1",
+            "TravEdge", new TravEdge("e1", new TravNode("x"), new TravNode("y1"), "active"));
+        await writer.RelateAsync(
+            nameof(TravNode), "x", "link", nameof(TravNode), "y2",
+            "TravEdge", new TravEdge("e2", new TravNode("x"), new TravNode("y2"), "inactive"));
+
+        // Act 1 — traverse to the association objects and assert the edge
+        // attributes are exposed for filtering.
+        var edges = query
+            .GetObjectSet<TravNode>(nameof(TravNode))
+            .Where(t => t.Id == "x")
+            .TraverseLink<TravEdge>("link");
+        var allEdges = await edges.ExecuteAsync();
+        var statuses = allEdges.Items.Select(e => e.Status).OrderBy(s => s, StringComparer.Ordinal).ToList();
+        await Assert.That(statuses).IsEquivalentTo(new[] { "active", "inactive" });
+
+        // Act 2 — filter on the edge attribute BEFORE the far hop, then hop to the
+        // destination endpoint ("To" role). Only the active edge's far node returns.
+        var activeFar = await query
+            .GetObjectSet<TravNode>(nameof(TravNode))
+            .Where(t => t.Id == "x")
+            .TraverseLink<TravEdge>("link")
+            .Where(e => e.Status == "active")
+            .TraverseLink<TravNode>("To")
+            .ExecuteAsync();
+        var activeIds = activeFar.Items.Select(n => n.Id).ToList();
+        await Assert.That(activeIds).IsEquivalentTo(new[] { "y1" });
+
+        // Act 3 — the unfiltered far hop returns BOTH endpoints, proving the
+        // edge-attribute filter changed the far-endpoint result set.
+        var allFar = await query
+            .GetObjectSet<TravNode>(nameof(TravNode))
+            .Where(t => t.Id == "x")
+            .TraverseLink<TravEdge>("link")
+            .TraverseLink<TravNode>("To")
+            .ExecuteAsync();
+        var allFarIds = allFar.Items.Select(n => n.Id).OrderBy(s => s, StringComparer.Ordinal).ToList();
+        await Assert.That(allFarIds).IsEquivalentTo(new[] { "y1", "y2" });
     }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTraversalTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTraversalTests.cs
@@ -246,6 +246,42 @@ public class InstanceAnchoredTraversalTests
         var allFarIds = allFar.Items.Select(n => n.Id).OrderBy(s => s, StringComparer.Ordinal).ToList();
         await Assert.That(allFarIds).IsEquivalentTo(new[] { "y1", "y2" });
     }
+
+    [Test]
+    public async Task TraverseLink_OverAssociation_ToSourceRoleEndpoint_ReturnsSourceNode()
+    {
+        // F-MED-1: hopping to the SOURCE-role endpoint ("From", index 0) must
+        // resolve the originating source node — not silently drop. Two distinct
+        // sources (x1, x2) each relate to a shared far node via an edge, so the
+        // source-role hop must surface the correct originating node per edge.
+        var graph = BuildGraph();
+        var (provider, query) = BuildQuery(graph);
+        provider.Seed(new TravNode("x1"), "x1", nameof(TravNode));
+        provider.Seed(new TravNode("x2"), "x2", nameof(TravNode));
+        provider.Seed(new TravNode("y"), "y", nameof(TravNode));
+
+        IObjectSetWriter writer = provider;
+        await writer.RelateAsync(
+            nameof(TravNode), "x1", "link", nameof(TravNode), "y",
+            "TravEdge", new TravEdge("e1", new TravNode("x1"), new TravNode("y"), "active"));
+        await writer.RelateAsync(
+            nameof(TravNode), "x2", "link", nameof(TravNode), "y",
+            "TravEdge", new TravEdge("e2", new TravNode("x2"), new TravNode("y"), "active"));
+
+        // Act — from x1, traverse to the edge then back to its SOURCE-role
+        // ("From") endpoint. The far node is x1, NOT the destination y.
+        var sourceFar = await query
+            .GetObjectSet<TravNode>(nameof(TravNode))
+            .Where(t => t.Id == "x1")
+            .TraverseLink<TravEdge>("link")
+            .TraverseLink<TravNode>("From")
+            .ExecuteAsync();
+
+        // Assert — exactly {x1}: the source-role hop resolved the originating
+        // node rather than silently dropping it.
+        var sourceIds = sourceFar.Items.Select(n => n.Id).ToList();
+        await Assert.That(sourceIds).IsEquivalentTo(new[] { "x1" });
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTraversalTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTraversalTests.cs
@@ -155,4 +155,29 @@ public class InstanceAnchoredTraversalTests
         var ids = result.Items.Select(n => n.Id).OrderBy(s => s, StringComparer.Ordinal).ToList();
         await Assert.That(ids).IsEquivalentTo(new[] { "a", "b" });
     }
+
+    [Test]
+    public async Task TraverseLink_InstanceWithNoRelations_ReturnsEmptySet()
+    {
+        // #114 regression guard: an instance with NO relation rows must traverse
+        // to the EMPTY set — and crucially must NOT return all target-type items.
+        // Targets a, b exist in the store but the source x is related to none.
+        var graph = BuildGraph();
+        var (provider, query) = BuildQuery(graph);
+        provider.Seed(new TravNode("x"), "x", nameof(TravNode));
+        provider.Seed(new TravNode("a"), "a", nameof(TravNode));
+        provider.Seed(new TravNode("b"), "b", nameof(TravNode));
+
+        // No RelateAsync calls — x has zero relations under "link".
+
+        // Act
+        var traversed = query
+            .GetObjectSet<TravNode>(nameof(TravNode))
+            .Where(t => t.Id == "x")
+            .TraverseLink<TravNode>("link");
+        var result = await traversed.ExecuteAsync();
+
+        // Assert — empty, NOT {a, b} (which the old type-based traversal returned).
+        await Assert.That(result.Items).IsEmpty();
+    }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTraversalTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTraversalTests.cs
@@ -369,3 +369,123 @@ public class SymbolKeyOnlyTraversalTests
         await Assert.That(rawIds).IsEquivalentTo(new[] { "a", "b" });
     }
 }
+
+// ---------------------------------------------------------------------------
+// F-MED-2 (DR-9, deferred): polyglot association detection is CLR-only.
+//
+// IsAssociationType / TryResolveAssociationDescriptor match on ClrType, so a
+// SymbolKey-only (ingested, ClrType == null) association is NOT recognized and
+// its TraverseLink degrades to PLAIN target-endpoint traversal. This pins that
+// documented limitation; polyglot association traversal is tracked under DR-9
+// and intentionally not implemented.
+// ---------------------------------------------------------------------------
+
+// A loaded CLR type used only to REQUEST the would-be edge view. The relate-store
+// row still carries an AssociationObjectId, but because the association descriptor
+// is SymbolKey-only its ClrType never matches this type, so the hop degrades.
+public sealed record PolyEdgeView(string Id);
+
+public class SymbolKeyOnlyAssociationDegradesTests
+{
+    private const string NodeDescriptor = "PolyAssocNode";
+    private const string EdgeDescriptor = "PolyAssocEdge";
+    private const string LinkName = "links";
+
+    private static OntologyGraph BuildSymbolKeyOnlyAssociationGraph()
+    {
+        // Node identity flows only through the supplied accessor (DR-1).
+        Func<object, object?> nodeId = instance => ((PolyglotNode)instance).RawId;
+
+        var node = new ObjectTypeDescriptor
+        {
+            Name = NodeDescriptor,
+            DomainName = "polyassoc",
+            ClrType = typeof(PolyglotNode),
+            Source = DescriptorSource.HandAuthored,
+            IdAccessor = nodeId,
+            Links =
+            [
+                new LinkDescriptor(LinkName, NodeDescriptor, LinkCardinality.OneToMany),
+            ],
+        };
+
+        // SymbolKey-only association: ClrType == null. Its IdAccessor reads the
+        // edge id off the same PolyglotNode shape used to store the edge object.
+        Func<object, object?> edgeId = instance => "edge:" + ((PolyglotNode)instance).RawId;
+
+        var edge = new ObjectTypeDescriptor
+        {
+            Name = EdgeDescriptor,
+            DomainName = "polyassoc",
+            ClrType = null, // SymbolKey-only: no loaded CLR identity.
+            SymbolKey = "scip-typescript ./poly.ts#PolyEdge",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = "polyassoc-source",
+            IdAccessor = edgeId,
+            Kind = ObjectKind.Association,
+            AssociationEndpoints =
+            [
+                new AssociationEndpoint("From", NodeDescriptor),
+                new AssociationEndpoint("To", NodeDescriptor),
+            ],
+        };
+
+        return new OntologyGraph(
+            domains: [new DomainDescriptor("polyassoc") { ObjectTypes = [node, edge] }],
+            objectTypes: [node, edge],
+            interfaces: [],
+            crossDomainLinks: [],
+            workflowChains: []);
+    }
+
+    [Test]
+    public async Task TraverseLink_OverSymbolKeyOnlyAssociation_DegradesToPlainTargetEndpoint()
+    {
+        // Arrange — store nodes, then an attributed relate whose association is a
+        // SymbolKey-only descriptor. The row DOES carry an AssociationObjectId.
+        var graph = BuildSymbolKeyOnlyAssociationGraph();
+        var provider = new InMemoryObjectSetProvider(graph);
+        var query = new OntologyQueryService(
+            graph,
+            provider,
+            Substitute.For<IActionDispatcher>(),
+            Substitute.For<IEventStreamProvider>());
+
+        provider.Seed(new PolyglotNode("x"), "x", NodeDescriptor);
+        provider.Seed(new PolyglotNode("y"), "y", NodeDescriptor);
+        // The edge object stored under the SymbolKey-only association partition.
+        provider.Seed(new PolyglotNode("e1"), "e1", EdgeDescriptor);
+
+        IObjectSetWriter writer = provider;
+        await writer.RelateAsync(
+            NodeDescriptor, "x", LinkName, NodeDescriptor, "y",
+            EdgeDescriptor, new PolyglotNode("e1"));
+
+        // Act — traverse from x. Requesting the node type yields the far node, as
+        // always. The PINNED behavior is that the association is NOT surfaced as a
+        // filterable edge: since EdgeDescriptor.ClrType is null, no requested CLR
+        // type can resolve it, so every hop degrades to plain target-endpoint
+        // traversal and returns the far NODE {y}.
+        var traversed = await query
+            .GetObjectSet<PolyglotNode>(NodeDescriptor)
+            .Where(n => n.RawId == "x")
+            .TraverseLink<PolyglotNode>(LinkName)
+            .ExecuteAsync();
+
+        var ids = traversed.Items.Select(n => n.RawId).ToList();
+        await Assert.That(ids).IsEquivalentTo(new[] { "y" });
+
+        // Assert — the SymbolKey-only association is unresolvable by CLR type, so
+        // the edge-view request also degrades to the far target endpoint rather
+        // than surfacing the stored edge object (DR-9 not implemented). The far
+        // node "y" is a PolyglotNode, so requesting PolyEdgeView yields nothing
+        // castable — degraded plain traversal never produces the edge object.
+        var edgeView = query
+            .GetObjectSet<PolyglotNode>(NodeDescriptor)
+            .Where(n => n.RawId == "x")
+            .TraverseLink<PolyEdgeView>(LinkName);
+        await Assert.That(async () => await edgeView.ExecuteAsync())
+            .Throws<InvalidCastException>();
+    }
+}

--- a/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTraversalTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTraversalTests.cs
@@ -1,5 +1,6 @@
 using Strategos.Ontology.Actions;
 using Strategos.Ontology.Builder;
+using Strategos.Ontology.Descriptors;
 using Strategos.Ontology.Events;
 using Strategos.Ontology.ObjectSets;
 using Strategos.Ontology.Query;
@@ -244,5 +245,91 @@ public class InstanceAnchoredTraversalTests
             .ExecuteAsync();
         var allFarIds = allFar.Items.Select(n => n.Id).OrderBy(s => s, StringComparer.Ordinal).ToList();
         await Assert.That(allFarIds).IsEquivalentTo(new[] { "y1", "y2" });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Task 13 (DR-8): SymbolKey-only (polyglot) relate -> traverse, NO reflection.
+//
+// An ingested descriptor has ClrType = null and SymbolKey set; its identity
+// flows ONLY through a source-supplied IdAccessor (DR-1). The instance below
+// hides its true id behind a transformation ("node:" + RawId) that NO
+// reflection-by-convention could reproduce, so any reflective id fallback
+// would yield the wrong id and the relate/traverse would resolve nothing. A
+// correct end-to-end result therefore proves the IdAccessor is the only id
+// path (INV-8).
+// ---------------------------------------------------------------------------
+
+public sealed record PolyglotNode(string RawId);
+
+public class SymbolKeyOnlyTraversalTests
+{
+    private const string Descriptor = "PolyNode";
+    private const string LinkName = "relates";
+
+    private static OntologyGraph BuildSymbolKeyOnlyGraph()
+    {
+        // The supplied accessor is the ONLY id path: id = "node:" + RawId.
+        Func<object, object?> idAccessor = instance => "node:" + ((PolyglotNode)instance).RawId;
+
+        var descriptor = new ObjectTypeDescriptor
+        {
+            Name = Descriptor,
+            DomainName = "poly",
+            ClrType = null, // SymbolKey-only: no loaded CLR identity.
+            SymbolKey = "scip-typescript ./poly.ts#PolyNode",
+            LanguageId = "typescript",
+            Source = DescriptorSource.Ingested,
+            SourceId = "poly-source",
+            IdAccessor = idAccessor,
+            Links =
+            [
+                new LinkDescriptor(LinkName, Descriptor, LinkCardinality.OneToMany),
+            ],
+        };
+
+        return new OntologyGraph(
+            domains: [new DomainDescriptor("poly") { ObjectTypes = [descriptor] }],
+            objectTypes: [descriptor],
+            interfaces: [],
+            crossDomainLinks: [],
+            workflowChains: []);
+    }
+
+    [Test]
+    public async Task RelateThenTraverse_SymbolKeyOnlyDescriptor_NoReflection()
+    {
+        // Arrange — a SymbolKey-only graph, instances stored under the ingested
+        // descriptor. Projected ids are "node:x", "node:a", "node:b", "node:c".
+        var graph = BuildSymbolKeyOnlyGraph();
+        var provider = new InMemoryObjectSetProvider(graph);
+        var query = new OntologyQueryService(
+            graph,
+            provider,
+            Substitute.For<IActionDispatcher>(),
+            Substitute.For<IEventStreamProvider>());
+
+        provider.Seed(new PolyglotNode("x"), "x", Descriptor);
+        provider.Seed(new PolyglotNode("a"), "a", Descriptor);
+        provider.Seed(new PolyglotNode("b"), "b", Descriptor);
+        provider.Seed(new PolyglotNode("c"), "c", Descriptor); // unrelated
+
+        IObjectSetWriter writer = provider;
+        // Relate via the projected ids (the accessor's transformed form).
+        await writer.RelateAsync(Descriptor, "node:x", LinkName, Descriptor, "node:a");
+        await writer.RelateAsync(Descriptor, "node:x", LinkName, Descriptor, "node:b");
+
+        // Act — traverse from the x instance end-to-end through the polyglot path.
+        var traversed = query
+            .GetObjectSet<PolyglotNode>(Descriptor)
+            .Where(n => n.RawId == "x")
+            .TraverseLink<PolyglotNode>(LinkName);
+        var result = await traversed.ExecuteAsync();
+
+        // Assert — exactly the related {a, b}, NOT the unrelated c. Correct
+        // resolution is only possible if every id was projected via the supplied
+        // IdAccessor (no reflection on PolyglotNode's CLR shape).
+        var rawIds = result.Items.Select(n => n.RawId).OrderBy(s => s, StringComparer.Ordinal).ToList();
+        await Assert.That(rawIds).IsEquivalentTo(new[] { "a", "b" });
     }
 }

--- a/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTraversalTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTraversalTests.cs
@@ -1,6 +1,8 @@
 using Strategos.Ontology.Actions;
+using Strategos.Ontology.Builder;
 using Strategos.Ontology.Events;
 using Strategos.Ontology.ObjectSets;
+using Strategos.Ontology.Query;
 
 namespace Strategos.Ontology.Tests.ObjectSets;
 
@@ -77,5 +79,80 @@ public class ObjectSetTraversalTests
         var narrowExpr = (InterfaceNarrowExpression)narrowed.Expression;
         await Assert.That(narrowExpr.InterfaceType).IsEqualTo(typeof(IDisposable));
         await Assert.That(narrowExpr.Source).IsTypeOf<RootExpression>();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DR-3 instance-anchored traversal (Tasks 10–13).
+//
+// These exercise the rewritten EvaluateTraverseLink end-to-end: a graph-aware
+// InMemoryObjectSetProvider stores instances, RelateAsync materializes rows,
+// and TraverseLink resolves by SOURCE INSTANCE (not target type) — closing
+// the #114 defect.
+// ---------------------------------------------------------------------------
+
+public sealed record TravNode(string Id, int Weight = 0);
+
+public sealed class TravNodeOntology : DomainOntology
+{
+    public override string DomainName => "trav";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<TravNode>(obj =>
+        {
+            obj.Key(n => n.Id);
+            obj.Property(n => n.Weight);
+            obj.HasMany<TravNode>("link");
+        });
+    }
+}
+
+public class InstanceAnchoredTraversalTests
+{
+    private static OntologyGraph BuildGraph()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain<TravNodeOntology>();
+        return graphBuilder.Build();
+    }
+
+    private static (InMemoryObjectSetProvider Provider, IOntologyQuery Query) BuildQuery(OntologyGraph graph)
+    {
+        var provider = new InMemoryObjectSetProvider(graph);
+        var query = new OntologyQueryService(
+            graph,
+            provider,
+            Substitute.For<IActionDispatcher>(),
+            Substitute.For<IEventStreamProvider>());
+        return (provider, query);
+    }
+
+    [Test]
+    public async Task TraverseLink_FromInstance_ReturnsOnlyRelatedTargets()
+    {
+        // Arrange — source x, targets a and b, plus an UNRELATED c of the same
+        // target type. The old type-based traversal would have returned a, b AND c.
+        var graph = BuildGraph();
+        var (provider, query) = BuildQuery(graph);
+        provider.Seed(new TravNode("x"), "x", nameof(TravNode));
+        provider.Seed(new TravNode("a"), "a", nameof(TravNode));
+        provider.Seed(new TravNode("b"), "b", nameof(TravNode));
+        provider.Seed(new TravNode("c"), "c", nameof(TravNode));
+
+        IObjectSetWriter writer = provider;
+        await writer.RelateAsync(nameof(TravNode), "x", "link", nameof(TravNode), "a");
+        await writer.RelateAsync(nameof(TravNode), "x", "link", nameof(TravNode), "b");
+
+        // Act — traverse from the x instance.
+        var traversed = query
+            .GetObjectSet<TravNode>(nameof(TravNode))
+            .Where(t => t.Id == "x")
+            .TraverseLink<TravNode>("link");
+        var result = await traversed.ExecuteAsync();
+
+        // Assert — exactly {a, b}, NOT the unrelated c.
+        var ids = result.Items.Select(n => n.Id).OrderBy(s => s, StringComparer.Ordinal).ToList();
+        await Assert.That(ids).IsEquivalentTo(new[] { "a", "b" });
     }
 }

--- a/src/Strategos.Ontology.Tests/OntologyGraphBuilderTests.cs
+++ b/src/Strategos.Ontology.Tests/OntologyGraphBuilderTests.cs
@@ -362,8 +362,53 @@ public class UnambiguousDomainOntology : DomainOntology
     }
 }
 
+// ---------------------------------------------------------------------------
+// DR-4 (Task 16) — reified association exposed as a graph edge
+// ---------------------------------------------------------------------------
+
+public sealed record GraphAssocPerson(string Id);
+
+public sealed record GraphAssocCompany(string Id);
+
+public sealed record GraphEmployment(string Id, GraphAssocPerson Employee, GraphAssocCompany Employer);
+
+public class GraphAssociationOntology : DomainOntology
+{
+    public override string DomainName => "graph-assoc";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<GraphAssocPerson>(obj => obj.Key(p => p.Id));
+        builder.Object<GraphAssocCompany>(obj => obj.Key(c => c.Id));
+
+        builder.Association<GraphEmployment>("GraphEmployment", a =>
+        {
+            a.Key(e => e.Id);
+            a.Between(e => e.Employee).And(e => e.Employer);
+        });
+    }
+}
+
 public class OntologyGraphBuilderTests
 {
+    [Test]
+    public async Task OntologyGraph_AssociationObject_ExposesEndpointsAsEdge()
+    {
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain<GraphAssociationOntology>();
+
+        var graph = graphBuilder.Build();
+
+        var edges = graph.GetAssociationEdges();
+        await Assert.That(edges).HasCount().EqualTo(1);
+
+        var edge = edges[0];
+        await Assert.That(edge.AssociationName).IsEqualTo("GraphEmployment");
+        await Assert.That(edge.DomainName).IsEqualTo("graph-assoc");
+        await Assert.That(edge.SourceDescriptorName).IsEqualTo(nameof(GraphAssocPerson));
+        await Assert.That(edge.DestinationDescriptorName).IsEqualTo(nameof(GraphAssocCompany));
+    }
+
     [Test]
     public async Task OntologyGraphBuilder_AddDomain_RegistersDomainOntology()
     {

--- a/src/Strategos.Ontology/AssociationEdge.cs
+++ b/src/Strategos.Ontology/AssociationEdge.cs
@@ -1,0 +1,26 @@
+namespace Strategos.Ontology;
+
+/// <summary>
+/// A reified association projected as a directed graph edge (DR-4). The
+/// association object's two endpoints become the edge's source and
+/// destination; the association itself supplies the edge identity
+/// (<see cref="AssociationName"/>) and may carry edge attributes on its
+/// underlying descriptor.
+/// </summary>
+/// <remarks>
+/// INV-8 (polyglot identity): source and destination are named by descriptor
+/// (<see cref="SourceDescriptorName"/> / <see cref="DestinationDescriptorName"/>),
+/// never by a CLR <see cref="System.Type"/>. INV-7 (immutable): an edge is an
+/// immutable record. Edge direction follows the authoring order:
+/// <c>Between(left).And(right)</c> ⇒ left is the source, right is the
+/// destination.
+/// </remarks>
+/// <param name="AssociationName">Descriptor name of the association object.</param>
+/// <param name="DomainName">Owning domain of the association.</param>
+/// <param name="SourceDescriptorName">Descriptor name of the left endpoint (edge source).</param>
+/// <param name="DestinationDescriptorName">Descriptor name of the right endpoint (edge destination).</param>
+public sealed record AssociationEdge(
+    string AssociationName,
+    string DomainName,
+    string SourceDescriptorName,
+    string DestinationDescriptorName);

--- a/src/Strategos.Ontology/Builder/AssociationBuilder.cs
+++ b/src/Strategos.Ontology/Builder/AssociationBuilder.cs
@@ -32,6 +32,8 @@ internal sealed class AssociationBuilder<TRel> : IAssociationBuilder<TRel>, IAss
 
     public AssociationBuilder(string domainName, string name)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(domainName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
         _domainName = domainName;
         _name = name;
     }

--- a/src/Strategos.Ontology/Builder/AssociationBuilder.cs
+++ b/src/Strategos.Ontology/Builder/AssociationBuilder.cs
@@ -1,0 +1,103 @@
+using System.Linq.Expressions;
+
+using Strategos.Ontology.Descriptors;
+
+namespace Strategos.Ontology.Builder;
+
+/// <summary>
+/// Builds a reified association descriptor (DR-4). Mirrors
+/// <see cref="ObjectTypeBuilder{T}"/>'s idioms — a key selector compiled to the
+/// reflection-free DR-1 <see cref="ObjectTypeDescriptor.IdAccessor"/>, plus its
+/// own edge-attribute properties — and adds the two typed endpoints.
+/// </summary>
+/// <remarks>
+/// INV-8: <see cref="Between{TLeft}"/>/<see cref="And{TRight}"/> read only the
+/// endpoint type's <c>Name</c> (mirroring <c>HasMany&lt;TLinked&gt;</c>) and the
+/// selector's member name; the produced <see cref="AssociationEndpoint"/>
+/// carries no CLR <see cref="System.Type"/>. INV-6: this builder is
+/// <c>sealed</c>. INV-7: it emits an immutable <see cref="ObjectTypeDescriptor"/>.
+/// </remarks>
+internal sealed class AssociationBuilder<TRel> : IAssociationBuilder<TRel>, IAssociationEndpointBuilder<TRel>
+    where TRel : class
+{
+    private readonly string _domainName;
+    private readonly string _name;
+    private readonly List<PropertyBuilder<TRel>> _propertyBuilders = [];
+    private readonly List<PropertyDescriptor> _namedProperties = [];
+
+    private PropertyDescriptor? _keyProperty;
+    private Func<object, object?>? _idAccessor;
+    private AssociationEndpoint? _left;
+    private AssociationEndpoint? _right;
+
+    public AssociationBuilder(string domainName, string name)
+    {
+        _domainName = domainName;
+        _name = name;
+    }
+
+    public void Key(Expression<Func<TRel, object>> keySelector)
+    {
+        var memberName = ExpressionHelper.ExtractMemberName(keySelector);
+        var memberType = ExpressionHelper.ExtractMemberType(keySelector);
+        _keyProperty = new PropertyDescriptor(memberName, memberType);
+
+        // Compile the key selector once and box it to the erased accessor shape,
+        // so the descriptor projects an instance's id with zero per-call
+        // reflection on the instance type (INV-8) — identical to ObjectTypeBuilder.
+        var compiled = keySelector.Compile();
+        _idAccessor = o => compiled((TRel)o);
+    }
+
+    public IAssociationEndpointBuilder<TRel> Between<TLeft>(Expression<Func<TRel, TLeft>> endpoint)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+        var role = ExpressionHelper.ExtractMemberName(endpoint);
+        _left = new AssociationEndpoint(role, typeof(TLeft).Name);
+        return this;
+    }
+
+    public void And<TRight>(Expression<Func<TRel, TRight>> endpoint)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+        var role = ExpressionHelper.ExtractMemberName(endpoint);
+        _right = new AssociationEndpoint(role, typeof(TRight).Name);
+    }
+
+    public IPropertyBuilder<TRel> Property(Expression<Func<TRel, object>> propertySelector)
+    {
+        var memberName = ExpressionHelper.ExtractMemberName(propertySelector);
+        var memberType = ExpressionHelper.ExtractMemberType(propertySelector);
+        var builder = new PropertyBuilder<TRel>(memberName, memberType);
+        _propertyBuilders.Add(builder);
+        return builder;
+    }
+
+    public IAssociationBuilder<TRel> Property<TProp>(string name)
+    {
+        _namedProperties.Add(new PropertyDescriptor(name, typeof(TProp)));
+        return this;
+    }
+
+    public ObjectTypeDescriptor Build()
+    {
+        if (_left is null || _right is null)
+        {
+            throw new InvalidOperationException(
+                $"Association '{_domainName}.{_name}' must declare both endpoints via "
+                + "Between<L>(...).And<R>(...) before the ontology is built.");
+        }
+
+        var properties = _propertyBuilders.ConvertAll(b => b.Build());
+        properties.AddRange(_namedProperties);
+
+        return new ObjectTypeDescriptor(_name, typeof(TRel), _domainName)
+        {
+            Kind = ObjectKind.Association,
+            KeyProperty = _keyProperty,
+            IdAccessor = _idAccessor,
+            Properties = properties.AsReadOnly(),
+            AssociationEndpoints = new[] { _left, _right }.AsReadOnly(),
+        };
+    }
+}

--- a/src/Strategos.Ontology/Builder/AssociationBuilder.cs
+++ b/src/Strategos.Ontology/Builder/AssociationBuilder.cs
@@ -38,6 +38,7 @@ internal sealed class AssociationBuilder<TRel> : IAssociationBuilder<TRel>, IAss
 
     public void Key(Expression<Func<TRel, object>> keySelector)
     {
+        ArgumentNullException.ThrowIfNull(keySelector);
         var memberName = ExpressionHelper.ExtractMemberName(keySelector);
         var memberType = ExpressionHelper.ExtractMemberType(keySelector);
         _keyProperty = new PropertyDescriptor(memberName, memberType);
@@ -66,6 +67,7 @@ internal sealed class AssociationBuilder<TRel> : IAssociationBuilder<TRel>, IAss
 
     public IPropertyBuilder<TRel> Property(Expression<Func<TRel, object>> propertySelector)
     {
+        ArgumentNullException.ThrowIfNull(propertySelector);
         var memberName = ExpressionHelper.ExtractMemberName(propertySelector);
         var memberType = ExpressionHelper.ExtractMemberType(propertySelector);
         var builder = new PropertyBuilder<TRel>(memberName, memberType);
@@ -75,6 +77,7 @@ internal sealed class AssociationBuilder<TRel> : IAssociationBuilder<TRel>, IAss
 
     public IAssociationBuilder<TRel> Property<TProp>(string name)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
         _namedProperties.Add(new PropertyDescriptor(name, typeof(TProp)));
         return this;
     }

--- a/src/Strategos.Ontology/Builder/IAssociationBuilder.cs
+++ b/src/Strategos.Ontology/Builder/IAssociationBuilder.cs
@@ -52,7 +52,7 @@ public interface IAssociationBuilder<TRel>
 }
 
 /// <summary>
-/// The second step of the <see cref="IAssociationBuilder{TRel}.Between{L}"/>
+/// The second step of the <see cref="IAssociationBuilder{TRel}.Between{TLeft}"/>
 /// fluent chain: declares the RIGHT endpoint.
 /// </summary>
 /// <typeparam name="TRel">The CLR type backing the association object.</typeparam>

--- a/src/Strategos.Ontology/Builder/IAssociationBuilder.cs
+++ b/src/Strategos.Ontology/Builder/IAssociationBuilder.cs
@@ -1,0 +1,68 @@
+using System.Linq.Expressions;
+
+using Strategos.Ontology.Descriptors;
+
+namespace Strategos.Ontology.Builder;
+
+/// <summary>
+/// Fluent authoring surface for a reified association (DR-4). An association is
+/// a standalone object-with-two-endpoints declared at the ontology level via
+/// <see cref="IOntologyBuilder.Association{TRel}(string, System.Action{IAssociationBuilder{TRel}})"/>.
+/// It carries its own key (DR-1 identity path), two typed endpoints, and its
+/// own edge-attribute properties.
+/// </summary>
+/// <typeparam name="TRel">The CLR type backing the association object.</typeparam>
+/// <remarks>
+/// INV-8: <see cref="Between{TLeft}"/>/<see cref="IAssociationEndpointBuilder{TRel}.And{TRight}"/>
+/// accept a generic endpoint type as authoring sugar, but the produced
+/// <see cref="AssociationEndpoint"/> stores only the endpoint's descriptor
+/// name — no CLR <see cref="System.Type"/> survives onto the descriptor as
+/// endpoint identity.
+/// </remarks>
+public interface IAssociationBuilder<TRel>
+    where TRel : class
+{
+    /// <summary>
+    /// Declares the association's key selector. Mirrors
+    /// <c>IObjectTypeBuilder&lt;T&gt;.Key</c>; the id flows through the DR-1
+    /// <see cref="ObjectTypeDescriptor.IdAccessor"/> path like any object type.
+    /// </summary>
+    void Key(Expression<Func<TRel, object>> keySelector);
+
+    /// <summary>
+    /// Declares the LEFT endpoint of the association via a selector onto the
+    /// property carrying it, then returns the step to declare the right
+    /// endpoint with <see cref="IAssociationEndpointBuilder{TRel}.And{TRight}"/>.
+    /// </summary>
+    /// <typeparam name="TLeft">The left endpoint's object type (authoring sugar).</typeparam>
+    IAssociationEndpointBuilder<TRel> Between<TLeft>(Expression<Func<TRel, TLeft>> endpoint);
+
+    /// <summary>
+    /// Declares an edge-attribute property on the association by selector.
+    /// Mirrors <c>IObjectTypeBuilder&lt;T&gt;.Property</c>.
+    /// </summary>
+    IPropertyBuilder<TRel> Property(Expression<Func<TRel, object>> propertySelector);
+
+    /// <summary>
+    /// Declares an edge-attribute property on the association by name and
+    /// CLR type, for callers that prefer the by-name form
+    /// (parity with <see cref="IEdgeBuilder.Property{TProp}"/>).
+    /// </summary>
+    IAssociationBuilder<TRel> Property<TProp>(string name);
+}
+
+/// <summary>
+/// The second step of the <see cref="IAssociationBuilder{TRel}.Between{L}"/>
+/// fluent chain: declares the RIGHT endpoint.
+/// </summary>
+/// <typeparam name="TRel">The CLR type backing the association object.</typeparam>
+public interface IAssociationEndpointBuilder<TRel>
+    where TRel : class
+{
+    /// <summary>
+    /// Declares the RIGHT endpoint of the association via a selector onto the
+    /// property carrying it.
+    /// </summary>
+    /// <typeparam name="TRight">The right endpoint's object type (authoring sugar).</typeparam>
+    void And<TRight>(Expression<Func<TRel, TRight>> endpoint);
+}

--- a/src/Strategos.Ontology/Builder/IOntologyBuilder.cs
+++ b/src/Strategos.Ontology/Builder/IOntologyBuilder.cs
@@ -25,6 +25,23 @@ public interface IOntologyBuilder
     void Interface<T>(string name, Action<IInterfaceBuilder<T>> configure)
         where T : class;
 
+    /// <summary>
+    /// Registers a reified association (DR-4): a standalone
+    /// object-with-two-endpoints. Unlike per-source links (<c>ManyToMany</c> et
+    /// al. on <see cref="IObjectTypeBuilder{T}"/>), an association is a
+    /// first-class object type that owns its own key and edge attributes and
+    /// links two endpoints declared via
+    /// <see cref="IAssociationBuilder{TRel}.Between{L}"/> +
+    /// <see cref="IAssociationEndpointBuilder{TRel}.And{R}"/>. It produces an
+    /// <see cref="ObjectTypeDescriptor"/> with
+    /// <see cref="ObjectTypeDescriptor.Kind"/> = <see cref="ObjectKind.Association"/>.
+    /// </summary>
+    /// <typeparam name="TRel">CLR type backing the association object.</typeparam>
+    /// <param name="name">Descriptor name of the association.</param>
+    /// <param name="configure">Configuration callback for the association builder.</param>
+    void Association<TRel>(string name, Action<IAssociationBuilder<TRel>> configure)
+        where TRel : class;
+
     ICrossDomainLinkBuilder CrossDomainLink(string name);
 
     /// <summary>

--- a/src/Strategos.Ontology/Builder/IOntologyBuilder.cs
+++ b/src/Strategos.Ontology/Builder/IOntologyBuilder.cs
@@ -31,8 +31,8 @@ public interface IOntologyBuilder
     /// al. on <see cref="IObjectTypeBuilder{T}"/>), an association is a
     /// first-class object type that owns its own key and edge attributes and
     /// links two endpoints declared via
-    /// <see cref="IAssociationBuilder{TRel}.Between{L}"/> +
-    /// <see cref="IAssociationEndpointBuilder{TRel}.And{R}"/>. It produces an
+    /// <see cref="IAssociationBuilder{TRel}.Between{TLeft}"/> +
+    /// <see cref="IAssociationEndpointBuilder{TRel}.And{TRight}"/>. It produces an
     /// <see cref="ObjectTypeDescriptor"/> with
     /// <see cref="ObjectTypeDescriptor.Kind"/> = <see cref="ObjectKind.Association"/>.
     /// </summary>

--- a/src/Strategos.Ontology/Builder/ObjectTypeBuilder.cs
+++ b/src/Strategos.Ontology/Builder/ObjectTypeBuilder.cs
@@ -37,6 +37,7 @@ internal sealed class ObjectTypeBuilder<T> : IObjectTypeBuilder<T>
     }
 
     private PropertyDescriptor? _keyProperty;
+    private Func<object, object?>? _idAccessor;
     private readonly List<PropertyBuilder<T>> _propertyBuilders = [];
     private readonly List<LinkBuilder> _linkBuilders = [];
     private readonly List<ActionBuilder<T>> _actionBuilders = [];
@@ -55,6 +56,12 @@ internal sealed class ObjectTypeBuilder<T> : IObjectTypeBuilder<T>
         var memberName = ExpressionHelper.ExtractMemberName(keySelector);
         var memberType = ExpressionHelper.ExtractMemberType(keySelector);
         _keyProperty = new PropertyDescriptor(memberName, memberType);
+
+        // Compile the already-captured key selector once and box it to the
+        // erased accessor shape, so the descriptor can project an instance's
+        // id with zero per-call reflection on the instance type (INV-8).
+        var compiled = keySelector.Compile();
+        _idAccessor = o => compiled((T)o);
     }
 
     public void Kind(ObjectKind kind)
@@ -167,6 +174,7 @@ internal sealed class ObjectTypeBuilder<T> : IObjectTypeBuilder<T>
         {
             Kind = _objectKind,
             KeyProperty = _keyProperty,
+            IdAccessor = _idAccessor,
             Properties = _propertyBuilders.ConvertAll(b => b.Build()).AsReadOnly(),
             Links = _linkBuilders.ConvertAll(b => b.Build()).AsReadOnly(),
             Actions = actions.AsReadOnly(),

--- a/src/Strategos.Ontology/Builder/OntologyBuilder.cs
+++ b/src/Strategos.Ontology/Builder/OntologyBuilder.cs
@@ -66,6 +66,21 @@ internal sealed class OntologyBuilder(string domainName) : IOntologyBuilder
         _interfaces.Add(builder.Build());
     }
 
+    public void Association<TRel>(string name, Action<IAssociationBuilder<TRel>> configure)
+        where TRel : class
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var builder = new AssociationBuilder<TRel>(domainName, name);
+        configure(builder);
+
+        // Register the association descriptor through the same _objectTypes path
+        // every other object type uses, so downstream composition (AONT040 dup
+        // names, the graph lookup, DR-1 id projection) treats it uniformly.
+        _objectTypes.Add(builder.Build());
+    }
+
     public ICrossDomainLinkBuilder CrossDomainLink(string name)
     {
         var builder = new CrossDomainLinkBuilder(name);

--- a/src/Strategos.Ontology/Descriptors/AssociationEndpoint.cs
+++ b/src/Strategos.Ontology/Descriptors/AssociationEndpoint.cs
@@ -1,0 +1,25 @@
+namespace Strategos.Ontology.Descriptors;
+
+/// <summary>
+/// One endpoint of a reified association (DR-4). An association is a standalone
+/// object type (<see cref="ObjectKind.Association"/>) that links two endpoints
+/// and may carry its own edge attributes.
+/// </summary>
+/// <remarks>
+/// INV-8 (polyglot identity): an endpoint references its object type by
+/// <see cref="DescriptorName"/> — a string — never by a CLR
+/// <see cref="System.Type"/>. The authoring builder accepts a generic
+/// <c>&lt;L&gt;</c>/<c>&lt;R&gt;</c> as sugar, but the resulting descriptor
+/// stores only the descriptor name (so a SymbolKey-only ingested endpoint is
+/// representable identically to a CLR one).
+/// INV-7 (immutable): this is an immutable record carrying no mutation surface.
+/// </remarks>
+/// <param name="Role">
+/// The property on the association object that carries this endpoint (e.g.
+/// <c>Employee</c> / <c>Employer</c>). Distinguishes the left and right
+/// endpoints when they share an object type (a self-association).
+/// </param>
+/// <param name="DescriptorName">
+/// The descriptor name of the endpoint's object type (e.g. <c>AssocPerson</c>).
+/// </param>
+public sealed record AssociationEndpoint(string Role, string DescriptorName);

--- a/src/Strategos.Ontology/Descriptors/LinkDescriptor.cs
+++ b/src/Strategos.Ontology/Descriptors/LinkDescriptor.cs
@@ -33,4 +33,13 @@ public sealed record LinkDescriptor(
 
     /// <summary>Field-level provenance — hand-authored vs. ingested.</summary>
     public DescriptorSource Source { get; init; } = DescriptorSource.HandAuthored;
+
+    /// <summary>
+    /// Whether a relate instance may connect an object to itself along this
+    /// link. DR-2 (DR-8): defaults to <c>false</c> — a relate whose source and
+    /// target are the same (descriptor, id) is rejected at runtime in
+    /// <c>RelateAsync</c> unless this is set. Promotion to a compile-time
+    /// analyzer is a later task; the DR-2 enforcement is runtime-only.
+    /// </summary>
+    public bool AllowsSelfLoop { get; init; }
 }

--- a/src/Strategos.Ontology/Descriptors/ObjectKind.cs
+++ b/src/Strategos.Ontology/Descriptors/ObjectKind.cs
@@ -10,4 +10,13 @@ public enum ObjectKind
 {
     Entity,
     Process,
+
+    /// <summary>
+    /// A reified association: a standalone object type that links two
+    /// endpoints (a left and a right object type) and may carry its own
+    /// properties on the edge. DR-4 (Ontology Edge Foundation): declared at
+    /// the ontology level via <c>IOntologyBuilder.Association&lt;TRel&gt;</c>,
+    /// not off a per-source link builder.
+    /// </summary>
+    Association,
 }

--- a/src/Strategos.Ontology/Descriptors/ObjectTypeDescriptor.cs
+++ b/src/Strategos.Ontology/Descriptors/ObjectTypeDescriptor.cs
@@ -159,6 +159,15 @@ public sealed record ObjectTypeDescriptor
 
     public ObjectKind Kind { get; init; } = ObjectKind.Entity;
 
+    /// <summary>
+    /// The two endpoints of a reified association, present only when
+    /// <see cref="Kind"/> is <see cref="ObjectKind.Association"/> (DR-4).
+    /// Empty for entity/process descriptors. Endpoints reference their object
+    /// type by descriptor name (INV-8) — the list never carries a CLR
+    /// <see cref="Type"/> denoting endpoint identity.
+    /// </summary>
+    public IReadOnlyList<AssociationEndpoint> AssociationEndpoints { get; init; } = [];
+
     public Type? ParentType { get; init; }
 
     public string? ParentTypeName { get; init; }

--- a/src/Strategos.Ontology/Descriptors/ObjectTypeDescriptor.cs
+++ b/src/Strategos.Ontology/Descriptors/ObjectTypeDescriptor.cs
@@ -128,6 +128,17 @@ public sealed record ObjectTypeDescriptor
 
     public PropertyDescriptor? KeyProperty { get; init; }
 
+    /// <summary>
+    /// Reflection-free projector of an instance to its key value. For
+    /// hand-authored descriptors this is compiled from the
+    /// <c>Key(...)</c> selector expression at build time; for ingested
+    /// (<see cref="SymbolKey"/>-only) descriptors it is supplied by the
+    /// contributing <c>IOntologySource</c>. Either way the accessor is the
+    /// single id-resolution path — no per-call reflection on the instance
+    /// type is ever performed (INV-8). Null when no key has been declared.
+    /// </summary>
+    public Func<object, object?>? IdAccessor { get; init; }
+
     public IReadOnlyList<PropertyDescriptor> Properties { get; init; } = [];
 
     public IReadOnlyList<LinkDescriptor> Links { get; init; } = [];

--- a/src/Strategos.Ontology/Identity/IObjectIdentityProjector.cs
+++ b/src/Strategos.Ontology/Identity/IObjectIdentityProjector.cs
@@ -1,0 +1,28 @@
+using Strategos.Ontology.Descriptors;
+
+namespace Strategos.Ontology.Identity;
+
+/// <summary>
+/// Projects a domain instance to its stable, deterministic string id using
+/// the descriptor's reflection-free <see cref="ObjectTypeDescriptor.IdAccessor"/>.
+/// </summary>
+/// <remarks>
+/// DR-1 (Ontology Edge Foundation). Replaces the ad-hoc
+/// <c>item?.ToString()</c> notion of instance identity with a real,
+/// polyglot-capable projector. The projector NEVER reflects over the
+/// instance's CLR type to locate the key (INV-8): both CLR and
+/// <c>SymbolKey</c>-only descriptors resolve through the same supplied
+/// <see cref="ObjectTypeDescriptor.IdAccessor"/>. No member of this
+/// namespace accepts or returns <see cref="System.Type"/>.
+/// </remarks>
+public interface IObjectIdentityProjector
+{
+    /// <summary>
+    /// Projects <paramref name="instance"/> to a deterministic id under
+    /// <paramref name="descriptor"/>. Throws <see cref="System.InvalidOperationException"/>
+    /// (naming the descriptor) when the descriptor exposes no id accessor or
+    /// the accessor yields a null key value — never silently, never via a
+    /// reflection fallback.
+    /// </summary>
+    string ProjectId(ObjectTypeDescriptor descriptor, object instance);
+}

--- a/src/Strategos.Ontology/Identity/IObjectIdentityProjector.cs
+++ b/src/Strategos.Ontology/Identity/IObjectIdentityProjector.cs
@@ -19,10 +19,26 @@ public interface IObjectIdentityProjector
 {
     /// <summary>
     /// Projects <paramref name="instance"/> to a deterministic id under
-    /// <paramref name="descriptor"/>. Throws <see cref="System.InvalidOperationException"/>
-    /// (naming the descriptor) when the descriptor exposes no id accessor or
-    /// the accessor yields a null key value — never silently, never via a
-    /// reflection fallback.
+    /// <paramref name="descriptor"/> — never silently, never via a reflection
+    /// fallback.
     /// </summary>
+    /// <param name="descriptor">The descriptor supplying the id accessor.</param>
+    /// <param name="instance">The instance to project.</param>
+    /// <returns>The deterministic projected id.</returns>
+    /// <exception cref="MissingIdAccessorException">
+    /// The descriptor exposes no id accessor — a CONFIGURATION error (the
+    /// descriptor was assembled without a <c>Key(...)</c> selector or an
+    /// <c>IOntologySource</c>-supplied accessor).
+    /// </exception>
+    /// <exception cref="NullKeyValueException">
+    /// The accessor ran but yielded a null key value — a DATA error (the
+    /// descriptor is configured, but the instance carries a null key).
+    /// </exception>
+    /// <remarks>
+    /// Both exceptions name the descriptor and both derive from
+    /// <see cref="System.InvalidOperationException"/>, so existing callers that
+    /// catch the latter keep working while callers that need to distinguish a
+    /// config error from a data error can catch the two specific types.
+    /// </remarks>
     string ProjectId(ObjectTypeDescriptor descriptor, object instance);
 }

--- a/src/Strategos.Ontology/Identity/MissingIdAccessorException.cs
+++ b/src/Strategos.Ontology/Identity/MissingIdAccessorException.cs
@@ -1,0 +1,32 @@
+namespace Strategos.Ontology.Identity;
+
+/// <summary>
+/// Thrown by <see cref="IObjectIdentityProjector.ProjectId"/> when the descriptor
+/// exposes no <see cref="Descriptors.ObjectTypeDescriptor.IdAccessor"/>.
+/// </summary>
+/// <remarks>
+/// DR-1 (FIX-E). This is a CONFIGURATION error — the descriptor was assembled
+/// without an id accessor (a hand-authored descriptor missing its <c>Key(...)</c>
+/// selector, or an ingested descriptor whose <c>IOntologySource</c> supplied
+/// none). It is distinct from <see cref="NullKeyValueException"/>, which is a
+/// DATA error (the accessor ran but yielded null), so callers can tell a
+/// misconfigured descriptor from bad instance data.
+/// </remarks>
+public sealed class MissingIdAccessorException : InvalidOperationException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MissingIdAccessorException"/> class,
+    /// naming the descriptor that lacks an id accessor.
+    /// </summary>
+    /// <param name="descriptorName">Descriptor that exposes no id accessor.</param>
+    public MissingIdAccessorException(string descriptorName)
+        : base($"Cannot project id for descriptor '{descriptorName}': descriptor '{descriptorName}' has no id accessor. "
+            + "Hand-authored descriptors derive it from the Key(...) selector; "
+            + "ingested descriptors must have one supplied by their IOntologySource.")
+    {
+        DescriptorName = descriptorName;
+    }
+
+    /// <summary>Descriptor name that exposes no id accessor.</summary>
+    public string DescriptorName { get; }
+}

--- a/src/Strategos.Ontology/Identity/NullKeyValueException.cs
+++ b/src/Strategos.Ontology/Identity/NullKeyValueException.cs
@@ -1,0 +1,29 @@
+namespace Strategos.Ontology.Identity;
+
+/// <summary>
+/// Thrown by <see cref="IObjectIdentityProjector.ProjectId"/> when the
+/// descriptor's id accessor runs but yields a null key value.
+/// </summary>
+/// <remarks>
+/// DR-1 (FIX-E). This is a DATA error — the descriptor is correctly configured
+/// (an accessor is present) but the instance carries a null key. It is distinct
+/// from <see cref="MissingIdAccessorException"/>, which is a CONFIGURATION error
+/// (no accessor at all), so callers can tell bad instance data from a
+/// misconfigured descriptor.
+/// </remarks>
+public sealed class NullKeyValueException : InvalidOperationException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullKeyValueException"/> class,
+    /// naming the descriptor whose key value resolved to null.
+    /// </summary>
+    /// <param name="descriptorName">Descriptor whose accessor yielded a null key value.</param>
+    public NullKeyValueException(string descriptorName)
+        : base($"Cannot project id for descriptor '{descriptorName}': the key value resolved to null.")
+    {
+        DescriptorName = descriptorName;
+    }
+
+    /// <summary>Descriptor name whose accessor yielded a null key value.</summary>
+    public string DescriptorName { get; }
+}

--- a/src/Strategos.Ontology/Identity/ObjectIdentityProjector.cs
+++ b/src/Strategos.Ontology/Identity/ObjectIdentityProjector.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Runtime.CompilerServices;
 
 using Strategos.Ontology.Descriptors;
 
@@ -11,6 +12,14 @@ namespace Strategos.Ontology.Identity;
 /// </summary>
 public sealed class ObjectIdentityProjector : IObjectIdentityProjector
 {
+    /// <summary>
+    /// Reserved delimiter joining composite-key elements. The ASCII Unit
+    /// Separator (U+001F) is a non-printable control character that does not
+    /// occur in well-formed key text, so the joined id is unambiguously
+    /// reversible and collision-free for tuple keys.
+    /// </summary>
+    public const string CompositeKeySeparator = "\u001F";
+
     /// <inheritdoc />
     public string ProjectId(ObjectTypeDescriptor descriptor, object instance)
     {
@@ -33,6 +42,28 @@ public sealed class ObjectIdentityProjector : IObjectIdentityProjector
                 $"Cannot project id for descriptor '{descriptor.Name}': the key value resolved to null.");
         }
 
-        return Convert.ToString(keyValue, CultureInfo.InvariantCulture) ?? string.Empty;
+        return Format(keyValue);
     }
+
+    private static string Format(object keyValue)
+    {
+        // Composite keys (ValueTuple / Tuple) join their elements with the
+        // reserved separator, deterministically and in declaration order.
+        // Single-value keys are formatted invariantly via ToString().
+        if (keyValue is ITuple tuple)
+        {
+            var parts = new string[tuple.Length];
+            for (var i = 0; i < tuple.Length; i++)
+            {
+                parts[i] = FormatScalar(tuple[i]);
+            }
+
+            return string.Join(CompositeKeySeparator, parts);
+        }
+
+        return FormatScalar(keyValue);
+    }
+
+    private static string FormatScalar(object? value) =>
+        Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
 }

--- a/src/Strategos.Ontology/Identity/ObjectIdentityProjector.cs
+++ b/src/Strategos.Ontology/Identity/ObjectIdentityProjector.cs
@@ -17,7 +17,16 @@ public sealed class ObjectIdentityProjector : IObjectIdentityProjector
         ArgumentNullException.ThrowIfNull(descriptor);
         ArgumentNullException.ThrowIfNull(instance);
 
-        var keyValue = descriptor.IdAccessor!(instance);
+        var accessor = descriptor.IdAccessor;
+        if (accessor is null)
+        {
+            throw new InvalidOperationException(
+                $"Cannot project id for descriptor '{descriptor.Name}': descriptor '{descriptor.Name}' has no id accessor. "
+                + "Hand-authored descriptors derive it from the Key(...) selector; "
+                + "ingested descriptors must have one supplied by their IOntologySource.");
+        }
+
+        var keyValue = accessor(instance);
         if (keyValue is null)
         {
             throw new InvalidOperationException(

--- a/src/Strategos.Ontology/Identity/ObjectIdentityProjector.cs
+++ b/src/Strategos.Ontology/Identity/ObjectIdentityProjector.cs
@@ -42,17 +42,15 @@ public sealed class ObjectIdentityProjector : IObjectIdentityProjector
         var accessor = descriptor.IdAccessor;
         if (accessor is null)
         {
-            throw new InvalidOperationException(
-                $"Cannot project id for descriptor '{descriptor.Name}': descriptor '{descriptor.Name}' has no id accessor. "
-                + "Hand-authored descriptors derive it from the Key(...) selector; "
-                + "ingested descriptors must have one supplied by their IOntologySource.");
+            // CONFIG error: the descriptor was assembled without an id accessor.
+            throw new MissingIdAccessorException(descriptor.Name);
         }
 
         var keyValue = accessor(instance);
         if (keyValue is null)
         {
-            throw new InvalidOperationException(
-                $"Cannot project id for descriptor '{descriptor.Name}': the key value resolved to null.");
+            // DATA error: the accessor ran but the instance's key was null.
+            throw new NullKeyValueException(descriptor.Name);
         }
 
         return Format(keyValue);

--- a/src/Strategos.Ontology/Identity/ObjectIdentityProjector.cs
+++ b/src/Strategos.Ontology/Identity/ObjectIdentityProjector.cs
@@ -1,0 +1,29 @@
+using System.Globalization;
+
+using Strategos.Ontology.Descriptors;
+
+namespace Strategos.Ontology.Identity;
+
+/// <summary>
+/// Default <see cref="IObjectIdentityProjector"/>. Resolves an instance's id
+/// solely through the descriptor's <see cref="ObjectTypeDescriptor.IdAccessor"/>,
+/// performing no per-call reflection on the instance type (INV-8).
+/// </summary>
+public sealed class ObjectIdentityProjector : IObjectIdentityProjector
+{
+    /// <inheritdoc />
+    public string ProjectId(ObjectTypeDescriptor descriptor, object instance)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+        ArgumentNullException.ThrowIfNull(instance);
+
+        var keyValue = descriptor.IdAccessor!(instance);
+        if (keyValue is null)
+        {
+            throw new InvalidOperationException(
+                $"Cannot project id for descriptor '{descriptor.Name}': the key value resolved to null.");
+        }
+
+        return Convert.ToString(keyValue, CultureInfo.InvariantCulture) ?? string.Empty;
+    }
+}

--- a/src/Strategos.Ontology/Identity/ObjectIdentityProjector.cs
+++ b/src/Strategos.Ontology/Identity/ObjectIdentityProjector.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 using Strategos.Ontology.Descriptors;
 
@@ -13,12 +14,24 @@ namespace Strategos.Ontology.Identity;
 public sealed class ObjectIdentityProjector : IObjectIdentityProjector
 {
     /// <summary>
-    /// Reserved delimiter joining composite-key elements. The ASCII Unit
-    /// Separator (U+001F) is a non-printable control character that does not
-    /// occur in well-formed key text, so the joined id is unambiguously
-    /// reversible and collision-free for tuple keys.
+    /// Reserved delimiter separating composite-key components. The ASCII Unit
+    /// Separator (U+001F) is a non-printable control character; it delimits the
+    /// length-prefixed encoding emitted by <see cref="Format"/> but, because each
+    /// component is length-prefixed, the encoding stays injective even when a
+    /// component's own text happens to contain this character.
     /// </summary>
-    public const string CompositeKeySeparator = "\u001F";
+    public const string CompositeKeySeparator = "";
+
+    // Discriminators emitted ahead of each composite-key component so the
+    // encoding is injective. A null element emits NullComponentMarker alone; a
+    // non-null element emits ValueComponentMarker, the component's char length,
+    // a colon, then the raw component text. Length-prefixing means a separator
+    // (or any other character) appearing INSIDE a component can never be
+    // mistaken for a component boundary, and the null marker is distinct from
+    // ValueComponentMarker + "0:" (the empty string), so null and "" never
+    // collide.
+    private const char NullComponentMarker = 'N';
+    private const char ValueComponentMarker = 'V';
 
     /// <inheritdoc />
     public string ProjectId(ObjectTypeDescriptor descriptor, object instance)
@@ -47,21 +60,45 @@ public sealed class ObjectIdentityProjector : IObjectIdentityProjector
 
     private static string Format(object keyValue)
     {
-        // Composite keys (ValueTuple / Tuple) join their elements with the
-        // reserved separator, deterministically and in declaration order.
+        // Composite keys (ValueTuple / Tuple) encode each element with a
+        // length-prefix and a null/value discriminator, joined by the reserved
+        // separator, deterministically and in declaration order. The encoding is
+        // injective: a component whose own text contains the separator cannot be
+        // confused with a boundary, and a null element is distinguishable from
+        // the empty string (see NullComponentMarker / ValueComponentMarker).
         // Single-value keys are formatted invariantly via ToString().
         if (keyValue is ITuple tuple)
         {
-            var parts = new string[tuple.Length];
+            var builder = new StringBuilder();
             for (var i = 0; i < tuple.Length; i++)
             {
-                parts[i] = FormatScalar(tuple[i]);
+                if (i > 0)
+                {
+                    builder.Append(CompositeKeySeparator);
+                }
+
+                AppendComponent(builder, tuple[i]);
             }
 
-            return string.Join(CompositeKeySeparator, parts);
+            return builder.ToString();
         }
 
         return FormatScalar(keyValue);
+    }
+
+    private static void AppendComponent(StringBuilder builder, object? value)
+    {
+        if (value is null)
+        {
+            builder.Append(NullComponentMarker);
+            return;
+        }
+
+        var text = FormatScalar(value);
+        builder.Append(ValueComponentMarker)
+            .Append(text.Length.ToString(CultureInfo.InvariantCulture))
+            .Append(':')
+            .Append(text);
     }
 
     private static string FormatScalar(object? value) =>

--- a/src/Strategos.Ontology/Merge/MergeTwo.cs
+++ b/src/Strategos.Ontology/Merge/MergeTwo.cs
@@ -18,6 +18,7 @@ namespace Strategos.Ontology.Merge;
 /// <item><description><see cref="ObjectTypeDescriptor.LanguageId"/>: hand wins.</description></item>
 /// <item><description><see cref="ObjectTypeDescriptor.Source"/>: always <see cref="DescriptorSource.HandAuthored"/> — hand wins on composition.</description></item>
 /// <item><description><see cref="ObjectTypeDescriptor.Name"/> and <see cref="ObjectTypeDescriptor.DomainName"/>: taken from hand; mismatch with ingested surfaces as AONT006 upstream.</description></item>
+/// <item><description><see cref="ObjectTypeDescriptor.AssociationEndpoints"/> (DR-4): hand wins; fall back to ingested when hand's is empty.</description></item>
 /// </list>
 /// <para>
 /// Intent-only fields are always taken from hand:
@@ -77,6 +78,13 @@ public static class MergeTwo
             ExternalLinkExtensionPoints = hand.ExternalLinkExtensionPoints,
             InterfacePropertyMappings = hand.InterfacePropertyMappings,
             Kind = hand.Kind,
+            // AssociationEndpoints follow the same hand-wins lattice as the other
+            // structural fields: hand wins, fall back to ingested when hand's is
+            // empty. Dropping it (the prior behavior) silently emptied a merged
+            // association descriptor's endpoints, severing the edge.
+            AssociationEndpoints = hand.AssociationEndpoints.Count > 0
+                ? hand.AssociationEndpoints
+                : ingested.AssociationEndpoints,
             ParentType = hand.ParentType,
             ParentTypeName = hand.ParentTypeName,
         };

--- a/src/Strategos.Ontology/Merge/MergeTwo.cs
+++ b/src/Strategos.Ontology/Merge/MergeTwo.cs
@@ -62,6 +62,11 @@ public static class MergeTwo
             SourceId = hand.SourceId,
             IngestedAt = hand.IngestedAt,
             KeyProperty = hand.KeyProperty,
+            // IdAccessor follows the ClrType lattice rule: hand wins, fallback
+            // to ingested. The merged descriptor must retain a reflection-free
+            // id path (INV-8); silently dropping the accessor here would force
+            // a later reflection fallback that DR-1 forbids.
+            IdAccessor = hand.IdAccessor ?? ingested.IdAccessor,
             Properties = MergeProperties(hand.Properties, ingested.Properties),
             Links = MergeLinks(hand.Links, ingested.Links),
             Actions = hand.Actions,

--- a/src/Strategos.Ontology/ObjectSets/IObjectSetWriter.cs
+++ b/src/Strategos.Ontology/ObjectSets/IObjectSetWriter.cs
@@ -83,6 +83,43 @@ public interface IObjectSetWriter
     Task RelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default);
 
     /// <summary>
+    /// Materializes an ATTRIBUTED relation (DR-4): a relation backed by a
+    /// reified association object that carries its own key and edge attributes.
+    /// Stores <paramref name="association"/> under
+    /// <paramref name="associationDescriptor"/>, projects its id via the DR-1
+    /// identity projector, and writes a relation row whose
+    /// <see cref="RelationRow.AssociationObjectId"/> equals that id.
+    /// </summary>
+    /// <remarks>
+    /// Endpoint validation is EAGER, identical to the plain
+    /// <see cref="RelateAsync(string, string, string, string, string, CancellationToken)"/>:
+    /// both <paramref name="srcId"/> and <paramref name="tgtId"/> must correspond
+    /// to stored instances or a <see cref="RelationEndpointNotFoundException"/>
+    /// is thrown and neither the association nor a row is written. The self-loop
+    /// policy applies as well.
+    /// </remarks>
+    /// <typeparam name="TRel">CLR type backing the association object.</typeparam>
+    /// <param name="srcDescriptor">Descriptor name of the source endpoint.</param>
+    /// <param name="srcId">Projected id of the source instance.</param>
+    /// <param name="linkName">Name of the link being materialized.</param>
+    /// <param name="tgtDescriptor">Descriptor name of the target endpoint.</param>
+    /// <param name="tgtId">Projected id of the target instance.</param>
+    /// <param name="associationDescriptor">Descriptor name of the association object type.</param>
+    /// <param name="association">The association instance to store and reference.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A task that completes when the association and row are written.</returns>
+    Task RelateAsync<TRel>(
+        string srcDescriptor,
+        string srcId,
+        string linkName,
+        string tgtDescriptor,
+        string tgtId,
+        string associationDescriptor,
+        TRel association,
+        CancellationToken ct = default)
+        where TRel : class;
+
+    /// <summary>
     /// Removes a previously-materialized relation. Removing a relation that does
     /// not exist is a no-op (no throw).
     /// </summary>

--- a/src/Strategos.Ontology/ObjectSets/IObjectSetWriter.cs
+++ b/src/Strategos.Ontology/ObjectSets/IObjectSetWriter.cs
@@ -130,5 +130,41 @@ public interface IObjectSetWriter
     /// <param name="tgtId">Projected id of the target instance.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A task that completes when the relation has been removed.</returns>
+    /// <remarks>
+    /// Removal is symmetric with the plain
+    /// <see cref="RelateAsync(string, string, string, string, string, CancellationToken)"/>
+    /// write key: this overload removes ONLY the plain (unattributed) row for the
+    /// endpoint pair. An attributed row backed by an association object is removed
+    /// via the
+    /// <see cref="UnrelateAsync(string, string, string, string, string, string, string, CancellationToken)"/>
+    /// overload, which also deletes the orphaned association object.
+    /// </remarks>
     Task UnrelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Removes a previously-materialized ATTRIBUTED relation (DR-4): the single
+    /// relation row whose <see cref="RelationRow.AssociationObjectId"/> equals
+    /// <paramref name="associationId"/>, and the now-orphaned association object
+    /// stored under <paramref name="associationDescriptor"/>. After removal the
+    /// association object is no longer queryable or traversable. Removing a
+    /// relation that does not exist is a no-op (no throw).
+    /// </summary>
+    /// <remarks>
+    /// This is the symmetric counterpart to the attributed
+    /// <see cref="RelateAsync{TRel}(string, string, string, string, string, string, TRel, CancellationToken)"/>:
+    /// the relate-store write key is
+    /// (TargetDescriptor, TargetId, AssociationObjectId), so removal targets that
+    /// same triple. Plain rows and sibling attributed rows (different association
+    /// ids) for the same endpoint pair are left intact.
+    /// </remarks>
+    /// <param name="srcDescriptor">Descriptor name of the source endpoint.</param>
+    /// <param name="srcId">Projected id of the source instance.</param>
+    /// <param name="linkName">Name of the link being removed.</param>
+    /// <param name="tgtDescriptor">Descriptor name of the target endpoint.</param>
+    /// <param name="tgtId">Projected id of the target instance.</param>
+    /// <param name="associationDescriptor">Descriptor name of the association object type.</param>
+    /// <param name="associationId">Projected id of the association object backing the row.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A task that completes when the relation and association object have been removed.</returns>
+    Task UnrelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, string associationDescriptor, string associationId, CancellationToken ct = default);
 }

--- a/src/Strategos.Ontology/ObjectSets/IObjectSetWriter.cs
+++ b/src/Strategos.Ontology/ObjectSets/IObjectSetWriter.cs
@@ -60,4 +60,38 @@ public interface IObjectSetWriter
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A task that completes when all items have been written.</returns>
     Task StoreBatchAsync<T>(string descriptorName, IReadOnlyList<T> items, CancellationToken ct = default) where T : class;
+
+    /// <summary>
+    /// Materializes a relation (link instance) from the stored source instance
+    /// to the stored target instance under the named link.
+    /// </summary>
+    /// <remarks>
+    /// Endpoint validation is EAGER: both <paramref name="srcId"/> and
+    /// <paramref name="tgtId"/> must correspond to instances already stored for
+    /// their respective descriptors, or a
+    /// <see cref="RelationEndpointNotFoundException"/> is thrown and no row is
+    /// written. This eager posture is the contract the future Npgsql provider
+    /// mirrors via foreign-key constraints.
+    /// </remarks>
+    /// <param name="srcDescriptor">Descriptor name of the source endpoint.</param>
+    /// <param name="srcId">Projected id of the source instance.</param>
+    /// <param name="linkName">Name of the link being materialized.</param>
+    /// <param name="tgtDescriptor">Descriptor name of the target endpoint.</param>
+    /// <param name="tgtId">Projected id of the target instance.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A task that completes when the relation has been written.</returns>
+    Task RelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Removes a previously-materialized relation. Removing a relation that does
+    /// not exist is a no-op (no throw).
+    /// </summary>
+    /// <param name="srcDescriptor">Descriptor name of the source endpoint.</param>
+    /// <param name="srcId">Projected id of the source instance.</param>
+    /// <param name="linkName">Name of the link being removed.</param>
+    /// <param name="tgtDescriptor">Descriptor name of the target endpoint.</param>
+    /// <param name="tgtId">Projected id of the target instance.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A task that completes when the relation has been removed.</returns>
+    Task UnrelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default);
 }

--- a/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
@@ -227,7 +227,12 @@ public sealed class InMemoryExpressionEvaluator
         TraverseLinkExpression traverse,
         Func<string, IReadOnlyList<object>> itemResolver)
     {
-        var sourceDescriptorName = ResolveSourceDescriptorName(traverse.Source);
+        // The source descriptor of a traversal is the descriptor of the IMMEDIATE
+        // upstream element type — not the chain root. A chained hop
+        // (.TraverseLink<TRel>("link").TraverseLink<TNode>("To")) must resolve its
+        // source as the association descriptor, so it routes through the
+        // far-endpoint hop rather than treating TNode as the source.
+        var sourceDescriptorName = ResolveImmediateSourceDescriptorName(traverse.Source);
 
         if (!_descriptorIndex.TryGetValue(sourceDescriptorName, out var sourceDescriptor))
         {
@@ -554,5 +559,24 @@ public sealed class InMemoryExpressionEvaluator
             RawFilterExpression raw => ResolveSourceDescriptorName(raw.Source),
             _ => throw new NotSupportedException(
                 $"Cannot resolve source descriptor from {expression.GetType().Name}"),
+        };
+
+    // Resolves the descriptor name of the IMMEDIATE upstream element type, unlike
+    // ResolveSourceDescriptorName which walks all the way to the chain root.
+    // Filters/includes preserve their source's element type, so we skip them to
+    // the nearest PRODUCING node: a traversal produces its linked type
+    // (ObjectType.Name); a root produces its declared descriptor name (which can
+    // differ from ObjectType.Name for a multi-registered type).
+    private static string ResolveImmediateSourceDescriptorName(ObjectSetExpression expression) =>
+        expression switch
+        {
+            RootExpression root => root.ObjectTypeName,
+            TraverseLinkExpression traverse => traverse.ObjectType.Name,
+            FilterExpression filter => ResolveImmediateSourceDescriptorName(filter.Source),
+            IncludeExpression include => ResolveImmediateSourceDescriptorName(include.Source),
+            InterfaceNarrowExpression narrow => narrow.InterfaceType.Name,
+            RawFilterExpression raw => ResolveImmediateSourceDescriptorName(raw.Source),
+            _ => throw new NotSupportedException(
+                $"Cannot resolve immediate source descriptor from {expression.GetType().Name}"),
         };
 }

--- a/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
@@ -344,10 +344,12 @@ public sealed class InMemoryExpressionEvaluator
             ?? throw new InvalidOperationException(
                 $"Endpoint hop '{role}' has no originating association traversal in its source chain.");
 
-        if (!_descriptorIndex.TryGetValue(
-                ResolveImmediateSourceDescriptorName(originatingTraversal.Source), out var originSource))
+        var originSourceDescriptorName = ResolveImmediateSourceDescriptorName(originatingTraversal.Source);
+        if (!_descriptorIndex.TryGetValue(originSourceDescriptorName, out var originSource))
         {
-            return [];
+            var available = string.Join(", ", _descriptorIndex.Keys);
+            throw new InvalidOperationException(
+                $"Object type '{originSourceDescriptorName}' not found in ontology graph. Available types: {available}");
         }
 
         var originInstances = EvaluateUntyped(originatingTraversal.Source, itemResolver);

--- a/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
@@ -345,7 +345,7 @@ public sealed class InMemoryExpressionEvaluator
                 $"Endpoint hop '{role}' has no originating association traversal in its source chain.");
 
         if (!_descriptorIndex.TryGetValue(
-                ResolveSourceDescriptorName(originatingTraversal.Source), out var originSource))
+                ResolveImmediateSourceDescriptorName(originatingTraversal.Source), out var originSource))
         {
             return [];
         }
@@ -548,25 +548,14 @@ public sealed class InMemoryExpressionEvaluator
             .ToList();
     }
 
-    private static string ResolveSourceDescriptorName(ObjectSetExpression expression) =>
-        expression switch
-        {
-            RootExpression root => root.ObjectTypeName,
-            FilterExpression filter => ResolveSourceDescriptorName(filter.Source),
-            IncludeExpression include => ResolveSourceDescriptorName(include.Source),
-            TraverseLinkExpression traverse => ResolveSourceDescriptorName(traverse.Source),
-            InterfaceNarrowExpression narrow => ResolveSourceDescriptorName(narrow.Source),
-            RawFilterExpression raw => ResolveSourceDescriptorName(raw.Source),
-            _ => throw new NotSupportedException(
-                $"Cannot resolve source descriptor from {expression.GetType().Name}"),
-        };
-
-    // Resolves the descriptor name of the IMMEDIATE upstream element type, unlike
-    // ResolveSourceDescriptorName which walks all the way to the chain root.
-    // Filters/includes preserve their source's element type, so we skip them to
-    // the nearest PRODUCING node: a traversal produces its linked type
-    // (ObjectType.Name); a root produces its declared descriptor name (which can
-    // differ from ObjectType.Name for a multi-registered type).
+    // Resolves the descriptor name of the IMMEDIATE upstream element type (not the
+    // chain root). Filters/includes preserve their source's element type, so we
+    // skip them to the nearest PRODUCING node: a traversal produces its linked
+    // type (ObjectType.Name); a root produces its declared descriptor name (which
+    // can differ from ObjectType.Name for a multi-registered type). This is what
+    // lets a chained TraverseLink resolve its source as the IMMEDIATE prior hop —
+    // e.g. an association hop routes through the far-endpoint path rather than
+    // mistaking the chain root for the source.
     private static string ResolveImmediateSourceDescriptorName(ObjectSetExpression expression) =>
         expression switch
         {

--- a/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
@@ -460,6 +460,15 @@ public sealed class InMemoryExpressionEvaluator
     // rather than surfacing the filterable edge object. Polyglot association
     // traversal (matching by SymbolKey instead of CLR Type) is tracked under
     // DR-9 and intentionally NOT implemented here.
+    //
+    // MULTI-REGISTRATION limitation (strategos #128, deferred): this only
+    // answers "is SOME association backed by this CLR type?" — it does not
+    // identify WHICH descriptor. When one CLR type backs multiple association
+    // descriptors (descriptor-identity-through-the-chain), the boolean is
+    // ambiguous and the downstream partition resolution
+    // (TryResolveAssociationDescriptor) may pick the wrong partition. Carrying
+    // descriptor identity (rather than CLR Type) through the traversal chain is
+    // tracked under strategos #128 and intentionally NOT fixed here.
     private bool IsAssociationType(Type type) =>
         _descriptorIndex.Values.Any(d => d.Kind == ObjectKind.Association && d.ClrType == type);
 
@@ -543,6 +552,15 @@ public sealed class InMemoryExpressionEvaluator
     // resolves here and its TraverseLink degrades to plain target-endpoint
     // traversal. Polyglot association traversal (matching by SymbolKey rather
     // than CLR Type) is tracked under DR-9 and intentionally NOT implemented.
+    //
+    // MULTI-REGISTRATION limitation (strategos #128, deferred): when one CLR
+    // type backs MULTIPLE association descriptors, this returns the FIRST
+    // matching descriptor in _descriptorIndex enumeration order — which may be
+    // the wrong partition for the traversal in flight, surfacing edge objects
+    // from a sibling association. Resolving the correct partition requires
+    // carrying descriptor identity (not CLR Type) through the traversal chain;
+    // that is tracked under strategos #128 (descriptor-identity-through-the-chain)
+    // and intentionally NOT fixed here.
     private bool TryResolveAssociationDescriptor(Type requestedType, out string associationDescriptorName)
     {
         foreach (var descriptor in _descriptorIndex.Values)
@@ -577,6 +595,16 @@ public sealed class InMemoryExpressionEvaluator
     // lets a chained TraverseLink resolve its source as the IMMEDIATE prior hop —
     // e.g. an association hop routes through the far-endpoint path rather than
     // mistaking the chain root for the source.
+    //
+    // ALIAS-LOSS limitation (strategos #128, deferred): a TraverseLinkExpression
+    // hop resolves to traverse.ObjectType.Name, which is the CLR/object-type name
+    // rather than the descriptor ALIAS the prior hop was registered under. After
+    // a hop the descriptor alias is therefore lost, so a subsequent hop whose
+    // source was an aliased (multi-registered) descriptor resolves against the
+    // bare type name and may route to the wrong partition. Threading the prior
+    // hop's descriptor identity (alias-preserving) through the chain is tracked
+    // under strategos #128 (descriptor-identity-through-the-chain) and
+    // intentionally NOT fixed here.
     private static string ResolveImmediateSourceDescriptorName(ObjectSetExpression expression) =>
         expression switch
         {

--- a/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
@@ -390,32 +390,40 @@ public sealed class InMemoryExpressionEvaluator
     // For the source-role endpoint hop, find the originating source instance id
     // that produced this row. Walks the origin instances and returns the first
     // whose rows include this exact row (same association object id + target).
+    //
+    // F-MED-1: a row produced by the association traversal MUST have an
+    // originating source — so failing to find one is an inconsistency, not a
+    // routine miss. Returning string.Empty here would feed ResolveById(..., "")
+    // → null → a SILENT drop, diverging from the destination-role hop's
+    // never-silent-drop contract (DR-8). Throw a typed error instead.
     private string ProjectedSourceIdForRow(
         IReadOnlyList<object> originInstances,
         ObjectTypeDescriptor originSource,
         TraverseLinkExpression originatingTraversal,
         RelationRow row)
     {
-        if (_relationResolver is null)
+        if (_relationResolver is not null)
         {
-            return string.Empty;
-        }
-
-        foreach (var instance in originInstances)
-        {
-            var srcId = _idProjector.ProjectId(originSource, instance);
-            foreach (var candidate in _relationResolver(originSource.Name, srcId, originatingTraversal.LinkName))
+            foreach (var instance in originInstances)
             {
-                if (candidate.AssociationObjectId == row.AssociationObjectId
-                    && candidate.TargetDescriptor == row.TargetDescriptor
-                    && candidate.TargetId == row.TargetId)
+                var srcId = _idProjector.ProjectId(originSource, instance);
+                foreach (var candidate in _relationResolver(originSource.Name, srcId, originatingTraversal.LinkName))
                 {
-                    return srcId;
+                    if (candidate.AssociationObjectId == row.AssociationObjectId
+                        && candidate.TargetDescriptor == row.TargetDescriptor
+                        && candidate.TargetId == row.TargetId)
+                    {
+                        return srcId;
+                    }
                 }
             }
         }
 
-        return string.Empty;
+        throw new InvalidOperationException(
+            $"Source-role endpoint hop on association '{originSource.Name}' could not resolve the " +
+            $"originating source for row (target '{row.TargetDescriptor}':'{row.TargetId}', " +
+            $"association '{row.AssociationObjectId}'). The relation row has no originating source " +
+            $"instance under link '{originatingTraversal.LinkName}' — the relate-store is inconsistent.");
     }
 
     private static int IndexOfEndpointRole(ObjectTypeDescriptor associationDescriptor, string role)

--- a/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
@@ -1,7 +1,22 @@
 using System.Linq.Expressions;
 using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Identity;
 
 namespace Strategos.Ontology.ObjectSets;
+
+/// <summary>
+/// Resolves the materialized relation rows for a relation triple
+/// (source descriptor, source id, link name), in deterministic read order.
+/// Backed by <see cref="InMemoryObjectSetProvider.GetRelations"/> (DR-2).
+/// </summary>
+/// <param name="srcDescriptor">Descriptor name of the source endpoint.</param>
+/// <param name="srcId">Projected id of the source instance.</param>
+/// <param name="linkName">Name of the link being traversed.</param>
+/// <returns>The relation rows for the triple, or an empty list when none exist.</returns>
+internal delegate IReadOnlyList<RelationRow> RelationResolver(
+    string srcDescriptor,
+    string srcId,
+    string linkName);
 
 /// <summary>
 /// Evaluates <see cref="ObjectSetExpression"/> trees against in-memory item collections
@@ -13,14 +28,22 @@ namespace Strategos.Ontology.ObjectSets;
 /// Include, Root). It does NOT handle <see cref="SimilarityExpression"/> (provider-specific
 /// scoring) or <see cref="RawFilterExpression"/> (throws <see cref="NotSupportedException"/>).
 /// <para>
-/// Link traversal is schema-level: <c>TraverseLink("countered_by")</c> resolves the link
-/// descriptor from the graph and returns all items of the target type. It does not follow
-/// materialized link instances between specific objects.
+/// DR-3: link traversal is INSTANCE-ANCHORED, not schema-level. <c>TraverseLink("link")</c>
+/// resolves the upstream source set to concrete instances, projects each source id via the
+/// reflection-free <see cref="IObjectIdentityProjector"/> (DR-1), and follows only the
+/// materialized relation rows stored for that source under the named link (DR-2). It returns
+/// exactly the related target instances — never all objects of the link's target type. An
+/// instance with no rows yields an empty set (#114). When a row carries a DR-4
+/// <see cref="RelationRow.AssociationObjectId"/>, traversing to the association descriptor's
+/// CLR type yields the filterable association object; traversing to the target endpoint type
+/// yields the far endpoint.
 /// </para>
 /// </remarks>
 public sealed class InMemoryExpressionEvaluator
 {
     private readonly Dictionary<string, ObjectTypeDescriptor> _descriptorIndex;
+    private readonly RelationResolver? _relationResolver;
+    private readonly IObjectIdentityProjector _idProjector;
 
     /// <summary>
     /// Initializes a new instance with the specified ontology graph.
@@ -33,6 +56,31 @@ public sealed class InMemoryExpressionEvaluator
     /// across different domains. Use unique descriptor names or qualify with domain.
     /// </exception>
     public InMemoryExpressionEvaluator(OntologyGraph graph)
+        : this(graph, relationResolver: null, idProjector: null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance wired to the relate-store for instance-anchored
+    /// traversal (DR-3). The owning <see cref="InMemoryObjectSetProvider"/> supplies its
+    /// own <see cref="InMemoryObjectSetProvider.GetRelations"/> accessor and id projector,
+    /// both internal to this assembly.
+    /// </summary>
+    /// <param name="graph">The frozen ontology graph.</param>
+    /// <param name="relationResolver">
+    /// Resolves the materialized relation rows for a source instance under a link. When
+    /// null (graph-only construction with no relate-store), instance-anchored traversal
+    /// yields an empty set — it never falls back to a type-level fetch.
+    /// </param>
+    /// <param name="idProjector">
+    /// The DR-1 projector used to map each upstream source/target instance to its stable
+    /// id with zero reflection on the instance type (INV-8). Defaults to the standard
+    /// <see cref="ObjectIdentityProjector"/> when null.
+    /// </param>
+    internal InMemoryExpressionEvaluator(
+        OntologyGraph graph,
+        RelationResolver? relationResolver,
+        IObjectIdentityProjector? idProjector)
     {
         ArgumentNullException.ThrowIfNull(graph);
 
@@ -49,6 +97,9 @@ public sealed class InMemoryExpressionEvaluator
                     nameof(graph));
             }
         }
+
+        _relationResolver = relationResolver;
+        _idProjector = idProjector ?? new ObjectIdentityProjector();
     }
 
     /// <summary>
@@ -115,9 +166,66 @@ public sealed class InMemoryExpressionEvaluator
             $"Filter predicate type '{compiled.GetType().Name}' is not compatible with Func<{typeof(T).Name}, bool>.");
     }
 
+    // Untyped (object-space) evaluation of a source expression, used by DR-3
+    // traversal to resolve the upstream instances regardless of their static
+    // element type. Filter predicates run by their own declared element type via
+    // DynamicInvoke, so a Func&lt;TSource, bool&gt; applies correctly even though
+    // the result list is typed as object. The id projection downstream is still
+    // reflection-free (DR-1 IdAccessor); this walk performs no reflection on the
+    // instance to LOCATE identity.
+    private List<object> EvaluateUntyped(
+        ObjectSetExpression expression,
+        Func<string, IReadOnlyList<object>> itemResolver)
+    {
+        switch (expression)
+        {
+            case RootExpression root:
+                return itemResolver(root.ObjectTypeName).ToList();
+
+            case IncludeExpression include:
+                return EvaluateUntyped(include.Source, itemResolver);
+
+            case FilterExpression filter:
+                var sourceItems = EvaluateUntyped(filter.Source, itemResolver);
+                var compiled = filter.Predicate.Compile();
+                return sourceItems
+                    .Where(item => (bool)compiled.DynamicInvoke(item)!)
+                    .ToList();
+
+            case InterfaceNarrowExpression narrow:
+                return EvaluateUntyped(narrow.Source, itemResolver)
+                    .Where(item => narrow.InterfaceType.IsInstanceOfType(item))
+                    .ToList();
+
+            case TraverseLinkExpression traverse:
+                // A chained traversal: resolve the prior hop's results in object
+                // space via the same core, so the association-vs-target decision
+                // is driven by the expression's own ObjectType.
+                return EvaluateTraverseLinkCore(traverse, itemResolver);
+
+            default:
+                throw new NotSupportedException(
+                    $"Expression type '{expression.GetType().Name}' is not supported as a traversal source.");
+        }
+    }
+
     private List<T> EvaluateTraverseLink<T>(
         TraverseLinkExpression traverse,
         Func<string, IReadOnlyList<object>> itemResolver) where T : class
+        => EvaluateTraverseLinkCore(traverse, itemResolver).Cast<T>().ToList();
+
+    // DR-3: instance-anchored traversal core. Resolve the upstream source set to
+    // concrete instances, project each source id (DR-1, reflection-free), follow
+    // ONLY the materialized relation rows for that source under the named link
+    // (DR-2), and resolve the requested instances from the rows — never a
+    // type-level fetch of all target-type items (the #114 defect).
+    //
+    // The requested type is carried on the expression (traverse.ObjectType), so
+    // the typed and untyped entry points make the same association-vs-target
+    // decision regardless of the caller's generic argument.
+    private List<object> EvaluateTraverseLinkCore(
+        TraverseLinkExpression traverse,
+        Func<string, IReadOnlyList<object>> itemResolver)
     {
         var sourceDescriptorName = ResolveSourceDescriptorName(traverse.Source);
 
@@ -128,6 +236,17 @@ public sealed class InMemoryExpressionEvaluator
                 $"Object type '{sourceDescriptorName}' not found in ontology graph. Available types: {available}");
         }
 
+        // DR-4 far-endpoint hop: when the upstream set is association objects
+        // (e.g. the result of a prior TraverseLink<TRel>), this traversal hops
+        // FROM each surviving association TO its endpoint, named by the
+        // association descriptor's endpoint role. The far endpoint is resolved
+        // from the SAME relation row that produced the association object — never
+        // by reflecting over the association instance's endpoint property.
+        if (sourceDescriptor.Kind == ObjectKind.Association)
+        {
+            return EvaluateAssociationEndpointHop(traverse, sourceDescriptor, itemResolver);
+        }
+
         var link = sourceDescriptor.Links.FirstOrDefault(l => l.Name == traverse.LinkName);
         if (link is null)
         {
@@ -136,8 +255,281 @@ public sealed class InMemoryExpressionEvaluator
                 $"Link '{traverse.LinkName}' not found on object type '{sourceDescriptorName}'. Available links: {available}");
         }
 
-        var targetItems = itemResolver(link.TargetTypeName);
-        return targetItems.Cast<T>().ToList();
+        // Resolve the upstream set to concrete source instances. Filters, narrows
+        // and prior traversals on the source all run first, so traversal is
+        // anchored to exactly the instances the upstream query selected. The
+        // untyped walk applies filter predicates by their declared element type
+        // (the source's typed Func&lt;TSource, bool&gt;), so it works whatever the
+        // upstream element type is.
+        var sourceInstances = EvaluateUntyped(traverse.Source, itemResolver);
+
+        var rows = GatherRows(sourceDescriptor, sourceDescriptorName, traverse.LinkName, sourceInstances);
+
+        // DR-4 association hop: when the requested type is the association
+        // descriptor's CLR type AND the rows carry an association object id, yield
+        // the association objects so edge attributes are filterable BEFORE the far
+        // hop. Otherwise yield the far-endpoint target instances.
+        if (TryResolveAssociationDescriptor(traverse.ObjectType, out var associationDescriptorName))
+        {
+            return ResolveAssociationObjects(rows, associationDescriptorName, itemResolver);
+        }
+
+        return ResolveTargetEndpoints(rows, itemResolver);
+    }
+
+    // Gathers the materialized relation rows for every selected source instance,
+    // in the store's deterministic read order (INV-7), de-duplicated across
+    // sources. Returns empty when no relate-store is wired in — instance-anchored
+    // traversal NEVER falls back to a type-level fetch (#114).
+    private List<RelationRow> GatherRows(
+        ObjectTypeDescriptor sourceDescriptor,
+        string sourceDescriptorName,
+        string linkName,
+        IReadOnlyList<object> sourceInstances)
+    {
+        var rows = new List<RelationRow>();
+        if (_relationResolver is null)
+        {
+            return rows;
+        }
+
+        var seenRowKeys = new HashSet<(string, string, string?)>();
+        foreach (var source in sourceInstances)
+        {
+            var srcId = _idProjector.ProjectId(sourceDescriptor, source);
+            foreach (var row in _relationResolver(sourceDescriptorName, srcId, linkName))
+            {
+                if (seenRowKeys.Add((row.TargetDescriptor, row.TargetId, row.AssociationObjectId)))
+                {
+                    rows.Add(row);
+                }
+            }
+        }
+
+        return rows;
+    }
+
+    // DR-4 far-endpoint hop. The traversal source is a set of association objects
+    // produced by a prior TraverseLink&lt;TRel&gt;; this hop resolves each
+    // surviving association's far endpoint. The link name must match one of the
+    // association descriptor's endpoint roles (index 0 = source, 1 = destination).
+    //
+    // The far endpoint is taken from the original relation row whose
+    // AssociationObjectId equals the surviving association's projected id, so an
+    // intervening .Where(a => a.Status == ...) filter on the association objects
+    // changes which far endpoints come back — without ever reflecting over the
+    // association instance to read its endpoint property.
+    private List<object> EvaluateAssociationEndpointHop(
+        TraverseLinkExpression traverse,
+        ObjectTypeDescriptor associationDescriptor,
+        Func<string, IReadOnlyList<object>> itemResolver)
+    {
+        var role = traverse.LinkName;
+        var endpointIndex = IndexOfEndpointRole(associationDescriptor, role);
+        if (endpointIndex < 0)
+        {
+            var roles = string.Join(", ", associationDescriptor.AssociationEndpoints.Select(e => e.Role));
+            throw new InvalidOperationException(
+                $"Endpoint role '{role}' not found on association '{associationDescriptor.Name}'. Available roles: {roles}");
+        }
+
+        // Re-derive the ORIGINAL rows from the association traversal in the source
+        // chain — these carry both the AssociationObjectId and the far endpoint.
+        var originatingTraversal = FindAssociationTraversal(traverse.Source)
+            ?? throw new InvalidOperationException(
+                $"Endpoint hop '{role}' has no originating association traversal in its source chain.");
+
+        if (!_descriptorIndex.TryGetValue(
+                ResolveSourceDescriptorName(originatingTraversal.Source), out var originSource))
+        {
+            return [];
+        }
+
+        var originInstances = EvaluateUntyped(originatingTraversal.Source, itemResolver);
+        var originRows = GatherRows(
+            originSource,
+            originSource.Name,
+            originatingTraversal.LinkName,
+            originInstances);
+
+        // The surviving (post-filter) association objects, by their projected id.
+        var survivingAssociationIds = EvaluateUntyped(traverse.Source, itemResolver)
+            .Select(a => _idProjector.ProjectId(associationDescriptor, a))
+            .ToHashSet(StringComparer.Ordinal);
+
+        // The destination-role endpoint (index 1) resolves via the row's
+        // (TargetDescriptor, TargetId); the source-role endpoint (index 0) resolves
+        // via the originating traversal's source side.
+        var results = new List<object>();
+        foreach (var row in originRows)
+        {
+            if (row.AssociationObjectId is null
+                || !survivingAssociationIds.Contains(row.AssociationObjectId))
+            {
+                continue;
+            }
+
+            var resolved = endpointIndex == 0
+                ? ResolveById(originSource.Name, ProjectedSourceIdForRow(originInstances, originSource, originatingTraversal, row), itemResolver)
+                : ResolveById(row.TargetDescriptor, row.TargetId, itemResolver);
+
+            if (resolved is not null)
+            {
+                results.Add(resolved);
+            }
+        }
+
+        return results;
+    }
+
+    // For the source-role endpoint hop, find the originating source instance id
+    // that produced this row. Walks the origin instances and returns the first
+    // whose rows include this exact row (same association object id + target).
+    private string ProjectedSourceIdForRow(
+        IReadOnlyList<object> originInstances,
+        ObjectTypeDescriptor originSource,
+        TraverseLinkExpression originatingTraversal,
+        RelationRow row)
+    {
+        if (_relationResolver is null)
+        {
+            return string.Empty;
+        }
+
+        foreach (var instance in originInstances)
+        {
+            var srcId = _idProjector.ProjectId(originSource, instance);
+            foreach (var candidate in _relationResolver(originSource.Name, srcId, originatingTraversal.LinkName))
+            {
+                if (candidate.AssociationObjectId == row.AssociationObjectId
+                    && candidate.TargetDescriptor == row.TargetDescriptor
+                    && candidate.TargetId == row.TargetId)
+                {
+                    return srcId;
+                }
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private static int IndexOfEndpointRole(ObjectTypeDescriptor associationDescriptor, string role)
+    {
+        for (var i = 0; i < associationDescriptor.AssociationEndpoints.Count; i++)
+        {
+            if (string.Equals(associationDescriptor.AssociationEndpoints[i].Role, role, StringComparison.Ordinal))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    // Walks a traversal source chain to the nearest TraverseLinkExpression that
+    // produced association objects (its ObjectType is a registered association
+    // descriptor's CLR type). Returns null when none is present.
+    private TraverseLinkExpression? FindAssociationTraversal(ObjectSetExpression expression) =>
+        expression switch
+        {
+            TraverseLinkExpression traverse when IsAssociationType(traverse.ObjectType) => traverse,
+            TraverseLinkExpression traverse => FindAssociationTraversal(traverse.Source),
+            FilterExpression filter => FindAssociationTraversal(filter.Source),
+            IncludeExpression include => FindAssociationTraversal(include.Source),
+            InterfaceNarrowExpression narrow => FindAssociationTraversal(narrow.Source),
+            _ => null,
+        };
+
+    private bool IsAssociationType(Type type) =>
+        _descriptorIndex.Values.Any(d => d.Kind == ObjectKind.Association && d.ClrType == type);
+
+    // Resolves the far-endpoint target instances referenced by the rows. Each row
+    // names a (TargetDescriptor, TargetId); the instance is the one in that
+    // descriptor's partition whose projected id matches TargetId.
+    private List<object> ResolveTargetEndpoints(
+        IReadOnlyList<RelationRow> rows,
+        Func<string, IReadOnlyList<object>> itemResolver)
+    {
+        var results = new List<object>(rows.Count);
+        foreach (var row in rows)
+        {
+            var resolved = ResolveById(row.TargetDescriptor, row.TargetId, itemResolver);
+            if (resolved is not null)
+            {
+                results.Add(resolved);
+            }
+        }
+
+        return results;
+    }
+
+    // Resolves the association objects referenced by the rows' AssociationObjectId
+    // (DR-4) from the association descriptor's partition. Rows with no association
+    // (plain DR-2 relate) contribute nothing to an association hop.
+    private List<object> ResolveAssociationObjects(
+        IReadOnlyList<RelationRow> rows,
+        string associationDescriptorName,
+        Func<string, IReadOnlyList<object>> itemResolver)
+    {
+        var results = new List<object>(rows.Count);
+        foreach (var row in rows)
+        {
+            if (row.AssociationObjectId is null)
+            {
+                continue;
+            }
+
+            var resolved = ResolveById(associationDescriptorName, row.AssociationObjectId, itemResolver);
+            if (resolved is not null)
+            {
+                results.Add(resolved);
+            }
+        }
+
+        return results;
+    }
+
+    // Resolves a single instance from a descriptor partition by matching its
+    // projected id (DR-1, reflection-free) against the requested id. Returns null
+    // when the partition has no matching instance.
+    private object? ResolveById(
+        string descriptorName,
+        string id,
+        Func<string, IReadOnlyList<object>> itemResolver)
+    {
+        if (!_descriptorIndex.TryGetValue(descriptorName, out var descriptor))
+        {
+            return null;
+        }
+
+        foreach (var candidate in itemResolver(descriptorName))
+        {
+            if (string.Equals(_idProjector.ProjectId(descriptor, candidate), id, StringComparison.Ordinal))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    // True when the requested CLR type is the type of a registered association
+    // descriptor (ObjectKind.Association). Drives the DR-4 association hop so a
+    // TraverseLink&lt;TRel&gt; surfaces the filterable edge object, while a
+    // TraverseLink&lt;FarEndpoint&gt; surfaces the far node.
+    private bool TryResolveAssociationDescriptor(Type requestedType, out string associationDescriptorName)
+    {
+        foreach (var descriptor in _descriptorIndex.Values)
+        {
+            if (descriptor.Kind == ObjectKind.Association && descriptor.ClrType == requestedType)
+            {
+                associationDescriptorName = descriptor.Name;
+                return true;
+            }
+        }
+
+        associationDescriptorName = string.Empty;
+        return false;
     }
 
     private List<T> EvaluateInterfaceNarrow<T>(

--- a/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
@@ -453,6 +453,13 @@ public sealed class InMemoryExpressionEvaluator
             _ => null,
         };
 
+    // CLR-ONLY limitation (DR-9, deferred): association detection compares the
+    // requested CLR Type against each descriptor's ClrType. A SymbolKey-only
+    // (ingested, ClrType == null) association can therefore never match, so a
+    // TraverseLink<TRel> over it degrades to plain target-endpoint traversal
+    // rather than surfacing the filterable edge object. Polyglot association
+    // traversal (matching by SymbolKey instead of CLR Type) is tracked under
+    // DR-9 and intentionally NOT implemented here.
     private bool IsAssociationType(Type type) =>
         _descriptorIndex.Values.Any(d => d.Kind == ObjectKind.Association && d.ClrType == type);
 
@@ -530,6 +537,12 @@ public sealed class InMemoryExpressionEvaluator
     // descriptor (ObjectKind.Association). Drives the DR-4 association hop so a
     // TraverseLink&lt;TRel&gt; surfaces the filterable edge object, while a
     // TraverseLink&lt;FarEndpoint&gt; surfaces the far node.
+    //
+    // CLR-ONLY limitation (DR-9, deferred): resolution matches on ClrType, so a
+    // SymbolKey-only (ingested, ClrType == null) association descriptor never
+    // resolves here and its TraverseLink degrades to plain target-endpoint
+    // traversal. Polyglot association traversal (matching by SymbolKey rather
+    // than CLR Type) is tracked under DR-9 and intentionally NOT implemented.
     private bool TryResolveAssociationDescriptor(Type requestedType, out string associationDescriptorName)
     {
         foreach (var descriptor in _descriptorIndex.Values)

--- a/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
@@ -202,6 +202,7 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         ArgumentNullException.ThrowIfNull(linkName);
         ArgumentNullException.ThrowIfNull(tgtDescriptor);
         ArgumentNullException.ThrowIfNull(tgtId);
+        ct.ThrowIfCancellationRequested();
 
         // Plain (unattributed) DR-2 relate: no association object backs the row.
         WriteRelationRow(srcDescriptor, srcId, linkName, tgtDescriptor, tgtId, associationObjectId: null);
@@ -227,6 +228,7 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         ArgumentNullException.ThrowIfNull(tgtId);
         ArgumentNullException.ThrowIfNull(associationDescriptor);
         ArgumentNullException.ThrowIfNull(association);
+        ct.ThrowIfCancellationRequested();
 
         // EAGER endpoint validation runs BEFORE the association object is stored,
         // so a failed attributed relate leaves neither a dangling association nor

--- a/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
@@ -377,24 +377,54 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         ArgumentNullException.ThrowIfNull(associationId);
         ct.ThrowIfCancellationRequested();
 
+        var removed = 0;
         if (_relations.TryGetValue((srcDescriptor, srcId, linkName), out var rows))
         {
             // Symmetric with the attributed RelateAsync<TRel> write key: remove the
             // single row whose AssociationObjectId equals associationId. The plain
             // row and any sibling attributed rows (different association ids) for
             // the same endpoint pair are left intact.
-            rows.RemoveAll(r =>
+            removed = rows.RemoveAll(r =>
                 r.TargetDescriptor == tgtDescriptor
                 && r.TargetId == tgtId
                 && r.AssociationObjectId == associationId);
         }
 
-        // Delete the now-orphaned association object from its partition so it is no
-        // longer queryable or traversable (mirrors the attributed relate, which
-        // STORED the object alongside the row).
-        RemoveStoredInstance(associationDescriptor, associationId);
+        // Conditional cleanup (FIX-D): only delete the stored association object
+        // when this call ACTUALLY removed its row AND no remaining row anywhere
+        // still references that association id. An unrelate naming a wrong
+        // (src, link, tgt) tuple removes nothing, so deleting the object would
+        // dangle the surviving correct row; likewise, if another row still points
+        // at the same association object, the object must survive.
+        if (removed > 0 && !AnyRowReferencesAssociation(associationId))
+        {
+            RemoveStoredInstance(associationDescriptor, associationId);
+        }
 
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// True when any relation row in any partition still references
+    /// <paramref name="associationId"/> via its
+    /// <see cref="RelationRow.AssociationObjectId"/>. Guards the attributed-unrelate
+    /// cleanup (FIX-D) so a shared association object is not deleted while a row
+    /// still points at it.
+    /// </summary>
+    private bool AnyRowReferencesAssociation(string associationId)
+    {
+        foreach (var partition in _relations.Values)
+        {
+            foreach (var row in partition)
+            {
+                if (string.Equals(row.AssociationObjectId, associationId, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
@@ -255,8 +255,8 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
     /// self-loop policy check, and idempotent row insertion. The duplicate key
     /// is (TargetDescriptor, TargetId, AssociationObjectId): a plain relate
     /// (null association id) collapses to one row per endpoint pair, while an
-    /// attributed relate can coexist with — or replace — a plain row for the
-    /// same endpoints when it carries a distinct association object.
+    /// attributed relate coexists with a plain row for the same endpoints when it
+    /// carries a distinct association object (it never replaces the plain row).
     /// </summary>
     private void WriteRelationRow(
         string srcDescriptor,

--- a/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
@@ -199,6 +199,67 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         ArgumentNullException.ThrowIfNull(tgtDescriptor);
         ArgumentNullException.ThrowIfNull(tgtId);
 
+        // Plain (unattributed) DR-2 relate: no association object backs the row.
+        WriteRelationRow(srcDescriptor, srcId, linkName, tgtDescriptor, tgtId, associationObjectId: null);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public async Task RelateAsync<TRel>(
+        string srcDescriptor,
+        string srcId,
+        string linkName,
+        string tgtDescriptor,
+        string tgtId,
+        string associationDescriptor,
+        TRel association,
+        CancellationToken ct = default)
+        where TRel : class
+    {
+        ArgumentNullException.ThrowIfNull(srcDescriptor);
+        ArgumentNullException.ThrowIfNull(srcId);
+        ArgumentNullException.ThrowIfNull(linkName);
+        ArgumentNullException.ThrowIfNull(tgtDescriptor);
+        ArgumentNullException.ThrowIfNull(tgtId);
+        ArgumentNullException.ThrowIfNull(associationDescriptor);
+        ArgumentNullException.ThrowIfNull(association);
+
+        // EAGER endpoint validation runs BEFORE the association object is stored,
+        // so a failed attributed relate leaves neither a dangling association nor
+        // a dangling row (mirrors the plain RelateAsync posture / DR-8).
+        ValidateEndpointExists(srcDescriptor, srcId);
+        ValidateEndpointExists(tgtDescriptor, tgtId);
+
+        // Project the association's id via the DR-1 projector. When the provider
+        // is graph-aware and the association descriptor is known, project through
+        // its IdAccessor; this is the same single id-resolution path DR-1 defines
+        // (no per-call reflection on the instance type, INV-8).
+        var associationObjectId = ProjectAssociationId(associationDescriptor, association);
+
+        // Store the association object under its descriptor partition.
+        await StoreAsync(associationDescriptor, association, ct).ConfigureAwait(false);
+
+        // Write the row referencing the stored association object.
+        WriteRelationRow(srcDescriptor, srcId, linkName, tgtDescriptor, tgtId, associationObjectId);
+    }
+
+    /// <summary>
+    /// Shared relate-row write path for both the plain and attributed
+    /// <c>RelateAsync</c> overloads. Performs eager endpoint validation, the
+    /// self-loop policy check, and idempotent row insertion. The duplicate key
+    /// is (TargetDescriptor, TargetId, AssociationObjectId): a plain relate
+    /// (null association id) collapses to one row per endpoint pair, while an
+    /// attributed relate can coexist with — or replace — a plain row for the
+    /// same endpoints when it carries a distinct association object.
+    /// </summary>
+    private void WriteRelationRow(
+        string srcDescriptor,
+        string srcId,
+        string linkName,
+        string tgtDescriptor,
+        string tgtId,
+        string? associationObjectId)
+    {
         // EAGER endpoint validation (DR-8): both endpoints must correspond to a
         // stored instance BEFORE any row is written, so a failed relate never
         // leaves a dangling row. This in-memory posture is the contract the
@@ -218,16 +279,44 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
 
         var rows = _relations.GetOrAdd((srcDescriptor, srcId, linkName), _ => new List<RelationRow>());
 
-        // Idempotent: relating the same (src, link, tgt) twice yields one row.
-        // Endpoint identity is (TargetDescriptor, TargetId); DR-2 never sets the
-        // DR-4 AssociationObjectId, so it is not part of the duplicate key here.
-        var alreadyRelated = rows.Any(r => r.TargetDescriptor == tgtDescriptor && r.TargetId == tgtId);
+        // Idempotent: relating the same (src, link, tgt, associationObjectId)
+        // twice yields one row. The DR-4 AssociationObjectId participates in the
+        // duplicate key so an attributed relate is distinguishable from a plain
+        // one over the same endpoint pair.
+        var alreadyRelated = rows.Any(r =>
+            r.TargetDescriptor == tgtDescriptor
+            && r.TargetId == tgtId
+            && r.AssociationObjectId == associationObjectId);
         if (!alreadyRelated)
         {
-            rows.Add(new RelationRow(tgtDescriptor, tgtId));
+            rows.Add(new RelationRow(tgtDescriptor, tgtId, associationObjectId));
+        }
+    }
+
+    /// <summary>
+    /// Projects an association instance to its id through the DR-1
+    /// <see cref="ObjectIdentityProjector"/> using the named descriptor's
+    /// <see cref="ObjectTypeDescriptor.IdAccessor"/>. Throws when the provider
+    /// is graph-aware but the descriptor is unknown — an attributed relate
+    /// against an undeclared association descriptor is a caller error, not a
+    /// silent no-op.
+    /// </summary>
+    private string ProjectAssociationId(string associationDescriptor, object association)
+    {
+        if (_descriptorIndex is null)
+        {
+            // Graph-less legacy mode: no descriptors, so fall back to the
+            // instance's own ToString() as the stable id (mirrors the seed-time
+            // posture for graph-less providers). DR-1 projection is unavailable.
+            return association.ToString() ?? string.Empty;
         }
 
-        return Task.CompletedTask;
+        if (!_descriptorIndex.TryGetValue(associationDescriptor, out var descriptor))
+        {
+            throw new RelationEndpointNotFoundException(associationDescriptor, "<association>");
+        }
+
+        return _idProjector.ProjectId(descriptor, association);
     }
 
     /// <inheritdoc />

--- a/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
@@ -331,13 +331,95 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         ArgumentNullException.ThrowIfNull(linkName);
         ArgumentNullException.ThrowIfNull(tgtDescriptor);
         ArgumentNullException.ThrowIfNull(tgtId);
+        ct.ThrowIfCancellationRequested();
 
         if (_relations.TryGetValue((srcDescriptor, srcId, linkName), out var rows))
         {
-            rows.RemoveAll(r => r.TargetDescriptor == tgtDescriptor && r.TargetId == tgtId);
+            // Symmetric with the plain RelateAsync write key
+            // (TargetDescriptor, TargetId, AssociationObjectId == null): remove
+            // ONLY the plain row. An attributed row (non-null AssociationObjectId)
+            // for the same endpoint pair survives — it is removed via the
+            // attributed UnrelateAsync overload, which also cleans up the object.
+            rows.RemoveAll(r =>
+                r.TargetDescriptor == tgtDescriptor
+                && r.TargetId == tgtId
+                && r.AssociationObjectId is null);
         }
 
         return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task UnrelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, string associationDescriptor, string associationId, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(srcDescriptor);
+        ArgumentNullException.ThrowIfNull(srcId);
+        ArgumentNullException.ThrowIfNull(linkName);
+        ArgumentNullException.ThrowIfNull(tgtDescriptor);
+        ArgumentNullException.ThrowIfNull(tgtId);
+        ArgumentNullException.ThrowIfNull(associationDescriptor);
+        ArgumentNullException.ThrowIfNull(associationId);
+        ct.ThrowIfCancellationRequested();
+
+        if (_relations.TryGetValue((srcDescriptor, srcId, linkName), out var rows))
+        {
+            // Symmetric with the attributed RelateAsync<TRel> write key: remove the
+            // single row whose AssociationObjectId equals associationId. The plain
+            // row and any sibling attributed rows (different association ids) for
+            // the same endpoint pair are left intact.
+            rows.RemoveAll(r =>
+                r.TargetDescriptor == tgtDescriptor
+                && r.TargetId == tgtId
+                && r.AssociationObjectId == associationId);
+        }
+
+        // Delete the now-orphaned association object from its partition so it is no
+        // longer queryable or traversable (mirrors the attributed relate, which
+        // STORED the object alongside the row).
+        RemoveStoredInstance(associationDescriptor, associationId);
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Removes the stored instance under <paramref name="descriptorName"/> whose
+    /// projected id (DR-1, reflection-free) equals <paramref name="id"/>, keeping
+    /// the parallel searchable-content and embedding lists index-aligned. A no-op
+    /// when the partition or matching instance is absent, or when the provider is
+    /// graph-less (no descriptor to project against).
+    /// </summary>
+    private void RemoveStoredInstance(string descriptorName, string id)
+    {
+        if (_descriptorIndex is null
+            || !_descriptorIndex.TryGetValue(descriptorName, out var descriptor)
+            || !_items.TryGetValue(descriptorName, out var items))
+        {
+            return;
+        }
+
+        for (var i = 0; i < items.Count; i++)
+        {
+            if (!string.Equals(_idProjector.ProjectId(descriptor, items[i]), id, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            items.RemoveAt(i);
+
+            // Keep the parallel lists aligned with _items (same partition key,
+            // same index → searchable content / embedding for that instance).
+            if (_searchableContent.TryGetValue(descriptorName, out var content) && i < content.Count)
+            {
+                content.RemoveAt(i);
+            }
+
+            if (_embeddings.TryGetValue(descriptorName, out var embeddings) && i < embeddings.Count)
+            {
+                embeddings.RemoveAt(i);
+            }
+
+            return;
+        }
     }
 
     /// <summary>

--- a/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
@@ -15,6 +15,10 @@ namespace Strategos.Ontology.ObjectSets;
 /// <remarks>
 /// <see cref="Seed{T}"/> is not thread-safe. Seed all items before querying,
 /// or synchronize access externally if seeding concurrently.
+/// The DR-2 relation store (relate/unrelate and traversal reads) IS safe to call
+/// concurrently — every access to a per-key <c>List&lt;RelationRow&gt;</c> is
+/// serialized by a single internal gate, so concurrent relate/unrelate stays
+/// idempotent and traversal never enumerates a list mid-mutation.
 /// When an <see cref="IEmbeddingProvider"/> is supplied, <see cref="ExecuteSimilarityAsync{T}"/>
 /// uses real cosine similarity against stored embeddings instead of keyword scoring.
 /// </remarks>
@@ -48,6 +52,15 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
     // graph-less instances, whose seeded items carry no key accessor.
     private readonly IReadOnlyDictionary<string, ObjectTypeDescriptor>? _descriptorIndex;
     private readonly ObjectIdentityProjector _idProjector = new();
+
+    // Serializes all relation-store access. ConcurrentDictionary guards only the
+    // partition map; the per-key List<RelationRow> values are still read, mutated,
+    // and enumerated unsynchronized — and AnyRowReferencesAssociation scans across
+    // ALL partitions, so a per-key lock would not cover it. A single re-entrant
+    // gate makes relate/unrelate idempotent and traversal reads race-free without
+    // the partial-fix trap. The lock is held only over in-memory list operations
+    // (no awaits), so it never blocks across an async boundary.
+    private readonly object _relationsGate = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="InMemoryObjectSetProvider"/> class.
@@ -294,23 +307,27 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
             throw new SelfLoopNotAllowedException(srcDescriptor, srcId, linkName);
         }
 
-        var rows = _relations.GetOrAdd((srcDescriptor, srcId, linkName), _ => new List<RelationRow>());
-
-        // Idempotent: relating the same (src, link, tgt, associationObjectId)
-        // twice yields one row. The DR-4 AssociationObjectId participates in the
-        // duplicate key so an attributed relate is distinguishable from a plain
-        // one over the same endpoint pair.
-        var alreadyRelated = rows.Any(r =>
-            r.TargetDescriptor == tgtDescriptor
-            && r.TargetId == tgtId
-            && r.AssociationObjectId == associationObjectId);
-        if (alreadyRelated)
+        lock (_relationsGate)
         {
-            return false;
-        }
+            var rows = _relations.GetOrAdd((srcDescriptor, srcId, linkName), _ => new List<RelationRow>());
 
-        rows.Add(new RelationRow(tgtDescriptor, tgtId, associationObjectId));
-        return true;
+            // Idempotent: relating the same (src, link, tgt, associationObjectId)
+            // twice yields one row. The DR-4 AssociationObjectId participates in the
+            // duplicate key so an attributed relate is distinguishable from a plain
+            // one over the same endpoint pair. The check-then-add must be atomic, so
+            // it runs under the gate.
+            var alreadyRelated = rows.Any(r =>
+                r.TargetDescriptor == tgtDescriptor
+                && r.TargetId == tgtId
+                && r.AssociationObjectId == associationObjectId);
+            if (alreadyRelated)
+            {
+                return false;
+            }
+
+            rows.Add(new RelationRow(tgtDescriptor, tgtId, associationObjectId));
+            return true;
+        }
     }
 
     /// <summary>
@@ -349,17 +366,20 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         ArgumentNullException.ThrowIfNull(tgtId);
         ct.ThrowIfCancellationRequested();
 
-        if (_relations.TryGetValue((srcDescriptor, srcId, linkName), out var rows))
+        lock (_relationsGate)
         {
-            // Symmetric with the plain RelateAsync write key
-            // (TargetDescriptor, TargetId, AssociationObjectId == null): remove
-            // ONLY the plain row. An attributed row (non-null AssociationObjectId)
-            // for the same endpoint pair survives — it is removed via the
-            // attributed UnrelateAsync overload, which also cleans up the object.
-            rows.RemoveAll(r =>
-                r.TargetDescriptor == tgtDescriptor
-                && r.TargetId == tgtId
-                && r.AssociationObjectId is null);
+            if (_relations.TryGetValue((srcDescriptor, srcId, linkName), out var rows))
+            {
+                // Symmetric with the plain RelateAsync write key
+                // (TargetDescriptor, TargetId, AssociationObjectId == null): remove
+                // ONLY the plain row. An attributed row (non-null AssociationObjectId)
+                // for the same endpoint pair survives — it is removed via the
+                // attributed UnrelateAsync overload, which also cleans up the object.
+                rows.RemoveAll(r =>
+                    r.TargetDescriptor == tgtDescriptor
+                    && r.TargetId == tgtId
+                    && r.AssociationObjectId is null);
+            }
         }
 
         return Task.CompletedTask;
@@ -377,28 +397,33 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         ArgumentNullException.ThrowIfNull(associationId);
         ct.ThrowIfCancellationRequested();
 
-        var removed = 0;
-        if (_relations.TryGetValue((srcDescriptor, srcId, linkName), out var rows))
+        lock (_relationsGate)
         {
-            // Symmetric with the attributed RelateAsync<TRel> write key: remove the
-            // single row whose AssociationObjectId equals associationId. The plain
-            // row and any sibling attributed rows (different association ids) for
-            // the same endpoint pair are left intact.
-            removed = rows.RemoveAll(r =>
-                r.TargetDescriptor == tgtDescriptor
-                && r.TargetId == tgtId
-                && r.AssociationObjectId == associationId);
-        }
+            var removed = 0;
+            if (_relations.TryGetValue((srcDescriptor, srcId, linkName), out var rows))
+            {
+                // Symmetric with the attributed RelateAsync<TRel> write key: remove the
+                // single row whose AssociationObjectId equals associationId. The plain
+                // row and any sibling attributed rows (different association ids) for
+                // the same endpoint pair are left intact.
+                removed = rows.RemoveAll(r =>
+                    r.TargetDescriptor == tgtDescriptor
+                    && r.TargetId == tgtId
+                    && r.AssociationObjectId == associationId);
+            }
 
-        // Conditional cleanup (FIX-D): only delete the stored association object
-        // when this call ACTUALLY removed its row AND no remaining row anywhere
-        // still references that association id. An unrelate naming a wrong
-        // (src, link, tgt) tuple removes nothing, so deleting the object would
-        // dangle the surviving correct row; likewise, if another row still points
-        // at the same association object, the object must survive.
-        if (removed > 0 && !AnyRowReferencesAssociation(associationId))
-        {
-            RemoveStoredInstance(associationDescriptor, associationId);
+            // Conditional cleanup (FIX-D): only delete the stored association object
+            // when this call ACTUALLY removed its row AND no remaining row anywhere
+            // still references that association id. The removal + cross-partition
+            // reference scan + delete run under one gate so a concurrent relate/unrelate
+            // cannot slip a referencing row in between the scan and the delete. An
+            // unrelate naming a wrong (src, link, tgt) tuple removes nothing, so
+            // deleting the object would dangle the surviving correct row; likewise, if
+            // another row still points at the same association object, it must survive.
+            if (removed > 0 && !AnyRowReferencesAssociation(associationId))
+            {
+                RemoveStoredInstance(associationDescriptor, associationId);
+            }
         }
 
         return Task.CompletedTask;
@@ -413,18 +438,23 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
     /// </summary>
     private bool AnyRowReferencesAssociation(string associationId)
     {
-        foreach (var partition in _relations.Values)
+        // Re-entrant: callers already hold _relationsGate (attributed UnrelateAsync).
+        // Taking it here too keeps this scan safe if it is ever called standalone.
+        lock (_relationsGate)
         {
-            foreach (var row in partition)
+            foreach (var partition in _relations.Values)
             {
-                if (string.Equals(row.AssociationObjectId, associationId, StringComparison.Ordinal))
+                foreach (var row in partition)
                 {
-                    return true;
+                    if (string.Equals(row.AssociationObjectId, associationId, StringComparison.Ordinal))
+                    {
+                        return true;
+                    }
                 }
             }
-        }
 
-        return false;
+            return false;
+        }
     }
 
     /// <summary>
@@ -485,14 +515,19 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
     /// <returns>Relation rows ordered by <see cref="RelationRow.TargetId"/>.</returns>
     internal IReadOnlyList<RelationRow> GetRelations(string srcDescriptor, string srcId, string linkName)
     {
-        if (!_relations.TryGetValue((srcDescriptor, srcId, linkName), out var rows))
+        lock (_relationsGate)
         {
-            return [];
-        }
+            if (!_relations.TryGetValue((srcDescriptor, srcId, linkName), out var rows))
+            {
+                return [];
+            }
 
-        return rows
-            .OrderBy(r => r.TargetId, StringComparer.Ordinal)
-            .ToList();
+            // Sort to a fresh list under the gate so the snapshot is taken without a
+            // concurrent relate/unrelate mutating the backing list mid-enumeration.
+            return rows
+                .OrderBy(r => r.TargetId, StringComparer.Ordinal)
+                .ToList();
+        }
     }
 
     /// <summary>

--- a/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
+using Strategos.Ontology.Descriptors;
 using Strategos.Ontology.Embeddings;
+using Strategos.Ontology.Identity;
 
 namespace Strategos.Ontology.ObjectSets;
 
@@ -40,6 +42,13 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
     private readonly IEmbeddingProvider? _embeddingProvider;
     private readonly InMemoryExpressionEvaluator? _evaluator;
 
+    // Descriptor index by name, populated for graph-aware instances (DR-2).
+    // Used to resolve the IdAccessor for eager endpoint validation in
+    // RelateAsync and the LinkDescriptor for the self-loop policy. Null for
+    // graph-less instances, whose seeded items carry no key accessor.
+    private readonly IReadOnlyDictionary<string, ObjectTypeDescriptor>? _descriptorIndex;
+    private readonly ObjectIdentityProjector _idProjector = new();
+
     /// <summary>
     /// Initializes a new instance of the <see cref="InMemoryObjectSetProvider"/> class.
     /// </summary>
@@ -72,6 +81,7 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
     {
         ArgumentNullException.ThrowIfNull(graph);
         _evaluator = new InMemoryExpressionEvaluator(graph);
+        _descriptorIndex = BuildDescriptorIndex(graph);
     }
 
     /// <summary>
@@ -88,7 +98,23 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
     {
         ArgumentNullException.ThrowIfNull(graph);
         _evaluator = new InMemoryExpressionEvaluator(graph);
+        _descriptorIndex = BuildDescriptorIndex(graph);
         _embeddingProvider = embeddingProvider;
+    }
+
+    // Name-keyed descriptor index for relate-time validation (DR-2). The
+    // evaluator constructed alongside this index already enforces globally
+    // unique descriptor names and throws on a collision, so by the time this
+    // runs the names are unique and last-write-wins is never reached.
+    private static IReadOnlyDictionary<string, ObjectTypeDescriptor> BuildDescriptorIndex(OntologyGraph graph)
+    {
+        var index = new Dictionary<string, ObjectTypeDescriptor>(StringComparer.Ordinal);
+        foreach (var objectType in graph.ObjectTypes)
+        {
+            index[objectType.Name] = objectType;
+        }
+
+        return index;
     }
 
     /// <summary>
@@ -173,6 +199,13 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         ArgumentNullException.ThrowIfNull(tgtDescriptor);
         ArgumentNullException.ThrowIfNull(tgtId);
 
+        // EAGER endpoint validation (DR-8): both endpoints must correspond to a
+        // stored instance BEFORE any row is written, so a failed relate never
+        // leaves a dangling row. This in-memory posture is the contract the
+        // future Npgsql provider mirrors via foreign-key constraints.
+        ValidateEndpointExists(srcDescriptor, srcId);
+        ValidateEndpointExists(tgtDescriptor, tgtId);
+
         var rows = _relations.GetOrAdd((srcDescriptor, srcId, linkName), _ => new List<RelationRow>());
 
         // Idempotent: relating the same (src, link, tgt) twice yields one row.
@@ -229,6 +262,42 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         return rows
             .OrderBy(r => r.TargetId, StringComparer.Ordinal)
             .ToList();
+    }
+
+    /// <summary>
+    /// Eager endpoint check (DR-8): throws <see cref="RelationEndpointNotFoundException"/>
+    /// unless some instance stored under <paramref name="descriptorName"/> projects
+    /// (via the descriptor's reflection-free <see cref="ObjectTypeDescriptor.IdAccessor"/>)
+    /// to <paramref name="id"/>.
+    /// </summary>
+    private void ValidateEndpointExists(string descriptorName, string id)
+    {
+        // A graph-less provider carries no descriptors (and thus no IdAccessor),
+        // so there is nothing to project against; eager validation is a no-op
+        // for that legacy seeding mode.
+        if (_descriptorIndex is null)
+        {
+            return;
+        }
+
+        if (!_descriptorIndex.TryGetValue(descriptorName, out var descriptor))
+        {
+            throw new RelationEndpointNotFoundException(descriptorName, id);
+        }
+
+        var stored = _items.TryGetValue(descriptorName, out var items) ? items : null;
+        if (stored is not null)
+        {
+            foreach (var instance in stored)
+            {
+                if (string.Equals(_idProjector.ProjectId(descriptor, instance), id, StringComparison.Ordinal))
+                {
+                    return;
+                }
+            }
+        }
+
+        throw new RelationEndpointNotFoundException(descriptorName, id);
     }
 
     /// <inheritdoc />

--- a/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
@@ -174,7 +174,15 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         ArgumentNullException.ThrowIfNull(tgtId);
 
         var rows = _relations.GetOrAdd((srcDescriptor, srcId, linkName), _ => new List<RelationRow>());
-        rows.Add(new RelationRow(tgtDescriptor, tgtId));
+
+        // Idempotent: relating the same (src, link, tgt) twice yields one row.
+        // Endpoint identity is (TargetDescriptor, TargetId); DR-2 never sets the
+        // DR-4 AssociationObjectId, so it is not part of the duplicate key here.
+        var alreadyRelated = rows.Any(r => r.TargetDescriptor == tgtDescriptor && r.TargetId == tgtId);
+        if (!alreadyRelated)
+        {
+            rows.Add(new RelationRow(tgtDescriptor, tgtId));
+        }
 
         return Task.CompletedTask;
     }

--- a/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
@@ -242,11 +242,17 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         // (no per-call reflection on the instance type, INV-8).
         var associationObjectId = ProjectAssociationId(associationDescriptor, association);
 
-        // Store the association object under its descriptor partition.
-        await StoreAsync(associationDescriptor, association, ct).ConfigureAwait(false);
-
-        // Write the row referencing the stored association object.
-        WriteRelationRow(srcDescriptor, srcId, linkName, tgtDescriptor, tgtId, associationObjectId);
+        // Write the row first; it dedups on (TargetDescriptor, TargetId,
+        // AssociationObjectId). Only store the association object when the row was
+        // ACTUALLY new — repeating the same attributed relate must not stack
+        // duplicate association objects behind a single deduped row (FIX-C),
+        // because the symmetric unrelate removes exactly one row + one object and
+        // a duplicate would dangle.
+        var rowAdded = WriteRelationRow(srcDescriptor, srcId, linkName, tgtDescriptor, tgtId, associationObjectId);
+        if (rowAdded)
+        {
+            await StoreAsync(associationDescriptor, association, ct).ConfigureAwait(false);
+        }
     }
 
     /// <summary>
@@ -258,7 +264,12 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
     /// attributed relate coexists with a plain row for the same endpoints when it
     /// carries a distinct association object (it never replaces the plain row).
     /// </summary>
-    private void WriteRelationRow(
+    /// <returns>
+    /// <c>true</c> when a NEW row was inserted; <c>false</c> when an identical row
+    /// already existed (the call was idempotent). The attributed overload uses
+    /// this to store the association object only on a genuinely new row (FIX-C).
+    /// </returns>
+    private bool WriteRelationRow(
         string srcDescriptor,
         string srcId,
         string linkName,
@@ -293,10 +304,13 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
             r.TargetDescriptor == tgtDescriptor
             && r.TargetId == tgtId
             && r.AssociationObjectId == associationObjectId);
-        if (!alreadyRelated)
+        if (alreadyRelated)
         {
-            rows.Add(new RelationRow(tgtDescriptor, tgtId, associationObjectId));
+            return false;
         }
+
+        rows.Add(new RelationRow(tgtDescriptor, tgtId, associationObjectId));
+        return true;
     }
 
     /// <summary>

--- a/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
@@ -206,6 +206,16 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         ValidateEndpointExists(srcDescriptor, srcId);
         ValidateEndpointExists(tgtDescriptor, tgtId);
 
+        // Self-loop policy (DR-8): relating an instance to itself is rejected
+        // unless the source descriptor's link declares AllowsSelfLoop. Runtime
+        // check only; analyzer promotion is a later task.
+        if (string.Equals(srcDescriptor, tgtDescriptor, StringComparison.Ordinal)
+            && string.Equals(srcId, tgtId, StringComparison.Ordinal)
+            && !SelfLoopAllowed(srcDescriptor, linkName))
+        {
+            throw new SelfLoopNotAllowedException(srcDescriptor, srcId, linkName);
+        }
+
         var rows = _relations.GetOrAdd((srcDescriptor, srcId, linkName), _ => new List<RelationRow>());
 
         // Idempotent: relating the same (src, link, tgt) twice yields one row.
@@ -298,6 +308,24 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         }
 
         throw new RelationEndpointNotFoundException(descriptorName, id);
+    }
+
+    /// <summary>
+    /// Resolves whether the named link on <paramref name="srcDescriptor"/>
+    /// permits self-loops (DR-8). Defaults to <c>false</c> — the safe posture —
+    /// when no descriptor index is present (graph-less mode) or the link is not
+    /// declared on the source descriptor.
+    /// </summary>
+    private bool SelfLoopAllowed(string srcDescriptor, string linkName)
+    {
+        if (_descriptorIndex is null
+            || !_descriptorIndex.TryGetValue(srcDescriptor, out var descriptor))
+        {
+            return false;
+        }
+
+        var link = descriptor.Links.FirstOrDefault(l => l.Name == linkName);
+        return link?.AllowsSelfLoop ?? false;
     }
 
     /// <inheritdoc />

--- a/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
@@ -80,7 +80,9 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
     public InMemoryObjectSetProvider(OntologyGraph graph)
     {
         ArgumentNullException.ThrowIfNull(graph);
-        _evaluator = new InMemoryExpressionEvaluator(graph);
+        // DR-3: wire the evaluator to this provider's relate-store + id projector
+        // so TraverseLink resolves by source instance, not target type.
+        _evaluator = new InMemoryExpressionEvaluator(graph, GetRelations, _idProjector);
         _descriptorIndex = BuildDescriptorIndex(graph);
     }
 
@@ -97,7 +99,9 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
     public InMemoryObjectSetProvider(OntologyGraph graph, IEmbeddingProvider? embeddingProvider)
     {
         ArgumentNullException.ThrowIfNull(graph);
-        _evaluator = new InMemoryExpressionEvaluator(graph);
+        // DR-3: wire the evaluator to this provider's relate-store + id projector
+        // so TraverseLink resolves by source instance, not target type.
+        _evaluator = new InMemoryExpressionEvaluator(graph, GetRelations, _idProjector);
         _descriptorIndex = BuildDescriptorIndex(graph);
         _embeddingProvider = embeddingProvider;
     }

--- a/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
@@ -30,6 +30,13 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
     private readonly ConcurrentDictionary<string, List<object>> _items = new();
     private readonly ConcurrentDictionary<string, List<string>> _searchableContent = new();
     private readonly ConcurrentDictionary<string, List<float[]>> _embeddings = new();
+
+    // Materialized relation rows (DR-2). Keyed by the relation triple's
+    // (srcDescriptor, srcId, linkName); the value is the list of target
+    // endpoints related to that source under that link. The raw store is
+    // insertion-ordered, but the READ path (GetRelations) never exposes that
+    // order — it sorts ordinal-by-TargetId so replay is deterministic (INV-7).
+    private readonly ConcurrentDictionary<(string SrcDescriptor, string SrcId, string LinkName), List<RelationRow>> _relations = new();
     private readonly IEmbeddingProvider? _embeddingProvider;
     private readonly InMemoryExpressionEvaluator? _evaluator;
 
@@ -155,6 +162,65 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
             ct.ThrowIfCancellationRequested();
             await StoreAsync(descriptorName, item, ct).ConfigureAwait(false);
         }
+    }
+
+    /// <inheritdoc />
+    public Task RelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(srcDescriptor);
+        ArgumentNullException.ThrowIfNull(srcId);
+        ArgumentNullException.ThrowIfNull(linkName);
+        ArgumentNullException.ThrowIfNull(tgtDescriptor);
+        ArgumentNullException.ThrowIfNull(tgtId);
+
+        var rows = _relations.GetOrAdd((srcDescriptor, srcId, linkName), _ => new List<RelationRow>());
+        rows.Add(new RelationRow(tgtDescriptor, tgtId));
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task UnrelateAsync(string srcDescriptor, string srcId, string linkName, string tgtDescriptor, string tgtId, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(srcDescriptor);
+        ArgumentNullException.ThrowIfNull(srcId);
+        ArgumentNullException.ThrowIfNull(linkName);
+        ArgumentNullException.ThrowIfNull(tgtDescriptor);
+        ArgumentNullException.ThrowIfNull(tgtId);
+
+        if (_relations.TryGetValue((srcDescriptor, srcId, linkName), out var rows))
+        {
+            rows.RemoveAll(r => r.TargetDescriptor == tgtDescriptor && r.TargetId == tgtId);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Reads the materialized relation rows for a given relation triple in a
+    /// deterministic, ordinal-by-<see cref="RelationRow.TargetId"/> order.
+    /// </summary>
+    /// <remarks>
+    /// INV-7: the returned list is a freshly-sorted snapshot — it never exposes
+    /// the relate-store's insertion order or raw
+    /// <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}"/>
+    /// enumeration order. DR-3 traversal consumes this accessor from the same
+    /// assembly.
+    /// </remarks>
+    /// <param name="srcDescriptor">Descriptor name of the source endpoint.</param>
+    /// <param name="srcId">Projected id of the source instance.</param>
+    /// <param name="linkName">Name of the link.</param>
+    /// <returns>Relation rows ordered by <see cref="RelationRow.TargetId"/>.</returns>
+    internal IReadOnlyList<RelationRow> GetRelations(string srcDescriptor, string srcId, string linkName)
+    {
+        if (!_relations.TryGetValue((srcDescriptor, srcId, linkName), out var rows))
+        {
+            return [];
+        }
+
+        return rows
+            .OrderBy(r => r.TargetId, StringComparer.Ordinal)
+            .ToList();
     }
 
     /// <inheritdoc />

--- a/src/Strategos.Ontology/ObjectSets/RelationEndpointNotFoundException.cs
+++ b/src/Strategos.Ontology/ObjectSets/RelationEndpointNotFoundException.cs
@@ -14,8 +14,8 @@ namespace Strategos.Ontology.ObjectSets;
 public sealed class RelationEndpointNotFoundException : Exception
 {
     /// <summary>
-    /// Initializes a new instance naming the missing endpoint's descriptor
-    /// and id so the message is actionable.
+    /// Initializes a new instance of the <see cref="RelationEndpointNotFoundException"/> class,
+    /// naming the missing endpoint's descriptor and id so the message is actionable.
     /// </summary>
     /// <param name="descriptorName">Descriptor of the missing endpoint.</param>
     /// <param name="id">Projected id that resolved to no stored instance.</param>

--- a/src/Strategos.Ontology/ObjectSets/RelationEndpointNotFoundException.cs
+++ b/src/Strategos.Ontology/ObjectSets/RelationEndpointNotFoundException.cs
@@ -23,6 +23,8 @@ public sealed class RelationEndpointNotFoundException : Exception
         : base($"Relation endpoint not found: no instance with id '{id}' is stored under descriptor '{descriptorName}'. "
             + "Both endpoints must be stored before they can be related (eager validation).")
     {
+        ArgumentNullException.ThrowIfNull(descriptorName);
+        ArgumentNullException.ThrowIfNull(id);
         DescriptorName = descriptorName;
         Id = id;
     }

--- a/src/Strategos.Ontology/ObjectSets/RelationEndpointNotFoundException.cs
+++ b/src/Strategos.Ontology/ObjectSets/RelationEndpointNotFoundException.cs
@@ -1,0 +1,35 @@
+namespace Strategos.Ontology.ObjectSets;
+
+/// <summary>
+/// Thrown when a relate operation names an endpoint (source or target) for
+/// which no instance is stored under the given descriptor.
+/// </summary>
+/// <remarks>
+/// DR-8 (eager endpoint validation). The in-memory provider validates both
+/// endpoints BEFORE writing any row, so a failed relate never leaves a
+/// dangling relation behind. This eager posture is the contract the future
+/// Npgsql provider mirrors via foreign-key constraints — the same caller
+/// error surfaces identically across backends.
+/// </remarks>
+public sealed class RelationEndpointNotFoundException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance naming the missing endpoint's descriptor
+    /// and id so the message is actionable.
+    /// </summary>
+    /// <param name="descriptorName">Descriptor of the missing endpoint.</param>
+    /// <param name="id">Projected id that resolved to no stored instance.</param>
+    public RelationEndpointNotFoundException(string descriptorName, string id)
+        : base($"Relation endpoint not found: no instance with id '{id}' is stored under descriptor '{descriptorName}'. "
+            + "Both endpoints must be stored before they can be related (eager validation).")
+    {
+        DescriptorName = descriptorName;
+        Id = id;
+    }
+
+    /// <summary>Descriptor name of the endpoint that could not be resolved.</summary>
+    public string DescriptorName { get; }
+
+    /// <summary>Projected id that resolved to no stored instance.</summary>
+    public string Id { get; }
+}

--- a/src/Strategos.Ontology/ObjectSets/RelationRow.cs
+++ b/src/Strategos.Ontology/ObjectSets/RelationRow.cs
@@ -2,8 +2,8 @@ namespace Strategos.Ontology.ObjectSets;
 
 /// <summary>
 /// An immutable materialized relation row: the target endpoint of a stored
-/// link instance, plus a reserved slot for a DR-4 attributed-relate
-/// association object.
+/// link instance, plus the id of the DR-4 attributed-relate association object
+/// backing the row (null for a plain DR-2 relation).
 /// </summary>
 /// <remarks>
 /// INV-7 (replay determinism): the row is an immutable record, and the
@@ -11,16 +11,16 @@ namespace Strategos.Ontology.ObjectSets;
 /// order — never raw insertion order or <see cref="System.Collections.Concurrent"/>
 /// enumeration order.
 /// <para>
-/// <see cref="AssociationObjectId"/> is RESERVED for DR-4 (attributed
-/// relate). DR-2 always leaves it null; DR-4 will populate it without
-/// reshaping the row.
+/// <see cref="AssociationObjectId"/> backs the DR-4 attributed relate. A plain
+/// DR-2 relate leaves it null; an attributed relate populates it with the
+/// association object's projected id, without reshaping the row.
 /// </para>
 /// </remarks>
 /// <param name="TargetDescriptor">The descriptor name of the target endpoint.</param>
 /// <param name="TargetId">The projected id of the target instance.</param>
 /// <param name="AssociationObjectId">
-/// Reserved for DR-4. The projected id of the association object backing an
-/// attributed relate; null for a plain (unattributed) DR-2 relation.
+/// The projected id of the association object backing a DR-4 attributed relate;
+/// null for a plain (unattributed) DR-2 relation.
 /// </param>
 public sealed record RelationRow(
     string TargetDescriptor,

--- a/src/Strategos.Ontology/ObjectSets/RelationRow.cs
+++ b/src/Strategos.Ontology/ObjectSets/RelationRow.cs
@@ -1,0 +1,28 @@
+namespace Strategos.Ontology.ObjectSets;
+
+/// <summary>
+/// An immutable materialized relation row: the target endpoint of a stored
+/// link instance, plus a reserved slot for a DR-4 attributed-relate
+/// association object.
+/// </summary>
+/// <remarks>
+/// INV-7 (replay determinism): the row is an immutable record, and the
+/// relate-store's read path returns rows in a deterministic, ordinal-by-id
+/// order — never raw insertion order or <see cref="System.Collections.Concurrent"/>
+/// enumeration order.
+/// <para>
+/// <see cref="AssociationObjectId"/> is RESERVED for DR-4 (attributed
+/// relate). DR-2 always leaves it null; DR-4 will populate it without
+/// reshaping the row.
+/// </para>
+/// </remarks>
+/// <param name="TargetDescriptor">The descriptor name of the target endpoint.</param>
+/// <param name="TargetId">The projected id of the target instance.</param>
+/// <param name="AssociationObjectId">
+/// Reserved for DR-4. The projected id of the association object backing an
+/// attributed relate; null for a plain (unattributed) DR-2 relation.
+/// </param>
+public sealed record RelationRow(
+    string TargetDescriptor,
+    string TargetId,
+    string? AssociationObjectId = null);

--- a/src/Strategos.Ontology/ObjectSets/SelfLoopNotAllowedException.cs
+++ b/src/Strategos.Ontology/ObjectSets/SelfLoopNotAllowedException.cs
@@ -22,6 +22,9 @@ public sealed class SelfLoopNotAllowedException : Exception
         : base($"Self-loop not allowed: cannot relate '{descriptorName}' instance '{id}' to itself "
             + $"along link '{linkName}'. Set LinkDescriptor.AllowsSelfLoop to permit self-loops on this link.")
     {
+        ArgumentNullException.ThrowIfNull(descriptorName);
+        ArgumentNullException.ThrowIfNull(id);
+        ArgumentNullException.ThrowIfNull(linkName);
         DescriptorName = descriptorName;
         Id = id;
         LinkName = linkName;

--- a/src/Strategos.Ontology/ObjectSets/SelfLoopNotAllowedException.cs
+++ b/src/Strategos.Ontology/ObjectSets/SelfLoopNotAllowedException.cs
@@ -1,0 +1,38 @@
+namespace Strategos.Ontology.ObjectSets;
+
+/// <summary>
+/// Thrown when a relate operation would connect an object to itself along a
+/// link whose <see cref="Descriptors.LinkDescriptor.AllowsSelfLoop"/> is
+/// <c>false</c>.
+/// </summary>
+/// <remarks>
+/// DR-8 (self-loop policy). The DR-2 enforcement is runtime-only; promotion to
+/// a compile-time analyzer is a later task.
+/// </remarks>
+public sealed class SelfLoopNotAllowedException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance naming the descriptor, the self-related id,
+    /// and the link so the message is actionable.
+    /// </summary>
+    /// <param name="descriptorName">Descriptor of the self-related endpoint.</param>
+    /// <param name="id">Projected id related to itself.</param>
+    /// <param name="linkName">Link the self-loop was attempted along.</param>
+    public SelfLoopNotAllowedException(string descriptorName, string id, string linkName)
+        : base($"Self-loop not allowed: cannot relate '{descriptorName}' instance '{id}' to itself "
+            + $"along link '{linkName}'. Set LinkDescriptor.AllowsSelfLoop to permit self-loops on this link.")
+    {
+        DescriptorName = descriptorName;
+        Id = id;
+        LinkName = linkName;
+    }
+
+    /// <summary>Descriptor name of the self-related endpoint.</summary>
+    public string DescriptorName { get; }
+
+    /// <summary>Projected id that was related to itself.</summary>
+    public string Id { get; }
+
+    /// <summary>Name of the link the self-loop was attempted along.</summary>
+    public string LinkName { get; }
+}

--- a/src/Strategos.Ontology/ObjectSets/SelfLoopNotAllowedException.cs
+++ b/src/Strategos.Ontology/ObjectSets/SelfLoopNotAllowedException.cs
@@ -12,8 +12,8 @@ namespace Strategos.Ontology.ObjectSets;
 public sealed class SelfLoopNotAllowedException : Exception
 {
     /// <summary>
-    /// Initializes a new instance naming the descriptor, the self-related id,
-    /// and the link so the message is actionable.
+    /// Initializes a new instance of the <see cref="SelfLoopNotAllowedException"/> class,
+    /// naming the descriptor, the self-related id, and the link so the message is actionable.
     /// </summary>
     /// <param name="descriptorName">Descriptor of the self-related endpoint.</param>
     /// <param name="id">Projected id related to itself.</param>

--- a/src/Strategos.Ontology/OntologyGraph.cs
+++ b/src/Strategos.Ontology/OntologyGraph.cs
@@ -143,6 +143,30 @@ public sealed class OntologyGraph
     public IReadOnlyList<ObjectTypeDescriptor> GetSubtypes(string objectType) =>
         ObjectTypes.Where(ot => ot.ParentTypeName == objectType).ToList().AsReadOnly();
 
+    /// <summary>
+    /// Projects every reified association (DR-4) — an object type with
+    /// <see cref="ObjectKind.Association"/> and two endpoints — into a directed
+    /// <see cref="AssociationEdge"/> whose source and destination are the two
+    /// endpoints (left ⇒ source, right ⇒ destination per authoring order).
+    /// </summary>
+    /// <remarks>
+    /// INV-8: edges name their endpoints by descriptor name, never by CLR type.
+    /// Edges are returned ordered by (DomainName, AssociationName) so the
+    /// projection is deterministic across processes (INV-7 / replay).
+    /// </remarks>
+    public IReadOnlyList<AssociationEdge> GetAssociationEdges() =>
+        ObjectTypes
+            .Where(ot => ot.Kind == ObjectKind.Association && ot.AssociationEndpoints.Count == 2)
+            .OrderBy(ot => ot.DomainName, StringComparer.Ordinal)
+            .ThenBy(ot => ot.Name, StringComparer.Ordinal)
+            .Select(ot => new AssociationEdge(
+                AssociationName: ot.Name,
+                DomainName: ot.DomainName,
+                SourceDescriptorName: ot.AssociationEndpoints[0].DescriptorName,
+                DestinationDescriptorName: ot.AssociationEndpoints[1].DescriptorName))
+            .ToList()
+            .AsReadOnly();
+
     public IReadOnlyList<WorkflowChain> FindWorkflowChains(string targetWorkflow) =>
         _workflowChainLookup.TryGetValue(targetWorkflow, out var chains)
             ? chains


### PR DESCRIPTION
## Ontology Edge Foundation (v2.9.0)

Builds the instance-level relationship layer for the ontology — the foundation slice of the edge-layer epic. The ontology previously advertised a property-graph affordance it could not back: links were schema-only and `TraverseLink` resolved by target **type**, returning every object of that type with no source-instance filter.

**Design:** `docs/designs/2026-06-03-ontology-edge-foundation.md` · **Plan:** `docs/plans/2026-06-03-ontology-edge-foundation.md`

### What landed (DR-1 → DR-2 → DR-4 → DR-3)
- **DR-1 — object-identity projector.** `IObjectIdentityProjector` derives a deterministic id from the declared key, reflection-free on **both** the CLR path (compiled from the existing `Key(...)` selector) and the `SymbolKey`-only path (source-supplied accessor). No `System.Type`-typed identity API.
- **DR-2 — in-memory relate-store.** `RelateAsync`/`UnrelateAsync`; rows stored separately, read ordinal-by-id (replay-deterministic); idempotent relate; eager endpoint validation (typed `RelationEndpointNotFoundException`); self-loop policy (`LinkDescriptor.AllowsSelfLoop`, typed error unless opted in).
- **DR-4 — reified associations.** `ontology.Association<TRel>(...)` with two typed endpoints + edge attributes; `ObjectKind.Association`; graph exposes association objects as edges; attributed-relate stores the association object + a row referencing it. Associations are immutable, sealed records.
- **DR-3 — instance-anchored traversal.** `TraverseLink` now resolves by **source instance** via the relate-store; association-backed traversal exposes edge attributes for filtering before the far-endpoint hop.

### Invariant conformance (mechanically enforced, not by convention)
`InvariantGuardTests` pin: **INV-2** (assembly references no Wolverine/Marten), **INV-6** (all new edge/identity/association types sealed), **INV-8** (no `System.Type` on the identity surface; SymbolKey-only relate→traverse exercised with zero reflection). **INV-7** immutable/replay-deterministic; **INV-5** dormant (no analyzer change).

### Tests & build
- **880 Ontology tests pass / 0 fail**; Npgsql suite green; full solution build **0 warnings / 0 errors**.
- Closes the #114 instance-traversal defect with an explicit zero-relations-returns-empty regression guard. 5 pre-existing traversal tests were updated from the old (buggy) type-based semantics to the corrected instance-anchored ones.
- Review surfaced 1 HIGH (`UnrelateAsync` write/remove key asymmetry + orphaned traversable association) — fixed with a symmetric remove key + association-object cleanup + regression tests — plus MEDIUM/LOW fixes (source-role hop now fails loud per DR-8; polyglot-association CLR-only limit documented + pinned; `CancellationToken` parity).

### Deferred (follow-on)
- **DR-5** footgun removal (`IEdgeBuilder`/`EdgeProperties`) + `AONT` diagnostic, **DR-6** cardinality analyzer rule, **DR-7** Npgsql/pgvector junction tables (relate currently `NotSupportedException` on the Npgsql provider), **DR-9** polyglot/CLR-free association traversal.
- One noted follow-up refactor: `EvaluateAssociationEndpointHop` complexity (no correctness impact).

Refs #114, #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
