### PR TITLE
feat(generators): lower step resilience into the saga — retry/timeout/compensation/confidence + WithContext (#135)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,14 @@ jobs:
       # its ~165k lines of test code otherwise land in the denominator and crater
       # the aggregate to ~18%. Filtering test assemblies out reports true
       # production coverage (~82%).
-      coverage-filters: '-*Tests'
+      #
+      # Also exclude the third-party Wolverine/Marten runtime assemblies (JasperFx
+      # and friends). The behavioral-test project (#135) references WolverineFx +
+      # Marten, whose runtime-codegen core (JasperFx — ~48k instrumented lines @
+      # ~29%) coverlet now instruments and counts as "production", dragging the
+      # weighted aggregate from ~82% to ~55%. These are external dependencies, not
+      # Strategos production code, so they do not belong in the coverage gate.
+      coverage-filters: '-*Tests;-JasperFx*;-Wolverine*;-Marten*;-Weasel*;-Npgsql*'
       runner: 'blacksmith-4vcpu-ubuntu-2204'
       dotnet-version: '10.0.x'
       dotnet-quality: 'preview'

--- a/docs/deferred-features.md
+++ b/docs/deferred-features.md
@@ -10,6 +10,27 @@
 
 This document catalogs all features from the Strategos design specification that were intentionally deferred from the initial implementation. Each deferral is analyzed for its rationale, impact, and recommended path forward.
 
+> **Status update — 2026-06-18 (epic #135, _step resilience lowering_).** Step-level
+> resilience is **now lowered into the emitted Wolverine + Marten saga and proven on a
+> real host** — superseding the parts of this analysis that described it as deferred or
+> only "declared." What now lowers end-to-end (each with a behavioral test that runs a
+> generated saga against a real Postgres):
+> - **`WithRetry`** → a per-handler Wolverine error policy (`Configure(HandlerChain)` → `OnAnyException().RetryTimes`/`RetryWithCooldown`).
+> - **`WithTimeout`** → a saga `TimeoutMessage` deadline race (idempotent guard). *Durable cross-restart delivery requires the Marten transactional outbox — `AddMarten(…).IntegrateWithWolverine()` — otherwise scheduled/timeout delivery is in-memory only.*
+> - **`Compensate<T>`** → the worker's `Configure` chain publishes the (previously orphaned) `Trigger…FailureHandlerCommand` after retries exhaust, and a dedicated saga compensation chain runs the rollback step → terminal `Failed`.
+> - **`RequireConfidence` / `OnLowConfidence`** → saga routing on the runtime confidence score.
+> - **`WithContext`** → the (previously dead) `ContextAssemblerEmitter` is wired in; a `.WithContext` step assembles **ontology-backed** context (`IObjectSetProvider.ExecuteSimilarityAsync`, no `Strategos.Rag`).
+> - **Expressibility:** `Then<TStep>(configure)` now also exists on the **branch** and **failure-handler** builders (fork landed earlier via #134).
+> - **Diagnostics:** invalid resilience config now reports `AGWF017`–`AGWF021`.
+>
+> **Known boundaries (carried as follow-ons, not regressions):** only a **single-step,
+> terminating** `OnLowConfidence` handler is lowered (multi-step chains + rejoin-to-main
+> are not yet); **workflow-level `OnFailure` handler-chain interop with `Compensate<T>` is
+> deferred** (see §2.1 — the workflow-level failure-handler chain is independently
+> non-functional); resilience config is attachable only via `.Then<TStep>(s => …)` (not
+> `StartWith`/`Finally`); and a `[Workflow("name")]` name must PascalCase to its
+> partial-class name. See `docs/designs/2026-06-17-step-resilience-lowering.md`.
+
 **Total Deferred Features:** 8
 **Deferral Categories:**
 - Agent-Specific Patterns (4 features)
@@ -273,11 +294,12 @@ These features relate to source generator capabilities.
 
 **Design Spec Reference:** Error Handling and Compensation
 
-**Current State:**
+**Current State (updated #135):**
 - Runtime DSL: `OnFailure(flow => flow.Then<NotifyFailure>())` works
-- Generator: Does not emit saga handlers for workflow-level OnFailure
+- **Step-level `Compensate<T>()` now lowers and RUNS** (#135): retries exhaust → the worker's `Configure` chain publishes `Trigger…FailureHandlerCommand` → a dedicated saga compensation chain runs the rollback step → terminal `Failed`. Proven on a real host.
+- **Still deferred:** the *workflow-level* `OnFailure` handler **chain** — #135 found it independently non-functional (its generated `ExecuteFailureHandler…WorkerCommand` has no worker handler). `Compensate<T>` deliberately routes through a separate, working compensation chain; the dedicated emitter no-ops when a workflow-level failure handler is present (to avoid a duplicate `Handle(Trigger…)` overload). Wiring the workflow-level chain + its interop with `Compensate<T>` is the remaining work here.
 
-**Deferral Rationale:**
+**Deferral Rationale (workflow-level OnFailure chain):**
 - **Infrastructure Complexity:** Failure handlers require exception capture, context preservation, and saga state coordination
 - **Partial Implementation Risk:** Incomplete failure handling is worse than no handling
 - **Priority:** Fork/Join and Approval patterns prioritized for MVP
@@ -285,8 +307,8 @@ These features relate to source generator capabilities.
 **Impact:**
 | Aspect | Impact Level | Description |
 |--------|--------------|-------------|
-| Error Recovery | Medium | Workflow-level failures route to `Failed` phase without custom handling |
-| Compensation | Low | Step-level `Compensate<T>()` works; only workflow-level affected |
+| Error Recovery | Medium | Workflow-level `OnFailure` *handler chain* still routes to `Failed` without running its handler steps |
+| Compensation | **Resolved** (#135) | Step-level `Compensate<T>()` now lowers + runs the rollback on a real saga |
 
 **Workaround:**
 ```csharp
@@ -513,11 +535,15 @@ All deferred features have documented workarounds using standard library pattern
 - Compensation handlers
 - Infrastructure implementations
 
+### Resolved by #135 (step resilience lowering)
+- Step `WithRetry` / `WithTimeout` / `Compensate<T>` / `RequireConfidence` + `OnLowConfidence` — now lower into the saga and run on a real host
+- `WithContext` — ontology-backed context assembly now lowers (Context Assembly below is resolved for the lowered path; manual assembly no longer required)
+
 ### What's Deferred (with Workarounds)
 - AgentStep base class -> Implement `IWorkflowStep<T>` with custom LLM integration
-- Context Assembly -> Manual assembly in step implementations
 - RAG Integration -> Standard DI with retrieval services
 - Conversation History -> `[Append]` attribute + manual summarization
-- OnFailure Emitters -> Partial class extension
+- Workflow-level OnFailure handler chain -> Partial class extension (step-level `Compensate<T>()` resolved by #135; see §2.1)
+- Multi-step / rejoining `OnLowConfidence` handlers -> single-step terminating handler lowered by #135; chains/rejoin pending
 - Projections -> Manual Marten projections
 - Agent Versioning -> Custom events in step implementations

--- a/docs/deferred-features.md
+++ b/docs/deferred-features.md
@@ -27,7 +27,10 @@ This document catalogs all features from the Strategos design specification that
 > terminating** `OnLowConfidence` handler is lowered (multi-step chains + rejoin-to-main
 > are not yet); **workflow-level `OnFailure` handler-chain interop with `Compensate<T>` is
 > deferred** (see §2.1 — the workflow-level failure-handler chain is independently
-> non-functional); resilience config is attachable only via `.Then<TStep>(s => …)` (not
+> non-functional); **terminal-failure / low-confidence audit is captured as queryable saga
+> document properties + structured logs, not yet as named `StepFailed` / `LowConfidenceRouted`
+> Marten *stream* events** (stream events apply only in EventSourced mode — a tracked
+> follow-on); resilience config is attachable only via `.Then<TStep>(s => …)` (not
 > `StartWith`/`Finally`); and a `[Workflow("name")]` name must PascalCase to its
 > partial-class name. See `docs/designs/2026-06-17-step-resilience-lowering.md`.
 

--- a/docs/designs/2026-06-17-step-resilience-lowering.md
+++ b/docs/designs/2026-06-17-step-resilience-lowering.md
@@ -4,6 +4,22 @@
 **Workflow:** `step-resilience-lowering` · **Invariant catalog:** `/strategos-design-invariants` (INV-1…INV-8) · **Research:** [`../research/2026-06-16-dsl-step-resilience-lowering-gap.md`](../research/2026-06-16-dsl-step-resilience-lowering-gap.md)
 **Wolverine/Marten claims are grounded in primary docs — every emit mechanism is cited inline (see [Sources](#sources)).**
 
+> **Post-implementation reconciliation (2026-06-18, after review).** Two design statements
+> diverged from what shipped; recorded here so the doc matches the code:
+> 1. **Audit events (DR-3 AC#3, DR-5, and the "Audit bridge" bullet) — partially descoped.**
+>    Terminal-failure / low-confidence audit data **is captured** — as queryable saga *document
+>    properties* (`FailedStepName`, `FailureExceptionType`/`Message`/`StackTrace`, …) plus
+>    structured logs — but **not** yet as named `StepFailed` / `RetryExhausted` /
+>    `LowConfidenceRouted` events appended to the Marten *event stream*. Stream-event emission
+>    is meaningful only in `EventSourced` mode and is tracked as a **follow-on** (resolves the
+>    design's Open Question #1 audit-event taxonomy). The audit-trail *goal* (queryable terminal
+>    history) is met via properties; the specific stream-event deliverable is deferred.
+> 2. **INV-8 wording — "SymbolKey" was imprecise.** `Compensate<T>` resolves the type *symbol*
+>    at parse time into a **fully-qualified type-name string descriptor** (`CompensationModel.CompensationStepTypeName`),
+>    never a CLR `System.Type`. This is the INV-8-conformant, binding-correct behavior and is
+>    consistent with every other step-type reference in the IR (`StepModel.StepTypeName` is also
+>    an FQN string). Read "SymbolKey" below as "symbol-resolved FQN descriptor string."
+
 ## Problem Statement
 
 The workflow DSL exposes and documents step resilience — `WithRetry`, `WithTimeout`, `Compensate<T>`, `RequireConfidence`, `OnLowConfidence` — but **none of it lowers into the emitted Wolverine+Marten saga, for any step kind.** The builder captures the config and the projection serialises it into the declarative export wire contract (`WorkflowDefinitionProjection.cs:266-307` maps `ConfidenceThreshold`/`OnLowConfidence`/`Compensation`/`Retry`/`Timeout`), but it is **dropped before code generation**: `StepModel` (`Generators/Models/StepModel.cs:22-29`) carries only validation + context fields, and `StepExtractor.WalkInvocationChainForStepModelsInternal` never parses the resilience calls. So `.WithRetry(2)` compiles, validates, exports, is documented as functional — and the running saga has no retry. The worker handler catches and re-throws "to let Wolverine handle retry/dead-letter" (`WorkerHandlerEmitter.cs:249-250`) against a policy that **does not exist** anywhere in `src/`; the compensation `Trigger{Name}FailureHandlerCommand` is generated (`SagaFailureHandlerComponentEmitter.cs:80`) but **never published**; confidence is a span tag (`WorkerHandlerEmitter.cs:218`), never a gate. Every existing test is shape-only (asserts generated *source text*), so a `.WithRetry(2)` that never retries passes the suite.
@@ -122,7 +138,7 @@ When `Compensation` is present, append `.Then.CompensatingAction<{WorkerCommand}
 **Acceptance criteria:**
 - Given a step with `.WithRetry(2).Compensate<Rollback>()` and a step that always throws, When the saga runs (DR-9), Then after 2 attempts the `Trigger…FailureHandlerCommand` is published, `Rollback.ExecuteAsync` runs exactly once, and the saga transitions to `Failed`.
 - Given `.Compensate<Rollback>()` **without** `.WithRetry`, Then compensation triggers on the first failure (retry-count defaults to 1 attempt).
-- A `StepFailed` event is appended to the Marten event stream recording the failed step name + exception type.
+- A `StepFailed` event is appended to the Marten event stream recording the failed step name + exception type. *(Shipped as queryable saga document properties + structured logs; the named stream event is a tracked follow-on — see the post-implementation reconciliation note at the top.)*
 
 ### DR-4: Timeout lowering (saga TimeoutMessage deadline race)
 

--- a/docs/designs/2026-06-17-step-resilience-lowering.md
+++ b/docs/designs/2026-06-17-step-resilience-lowering.md
@@ -1,0 +1,234 @@
+# Step Resilience Lowering — retry / timeout / compensation / confidence
+
+**Date:** 2026-06-17 · **Epic:** [#135](https://github.com/lvlup-sw/strategos/issues/135) · **Type:** bug (non-functional shipped feature) · **Scope:** core engine (`Strategos.Generators`), not edge-layer
+**Workflow:** `step-resilience-lowering` · **Invariant catalog:** `/strategos-design-invariants` (INV-1…INV-8) · **Research:** [`../research/2026-06-16-dsl-step-resilience-lowering-gap.md`](../research/2026-06-16-dsl-step-resilience-lowering-gap.md)
+**Wolverine/Marten claims are grounded in primary docs — every emit mechanism is cited inline (see [Sources](#sources)).**
+
+## Problem Statement
+
+The workflow DSL exposes and documents step resilience — `WithRetry`, `WithTimeout`, `Compensate<T>`, `RequireConfidence`, `OnLowConfidence` — but **none of it lowers into the emitted Wolverine+Marten saga, for any step kind.** The builder captures the config and the projection serialises it into the declarative export wire contract (`WorkflowDefinitionProjection.cs:266-307` maps `ConfidenceThreshold`/`OnLowConfidence`/`Compensation`/`Retry`/`Timeout`), but it is **dropped before code generation**: `StepModel` (`Generators/Models/StepModel.cs:22-29`) carries only validation + context fields, and `StepExtractor.WalkInvocationChainForStepModelsInternal` never parses the resilience calls. So `.WithRetry(2)` compiles, validates, exports, is documented as functional — and the running saga has no retry. The worker handler catches and re-throws "to let Wolverine handle retry/dead-letter" (`WorkerHandlerEmitter.cs:249-250`) against a policy that **does not exist** anywhere in `src/`; the compensation `Trigger{Name}FailureHandlerCommand` is generated (`SagaFailureHandlerComponentEmitter.cs:80`) but **never published**; confidence is a span tag (`WorkerHandlerEmitter.cs:218`), never a gate. Every existing test is shape-only (asserts generated *source text*), so a `.WithRetry(2)` that never retries passes the suite.
+
+Two scope corrections from the issue thread are folded in: **`WithContext`** (`ContextAssemblerEmitter`) is *also* declared-but-not-lowered — it exists, is ontology-wired (`IObjectSetProvider` / `ExecuteSimilarityAsync`), but is never invoked by `WorkflowIncrementalGenerator`; and fork-path `ValidateState` lowering already landed via #134.
+
+## Dependency spine
+
+```
+                                 ┌─► DR-2 retry  ─────────────┐
+DR-1  Resilience IR + parse  ────┼─► DR-4 timeout ────────────┤
+(StepModel fields + StepExtractor├─► DR-5 confidence gate ────┼─► DR-9  Behavioral harness
+ parse branches; INV-8 SymbolKey)└─► DR-3 compensation / OnFailure   (full Wolverine+Marten host —
+        │                              (closes the orphan trigger;     ACCEPTANCE UNLOCK for DR-2..DR-6)
+        │                               needs DR-2 retry-exhaustion)
+        ├─► DR-8  INV-5 resilience diagnostics (rides DR-1's new config surface)
+        └─► DR-7  Expressibility (Then<T>(cfg) on branch + failure contexts; fork landed #134)
+
+DR-6  WithContext wire-in (independent track — ontology emitter already exists, just unwired)
+```
+
+**Keystone:** DR-1 is foundational — every emitter reads the IR. **Acceptance unlock:** DR-9 — retry/timeout are *Wolverine runtime behaviours*; they cannot be proven by source-text assertions, so the behavioral harness gates the acceptance of every emit DR.
+
+## Invariant constraints (from `/strategos-design-invariants`, verdict: **conditional**)
+
+| Invariant | Constraint this design adopts |
+|---|---|
+| **INV-1** (HIGH) | All resilience lowers **through `Strategos.Generators` onto Wolverine primitives** — never a parallel runtime, custom retry loop service, or hand-rolled saga store. Retry/compensation emit as a per-handler `Configure(HandlerChain)` on the **already-emitted** `{Step}Handler`; timeout emits as a saga `TimeoutMessage`; confidence as a saga-routing branch. No new `: Saga` class outside `SagaEmitter`; no Wolverine/Marten `PackageReference` added to a runtime project (only the **test** project, DR-9). |
+| **INV-7** (HIGH) | Retry **re-delivers the same envelope** → the worker re-runs `_step.ExecuteAsync(command.State,…)` against the **same immutable state**; no mutation-across-attempts. Compensation/timeout handlers return `state with {…}`, never write through input. New saga audit fields (DR-3) are `init`-only. |
+| **INV-5** (HIGH) | New validation takes the **next free monotonic `AGWF` id verified against the live ceiling `AGWF016`** (`Strategos.Contracts/Generated/AgwfCodes.g.cs`; the INV-5 reference's "AGWF001..010" is **stale**) → new ids start at **AGWF017**. No id reused/renumbered. The "declared-but-inert" silent no-op is converted into a real signal (DR-8). |
+| **INV-6** (HIGH) | New `StepModel` fields, parser helpers, models (`RetryModel`, `TimeoutModel`, `CompensationModel`, `ConfidenceModel`), and any new emitter types are `sealed` records with `init`-only members; extend the sealed-guard test. |
+| **INV-8** (MEDIUM) | `Compensate<TCompensation>()` threads the compensation step's **`SymbolKey`/type symbol** into the IR (consistent with how step types are already referenced), never a stringly-typed name. The projection's `CompensationStepType.Name` moniker (`WorkflowDefinitionProjection.cs:295`) is export-only and is **not** the generator's identity source. |
+
+INV-2/3/4 do not bind (no ontology-analyzer change beyond DR-6's existing emitter; no MCP-spec change; no new DSL nomenclature).
+
+## Approaches considered
+
+The load-bearing fork is **where resilience lowering lives** — Wolverine's per-handler policy engine vs. generated saga control flow. (Behavioral-harness depth and the `WithContext` wire-vs-delete were settled separately: full integration host; wire in.)
+
+### Option 1: Wolverine-native, maximal (simple but limited)
+
+**Approach:** Lower retry/compensation as the thinnest per-handler `Configure(HandlerChain)` glue and delegate all control flow to Wolverine's policy engine; timeout via `TimeoutMessage`; confidence via saga branch.
+
+**Pros:**
+- Least generated code; rides Wolverine's tested retry/backoff/jitter
+- INV-1 textbook — Wolverine primitives, zero parallel mechanism
+
+**Cons:**
+- Retry attempt count/timing live in Wolverine envelope internals, **not** the Marten audit log — erodes Strategos's time-travel/audit value-prop
+- Behavior observable only by running a real host
+
+**Best when:** the team trusts Wolverine's policy engine fully and does not need per-attempt history in the event log.
+
+### Option 2: Saga-orchestrated (flexible but complex)
+
+**Approach:** Generator emits explicit retry counters in saga state, re-dispatch loops, saga-scheduled timeout commands (the `ScheduleAsync` approval precedent), and an explicit failure-trigger publish. Wolverine is "just transport."
+
+**Pros:**
+- Every attempt/timeout/compensation is a Marten event — first-class audit + time-travel; deterministic and inspectable
+- Testable without Wolverine's policy engine
+
+**Cons:**
+- Reinvents retry/backoff Wolverine gives free; largest SG blast radius
+- Trips INV-1 **MEDIUM** (parallel abstraction fragmenting the runtime story)
+
+**Best when:** audit fidelity dominates and the runtime must be fully replayable without Wolverine-internal state.
+
+### Option 3: Right-tool-per-capability — hybrid (SELECTED)
+
+**Approach:** Each capability lowers onto the cheapest *correct* Wolverine primitive: retry+compensation via per-handler `Configure`/`CompensatingAction`, **plus** a `StepFailed`/`RetryExhausted` audit event so the log still records terminal failure; timeout via saga `TimeoutMessage`; confidence via saga branch.
+
+**Pros:**
+- Cheapest correct primitive per capability; INV-1-clean
+- Preserves the audit trail where it matters (Option 1's gap) without reinventing Wolverine retry (Option 2's cost)
+- Smallest correct surface
+
+**Cons:**
+- Two lowering styles (handler-policy + saga-message) to learn
+- The audit-event emission from `CompensatingAction` is a small extra bridge
+
+**Best when:** you want INV-1 conformance *and* audit fidelity — the Strategos default. **Recommended and selected.**
+
+## Chosen Approach
+
+Settled in Phase 2: **Approach C / Option 3 — right-tool-per-capability (hybrid)**, full-epic scope, full integration-host behavioral harness, and **wire** `WithContext` in. Each capability lowers onto the cheapest *correct* Wolverine primitive the primary docs point to, while preserving Strategos's audit-trail value-prop where attempt/failure history matters.
+
+- **Retry + compensation** → a generated static `Configure(HandlerChain)` companion on the `{Step}Handler`. Wolverine scopes error policy **per handler** via this method or method/class attributes — no global `WolverineOptions.Policies` needed (refuting the first archaeology pass). [E1] After retries exhaust, `.Then.CompensatingAction<TWorkerCmd>((cmd,ex,bus)=>bus.PublishAsync(new Trigger{Name}FailureHandlerCommand(…)))` **publishes** the existing-but-orphaned trigger command — closing the dead path with a real, Wolverine-native publish site. [E2]
+- **Timeout** → the saga `TimeoutMessage` base class: the saga cascades `record {Step}Timeout(Guid WorkflowId) : TimeoutMessage(t)` on step-start and handles it later as a **deadline race** (did the `CompletedEvent` arrive before the timeout fired?). This mirrors the repo's existing approval-timeout `ScheduleAsync` precedent. [S1]
+- **Confidence** → a saga-routing branch comparing `result.Confidence` to the declared threshold and dispatching the existing `OnLowConfidence` `IBranchBuilder`. Pure saga logic, no Wolverine infra.
+- **Audit bridge:** `CompensatingAction` and the confidence branch emit `StepRetryExhausted` / `StepFailed` / `LowConfidenceRouted` events so the Marten log records terminal failure — the one place Approach A would have hidden history inside Wolverine's envelope.
+
+## Requirements
+
+### DR-1: Resilience IR + parse plumbing
+
+Extend the generator IR and parser so resilience config survives to emit-time. Add to `StepModel` (`Generators/Models/StepModel.cs`) `sealed`/`init` fields: `RetryModel? Retry`, `TimeoutModel? Timeout`, `CompensationModel? Compensation`, `ConfidenceModel? Confidence`. Add parse branches + argument parsers to `StepExtractor.WalkInvocationChainForStepModelsInternal` (`Generators/Helpers/StepExtractor.cs:760-825`) for `.WithRetry`, `.WithTimeout`, `.Compensate`, `.RequireConfidence`, `.OnLowConfidence`. `Compensate<TCompensation>()` resolves the type-argument **symbol** (INV-8 `SymbolKey`), not a name string. No projection work — the wire contract already models all of it.
+
+**Acceptance criteria:**
+- Given a workflow step declaring `.WithRetry(2, TimeSpan.FromSeconds(5)).WithTimeout(t).Compensate<Rollback>().RequireConfidence(0.85)`, When the generator runs, Then the resulting `StepModel` carries a populated `Retry`/`Timeout`/`Compensation`/`Confidence`, and `Compensation` references `Rollback` by type symbol.
+- Given the same in a `LoopBuilder` step, Then the config is parsed identically (the matrix gap closes for both `WorkflowBuilder` and `LoopBuilder`).
+- New IR records are `sealed` with `init`-only members (INV-6 sealed-guard test extended).
+
+### DR-2: Retry lowering (per-handler Wolverine policy)
+
+Emit a static `public static void Configure(HandlerChain chain)` on the generated `{Step}Handler` when `Retry` is present. Map `WithRetry(n)` → `chain.OnAnyException().RetryTimes(n)`; `WithRetry(n, delay)` and the richer `RetryConfiguration` (`InitialDelay`/`BackoffMultiplier`/`MaxDelay`/`UseJitter`, already in the wire model) → `RetryWithCooldown(delays…)` with Wolverine jitter (`.WithExponentialJitter()` etc.) when `UseJitter`. [E1] The worker `catch { throw; }` stays — re-throw is what feeds Wolverine's policy.
+
+**Acceptance criteria:**
+- Given a step with `.WithRetry(2)` and a step that throws a transient exception on attempts 1–2 and succeeds on attempt 3, When the compiled saga runs in a real Wolverine host (DR-9), Then the step's `ExecuteAsync` is invoked exactly 3 times and the saga completes successfully.
+- Given `.WithRetry(3, 5s)`, Then the emitted `Configure` contains `RetryWithCooldown` with three cooldown entries (not `RetryTimes`).
+- Given no `.WithRetry`, Then **no** `Configure` method is emitted for that handler (no behavior change for non-resilient steps).
+
+### DR-3: Compensation / OnFailure lowering (close the dead path)
+
+When `Compensation` is present, append `.Then.CompensatingAction<{WorkerCommand}>((cmd, ex, bus) => bus.PublishAsync(new Trigger{Name}FailureHandlerCommand(cmd.WorkflowId, "{Step}", ex.Message, ex.GetType().Name, ex.StackTrace)), InvokeResult.Stop)` to the handler's `Configure` chain — supplying the **runtime publish site** the orphaned `SagaFailureHandlerComponentEmitter` output has always lacked. [E2] The compensation step itself runs as the failure-handler step chain that already exists. Emit a `StepRetryExhausted`/`StepFailed` event into the saga's Marten stream for audit.
+
+**Acceptance criteria:**
+- Given a step with `.WithRetry(2).Compensate<Rollback>()` and a step that always throws, When the saga runs (DR-9), Then after 2 attempts the `Trigger…FailureHandlerCommand` is published, `Rollback.ExecuteAsync` runs exactly once, and the saga transitions to `Failed`.
+- Given `.Compensate<Rollback>()` **without** `.WithRetry`, Then compensation triggers on the first failure (retry-count defaults to 1 attempt).
+- A `StepFailed` event is appended to the Marten event stream recording the failed step name + exception type.
+
+### DR-4: Timeout lowering (saga TimeoutMessage deadline race)
+
+When `Timeout` is present, emit `record {Step}Timeout(Guid WorkflowId) : TimeoutMessage(<t>)` and cascade it from the step-start handler; emit a saga `Handle({Step}Timeout, …)` that, **if the step has not already completed** (phase guard), routes to the failure/compensation path; otherwise it is a no-op (the `CompletedEvent` won the race). [S1] Durable cross-restart delivery requires the Marten outbox (`IntegrateWithWolverine()` + durable inbox/outbox); the design documents this as a deployment prerequisite. [S2][S3]
+
+**Acceptance criteria:**
+- Given a step with `.WithTimeout(50ms)` and a step that sleeps 500ms, When the saga runs (DR-9), Then the `{Step}Timeout` handler fires before completion and the saga routes to the timeout/failure path.
+- Given a step with `.WithTimeout(5s)` that completes in 10ms, Then the timeout handler is a no-op (idempotent phase guard; saga not double-failed).
+- **Documented constraint:** the timeout is a saga-level *deadline*, not hard cancellation of the in-flight handler; the handler's `CancellationToken` is passed for cooperative cancellation but enforcement is the deadline race.
+
+### DR-5: Confidence gate lowering
+
+When `Confidence` is present, after the step executes compare `result.Confidence` to `ConfidenceThreshold`; if below, route to the `OnLowConfidence` `IBranchBuilder` (already a lowering-capable construct) instead of the normal completion path; emit a `LowConfidenceRouted` audit event. Confidence ≥ threshold proceeds normally. Replaces the telemetry-only `activity?.SetTag("step.confidence", …)`.
+
+**Acceptance criteria:**
+- Given `.RequireConfidence(0.85).OnLowConfidence(alt => alt.Then<HumanReview>())` and a step returning `Confidence = 0.5`, When the saga runs, Then `HumanReview` executes and the primary continuation does not.
+- Given the same step returning `Confidence = 0.9`, Then the normal next step runs and the low-confidence branch does not.
+- `RequireConfidence` without `OnLowConfidence` fails the workflow on low confidence (no silent continue) and is flagged by DR-8.
+
+### DR-6: WithContext wire-in (ontology-backed)
+
+Invoke the existing `ContextAssemblerEmitter` (+ `ContextModelExtractor`) from `WorkflowIncrementalGenerator` so a `.WithContext(…)` step emits its `{Step}ContextAssembler` (an `IObjectSetProvider` consumer whose `FromRetrieval<TCollection>` lowers to `ExecuteSimilarityAsync`). This is the ontology-aligned path (no `Strategos.Rag` reference), advancing that library's retirement.
+
+**Acceptance criteria:**
+- Given a step with `.WithContext(ctx => ctx.FromState(…).FromRetrieval<Lib>(…).FromLiteral(…))`, When the generator runs, Then `WorkflowIncrementalGenerator` emits the `{Step}ContextAssembler` and wires it into the worker handler's execution.
+- Given the saga runs (DR-9) with a stub `IObjectSetProvider`, Then the step receives assembled context (state + retrieval + literal) and the provider's `ExecuteSimilarityAsync` is invoked with the declared `TopK`/`MinRelevance`.
+- No `Strategos.Rag` reference is introduced anywhere in the context path.
+
+### DR-7: Expressibility on branch + failure-handler contexts
+
+Add the `Then<TStep>(Action<IStepConfiguration<TState>>)` overload to the contexts still missing it — branch and failure-handler builders (fork landed via #134). Resilience config declared inside those contexts must reach DR-1's IR (e.g. `StepExtractor.ParseForkPathStepModels`-style parsing for branch/failure paths).
+
+**Acceptance criteria:**
+- Given a `.OnLowConfidence(alt => alt.Then<X>(s => s.WithRetry(2)))` declaration, When the generator runs, Then the branch step's `StepModel` carries the retry config and DR-2 emits its `Configure`.
+- Public-API additions update the `PublicAPI.Unshipped.txt` baseline (RS0016/RS0017 — break by design, do not suppress).
+
+### DR-8: INV-5 resilience diagnostics
+
+Assign new `AGWF` ids (next-free from live ceiling **AGWF016** → start **AGWF017**), reported at the earliest tier (analyzer over builder-throw): invalid retry count (`< 1`), non-positive timeout, `Compensate<T>` where `T` is not a registered `IWorkflowStep<TState>`, `RequireConfidence` outside `[0,1]`, and `RequireConfidence` without `OnLowConfidence`. The pre-existing builder-runtime throws (e.g. `WithRetry` `ArgumentOutOfRangeException`) are mirrored as stable ids so consumers can suppress.
+
+**Acceptance criteria:**
+- Given `.Compensate<NotAStep>()`, When compiling, Then `AGWF0NN` (next-free) is reported at the call site.
+- Given `.RequireConfidence(1.5)`, Then a diagnostic fires at analyzer tier.
+- Every new id is the next unused monotonic value verified against `AgwfCodes.g.cs`; none reused/renumbered; ids added to `AgwfCodes.g.cs` + `WorkflowDiagnostics.cs`.
+
+### DR-9: Behavioral-test harness (acceptance unlock)
+
+New integration test project (`Strategos.Generators.Behavioral.Tests`) that compiles fixture workflows (SG runs at build), stands up a **real Wolverine `IHost` + Marten + Testcontainers Postgres** (`UseWolverine`, `AddMarten(...).IntegrateWithWolverine()`), sends the start command, and asserts runtime behavior via instrumented steps (attempt counters, timers). Adds `Wolverine`, `Marten`, `Npgsql`, `Testcontainers.PostgreSql` to `Directory.Packages.props` — currently **none** are referenced. Shared Postgres container via TUnit `[ClassDataSource]`/`IAsyncLifetime`; `[NotInParallel]` where a shared host is asserted (per `project_tunit_static_state_parallelism`).
+
+**Acceptance criteria:**
+- The harness can compile an emitted saga, run it against a real host, and observe: a step retried N times, a `TimeoutMessage` delivered, a compensation step executed, a low-confidence branch taken.
+- A regression that reverts any DR-2..DR-6 lowering to a no-op makes the corresponding behavioral test **fail** (the property the shape-only suite lacks).
+- Container lifecycle is shared across the suite (one Postgres per run, not per test).
+
+### DR-10: Error handling, composition, and edge cases
+
+Resilience features compose on a single step and across the saga; specify the interactions.
+
+**Acceptance criteria:**
+- **Ordering / composition:** Given a step with `.WithRetry(2).WithTimeout(t).Compensate<R>().RequireConfidence(c)`, Then retries are attempted first; the timeout deadline spans the whole step (including retries); compensation runs only after retries exhaust; a *successful* attempt then evaluated as low-confidence routes via `OnLowConfidence` (not compensation). The doc states this precedence explicitly.
+- **INV-7 under retry:** Given a non-idempotent-looking step, When retried, Then each attempt receives the **same immutable `command.State`** (re-delivery), proven by asserting the input state is identical across attempts.
+- **Timeout vs. retry race:** Given timeout fires mid-retry, Then the saga fails-by-timeout idempotently and a late `CompletedEvent` does not resurrect the saga (phase guard).
+- **Durability:** Given the host restarts with a scheduled timeout pending and the Marten outbox enabled, Then the timeout still delivers (documented prerequisite [S2][S3]); without the outbox, the doc warns timeout/scheduled-retry are in-memory only.
+- **No-config baseline:** Given a step with **no** resilience config, Then emitted saga/handler output is byte-for-byte unchanged from today (no `Configure`, no timeout message) — guarded by an existing golden/shape test.
+
+## Technical Design
+
+**Where each capability emits (all inside `Strategos.Generators`, INV-1):**
+
+| Capability | Emit site | Wolverine primitive |
+|---|---|---|
+| Retry | `{Step}Handler.Configure(HandlerChain)` | `chain.OnAnyException().RetryTimes(n)` / `.RetryWithCooldown(delays).WithExponentialJitter()` [E1] |
+| Compensation | same `Configure`, `.Then` | `.CompensatingAction<{WorkerCmd}>((cmd,ex,bus)=>bus.PublishAsync(new Trigger…FailureHandlerCommand(…)), InvokeResult.Stop)` [E2] |
+| Timeout | `SagaEmitter` step-start + new handler | `record {Step}Timeout : TimeoutMessage(t)` cascaded; `Handle({Step}Timeout,…)` deadline race [S1] |
+| Confidence | worker/saga completion routing | branch on `result.Confidence < threshold` → `OnLowConfidence` dispatch |
+| Context (DR-6) | `WorkflowIncrementalGenerator` | invoke existing `ContextAssemblerEmitter` → `IObjectSetProvider.ExecuteSimilarityAsync` |
+
+`Envelope.Attempts` is available to handlers by taking `Envelope` as a parameter, should a capability need the live attempt count. [E3] Retry redelivery is the same envelope → INV-7-clean by construction.
+
+## Integration Points
+
+- `Generators/Models/StepModel.cs` — new IR fields (DR-1).
+- `Generators/Helpers/StepExtractor.cs:760-825` + `ParseForkPathStepModels` — parse branches (DR-1, DR-7).
+- `Generators/Emitters/WorkerHandlerEmitter.cs` — emit `Configure` companion; replace confidence-tag with gate (DR-2/3/5).
+- `Generators/Emitters/Saga/*`, `SagaEmitter.cs` — timeout message + handler; failure-handler trigger now actually published (DR-3/4).
+- `Generators/WorkflowIncrementalGenerator.cs` — invoke `ContextAssemblerEmitter` (DR-6).
+- `Diagnostics/WorkflowDiagnostics.cs` + `Contracts/Generated/AgwfCodes.g.cs` — AGWF017+ (DR-8).
+- `Directory.Packages.props` + new `Strategos.Generators.Behavioral.Tests` (DR-9).
+- Docs to reconcile once lowering ships: `docs/theory/agentic-workflow-theory.md`, `docs/deferred-features.md`, `docs/workflow-library-roadmap-v2.md`, `Abstractions/IStepConfiguration.cs` XML docs.
+
+## Testing Strategy
+
+Three tiers. **(1)** Generator unit tests (existing style) assert the new IR is parsed and the `Configure`/timeout source is emitted. **(2)** DR-9 behavioral suite proves the runtime properties (retry count, timeout fire, compensation run, confidence route) against a real Wolverine+Marten host — the mandatory close of the "shape-only tests can't catch this" failure. **(3)** A golden no-config test pins zero behavior change for steps without resilience. Per `feedback_tunit_test_invocation`, behavioral tests are invoked via `-- --treenode-filter`, not `--filter`.
+
+## Open Questions
+
+1. **Audit-event taxonomy** — exact event names/shapes for `StepRetryExhausted` / `StepFailed` / `LowConfidenceRouted` and whether they reuse existing failure events. (Resolve in /plan.)
+2. **Timeout granularity** — is a per-step deadline sufficient, or is a per-attempt timeout also wanted? Design assumes per-step (spans retries) per DR-10; confirm.
+3. **Durable-outbox default** — should `IntegrateWithWolverine()` + durable inbox/outbox be the emitted/recommended default for timeout correctness, or left to the consumer with a diagnostic/doc warning? Leaning: document prerequisite + sample, do not force.
+
+## Sources
+
+Authoritative Wolverine/Marten docs (pulled this session; do not infer beyond these):
+- **[E1]** Per-handler error policy via static `Configure(HandlerChain)` and method/class attributes (`[MaximumAttempts]`, `[RetryNow]`, `[ScheduleRetry]`), `OnException`/`OnAnyException` → `RetryTimes`/`RetryWithCooldown`/`ScheduleRetry`/jitter — wolverinefx.net/guide/handlers/error-handling.html ; github.com/jasperfx/wolverine `docs/guide/handlers/error-handling.md`.
+- **[E2]** `.Then.CompensatingAction<T>((msg,ex,bus)=>bus.PublishAsync(…), InvokeResult.Stop)` / `CustomAction` / `UserDefinedContinuation` — publishes a message after retries exhaust — same source as [E1].
+- **[E3]** `Envelope.Attempts` via `Envelope` handler parameter — github.com/jasperfx/wolverine `docs/guide/handlers/index.md`.
+- **[S1]** Saga `TimeoutMessage` base class + `MarkCompleted()` deadline pattern — wolverinefx.net/guide/durability/sagas.html.
+- **[S2]** Scheduled messages (`ScheduleAsync`, `DelayedFor`, `ScheduledAt`) are in-memory by default; durability needs transactional outbox — wolverinefx.net/guide/messaging/message-bus.html.
+- **[S3]** `AddMarten(…).IntegrateWithWolverine()` configures Marten as saga storage + durable inbox/outbox — wolverinefx.net/guide/durability/marten.html.

--- a/docs/diagnostics/agwf.md
+++ b/docs/diagnostics/agwf.md
@@ -22,3 +22,8 @@ from the generated `AgwfCode` enum; this table is generated from the same source
 | AGWF014 | error | Loop without body | Loop '{0}' in workflow '{1}' has no steps in its body. A loop must contain at least one step. | 0.2.0 |
 | AGWF015 | error | Invalid persistence mode | Workflow '{0}' specifies an unrecognized Persistence value ({1}). Valid values are SagaDocument (0) and EventSourced (1). | 0.2.0 |
 | AGWF016 | error | Event-sourced workflow requires state type | Workflow '{0}' uses PersistenceMode.EventSourced but no state type was found. Event-sourced workflows require a state type that implements IEventSourcedState<TState> with an ApplyEvent method. | 0.2.0 |
+| AGWF017 | error | Compensation step is not a workflow step | Step '{0}' in workflow '{1}' compensates with '{2}', which does not implement IWorkflowStep<TState>. Compensation types must be a registered workflow step. | 2.10.0 |
+| AGWF018 | error | Confidence threshold out of range | Step '{0}' in workflow '{1}' calls RequireConfidence({2}). The threshold must be between 0.0 and 1.0 inclusive. | 2.10.0 |
+| AGWF019 | warning | RequireConfidence without OnLowConfidence handler | Step '{0}' in workflow '{1}' calls RequireConfidence but declares no OnLowConfidence handler. Add OnLowConfidence(alt => ...) so low-confidence results have a routing path. | 2.10.0 |
+| AGWF020 | error | Retry maxAttempts below one | Step '{0}' in workflow '{1}' configures WithRetry({2}). The maxAttempts value must be at least 1. | 2.10.0 |
+| AGWF021 | error | Non-positive timeout | Step '{0}' in workflow '{1}' configures WithTimeout with a non-positive duration. The timeout must be greater than zero. | 2.10.0 |

--- a/docs/plans/2026-06-17-step-resilience-lowering.md
+++ b/docs/plans/2026-06-17-step-resilience-lowering.md
@@ -1,0 +1,347 @@
+# Implementation Plan — Step Resilience Lowering
+
+**Design:** [`docs/designs/2026-06-17-step-resilience-lowering.md`](../designs/2026-06-17-step-resilience-lowering.md)
+**Epic:** [#135](https://github.com/lvlup-sw/strategos/issues/135) · **Scope:** core engine (`Strategos.Generators`) · **Workflow:** `step-resilience-lowering`
+
+## Iron Law
+
+NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST. Every task starts `[RED]`, states the expected failure, then `[GREEN]` minimum code, then `[REFACTOR]`.
+
+> **Test invocation (TUnit):** `dotnet test --filter` does NOT work in this repo. Run a project's suite with `dotnet run --project <proj> -c Debug`, and filter with `-- --treenode-filter "/*/*/*/Method_*"`.
+
+## Diagnostic-ID note (INV-5)
+
+The INV-5 reference doc's "AGWF001..010" is **stale**. Live ceiling is **AGWF016** (verified against `src/Strategos.Contracts/Generated/AgwfCodes.g.cs`; gaps exist at 005–008, 011, 013). Provisional next-free ids below are **AGWF017+**; the implementer **verifies next-free against `AgwfCodes.g.cs` at GREEN time** and documents each id there + in `WorkflowDiagnostics.cs`. No existing id is removed/renumbered.
+
+## Wolverine-API note (grounding)
+
+Emit targets are pinned to primary docs (design [Sources]): retry/compensation → per-handler `static Configure(HandlerChain)` with `OnAnyException().RetryTimes/RetryWithCooldown` + `.Then.CompensatingAction<T>(…, InvokeResult.Stop)`; timeout → saga `record …Timeout : TimeoutMessage(t)`; durability → `AddMarten(…).IntegrateWithWolverine()` + durable inbox/outbox. Implementers must not substitute global `WolverineOptions.Policies` for the per-handler form.
+
+## Traceability matrix (DR-N → tasks)
+
+| DR | Requirement | Tasks |
+|----|-------------|-------|
+| DR-1 | Resilience IR + parse plumbing (keystone) | T1, T2, T3, T4 |
+| DR-9 | Behavioral-test harness (acceptance unlock) | T5, T6 (+ all Track D/H behavioral) |
+| DR-2 | Retry lowering (per-handler `Configure`) | T7, T11 |
+| DR-3 | Compensation / OnFailure (close orphan trigger) | T8, T12 |
+| DR-4 | Timeout (saga `TimeoutMessage` deadline race) | T9, T13 |
+| DR-5 | Confidence gate (saga branch) | T10, T14 |
+| DR-6 | WithContext wire-in (ontology-backed) | T15, T16 |
+| DR-7 | Expressibility on branch + failure contexts | T17 |
+| DR-8 | INV-5 resilience diagnostics (AGWF017+) | T18 |
+| DR-10 | Composition / error / edge cases | T19, T20, T21, T22 |
+| INV-6 | Sealed-guard extension | T23 |
+| Docs | Integration-points doc reconciliation | T24 |
+
+## Parallelization
+
+```
+Group 1 (start immediately, parallel — disjoint projects):
+  ├─ Track A: T1 → T2 → T3 → T4         (DR-1 IR+parse keystone — blocks C, F, G, H)
+  └─ Track B: T5 → T6                   (DR-9 harness scaffolding — new project, disjoint)
+
+Group 2 (after Track A):
+  ├─ Track C: T7 → T8 ; T9 ; T10        (emit — T7→T8 share WorkerHandlerEmitter chain; T9/T10 sequence on saga emitters)
+  ├─ Track E: T15 → T16                 (DR-6 — WorkflowIncrementalGenerator entry; parallel w/ C)
+  ├─ Track G: T18                       (DR-8 diagnostics — WorkflowDiagnostics/analyzer; parallel w/ C)
+  └─ Track F: T17                       (DR-7 expressibility — branch/failure builders + parse path)
+
+Group 3 (after Track B + matching Track C task — new test project, disjoint files → parallel):
+  └─ Track D: T11 ∥ T12 ∥ T13 ∥ T14     (behavioral proof per capability)
+
+Group 4 (after Track C + D):
+  └─ Track H: T19 → T20 ; T21 ; T22 ; T23   (composition, races, immutability, golden baseline, sealed-guard)
+
+Final: T24 (docs reconciliation)
+```
+
+Worktree isolation: Track A (`StepModel.cs`/`StepExtractor.cs` + new IR models) and Track B (`Strategos.Generators.Behavioral.Tests` new project) touch disjoint files — worktree-parallel-safe. Within Track C, T7→T8 share `WorkerHandlerEmitter.cs` (sequential); T9/T10 touch `SagaEmitter`/`Saga/*` emitters. Track D test files are one-per-capability (disjoint) once the harness (T6) exists.
+
+---
+
+## Track A — DR-1: Resilience IR + parse (keystone)
+
+### Task 1: Resilience IR models + StepModel fields
+**Phase:** RED → GREEN → REFACTOR · **Implements:** DR-1 · **testingStrategy:** unit (propertyTests: no, benchmarks: no)
+
+1. [RED] `StepModel_WithResilienceConfig_CarriesRetryTimeoutCompensationConfidence`
+   - File: `src/Strategos.Generators.Tests/Models/StepModelResilienceTests.cs`
+   - Expected failure: `StepModel` has no `Retry`/`Timeout`/`Compensation`/`Confidence` members; `RetryModel`/`TimeoutModel`/`CompensationModel`/`ConfidenceModel` don't exist.
+2. [GREEN] Add `sealed record` models (`RetryModel`, `TimeoutModel`, `CompensationModel`, `ConfidenceModel`) under `Generators/Models/`; add `init`-only fields to `StepModel` (`StepModel.cs:22-29`) + the `Create` factory + validation.
+3. [REFACTOR] XML docs; keep existing positional params backward-compatible (new params default `null`).
+
+**Dependencies:** None · **Parallelizable:** No (Track A head)
+
+### Task 2: StepExtractor parses `.WithRetry` / `.WithTimeout`
+**Phase:** RED → GREEN → REFACTOR · **Implements:** DR-1 · **testingStrategy:** unit
+
+1. [RED] `WalkInvocationChain_StepWithWithRetryAndTimeout_PopulatesRetryAndTimeoutModels`
+   - File: `src/Strategos.Generators.Tests/Helpers/StepExtractorResilienceTests.cs`
+   - Expected failure: `WalkInvocationChainForStepModelsInternal` (`StepExtractor.cs:760-825`) ignores `.WithRetry`/`.WithTimeout`; resulting `StepModel.Retry`/`.Timeout` are null.
+2. [GREEN] Add parse branches + argument parsers for `WithRetry(int)`, `WithRetry(int, TimeSpan)`, `WithTimeout(TimeSpan)` mapping to the IR (incl. the richer `RetryConfiguration` fields when present).
+3. [REFACTOR] Extract a `ParseResilienceCall(...)` helper.
+
+**Dependencies:** T1 · **Parallelizable:** No
+
+### Task 3: StepExtractor parses `.Compensate<T>` (INV-8 SymbolKey) + confidence
+**Phase:** RED → GREEN → REFACTOR · **Implements:** DR-1 (INV-8) · **testingStrategy:** unit
+
+1. [RED] `WalkInvocationChain_CompensateOfT_CarriesCompensationStepSymbolKey` + `WalkInvocationChain_RequireConfidenceOnLowConfidence_PopulatesConfidenceModel`
+   - File: `src/Strategos.Generators.Tests/Helpers/StepExtractorResilienceTests.cs`
+   - Expected failure: `.Compensate<T>`/`.RequireConfidence`/`.OnLowConfidence` unparsed; no compensation type symbol captured.
+2. [GREEN] Parse the type-argument **symbol** for `Compensate<T>` into `CompensationModel` (SymbolKey, not name-string); parse confidence threshold + `OnLowConfidence` branch reference.
+3. [REFACTOR] Assert INV-8: no `typeof`/name-string identity for the compensation target on this path.
+
+**Dependencies:** T2 · **Parallelizable:** No
+
+### Task 4: Loop + fork-path parse parity
+**Phase:** RED → GREEN · **Implements:** DR-1 · **testingStrategy:** unit
+
+1. [RED] `WalkInvocationChain_WithRetryInsideLoopStep_PopulatesRetryModel`
+   - File: `src/Strategos.Generators.Tests/Helpers/StepExtractorResilienceTests.cs`
+   - Expected failure: loop/fork step parse path does not thread resilience config (matrix gap: `LoopBuilder` column).
+2. [GREEN] Thread the DR-1 parsing into the loop and fork-path step extraction so config is captured identically.
+
+**Dependencies:** T3 · **Parallelizable:** No
+
+---
+
+## Track B — DR-9: Behavioral-test harness scaffolding
+
+### Task 5: New behavioral test project + package backbone
+**Phase:** RED → GREEN → REFACTOR · **Implements:** DR-9 · **testingStrategy:** integration (propertyTests: no, benchmarks: no)
+
+1. [RED] `PostgresFixture_StartsContainer_ConnectionOpens`
+   - File: `src/Strategos.Generators.Behavioral.Tests/Infrastructure/PostgresFixtureSmokeTests.cs`
+   - Expected failure: project, packages, and `PostgresFixture` don't exist (no `Wolverine`/`Marten`/`Npgsql`/`Testcontainers.PostgreSql` in `Directory.Packages.props`).
+2. [GREEN] Create `Strategos.Generators.Behavioral.Tests.csproj`; add the four packages to `src/Directory.Packages.props`; implement a `PostgresFixture : IAsyncLifetime` (Testcontainers) shared via TUnit `[ClassDataSource]`. Add to `Strategos.sln`. Mark `[NotInParallel]` where a shared host is asserted (per `project_tunit_static_state_parallelism`).
+3. [REFACTOR] Centralize the connection-string accessor.
+
+**Dependencies:** None · **Parallelizable:** Yes (with Track A — disjoint files)
+
+### Task 6: Wolverine + Marten host fixture over a compiled fixture workflow
+**Phase:** RED → GREEN → REFACTOR · **Implements:** DR-9 · **testingStrategy:** integration
+
+1. [RED] `Host_FixtureWorkflow_StartsAndCompletesHappyPath`
+   - File: `src/Strategos.Generators.Behavioral.Tests/Infrastructure/HostFixtureTests.cs`
+   - Expected failure: no `UseWolverine` host + `AddMarten(...).IntegrateWithWolverine()` wiring; no SG-compiled fixture workflow with instrumentable steps.
+2. [GREEN] Add a fixture workflow (steps with injectable behaviors — counters/delays/throw-on-attempt) compiled by the SG in this project; build the Wolverine+Marten host fixture using `PostgresFixture`; send the start command via `IMessageBus`; assert happy-path completion.
+3. [REFACTOR] Expose a `RunWorkflowAsync(start)` + step-instrumentation helper reused by Track D.
+
+**Dependencies:** T5 · **Parallelizable:** No
+
+---
+
+## Track C — emit lowering (needs Track A)
+
+### Task 7: Retry emit — per-handler `Configure(HandlerChain)`
+**Phase:** RED → GREEN → REFACTOR · **Implements:** DR-2 · **testingStrategy:** unit
+
+1. [RED] `Emit_StepWithWithRetry2_GeneratesConfigureWithRetryTimes` + `Emit_StepWithWithRetryAndDelay_GeneratesRetryWithCooldown`
+   - File: `src/Strategos.Generators.Tests/Emitters/RetryLoweringTests.cs`
+   - Expected failure: `{Step}Handler` has no `Configure(HandlerChain)`; `WorkerHandlerEmitter` emits no retry policy.
+2. [GREEN] In `WorkerHandlerEmitter`, when `StepModel.Retry` is set, emit `public static void Configure(HandlerChain chain)` → `chain.OnAnyException().RetryTimes(n)` (no delay) or `.RetryWithCooldown(delays…)` (+ jitter when `UseJitter`). Keep `catch { throw; }`.
+3. [REFACTOR] Guard: no `Configure` emitted when `Retry`/`Compensation` both absent.
+
+**Dependencies:** T4 · **Parallelizable:** No (shares the `WorkerHandlerEmitter` Configure chain; must precede the compensation emit)
+
+### Task 8: Compensation emit — `CompensatingAction` publishes the orphan trigger
+**Phase:** RED → GREEN → REFACTOR · **Implements:** DR-3 · **testingStrategy:** unit
+
+1. [RED] `Emit_StepWithCompensate_ConfigureChainPublishesTriggerFailureHandlerCommand`
+   - File: `src/Strategos.Generators.Tests/Emitters/CompensationLoweringTests.cs`
+   - Expected failure: `Trigger{Name}FailureHandlerCommand` is still never published; no `.Then.CompensatingAction` in emitted `Configure`.
+2. [GREEN] Append `.Then.CompensatingAction<{WorkerCommand}>((cmd,ex,bus)=>bus.PublishAsync(new Trigger{Name}FailureHandlerCommand(cmd.WorkflowId,"{Step}",ex.Message,ex.GetType().Name,ex.StackTrace)), InvokeResult.Stop)` to the chain; emit a `StepFailed`/`RetryExhausted` event append into the saga stream.
+3. [REFACTOR] Share the `Configure`-chain builder with the retry emit; `Compensate` without `WithRetry` ⇒ single attempt then compensate.
+
+**Dependencies:** T7 · **Parallelizable:** No
+
+### Task 9: Timeout emit — saga `TimeoutMessage` + deadline-race handler
+**Phase:** RED → GREEN → REFACTOR · **Implements:** DR-4 · **testingStrategy:** unit
+
+1. [RED] `Emit_StepWithTimeout_GeneratesTimeoutMessageRecordAndSagaHandler`
+   - File: `src/Strategos.Generators.Tests/Emitters/TimeoutLoweringTests.cs`
+   - Expected failure: no `record {Step}Timeout : TimeoutMessage`; step-start handler doesn't cascade it; no `Handle({Step}Timeout,…)`.
+2. [GREEN] In `SagaEmitter`/`Saga/*`, emit `record {Step}Timeout(Guid WorkflowId) : TimeoutMessage(<t>)`, cascade it from the step-start handler, and emit a `Handle({Step}Timeout,…)` that routes to failure/compensation **only if the step phase hasn't completed** (idempotent guard).
+3. [REFACTOR] Reuse the approval-timeout emit helpers where shared.
+
+**Dependencies:** T4 · **Parallelizable:** Yes (different emitter file from the retry/compensation chain; sequences with the confidence emit on the saga emitters)
+
+### Task 10: Confidence gate emit — saga branch
+**Phase:** RED → GREEN → REFACTOR · **Implements:** DR-5 · **testingStrategy:** unit
+
+1. [RED] `Emit_StepWithRequireConfidence_GeneratesConfidenceThresholdBranchDispatch`
+   - File: `src/Strategos.Generators.Tests/Emitters/ConfidenceLoweringTests.cs`
+   - Expected failure: emitter only sets a `step.confidence` span tag (`WorkerHandlerEmitter.cs:218`); no comparison to threshold, no `OnLowConfidence` dispatch.
+2. [GREEN] Emit a saga-routing branch: when `result.Confidence < ConfidenceThreshold`, dispatch the `OnLowConfidence` branch; else normal continuation. Emit a `LowConfidenceRouted` event. Keep the telemetry tag.
+3. [REFACTOR] `RequireConfidence` without `OnLowConfidence` ⇒ fail path (covered by the DR-8 diagnostic task).
+
+**Dependencies:** T4 · **Parallelizable:** Yes (sequences with the timeout emit on the saga emitters)
+
+---
+
+## Track D — behavioral proof (needs Track B + matching Track C task)
+
+### Task 11: Retry actually retries
+**Phase:** RED → GREEN · **Implements:** DR-2, DR-9 · **testingStrategy:** integration
+
+1. [RED] `Saga_StepWithWithRetry2_InvokesStepExactlyTwiceThenSucceeds`
+   - File: `src/Strategos.Generators.Behavioral.Tests/RetryBehaviorTests.cs`
+   - Expected failure: without DR-2 emit, the step runs once and the saga dead-letters/throws.
+2. [GREEN] Fixture step throws transiently on attempts 1–2, succeeds on 3; assert `step.Attempts == 3` and saga completes. (Verifies the property the shape suite cannot.)
+
+**Dependencies:** T6, T7 · **Parallelizable:** Yes (disjoint behavioral test files across the capability suites)
+
+### Task 12: Compensation runs after retries exhaust
+**Phase:** RED → GREEN · **Implements:** DR-3, DR-9 · **testingStrategy:** integration
+
+1. [RED] `Saga_RetryExhaustedWithCompensate_RunsCompensationOnceAndTransitionsToFailed`
+   - File: `src/Strategos.Generators.Behavioral.Tests/CompensationBehaviorTests.cs`
+   - Expected failure: compensation step never runs (trigger never published) pre-DR-3.
+2. [GREEN] Fixture step always throws with `.WithRetry(2).Compensate<Rollback>()`; assert `Rollback.Runs == 1`, saga phase `Failed`, and a `StepFailed` event in the Marten stream.
+
+**Dependencies:** T6, T8 · **Parallelizable:** Yes
+
+### Task 13: Timeout fires; idempotent when step wins the race
+**Phase:** RED → GREEN · **Implements:** DR-4, DR-9 · **testingStrategy:** integration
+
+1. [RED] `Saga_StepExceedsTimeout_RoutesToTimeoutPath` + `Saga_StepCompletesBeforeTimeout_TimeoutHandlerIsNoOp`
+   - File: `src/Strategos.Generators.Behavioral.Tests/TimeoutBehaviorTests.cs`
+   - Expected failure: no timeout enforcement pre-DR-4.
+2. [GREEN] One fixture step sleeps past a 50ms timeout (routes to failure); another completes in 10ms with a 5s timeout (handler no-op, saga not double-failed). Durable inbox/outbox enabled on the host.
+
+**Dependencies:** T6, T9 · **Parallelizable:** Yes
+
+### Task 14: Low confidence routes to the alternate branch
+**Phase:** RED → GREEN · **Implements:** DR-5, DR-9 · **testingStrategy:** integration
+
+1. [RED] `Saga_LowConfidence_RoutesToOnLowConfidenceBranch` + `Saga_HighConfidence_ProceedsOnPrimaryPath`
+   - File: `src/Strategos.Generators.Behavioral.Tests/ConfidenceBehaviorTests.cs`
+   - Expected failure: confidence is telemetry-only pre-DR-5; both cases take the primary path.
+2. [GREEN] Fixture step returns `Confidence=0.5` (asserts `HumanReview` ran, primary did not) and `0.9` (asserts primary ran).
+
+**Dependencies:** T6, T10 · **Parallelizable:** Yes
+
+---
+
+## Track E — DR-6: WithContext wire-in
+
+### Task 15: Wire `ContextAssemblerEmitter` into the generator
+**Phase:** RED → GREEN → REFACTOR · **Implements:** DR-6 · **testingStrategy:** unit
+
+1. [RED] `Generate_StepWithWithContext_EmitsContextAssembler`
+   - File: `src/Strategos.Generators.Tests/Emitters/ContextWireInTests.cs`
+   - Expected failure: `WorkflowIncrementalGenerator` never invokes `ContextAssemblerEmitter`; no `{Step}ContextAssembler` in generated output.
+2. [GREEN] Invoke `ContextAssemblerEmitter` (+ `ContextModelExtractor`) from `WorkflowIncrementalGenerator` for `.WithContext` steps; wire the assembler into the worker handler. No `Strategos.Rag` reference.
+3. [REFACTOR] Assert `using Strategos.Ontology.ObjectSets` only; confirm `IObjectSetProvider` dependency.
+
+**Dependencies:** T4 · **Parallelizable:** Yes (with Track C — generator-entry file, disjoint from emitters)
+
+### Task 16: WithContext assembles ontology context at runtime
+**Phase:** RED → GREEN · **Implements:** DR-6, DR-9 · **testingStrategy:** integration
+
+1. [RED] `Saga_StepWithContext_AssemblesContextAndInvokesExecuteSimilarity`
+   - File: `src/Strategos.Generators.Behavioral.Tests/ContextBehaviorTests.cs`
+   - Expected failure: no assembler invoked pre-DR-6.
+2. [GREEN] Stub `IObjectSetProvider`; assert the step receives assembled context (state+retrieval+literal) and `ExecuteSimilarityAsync` is called with the declared `TopK`/`MinRelevance`.
+
+**Dependencies:** T6, T15 · **Parallelizable:** Yes
+
+---
+
+## Track F — DR-7: Expressibility on branch + failure contexts
+
+### Task 17: `Then<TStep>(Action<IStepConfiguration>)` on branch + failure builders
+**Phase:** RED → GREEN → REFACTOR · **Implements:** DR-7 · **testingStrategy:** unit
+
+1. [RED] `BranchBuilder_ThenWithConfig_StepModelCarriesRetry` + `FailureHandlerBuilder_ThenWithConfig_StepModelCarriesRetry`
+   - File: `src/Strategos.Generators.Tests/Builders/BranchFailureConfigExpressibilityTests.cs`
+   - Expected failure: the configure-overload is absent on branch/failure builders (fork landed via #134); declared config doesn't reach the IR.
+2. [GREEN] Add the overload to the branch + failure-handler builders; thread config through their parse paths (`ParseForkPathStepModels`-style). Update `PublicAPI.Unshipped.txt` (RS0016/RS0017 break by design — do not suppress).
+3. [REFACTOR] De-dupe the configure-capture across fork/branch/failure.
+
+**Dependencies:** T3 · **Parallelizable:** Yes (after Track A; touches builder files + parse path)
+
+---
+
+## Track G — DR-8: INV-5 resilience diagnostics
+
+### Task 18: Analyzer diagnostics for invalid resilience config (AGWF017+)
+**Phase:** RED → GREEN → REFACTOR · **Implements:** DR-8 · **testingStrategy:** unit (analyzer)
+
+1. [RED] `Analyze_CompensateNonStepType_FiresNextFreeAgwf` + `Analyze_RequireConfidenceOutOfRange_Fires` + `Analyze_RequireConfidenceWithoutOnLowConfidence_Fires` + conformant negative cases
+   - File: `src/Strategos.Generators.Tests/Diagnostics/ResilienceDiagnosticsTests.cs`
+   - Expected failure: no analyzer rule covers these; live ceiling AGWF016, next-free unused.
+2. [GREEN] Add descriptors at next-free ids (verify against `AgwfCodes.g.cs`): `Compensate<T>` not an `IWorkflowStep<TState>`, `RequireConfidence` ∉ [0,1], `RequireConfidence` without `OnLowConfidence`, retry `<1`, non-positive timeout. Report at analyzer tier (earliest). Mirror builder-runtime throws as stable ids.
+3. [REFACTOR] Document each new id in `AgwfCodes.g.cs` + `WorkflowDiagnostics.cs`.
+
+**Dependencies:** T4 · **Parallelizable:** Yes (with Track C — diagnostics/analyzer files disjoint from emitters)
+
+---
+
+## Track H — DR-10: Error handling, composition, and edge cases
+
+This track covers DR-10's error handling, composition precedence, failure-mode races, the INV-7 immutability edge case, and the no-config baseline.
+
+### Task 19: Composition precedence and error-handling across composed resilience
+**Phase:** RED → GREEN · **Implements:** DR-10 (error handling, composition, edge cases) · **testingStrategy:** integration
+
+1. [RED] `Saga_StepWithAllResilience_RetriesThenTimeoutSpansRetriesThenCompensates_AndLowConfidenceRoutesNotCompensates`
+   - File: `src/Strategos.Generators.Behavioral.Tests/CompositionBehaviorTests.cs`
+   - Expected failure: precedence undefined until all emit DRs compose.
+2. [GREEN] Assert: retries first; timeout deadline spans all retries; compensation only after retries exhaust; a *successful-but-low-confidence* attempt routes via `OnLowConfidence`, **not** compensation.
+
+**Dependencies:** T11, T12, T13, T14 · **Parallelizable:** No (Track H head)
+
+### Task 20: Timeout-vs-retry race + late-completion idempotency
+**Phase:** RED → GREEN · **Implements:** DR-10 · **testingStrategy:** integration
+
+1. [RED] `Saga_TimeoutDuringRetry_FailsByTimeoutIdempotently_LateCompletedDoesNotResurrect`
+   - File: `src/Strategos.Generators.Behavioral.Tests/CompositionBehaviorTests.cs`
+   - Expected failure: a late `CompletedEvent` after a fired timeout could resurrect/double-process the saga.
+2. [GREEN] Assert the saga fails-by-timeout once and a late completed event is ignored (phase guard).
+
+**Dependencies:** T19 · **Parallelizable:** No
+
+### Task 21: INV-7 — same immutable input across retry attempts
+**Phase:** RED → GREEN · **Implements:** DR-10 (INV-7) · **testingStrategy:** integration (propertyTests: yes)
+
+1. [RED] `Saga_StepRetried_EachAttemptReceivesIdenticalImmutableState`
+   - File: `src/Strategos.Generators.Behavioral.Tests/RetryBehaviorTests.cs`
+   - Expected failure: no assertion that re-delivery preserves identical input across attempts.
+2. [GREEN] Capture the input state reference/value per attempt; assert all attempts received the same immutable state (no mutation-across-attempts). Property test over varied state shapes.
+
+**Dependencies:** T11 · **Parallelizable:** Yes
+
+### Task 22: No-config golden baseline
+**Phase:** RED → GREEN · **Implements:** DR-10 · **testingStrategy:** unit (golden)
+
+1. [RED] `Emit_StepWithoutResilience_GeneratedOutputUnchangedFromBaseline`
+   - File: `src/Strategos.Generators.Tests/Emitters/NoConfigBaselineTests.cs`
+   - Expected failure: assert no `Configure`, no `TimeoutMessage`, no confidence branch for a config-free step; pin via Verify snapshot.
+2. [GREEN] Confirm the emit guards (T7–T10) leave config-free steps byte-identical to the pre-change baseline.
+
+**Dependencies:** T7, T8, T9, T10 · **Parallelizable:** Yes
+
+### Task 23: INV-6 sealed-guard extension
+**Phase:** RED → GREEN · **Implements:** INV-6 · **testingStrategy:** unit
+
+1. [RED] `InvariantGuard_ResilienceIrAndModelTypes_AreSealedRecords`
+   - File: `src/Strategos.Generators.Tests/InvariantGuardTests.cs` (extend existing)
+   - Expected failure: new types not asserted sealed/`init`-only.
+2. [GREEN] Add the new IR/model/emitter types to the sealed-guard reflection assertion.
+
+**Dependencies:** T1 · **Parallelizable:** Yes
+
+---
+
+## Track I — Docs
+
+### Task 24: Reconcile docs to "enforced" (no longer "declared, not lowered")
+**Phase:** Documentation (no test — explicitly non-TDD) · **Implements:** DR-8 / Integration Points
+
+- Update `Abstractions/IStepConfiguration.cs` XML docs, `docs/theory/agentic-workflow-theory.md`, `docs/deferred-features.md`, `docs/workflow-library-roadmap-v2.md` to reflect that step resilience now lowers (retry/timeout/compensation/confidence) + the durable-outbox prerequisite for timeout. Note the WithContext ontology-backed wire-in.
+
+**Dependencies:** T11–T16 (land after behavior proven) · **Parallelizable:** Yes
+**Note:** Documentation-only task — exempt from the Iron Law (no production code).

--- a/docs/research/2026-06-16-dsl-step-resilience-lowering-gap.md
+++ b/docs/research/2026-06-16-dsl-step-resilience-lowering-gap.md
@@ -1,0 +1,105 @@
+# Investigation Spike: Workflow Step Resilience Config Is Declared But Never Lowered Into the Saga
+
+- **Date:** 2026-06-16
+- **Workflow:** `dsl-resilience-lowering-spike` (discovery; deliverable = document, no code)
+- **Trigger:** during DR-17 (#134) implementation, the implementer found that fork-path `Then(configure)` could not lower `WithRetry`/`WithTimeout`/`Compensate` because nothing lowers them for *any* step kind — only the declarative export carries them.
+- **Method:** two independent read-only code-archaeology passes over `src/Strategos` + `src/Strategos.Generators` + `src/Strategos.Contracts*` + `**/*Tests*` — one mapping the capability×context lowering matrix, one checking runtime/export/test reality. Both converged.
+- **Status:** **CONFIRMED, very high confidence.** A shipped, documented DSL feature (step-level resilience) is non-functional. Findings below scope the follow-up epic.
+
+---
+
+## 1. BLUF
+
+The Strategos workflow DSL exposes `IStepConfiguration` capabilities — `WithRetry`, `WithTimeout`, `Compensate<T>`, `RequireConfidence`, `OnLowConfidence` — and documents them as runtime behavior. **None of them lower into the emitted Wolverine+Marten saga, for any step kind.** They are parsed only far enough to reach the declarative export wire contract, then dropped before code generation. The `OnFailure`/compensation path is inert for the same root reason: the saga generates a failure-handler trigger command that is **never published at runtime**. The entire test suite is shape-only, so it passes while the feature does nothing. The XML docs and design docs advertise these as working.
+
+**Only `ValidateState` (validation guard) lowers to the saga.** *(Correction, verified 2026-06-16 during the #134 fold-in: `WithContext`'s emitter `ContextAssemblerEmitter` exists with unit tests but is **never invoked** by `WorkflowIncrementalGenerator` — only test call sites — so RAG context does **not** lower in production either; it joins the declared-not-enforced set. The two tracer passes saw the emitter exists but did not verify it is wired into the generation pipeline.)* Approval timeouts (`AwaitApproval(...).OnTimeout(...)`) lower too, but that is a *separate* feature, not step `WithTimeout`.
+
+This corroborates and extends the DR-17 finding: the gap is single-rooted, total, and masked.
+
+---
+
+## 2. Scope of the gap — the capability × context matrix
+
+The generator re-parses the builder lambda from syntax and recognizes only a fixed method set, so it never sees a per-step config object. The lowering verdict is therefore **uniform across all contexts**; only *expressibility* differs.
+
+| Capability | WorkflowBuilder | LoopBuilder | ForkPath | Branch | Approval | Failure |
+|---|---|---|---|---|---|---|
+| `WithRetry` / `WithTimeout` / `Compensate` / `RequireConfidence` / `OnLowConfidence` | EXPORT-ONLY | EXPORT-ONLY | NOT-EXPRESSIBLE | NOT-EXPRESSIBLE | NOT-EXPRESSIBLE | NOT-EXPRESSIBLE |
+| `ValidateState` | **LOWERS** | **LOWERS** | NOT-EXPRESSIBLE | NOT-EXPRESSIBLE | NOT-EXPRESSIBLE | NOT-EXPRESSIBLE |
+| `WithContext` | NOT LOWERED † | NOT LOWERED † | NOT-EXPRESSIBLE | NOT-EXPRESSIBLE | NOT-EXPRESSIBLE | NOT-EXPRESSIBLE |
+
+† **Correction (2026-06-16):** `ContextAssemblerEmitter` is never invoked by `WorkflowIncrementalGenerator` (test-only call sites) — `WithContext` does **not** lower in production. Only `ValidateState` does.
+
+- Only top-level + loop accept a step-config lambda: `WorkflowBuilder.Then<TStep>(Action<IStepConfiguration<TState>>)` (`WorkflowBuilder.cs:133`, attaches at `:149`); `LoopBuilder.Then<TStep>(...)` (`LoopBuilder.cs:85`, `:96`). DR-17 (#134) just added the same overload to `IForkPathBuilder` (still export-only / inert for resilience, since lowering doesn't exist).
+- The other contexts have no config-lambda overload: `IForkPathBuilder.cs:36,60` (pre-#134), `IBranchBuilder.cs:38,60`, `IFailureBuilder.cs:36,48`; `IApprovalBuilder` has no step `Then` at all. So even `ValidateState`/`WithContext` are not-expressible there.
+
+---
+
+## 3. The single-rooted mechanism — where the config dies
+
+The drop is **by omission of fields in the generator IR**:
+
+1. **`StepModel` (`StepModel.cs:22-29`)** carries only `ValidationPredicate`, `ValidationErrorMessage`, `Context`. There is no retry/timeout/compensation/confidence field — the emitter has nowhere to read them from. **Root cause.**
+2. **`StepExtractor.WalkInvocationChainForStepModelsInternal` (`StepExtractor.cs:760-825`)** branches only on `RepeatUntil`/`Fork`/`Branch`/`Join`/`Then`/`ValidateState`. `.WithRetry`/`.WithTimeout`/`.Compensate`/`.RequireConfidence`/`.OnLowConfidence` fall through the receiver-recursion (`:810-824`) and are silently skipped.
+3. **No emitter can emit them.** Saga emitters read only `StepModel.HasValidation`/`ValidationPredicate` (`StepStartHandlerEmitter.cs:78,111`) and `StepModel.Context` (`ContextAssemblerEmitter.cs:82,117`).
+
+The config is **EXPORT-ONLY** (not lost everywhere) because the runtime builder fully captures it in `StepConfigurationDefinition.cs:30-74` and `WorkflowDefinitionProjection.ProjectConfiguration` (`WorkflowDefinitionProjection.cs:266-282`, `ProjectRetry:300`, `ProjectCompensation:292`, `ProjectLowConfidence:284`) serializes all of it into the wire contract. It survives to the export and dies before the saga.
+
+---
+
+## 4. Runtime reality — inert beyond export
+
+- **No retry/timeout wrapping in the emitted saga.** `StepStartHandlerEmitter.cs:78-86` wraps only a validation guard; otherwise a bare handler (`EmitStandardHandler:144`) transitions phase + dispatches the worker. No retry loop, no timeout.
+- **The worker re-throws to a handler that doesn't exist.** `WorkerHandlerEmitter.cs:249-250` catches and re-throws with the comment *"let Wolverine handle retry/dead-letter"* — but a solution-wide grep for `OnException`/`RetryWithCooldown`/`ScheduleRetry`/`MaximumAttempts`/`.Policies`/`Polly`/`WolverineOptions` across `Strategos.Infrastructure`, `Strategos.Agents`, `Strategos/Configuration` returns **zero** retry config. No per-step and no global message retry, anywhere.
+- **Compensation / `OnFailure` is also inert.** The saga generates `Trigger{Name}FailureHandlerCommand` + handler (`SagaFailureHandlerComponentEmitter.cs:75-102`), but a grep for `new Trigger…`/`PublishAsync`/`SendAsync`/`InvokeAsync` referencing it (outside the generator that defines it) finds nothing — **it is never published**. The worker catch only re-throws.
+- **Confidence is telemetry, not a gate.** `WorkerHandlerEmitter.cs:218,231` set `step.confidence` as a span tag + write it to the completed event; nothing compares against `ConfidenceThreshold` or dispatches the `OnLowConfidence` path.
+
+---
+
+## 5. What DOES lower (bounds the gap exactly)
+
+- **`ValidateState`** → real guard-then-dispatch: `StepStartHandlerEmitter.EmitValidationHandler (:88-129)` emits `if(!(<pred>)){ Phase=…ValidationFailed; yield return …; yield break; }`, backed by `PhaseEnumEmitter.cs:96-101` + `EventsEmitter.cs:169-173`.
+- ~~**`WithContext`**~~ → **correction:** `ContextAssemblerEmitter (:82-157)` exists but is **never invoked** by `WorkflowIncrementalGenerator` (only test call sites). RAG context does **not** lower in production — move it to the declared-not-enforced set, not here.
+- **Approval timeout** (`AwaitApproval(...).OnTimeout(...)`) → `CommandsEmitter.EmitTimeoutCommand (:374)` + `SagaApprovalHandlersEmitter.EmitTimeoutHandler (:155)`; sets `Deadline = …Add(evt.Timeout)`. **Approval-specific — not step `WithTimeout`.**
+
+---
+
+## 6. Test-coverage gap — fully masked
+
+No test asserts retry/timeout/compensation **behavior**. The closest, all shape-only:
+- `Definitions/RetryConfigurationTests.cs`, `CompensationConfigurationTests.cs` — value-object construction.
+- `Builders/StepConfigurationBuilderTests.cs:87-124` — assert config lands on `Configuration.Retry/.Compensation` (definition presence).
+- `Contracts.Tests/Workflow/IrCompletenessTests.cs` — projection/wire carries config (export shape).
+- `Generators.Tests/OnFailureIntegrationTests.cs` — closest to behavioral, but asserts only generated **source text** `Contains("Trigger…FailureHandlerCommand")`; never compiles+runs the saga, never asserts anything publishes the trigger.
+
+The suite is **structurally incapable** of catching a `.WithRetry(2)` that never retries — it only ever checks that config is *present in the definition/export*.
+
+---
+
+## 7. Blast radius
+
+- **Advertised as shipped:** `IStepConfiguration.cs:21-36` lists "Compensation steps for rollback / Retry policies for transient failures / Execution timeouts," with an example `.Compensate<RollbackAssessment>().WithRetry(3, …).WithTimeout(…)`. Method docs read as runtime guarantees (`:64,72,93`). `StepConfigurationDefinition.cs:18-20`, `CompensationConfiguration.cs:9-18` describe rollback/retry/timeout as behavior.
+- **Consumer impact:** any workflow author writing `.WithRetry(n)`/`.WithTimeout(t)`/`.Compensate<T>()` gets a silent no-op — it compiles, validates, exports, and is documented as functional, but the running saga has no retry, no timeout, no compensation. This is precisely the reliability expression that downstream consumers (e.g. lvlup-sw/basileus#277's per-analyst resilience) assumed worked.
+- **Docs to reconcile:** `docs/theory/agentic-workflow-theory.md`, `docs/deferred-features.md`, `docs/workflow-library-roadmap-v2.md`, plus the contracts design docs (a focused pass should separate "advertised working" from "listed deferred" — `docs/deferred-features.md` may already hedge some).
+
+---
+
+## 8. Scope of the fix (the follow-up epic) + relation to #134
+
+The gap is single-rooted, so the fix is well-bounded. The epic should cover:
+
+1. **IR + parse:** add retry/timeout/compensation/confidence fields to `StepModel`; add parse branches (+ argument parsers) to `StepExtractor` (the wire contract already models all of it — no projection work).
+2. **Emit (the INV-1 design):** decide how each maps onto Wolverine+Marten and emit it — retry → Wolverine retry/error policy or a saga retry loop; timeout → scheduled-message/`Deadline`; **compensation → actually publish `Trigger{Name}FailureHandlerCommand` on step failure** (close the existing dead path); confidence-gate → emit the threshold comparison + `OnLowConfidence` alternate-path dispatch.
+3. **Expressibility:** add `Then<TStep>(Action<IStepConfiguration>)` to the still-missing contexts (branch, failure; fork landed via #134) so config is reachable where it makes sense.
+4. **Behavioral tests (mandatory):** compile+run the emitted saga and assert a step is *actually* retried N times / times out / runs its compensation — so the gap cannot recur. The current shape-only posture is the deeper failure.
+5. **Docs:** until lowering ships, mark step resilience as "declared, not yet enforced" rather than implying runtime behavior.
+
+**Relation to #134 / DR-17:** #134's `Then(configure)` overload closes a real builder-completeness wart and is green, but on its own it only adds *export-only* surface for resilience (consistent with all other contexts). The genuinely *functional* fork-path win is the separate `ParseForkPathStepModels` fix (fork-path `ValidateState` was being dropped — and it DOES lower for other step kinds) — folded into #134 and shipped. (`WithContext` does **not** lower for any step kind — §5 correction — so it was not part of that fix.) The retry/timeout/compensation enforcement for fork (and every other context), plus wiring `WithContext`'s dead emitter, belongs to this epic.
+
+---
+
+## 9. Sources
+
+`Abstractions/IStepConfiguration.cs`; `Builders/{StepConfigurationBuilder,WorkflowBuilder:133-149,LoopBuilder:85-96}.cs`; `Abstractions/{IWorkflowBuilder,ILoopBuilder,IForkPathBuilder,IBranchBuilder,IApprovalBuilder,IFailureBuilder}.cs`; `Definitions/{StepConfigurationDefinition,StepDefinition,CompensationConfiguration}.cs`; `Contracts/WorkflowDefinitionProjection.cs:121-314`; `Contracts/Generated/{CompensationConfiguration,StepConfigurationDefinition}.g.cs`; `Generators/Models/StepModel.cs:22-29`; `Generators/Helpers/{StepExtractor.cs:760-825,1002-1048,ContextModelExtractor,ApprovalExtractor:177-205}.cs`; `Generators/Emitters/{SagaEmitter,Saga/StepStartHandlerEmitter:70-129,ContextAssemblerEmitter,CommandsEmitter:243-380,Saga/SagaApprovalHandlersEmitter,Saga/SagaFailureHandlerComponentEmitter:75-102,ApprovalIntegrationHandlerEmitter,WorkerHandlerEmitter:181-253,EventsEmitter:169-236,PhaseEnumEmitter:96-101}.cs`; tests `Strategos.Tests/Definitions/{RetryConfiguration,CompensationConfiguration}Tests.cs`, `Strategos.Tests/Builders/StepConfigurationBuilderTests.cs:87-124`, `Strategos.Contracts.Tests/Workflow/IrCompletenessTests.cs`, `Strategos.Generators.Tests/OnFailureIntegrationTests.cs`; solution-wide greps over `Generators/` (`Retry|Timeout|Compensat|Confidence`) and over `src/` (`OnException|RetryWithCooldown|Polly|WolverineOptions|new Trigger`).
+
+**Confidence:** very high — two independent passes converged on the same single-rooted mechanism with concrete `file:symbol` evidence; the conclusion is corroborated by the absence (grep-verified) of any retry policy or trigger-publish anywhere in the runtime.

--- a/docs/workflow-library-roadmap-v2.md
+++ b/docs/workflow-library-roadmap-v2.md
@@ -440,6 +440,12 @@ public record ConversationalState
 
 ### F6: Step-Scoped Failure Handlers
 
+> **Foundation shipped (#135, 2026-06-18):** step-level `WithRetry` / `WithTimeout` /
+> `Compensate<T>` / `RequireConfidence` now lower into the generated Wolverine+Marten saga
+> (proven on a real host). The items below build on that foundation; still pending are
+> per-step exception-type routing, automatic reverse-order compensation, and the
+> workflow-level `OnFailure` handler chain. See `docs/designs/2026-06-17-step-resilience-lowering.md`.
+
 **Consumer Benefit:**
 > *"Each step can have its own error handling. Payment failures trigger refunds; other failures just log."*
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,6 +9,7 @@
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
@@ -62,6 +63,11 @@
          Testcontainers for the fixture + smoke test only. -->
     <PackageVersion Include="WolverineFx" Version="6.12.0" />
     <PackageVersion Include="WolverineFx.Marten" Version="6.12.0" />
+    <!-- WolverineFx 6.x dropped the in-box runtime (Roslyn) compiler; the
+         generated saga/handler glue is compiled at runtime in the behavioral
+         host fixture. RuntimeCompilation auto-registers the IAssemblyGenerator
+         so the host can start in TypeLoadMode.Dynamic. -->
+    <PackageVersion Include="WolverineFx.RuntimeCompilation" Version="6.12.0" />
     <PackageVersion Include="Marten" Version="9.9.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />
   </ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -49,5 +49,20 @@
     <PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.4.0" />
     <!-- Model Context Protocol -->
     <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
+    <!-- Behavioral-test harness (#135 DR-9): compile + RUN the generated
+         Wolverine+Marten saga against a real Postgres (Testcontainers).
+         WolverineFx 6.x is the current stable line with a native net10.0
+         target; it exposes CompensatingAction on the error-handling chain
+         and the TimeoutMessage saga base needed by later DR-9 tasks. The
+         design's "3.x" note predates the 6.x release; 6.12.0 supersedes it.
+         WolverineFx.Marten 6.12.0 depends on Marten 9.8.0 — pinned to 9.9.0
+         (>= 9.8.0). Npgsql 10.0.3 (above) satisfies Weasel.Postgresql's
+         Npgsql >= 9.0.4 floor. Wolverine/Marten are referenced now but only
+         *used* by a later host-wiring task; this task uses Npgsql +
+         Testcontainers for the fixture + smoke test only. -->
+    <PackageVersion Include="WolverineFx" Version="6.12.0" />
+    <PackageVersion Include="WolverineFx.Marten" Version="6.12.0" />
+    <PackageVersion Include="Marten" Version="9.9.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />
   </ItemGroup>
 </Project>

--- a/src/Strategos.Agents/Abstractions/IContextAwareStep.cs
+++ b/src/Strategos.Agents/Abstractions/IContextAwareStep.cs
@@ -1,0 +1,48 @@
+// =============================================================================
+// <copyright file="IContextAwareStep.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// =============================================================================
+
+using Strategos.Agents.Models;
+
+namespace Strategos.Agents.Abstractions;
+
+/// <summary>
+/// Opt-in contract a workflow step implements to receive runtime
+/// <see cref="AssembledContext"/> assembled from its <c>.WithContext(...)</c>
+/// declaration (DR-6).
+/// </summary>
+/// <remarks>
+/// <para>
+/// When a step declares <c>.WithContext(...)</c>, the source generator emits a
+/// <c>{Step}ContextAssembler</c> and wires it into the step's worker handler.
+/// Before the handler calls the step's <c>ExecuteAsync</c>, it assembles the
+/// declared context (state values, ontology retrieval, literals) and — if the
+/// step implements this interface — hands the result to
+/// <see cref="ReceiveContext"/>.
+/// </para>
+/// <para>
+/// This is intentionally an opt-in side channel rather than a change to
+/// <see cref="IWorkflowStep{TState}.ExecuteAsync"/>: a step that does not need
+/// assembled context (or that ignores it) keeps the unchanged execution
+/// signature, and a step that wants the context implements this one method.
+/// The handler always assembles the context for a context-declaring step (so
+/// ontology retrieval still runs and is observable), and only the delivery to
+/// the step is gated on this interface.
+/// </para>
+/// </remarks>
+public interface IContextAwareStep
+{
+    /// <summary>
+    /// Receives the context assembled for this step's current execution. Invoked
+    /// by the generated worker handler immediately before the step's
+    /// <c>ExecuteAsync</c>.
+    /// </summary>
+    /// <param name="context">
+    /// The assembled context (state, retrieval, and literal segments) for this
+    /// execution. Never <see langword="null"/>; an empty context is
+    /// <see cref="AssembledContext.Empty"/>.
+    /// </param>
+    void ReceiveContext(AssembledContext context);
+}

--- a/src/Strategos.Contracts.Tests/Diagnostics/AgwfCatalogEmitterTests.cs
+++ b/src/Strategos.Contracts.Tests/Diagnostics/AgwfCatalogEmitterTests.cs
@@ -11,7 +11,7 @@ namespace Strategos.Contracts.Tests.Diagnostics;
 /// <summary>
 /// T3 — the canonical <c>agwf-catalog.json</c> data artifact. After the full
 /// codegen pipeline runs, the catalog file exists under the contracts project,
-/// carries a manifest (<c>catalog_version</c>), and enumerates exactly the 10
+/// carries a manifest (<c>catalog_version</c>), and enumerates exactly the 15
 /// ground-truth entries ordered by ID, each with full metadata
 /// (<c>name</c>/<c>id</c>/<c>severity</c>/<c>summary</c>/<c>remediation</c>/
 /// <c>since</c>).
@@ -24,11 +24,12 @@ public sealed class AgwfCatalogEmitterTests
     [
         "AGWF001", "AGWF002", "AGWF003", "AGWF004", "AGWF009",
         "AGWF010", "AGWF012", "AGWF014", "AGWF015", "AGWF016",
+        "AGWF017", "AGWF018", "AGWF019", "AGWF020", "AGWF021",
     ];
 
     /// <summary>
     /// Regenerates from committed schemas and asserts the emitted catalog JSON
-    /// has a <c>catalog_version</c> manifest field and exactly 10 entries ordered
+    /// has a <c>catalog_version</c> manifest field and exactly 15 entries ordered
     /// by ID, each carrying the full metadata set.
     /// </summary>
     [Test]
@@ -48,7 +49,7 @@ public sealed class AgwfCatalogEmitterTests
 
         var entries = root.GetProperty("entries");
         await Assert.That(entries.GetArrayLength()).IsEqualTo(GroundTruthCodes.Length)
-            .Because("the catalog must enumerate exactly the 10 ground-truth entries.");
+            .Because("the catalog must enumerate exactly the 15 ground-truth entries.");
 
         var ids = new List<string>();
         foreach (var entry in entries.EnumerateArray())

--- a/src/Strategos.Contracts.Tests/Diagnostics/AgwfCatalogSchemaTests.cs
+++ b/src/Strategos.Contracts.Tests/Diagnostics/AgwfCatalogSchemaTests.cs
@@ -12,26 +12,27 @@ namespace Strategos.Contracts.Tests.Diagnostics;
 /// T2 — the AGWF catalog TypeSpec source emits, after <c>tsp compile</c>, one
 /// JSON Schema per ground-truth diagnostic code carrying machine-readable
 /// <c>const</c> metadata (R-lit representation; DR-1). Asserts the catalog
-/// enumerates exactly the 10 defined codes — <c>AGWF001, 002, 003, 004, 009,
-/// 010, 012, 014, 015, 016</c> — with gaps preserved as gaps (INV-5: no
-/// renumber), each carrying <c>id</c>/<c>severity</c>/<c>summary</c>/
+/// enumerates exactly the 15 defined codes — <c>AGWF001, 002, 003, 004, 009,
+/// 010, 012, 014, 015, 016, 017, 018, 019, 020, 021</c> — with gaps preserved as
+/// gaps (INV-5: no renumber), each carrying <c>id</c>/<c>severity</c>/<c>summary</c>/
 /// <c>remediation</c>/<c>since</c>.
 /// </summary>
 [Property("Category", "Diagnostics")]
 [NotInParallel("tsp-compile")]
 public sealed class AgwfCatalogSchemaTests
 {
-    /// <summary>The 10 ground-truth AGWF codes (INV-5: gaps stay gaps, no renumber).</summary>
+    /// <summary>The 15 ground-truth AGWF codes (INV-5: gaps stay gaps, no renumber).</summary>
     private static readonly string[] GroundTruthCodes =
     [
         "AGWF001", "AGWF002", "AGWF003", "AGWF004", "AGWF009",
         "AGWF010", "AGWF012", "AGWF014", "AGWF015", "AGWF016",
+        "AGWF017", "AGWF018", "AGWF019", "AGWF020", "AGWF021",
     ];
 
     /// <summary>
     /// Compiles the TypeSpec sources, then asserts each AGWF entry schema carries
     /// the five metadata fields as <c>const</c> literals and the union of their
-    /// <c>id</c> consts equals exactly the 10 ground-truth codes.
+    /// <c>id</c> consts equals exactly the 15 ground-truth codes.
     /// </summary>
     [Test]
     public async Task AgwfCatalogSchema_TenCodes_EmittedWithMetadata()
@@ -64,6 +65,6 @@ public sealed class AgwfCatalogSchemaTests
 
         await Assert.That(ids.OrderBy(x => x, StringComparer.Ordinal).ToArray())
             .IsEquivalentTo(GroundTruthCodes.OrderBy(x => x, StringComparer.Ordinal).ToArray())
-            .Because("the catalog must enumerate exactly the 10 ground-truth codes (INV-5: gaps stay gaps).");
+            .Because("the catalog must enumerate exactly the 15 ground-truth codes (INV-5: gaps stay gaps).");
     }
 }

--- a/src/Strategos.Contracts.Tests/Diagnostics/AgwfCodeEnumTests.cs
+++ b/src/Strategos.Contracts.Tests/Diagnostics/AgwfCodeEnumTests.cs
@@ -10,7 +10,7 @@ using System.Text.Json;
 namespace Strategos.Contracts.Tests.Diagnostics;
 
 /// <summary>
-/// T4 — the generated <c>AgwfCode</c> C# enum. Asserts it has exactly 10
+/// T4 — the generated <c>AgwfCode</c> C# enum. Asserts it has exactly 15
 /// members carrying <em>symbolic</em> names (the contract Exarchos round-trips
 /// against by name; INV-5), each serializing to its <c>AGWF0xx</c> wire string
 /// via the <c>[JsonStringEnumMemberName]</c> path.
@@ -31,6 +31,11 @@ public sealed class AgwfCodeEnumTests
         ("LoopWithoutBody", "AGWF014"),
         ("InvalidPersistenceMode", "AGWF015"),
         ("EventSourcedRequiresState", "AGWF016"),
+        ("CompensateNotAStep", "AGWF017"),
+        ("ConfidenceThresholdOutOfRange", "AGWF018"),
+        ("RequireConfidenceWithoutHandler", "AGWF019"),
+        ("RetryMaxAttemptsBelowOne", "AGWF020"),
+        ("NonPositiveTimeout", "AGWF021"),
     ];
 
     /// <summary>
@@ -38,7 +43,7 @@ public sealed class AgwfCodeEnumTests
     /// member set and the wire round-trip (serialize → <c>AGWF0xx</c>, back).
     /// </summary>
     [Test]
-    public async Task AgwfCodeEnum_TenMembers_RoundTripsWireValues()
+    public async Task AgwfCodeEnum_FifteenMembers_RoundTripsWireValues()
     {
         var enumType = typeof(ContractsMarker).Assembly
             .GetTypes()
@@ -51,7 +56,7 @@ public sealed class AgwfCodeEnumTests
 
         var members = Enum.GetNames(enumType!);
         await Assert.That(members.Length).IsEqualTo(Expected.Length)
-            .Because("AgwfCode must have exactly 10 members.");
+            .Because("AgwfCode must have exactly 15 members.");
 
         var options = Strategos.Contracts.ContractsJson.Options;
         foreach (var (name, wire) in Expected)

--- a/src/Strategos.Contracts.Tests/Diagnostics/AgwfMarkdownTests.cs
+++ b/src/Strategos.Contracts.Tests/Diagnostics/AgwfMarkdownTests.cs
@@ -9,7 +9,7 @@ namespace Strategos.Contracts.Tests.Diagnostics;
 /// <summary>
 /// T5 — the generated <c>docs/diagnostics/agwf.md</c> reference page. After
 /// codegen, the page carries a Markdown table with the columns
-/// id/severity/summary/remediation/since and exactly 10 data rows, one per
+/// id/severity/summary/remediation/since and exactly 15 data rows, one per
 /// ground-truth code, sorted by ID.
 /// </summary>
 [Property("Category", "Diagnostics")]
@@ -19,6 +19,7 @@ public sealed class AgwfMarkdownTests
     [
         "AGWF001", "AGWF002", "AGWF003", "AGWF004", "AGWF009",
         "AGWF010", "AGWF012", "AGWF014", "AGWF015", "AGWF016",
+        "AGWF017", "AGWF018", "AGWF019", "AGWF020", "AGWF021",
     ];
 
     /// <summary>
@@ -55,7 +56,7 @@ public sealed class AgwfMarkdownTests
             .ToList();
 
         await Assert.That(dataRows.Count).IsEqualTo(GroundTruthCodes.Length)
-            .Because("the table must have exactly 10 data rows, one per code.");
+            .Because("the table must have exactly 15 data rows, one per code.");
 
         var rowIds = dataRows
             .Select(r => GroundTruthCodes.First(c => r.Contains(c, StringComparison.Ordinal)))

--- a/src/Strategos.Contracts/Diagnostics/AgwfCatalog.tsp
+++ b/src/Strategos.Contracts/Diagnostics/AgwfCatalog.tsp
@@ -11,7 +11,7 @@ namespace LevelUp.Strategos.Contracts;
  * generated `AgwfCode` C# enum, and the codegen pipeline emits the canonical
  * `agwf-catalog.json` data artifact + `docs/diagnostics/agwf.md` reference.
  *
- * Ground truth = exactly **10 defined codes** with gaps preserved as gaps
+ * Ground truth = exactly **15 defined codes** with gaps preserved as gaps
  * (INV-5: never renumber). Member names are the contract Exarchos's TypeScript
  * enum round-trips against *by name* (not ordinal).
  *
@@ -31,6 +31,11 @@ enum AgwfCode {
   LoopWithoutBody: "AGWF014",
   InvalidPersistenceMode: "AGWF015",
   EventSourcedRequiresState: "AGWF016",
+  CompensateNotAStep: "AGWF017",
+  ConfidenceThresholdOutOfRange: "AGWF018",
+  RequireConfidenceWithoutHandler: "AGWF019",
+  RetryMaxAttemptsBelowOne: "AGWF020",
+  NonPositiveTimeout: "AGWF021",
 }
 
 /** AGWF001 — Empty workflow name. */
@@ -131,4 +136,54 @@ model AgwfEntryEventSourcedRequiresState {
   summary: "Event-sourced workflow requires state type";
   remediation: "Workflow '{0}' uses PersistenceMode.EventSourced but no state type was found. Event-sourced workflows require a state type that implements IEventSourcedState<TState> with an ApplyEvent method.";
   since: "0.2.0";
+}
+
+/** AGWF017 — Compensation step is not a workflow step. */
+@jsonSchema
+model AgwfEntryCompensateNotAStep {
+  id: "AGWF017";
+  severity: "error";
+  summary: "Compensation step is not a workflow step";
+  remediation: "Step '{0}' in workflow '{1}' compensates with '{2}', which does not implement IWorkflowStep<TState>. Compensation types must be a registered workflow step.";
+  since: "2.10.0";
+}
+
+/** AGWF018 — Confidence threshold out of range. */
+@jsonSchema
+model AgwfEntryConfidenceThresholdOutOfRange {
+  id: "AGWF018";
+  severity: "error";
+  summary: "Confidence threshold out of range";
+  remediation: "Step '{0}' in workflow '{1}' calls RequireConfidence({2}). The threshold must be between 0.0 and 1.0 inclusive.";
+  since: "2.10.0";
+}
+
+/** AGWF019 — RequireConfidence without OnLowConfidence handler. */
+@jsonSchema
+model AgwfEntryRequireConfidenceWithoutHandler {
+  id: "AGWF019";
+  severity: "warning";
+  summary: "RequireConfidence without OnLowConfidence handler";
+  remediation: "Step '{0}' in workflow '{1}' calls RequireConfidence but declares no OnLowConfidence handler. Add OnLowConfidence(alt => ...) so low-confidence results have a routing path.";
+  since: "2.10.0";
+}
+
+/** AGWF020 — Retry maxAttempts below one. */
+@jsonSchema
+model AgwfEntryRetryMaxAttemptsBelowOne {
+  id: "AGWF020";
+  severity: "error";
+  summary: "Retry maxAttempts below one";
+  remediation: "Step '{0}' in workflow '{1}' configures WithRetry({2}). The maxAttempts value must be at least 1.";
+  since: "2.10.0";
+}
+
+/** AGWF021 — Non-positive timeout. */
+@jsonSchema
+model AgwfEntryNonPositiveTimeout {
+  id: "AGWF021";
+  severity: "error";
+  summary: "Non-positive timeout";
+  remediation: "Step '{0}' in workflow '{1}' configures WithTimeout with a non-positive duration. The timeout must be greater than zero.";
+  since: "2.10.0";
 }

--- a/src/Strategos.Contracts/Generated/AgwfCode.g.cs
+++ b/src/Strategos.Contracts/Generated/AgwfCode.g.cs
@@ -58,4 +58,24 @@ public enum AgwfCode
     /// <summary>AGWF016 — Event-sourced workflow requires state type.</summary>
     [JsonStringEnumMemberName("AGWF016")]
     EventSourcedRequiresState,
+
+    /// <summary>AGWF017 — Compensation step is not a workflow step.</summary>
+    [JsonStringEnumMemberName("AGWF017")]
+    CompensateNotAStep,
+
+    /// <summary>AGWF018 — Confidence threshold out of range.</summary>
+    [JsonStringEnumMemberName("AGWF018")]
+    ConfidenceThresholdOutOfRange,
+
+    /// <summary>AGWF019 — RequireConfidence without OnLowConfidence handler.</summary>
+    [JsonStringEnumMemberName("AGWF019")]
+    RequireConfidenceWithoutHandler,
+
+    /// <summary>AGWF020 — Retry maxAttempts below one.</summary>
+    [JsonStringEnumMemberName("AGWF020")]
+    RetryMaxAttemptsBelowOne,
+
+    /// <summary>AGWF021 — Non-positive timeout.</summary>
+    [JsonStringEnumMemberName("AGWF021")]
+    NonPositiveTimeout,
 }

--- a/src/Strategos.Contracts/Generated/AgwfCodes.g.cs
+++ b/src/Strategos.Contracts/Generated/AgwfCodes.g.cs
@@ -44,5 +44,20 @@ namespace Strategos.Contracts.Generated
 
         /// <summary>AGWF016 — Event-sourced workflow requires state type.</summary>
         public const string EventSourcedRequiresState = "AGWF016";
+
+        /// <summary>AGWF017 — Compensation step is not a workflow step.</summary>
+        public const string CompensateNotAStep = "AGWF017";
+
+        /// <summary>AGWF018 — Confidence threshold out of range.</summary>
+        public const string ConfidenceThresholdOutOfRange = "AGWF018";
+
+        /// <summary>AGWF019 — RequireConfidence without OnLowConfidence handler.</summary>
+        public const string RequireConfidenceWithoutHandler = "AGWF019";
+
+        /// <summary>AGWF020 — Retry maxAttempts below one.</summary>
+        public const string RetryMaxAttemptsBelowOne = "AGWF020";
+
+        /// <summary>AGWF021 — Non-positive timeout.</summary>
+        public const string NonPositiveTimeout = "AGWF021";
     }
 }

--- a/src/Strategos.Contracts/Generated/agwf-catalog.json
+++ b/src/Strategos.Contracts/Generated/agwf-catalog.json
@@ -1,6 +1,6 @@
 {
   "catalog_version": "0.2.0",
-  "count": 10,
+  "count": 15,
   "entries": [
     {
       "name": "EmptyWorkflowName",
@@ -81,6 +81,46 @@
       "summary": "Event-sourced workflow requires state type",
       "remediation": "Workflow '{0}' uses PersistenceMode.EventSourced but no state type was found. Event-sourced workflows require a state type that implements IEventSourcedState<TState> with an ApplyEvent method.",
       "since": "0.2.0"
+    },
+    {
+      "name": "CompensateNotAStep",
+      "id": "AGWF017",
+      "severity": "error",
+      "summary": "Compensation step is not a workflow step",
+      "remediation": "Step '{0}' in workflow '{1}' compensates with '{2}', which does not implement IWorkflowStep<TState>. Compensation types must be a registered workflow step.",
+      "since": "2.10.0"
+    },
+    {
+      "name": "ConfidenceThresholdOutOfRange",
+      "id": "AGWF018",
+      "severity": "error",
+      "summary": "Confidence threshold out of range",
+      "remediation": "Step '{0}' in workflow '{1}' calls RequireConfidence({2}). The threshold must be between 0.0 and 1.0 inclusive.",
+      "since": "2.10.0"
+    },
+    {
+      "name": "RequireConfidenceWithoutHandler",
+      "id": "AGWF019",
+      "severity": "warning",
+      "summary": "RequireConfidence without OnLowConfidence handler",
+      "remediation": "Step '{0}' in workflow '{1}' calls RequireConfidence but declares no OnLowConfidence handler. Add OnLowConfidence(alt => ...) so low-confidence results have a routing path.",
+      "since": "2.10.0"
+    },
+    {
+      "name": "RetryMaxAttemptsBelowOne",
+      "id": "AGWF020",
+      "severity": "error",
+      "summary": "Retry maxAttempts below one",
+      "remediation": "Step '{0}' in workflow '{1}' configures WithRetry({2}). The maxAttempts value must be at least 1.",
+      "since": "2.10.0"
+    },
+    {
+      "name": "NonPositiveTimeout",
+      "id": "AGWF021",
+      "severity": "error",
+      "summary": "Non-positive timeout",
+      "remediation": "Step '{0}' in workflow '{1}' configures WithTimeout with a non-positive duration. The timeout must be greater than zero.",
+      "since": "2.10.0"
     }
   ]
 }

--- a/src/Strategos.Contracts/schemas/json-schema/AgwfCode.json
+++ b/src/Strategos.Contracts/schemas/json-schema/AgwfCode.json
@@ -12,7 +12,12 @@
         "AGWF012",
         "AGWF014",
         "AGWF015",
-        "AGWF016"
+        "AGWF016",
+        "AGWF017",
+        "AGWF018",
+        "AGWF019",
+        "AGWF020",
+        "AGWF021"
     ],
-    "description": "AGWF — the workflow source-generator diagnostic codes. **Single canonical\nsource** (#52): the codes and their metadata live here in TypeSpec; the\nRoslyn analyzer (`WorkflowDiagnostics`) sources its `id` strings from the\ngenerated `AgwfCode` C# enum, and the codegen pipeline emits the canonical\n`agwf-catalog.json` data artifact + `docs/diagnostics/agwf.md` reference.\n\nGround truth = exactly **10 defined codes** with gaps preserved as gaps\n(INV-5: never renumber). Member names are the contract Exarchos's TypeScript\nenum round-trips against *by name* (not ordinal).\n\nRepresentation = **R-lit** (DR-1): each entry is a literal-typed model whose\nfields emit as JSON Schema `const`, read by `AgwfCatalogEmitter`. Adding a\ncode is a minor bump; renaming/removing one is a major bump."
+    "description": "AGWF — the workflow source-generator diagnostic codes. **Single canonical\nsource** (#52): the codes and their metadata live here in TypeSpec; the\nRoslyn analyzer (`WorkflowDiagnostics`) sources its `id` strings from the\ngenerated `AgwfCode` C# enum, and the codegen pipeline emits the canonical\n`agwf-catalog.json` data artifact + `docs/diagnostics/agwf.md` reference.\n\nGround truth = exactly **15 defined codes** with gaps preserved as gaps\n(INV-5: never renumber). Member names are the contract Exarchos's TypeScript\nenum round-trips against *by name* (not ordinal).\n\nRepresentation = **R-lit** (DR-1): each entry is a literal-typed model whose\nfields emit as JSON Schema `const`, read by `AgwfCatalogEmitter`. Adding a\ncode is a minor bump; renaming/removing one is a major bump."
 }

--- a/src/Strategos.Contracts/schemas/json-schema/AgwfEntryCompensateNotAStep.json
+++ b/src/Strategos.Contracts/schemas/json-schema/AgwfEntryCompensateNotAStep.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "AgwfEntryCompensateNotAStep.json",
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string",
+            "const": "AGWF017"
+        },
+        "severity": {
+            "type": "string",
+            "const": "error"
+        },
+        "summary": {
+            "type": "string",
+            "const": "Compensation step is not a workflow step"
+        },
+        "remediation": {
+            "type": "string",
+            "const": "Step '{0}' in workflow '{1}' compensates with '{2}', which does not implement IWorkflowStep<TState>. Compensation types must be a registered workflow step."
+        },
+        "since": {
+            "type": "string",
+            "const": "2.10.0"
+        }
+    },
+    "required": [
+        "id",
+        "severity",
+        "summary",
+        "remediation",
+        "since"
+    ],
+    "description": "AGWF017 — Compensation step is not a workflow step."
+}

--- a/src/Strategos.Contracts/schemas/json-schema/AgwfEntryConfidenceThresholdOutOfRange.json
+++ b/src/Strategos.Contracts/schemas/json-schema/AgwfEntryConfidenceThresholdOutOfRange.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "AgwfEntryConfidenceThresholdOutOfRange.json",
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string",
+            "const": "AGWF018"
+        },
+        "severity": {
+            "type": "string",
+            "const": "error"
+        },
+        "summary": {
+            "type": "string",
+            "const": "Confidence threshold out of range"
+        },
+        "remediation": {
+            "type": "string",
+            "const": "Step '{0}' in workflow '{1}' calls RequireConfidence({2}). The threshold must be between 0.0 and 1.0 inclusive."
+        },
+        "since": {
+            "type": "string",
+            "const": "2.10.0"
+        }
+    },
+    "required": [
+        "id",
+        "severity",
+        "summary",
+        "remediation",
+        "since"
+    ],
+    "description": "AGWF018 — Confidence threshold out of range."
+}

--- a/src/Strategos.Contracts/schemas/json-schema/AgwfEntryNonPositiveTimeout.json
+++ b/src/Strategos.Contracts/schemas/json-schema/AgwfEntryNonPositiveTimeout.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "AgwfEntryNonPositiveTimeout.json",
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string",
+            "const": "AGWF021"
+        },
+        "severity": {
+            "type": "string",
+            "const": "error"
+        },
+        "summary": {
+            "type": "string",
+            "const": "Non-positive timeout"
+        },
+        "remediation": {
+            "type": "string",
+            "const": "Step '{0}' in workflow '{1}' configures WithTimeout with a non-positive duration. The timeout must be greater than zero."
+        },
+        "since": {
+            "type": "string",
+            "const": "2.10.0"
+        }
+    },
+    "required": [
+        "id",
+        "severity",
+        "summary",
+        "remediation",
+        "since"
+    ],
+    "description": "AGWF021 — Non-positive timeout."
+}

--- a/src/Strategos.Contracts/schemas/json-schema/AgwfEntryRequireConfidenceWithoutHandler.json
+++ b/src/Strategos.Contracts/schemas/json-schema/AgwfEntryRequireConfidenceWithoutHandler.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "AgwfEntryRequireConfidenceWithoutHandler.json",
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string",
+            "const": "AGWF019"
+        },
+        "severity": {
+            "type": "string",
+            "const": "warning"
+        },
+        "summary": {
+            "type": "string",
+            "const": "RequireConfidence without OnLowConfidence handler"
+        },
+        "remediation": {
+            "type": "string",
+            "const": "Step '{0}' in workflow '{1}' calls RequireConfidence but declares no OnLowConfidence handler. Add OnLowConfidence(alt => ...) so low-confidence results have a routing path."
+        },
+        "since": {
+            "type": "string",
+            "const": "2.10.0"
+        }
+    },
+    "required": [
+        "id",
+        "severity",
+        "summary",
+        "remediation",
+        "since"
+    ],
+    "description": "AGWF019 — RequireConfidence without OnLowConfidence handler."
+}

--- a/src/Strategos.Contracts/schemas/json-schema/AgwfEntryRetryMaxAttemptsBelowOne.json
+++ b/src/Strategos.Contracts/schemas/json-schema/AgwfEntryRetryMaxAttemptsBelowOne.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "AgwfEntryRetryMaxAttemptsBelowOne.json",
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string",
+            "const": "AGWF020"
+        },
+        "severity": {
+            "type": "string",
+            "const": "error"
+        },
+        "summary": {
+            "type": "string",
+            "const": "Retry maxAttempts below one"
+        },
+        "remediation": {
+            "type": "string",
+            "const": "Step '{0}' in workflow '{1}' configures WithRetry({2}). The maxAttempts value must be at least 1."
+        },
+        "since": {
+            "type": "string",
+            "const": "2.10.0"
+        }
+    },
+    "required": [
+        "id",
+        "severity",
+        "summary",
+        "remediation",
+        "since"
+    ],
+    "description": "AGWF020 — Retry maxAttempts below one."
+}

--- a/src/Strategos.Generators.Behavioral.Tests/CompensationBehaviorTests.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/CompensationBehaviorTests.cs
@@ -1,0 +1,94 @@
+// -----------------------------------------------------------------------
+// <copyright file="CompensationBehaviorTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Generators.Behavioral.Tests.Workflows;
+
+namespace Strategos.Generators.Behavioral.Tests;
+
+/// <summary>
+/// End-to-end behavioral proof (DR-3 T012) that a step's
+/// <c>.WithRetry(2).Compensate&lt;RollbackStep&gt;()</c> actually runs its
+/// compensation at runtime once retries are exhausted: the generated worker
+/// <c>Configure(HandlerChain)</c> error chain publishes the trigger
+/// failure-handler command, and the generated saga compensation chain dispatches
+/// and runs the rollback step, then routes the saga to its terminal Failed phase.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The compensated step throws on every invocation, so Wolverine retries it three
+/// times total (initial + two retries) and then the lowered compensation path
+/// fires. Before DR-3 the generator emitted a never-published trigger command and
+/// the compensation step never ran; with DR-3 the rollback runs exactly once and
+/// the saga reaches its terminal phase (the saga document is removed by
+/// <c>MarkCompleted()</c>). Asserting exactly one rollback invocation plus terminal
+/// completion proves the compensation lowering, not just that the saga eventually
+/// stopped.
+/// </para>
+/// <para>
+/// Marked <see cref="NotInParallelAttribute"/> because it shares the single
+/// process-wide container + host and observes the process-shared invocation log.
+/// </para>
+/// </remarks>
+[Property("Category", "Integration")]
+[NotInParallel]
+[ClassDataSource<CompensationHostFixture>(Shared = SharedType.PerTestSession)]
+public sealed class CompensationBehaviorTests
+{
+    private readonly CompensationHostFixture host;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CompensationBehaviorTests"/>
+    /// class.
+    /// </summary>
+    /// <param name="host">
+    /// The shared Wolverine+Marten host fixture, injected by TUnit and shared
+    /// across the entire test session.
+    /// </param>
+    public CompensationBehaviorTests(CompensationHostFixture host)
+    {
+        this.host = host;
+    }
+
+    /// <summary>
+    /// Starts the generated compensation-proof workflow saga whose middle step
+    /// declares <c>.WithRetry(2).Compensate&lt;RollbackStep&gt;()</c> and throws on
+    /// every invocation. Asserts the compensation <see cref="RollbackStep"/> ran
+    /// exactly once, the failing step ran three times (initial + two retries), the
+    /// terminal step never ran, and the saga reached its terminal (Failed) phase.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Saga_RetryExhaustedWithCompensate_RunsCompensationOnceAndTransitionsToFailed()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+
+        var initialState = new CompensationState { WorkflowId = workflowId };
+        var startCommand = new StartCompensationProofCommand(workflowId, initialState);
+
+        var reachedTerminal = await this.host.RunToTerminalAsync<CompensationProofSaga>(
+            workflowId,
+            startCommand);
+
+        // The saga reached its terminal phase: the saga document is deleted by
+        // MarkCompleted() on the compensation completed handler, so its absence is
+        // the terminal-Failed signal.
+        await Assert.That(reachedTerminal).IsTrue();
+
+        // The compensation step ran exactly once: this is the compensation proof.
+        await Assert.That(this.host.Invocations.CountFor(nameof(RollbackStep))).IsEqualTo(1);
+
+        // The failing step ran three times (initial attempt + two retries lowered
+        // from .WithRetry(2)) before compensation fired.
+        await Assert.That(this.host.Invocations.CountFor(nameof(CompensatedFailingStep))).IsEqualTo(3);
+
+        // The deterministic prepare step ran once; the terminal step never ran
+        // because compensation routed the saga to Failed before the happy path.
+        await Assert.That(this.host.Invocations.CountFor(nameof(CompensationPrepareStep))).IsEqualTo(1);
+        await Assert.That(this.host.Invocations.CountFor(nameof(CompensationNeverReachedStep))).IsEqualTo(0);
+    }
+}

--- a/src/Strategos.Generators.Behavioral.Tests/CompositionBehaviorTests.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/CompositionBehaviorTests.cs
@@ -1,0 +1,349 @@
+// -----------------------------------------------------------------------
+// <copyright file="CompositionBehaviorTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Generators.Behavioral.Tests.Workflows;
+
+namespace Strategos.Generators.Behavioral.Tests;
+
+/// <summary>
+/// End-to-end behavioral proof (epic #135, DR-10, T019/T020/T021) that the four
+/// lowered step-resilience capabilities COMPOSE and behave at the edges when
+/// declared together on a SINGLE step:
+/// <c>.WithRetry(n).WithTimeout(t).Compensate&lt;T&gt;().RequireConfidence(x)
+/// .OnLowConfidence(alt =&gt; alt.Then&lt;H&gt;())</c>, run against a real
+/// PostgreSQL container.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the first time all four are exercised together. They lower onto
+/// disjoint generated surfaces — retry + compensation on the worker handler's
+/// <c>Configure(HandlerChain)</c>, timeout as a cascaded saga deadline race, and
+/// the confidence gate in the step's completed handler — so they compose without
+/// a duplicate-<c>Handle</c> collision. The tests assert the design's precedence:
+/// <list type="bullet">
+///   <item><description>
+///     <b>T019a</b> transient-then-success + HIGH confidence: retried, completes
+///     on the primary path (no compensation, no low-confidence route).
+///   </description></item>
+///   <item><description>
+///     <b>T019b</b> first-try success + LOW confidence: routes to the
+///     OnLowConfidence handler, NOT compensation (success ≠ failure).
+///   </description></item>
+///   <item><description>
+///     <b>T019c</b> always-throws: retries exhaust → compensation runs → Failed.
+///   </description></item>
+///   <item><description>
+///     <b>T020</b> timeout firing mid-retry: fails-by-timeout exactly once; a late
+///     completion / retry does not resurrect the terminated saga.
+///   </description></item>
+///   <item><description>
+///     <b>T021</b> INV-7: every retry attempt receives the same immutable input.
+///   </description></item>
+/// </list>
+/// </para>
+/// <para>
+/// Marked <see cref="NotInParallelAttribute"/> because these share the single
+/// process-wide container + host and observe the process-shared invocation log
+/// and probes.
+/// </para>
+/// </remarks>
+[Property("Category", "Integration")]
+[NotInParallel]
+[ClassDataSource<CompositionHostFixture>(Shared = SharedType.PerTestSession)]
+public sealed class CompositionBehaviorTests
+{
+    private readonly CompositionHostFixture host;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CompositionBehaviorTests"/>
+    /// class.
+    /// </summary>
+    /// <param name="host">
+    /// The shared Wolverine+Marten composition host fixture, injected by TUnit and
+    /// shared across the entire test session.
+    /// </param>
+    public CompositionBehaviorTests(CompositionHostFixture host)
+    {
+        this.host = host;
+    }
+
+    /// <summary>
+    /// T019a — composition precedence: a step with all four resilience capabilities
+    /// that throws on attempts 1-2 then succeeds on attempt 3 with HIGH confidence
+    /// (0.9 ≥ 0.85). Asserts the composed retry carried it through (three attempts),
+    /// the saga proceeded on the primary path to the finish step, and NEITHER the
+    /// low-confidence handler NOR the compensation ran.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Saga_StepWithAllResilience_RetriesThenHighConfidenceCompletesNotCompensates()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+
+        var initialState = new CompositionState { WorkflowId = workflowId };
+        var startCommand = new StartCompositionTransientCommand(workflowId, initialState);
+
+        var reachedTerminal = await this.host.RunToTerminalAsync<CompositionTransientSaga>(
+            workflowId,
+            startCommand);
+
+        // The saga reached its terminal phase via the primary finish step's
+        // MarkCompleted() — it only gets there if retry carried the step through.
+        await Assert.That(reachedTerminal).IsTrue();
+
+        // Retry precedence: the all-four step ran exactly three times (initial +
+        // two retries lowered from .WithRetry(2)), composed with the other three.
+        await Assert.That(this.host.Invocations.CountFor(nameof(TransientAllResilienceStep))).IsEqualTo(3);
+
+        // Kickoff + the primary finish step each ran once (high-confidence success).
+        await Assert.That(this.host.Invocations.CountFor(nameof(TransientKickoffStep))).IsEqualTo(1);
+        await Assert.That(this.host.Invocations.CountFor(nameof(TransientFinishStep))).IsEqualTo(1);
+
+        // Precedence proof: success with acceptable confidence did NOT route to the
+        // OnLowConfidence handler...
+        await Assert.That(this.host.Invocations.CountFor(nameof(TransientReviewStep))).IsEqualTo(0);
+
+        // ...and did NOT trip the compensation (failure) path.
+        await Assert.That(this.host.Invocations.CountFor(nameof(TransientRollbackStep))).IsEqualTo(0);
+    }
+
+    /// <summary>
+    /// T019b — composition precedence: a step with all four resilience capabilities
+    /// that SUCCEEDS on its first try but returns LOW confidence (0.5 &lt; 0.85).
+    /// Asserts that success-but-low-confidence routes to the OnLowConfidence handler
+    /// (NOT compensation — a low-confidence success is not a failure) and the
+    /// primary finish step is skipped.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Saga_StepWithAllResilience_FirstTryLowConfidenceRoutesNotCompensates()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+
+        var initialState = new CompositionState { WorkflowId = workflowId };
+        var startCommand = new StartCompositionLowConfidenceCommand(workflowId, initialState);
+
+        var reachedTerminal = await this.host.RunToTerminalAsync<CompositionLowConfidenceSaga>(
+            workflowId,
+            startCommand);
+
+        // The saga reached its terminal phase via the OnLowConfidence handler's
+        // MarkCompleted().
+        await Assert.That(reachedTerminal).IsTrue();
+
+        // The step succeeded on its FIRST attempt (no retry needed).
+        await Assert.That(this.host.Invocations.CountFor(nameof(LowConfAllResilienceStep))).IsEqualTo(1);
+        await Assert.That(this.host.Invocations.CountFor(nameof(LowConfKickoffStep))).IsEqualTo(1);
+
+        // Precedence proof: confidence 0.5 < 0.85 → the OnLowConfidence handler ran...
+        await Assert.That(this.host.Invocations.CountFor(nameof(LowConfReviewStep))).IsEqualTo(1);
+
+        // ...the compensation (failure) path did NOT run — a low-confidence success
+        // is not a failure, so it must not roll back...
+        await Assert.That(this.host.Invocations.CountFor(nameof(LowConfRollbackStep))).IsEqualTo(0);
+
+        // ...and the primary finish step was skipped (the gate diverted to the
+        // handler, which completed the saga).
+        await Assert.That(this.host.Invocations.CountFor(nameof(LowConfFinishStep))).IsEqualTo(0);
+    }
+
+    /// <summary>
+    /// T019c — composition precedence: a step with all four resilience capabilities
+    /// that throws on EVERY attempt. Asserts the composed retry exhausts (three
+    /// attempts), the compensation (rollback) runs exactly once, the saga reaches
+    /// its terminal Failed phase, and NEITHER the low-confidence handler NOR the
+    /// finish step run (the step never produced a completed event).
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Saga_StepWithAllResilience_RetriesExhaustThenCompensatesNotLowConfidence()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+
+        var initialState = new CompositionState { WorkflowId = workflowId };
+        var startCommand = new StartCompositionFailCommand(workflowId, initialState);
+
+        var reachedTerminal = await this.host.RunToTerminalAsync<CompositionFailSaga>(
+            workflowId,
+            startCommand);
+
+        // The saga reached its terminal Failed phase: the compensation completed
+        // handler calls MarkCompleted(), removing the persisted saga document.
+        await Assert.That(reachedTerminal).IsTrue();
+
+        // Retry precedence: the always-throwing step ran exactly three times
+        // (initial + two retries) before retries exhausted.
+        await Assert.That(this.host.Invocations.CountFor(nameof(FailAllResilienceStep))).IsEqualTo(3);
+
+        // Compensation precedence: the rollback ran exactly once after exhaustion.
+        await Assert.That(this.host.Invocations.CountFor(nameof(FailRollbackStep))).IsEqualTo(1);
+
+        // The kickoff ran once.
+        await Assert.That(this.host.Invocations.CountFor(nameof(FailKickoffStep))).IsEqualTo(1);
+
+        // Precedence proof: a thrown (never-completed) step did NOT route to the
+        // confidence handler (there was no completed event to gate)...
+        await Assert.That(this.host.Invocations.CountFor(nameof(FailReviewStep))).IsEqualTo(0);
+
+        // ...and the happy-path finish step never ran (compensation routed to Failed).
+        await Assert.That(this.host.Invocations.CountFor(nameof(FailFinishStep))).IsEqualTo(0);
+    }
+
+    /// <summary>
+    /// T020 — timeout-vs-retry race + late-completion idempotency: a step with
+    /// <c>.WithRetry(3, 200ms).WithTimeout(50ms)</c> whose attempts each sleep
+    /// ~100ms, so the 50ms saga deadline fires mid-retry. Asserts the saga
+    /// fails-by-timeout exactly once (reaches its terminal Failed phase, observed by
+    /// saga-document absence) and that the late completion / continued retry
+    /// activity does NOT resurrect or re-fail the saga: the step after the timed
+    /// step never runs, and the timeout fired only after at least one attempt
+    /// started (the deadline raced mid-retry).
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Saga_TimeoutDuringRetry_FailsByTimeoutIdempotently_LateCompletedDoesNotResurrect()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+        this.host.Race.Reset();
+
+        var initialState = new CompositionState { WorkflowId = workflowId };
+        var startCommand = new StartCompositionRaceCommand(workflowId, initialState);
+
+        var reachedTerminal = await this.host.RunToTerminalAsync<CompositionRaceSaga>(
+            workflowId,
+            startCommand);
+
+        // The saga reached its terminal Failed phase exactly once: the timeout's
+        // MarkCompleted() removed the saga document, and the absence is the
+        // authoritative terminal signal. (Idempotency: the race-guarded timeout
+        // handler routes to Failed only while the step's phase is current; the
+        // saga's document then being gone means no later message re-failed it.)
+        await Assert.That(reachedTerminal).IsTrue();
+
+        // The kickoff ran once; at least one slow attempt started (so the timeout
+        // genuinely raced an in-flight retry, not a never-started step).
+        await Assert.That(this.host.Invocations.CountFor(nameof(RaceKickoffStep))).IsEqualTo(1);
+        await Assert.That(this.host.Invocations.CountFor(nameof(RaceSlowStep))).IsGreaterThanOrEqualTo(1);
+        await Assert.That(this.host.Race.AttemptStarts.Count).IsGreaterThanOrEqualTo(1);
+
+        // Late-completion idempotency: the step AFTER the timed step never ran. The
+        // timeout routed the saga to Failed + MarkCompleted() before its start
+        // command could be cascaded, and no late completion / retry resurrected the
+        // saga to push the chain forward.
+        await Assert.That(this.host.Invocations.CountFor(nameof(RaceNeverReachedStep))).IsEqualTo(0);
+
+        // Give any in-flight late retry one more poll budget to (not) resurrect the
+        // saga, then re-confirm it stayed terminal and never reached the next step.
+        await Task.Delay(TimeSpan.FromMilliseconds(500), CancellationToken.None);
+        await Assert.That(this.host.Invocations.CountFor(nameof(RaceNeverReachedStep))).IsEqualTo(0);
+    }
+
+    /// <summary>
+    /// T021 — INV-7: a retried step (<c>.WithRetry(2)</c>) that throws twice then
+    /// succeeds records the input <see cref="CompositionState"/> instance it
+    /// received on each attempt. Asserts every attempt received the SAME immutable
+    /// input value (Wolverine re-delivers the same envelope across retries; the saga
+    /// never mutates the input across attempts).
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Saga_StepRetried_EachAttemptReceivesIdenticalImmutableState()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+        this.host.Immutable.Reset();
+
+        var initialState = new CompositionState { WorkflowId = workflowId, Token = "immutable-run-token" };
+        var startCommand = new StartCompositionImmutableCommand(workflowId, initialState);
+
+        var reachedTerminal = await this.host.RunToTerminalAsync<CompositionImmutableSaga>(
+            workflowId,
+            startCommand);
+
+        // The saga reached its terminal Completed phase (the step eventually
+        // succeeded on its third attempt and the finish step completed).
+        await Assert.That(reachedTerminal).IsTrue();
+
+        // The retried step ran exactly three times (initial + two retries).
+        await Assert.That(this.host.Invocations.CountFor(nameof(ImmutableRetriedStep))).IsEqualTo(3);
+
+        // INV-7: the probe captured one input per attempt.
+        var seenInputs = this.host.Immutable.SeenInputs;
+        await Assert.That(seenInputs.Count).IsEqualTo(3);
+
+        // Every attempt received the SAME immutable input value: identical record
+        // value (structural equality) across all attempts, and the per-run token was
+        // never mutated across retries.
+        var first = seenInputs[0];
+        foreach (var seen in seenInputs)
+        {
+            await Assert.That(seen).IsEqualTo(first);
+            await Assert.That(seen.Token).IsEqualTo("immutable-run-token");
+            await Assert.That(seen.WorkflowId).IsEqualTo(workflowId);
+        }
+    }
+
+    /// <summary>
+    /// T021 (property-style) — INV-7 over a couple of distinct
+    /// <see cref="CompositionState"/> shapes. Reruns the identical-immutable-input
+    /// assertion with varying initial token + step-count seeds to confirm the
+    /// invariant holds independent of the input shape: every retry attempt of the
+    /// same step always receives the same immutable input value the saga handed it,
+    /// never a mutated one.
+    /// </summary>
+    /// <param name="token">The per-run token seeded into the initial state.</param>
+    /// <param name="initialStepCount">The initial step count seeded into the state.</param>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [Arguments("alpha-shape", 0)]
+    [Arguments("beta-shape", 7)]
+    [Arguments("", 42)]
+    public async Task Saga_StepRetried_ImmutableInputInvariantHoldsAcrossStateShapes(
+        string token,
+        int initialStepCount)
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+        this.host.Immutable.Reset();
+
+        var initialState = new CompositionState
+        {
+            WorkflowId = workflowId,
+            Token = token,
+            StepCount = initialStepCount,
+        };
+        var startCommand = new StartCompositionImmutableCommand(workflowId, initialState);
+
+        var reachedTerminal = await this.host.RunToTerminalAsync<CompositionImmutableSaga>(
+            workflowId,
+            startCommand);
+
+        await Assert.That(reachedTerminal).IsTrue();
+
+        // The retried step ran three times (initial + two retries) for every shape.
+        await Assert.That(this.host.Invocations.CountFor(nameof(ImmutableRetriedStep))).IsEqualTo(3);
+
+        var seenInputs = this.host.Immutable.SeenInputs;
+        await Assert.That(seenInputs.Count).IsEqualTo(3);
+
+        // Property: for ANY input shape, every attempt sees the same immutable value
+        // the kickoff folded forward (the kickoff increments StepCount once before
+        // the retried step), with the seeded token preserved across all attempts.
+        var first = seenInputs[0];
+        foreach (var seen in seenInputs)
+        {
+            await Assert.That(seen).IsEqualTo(first);
+            await Assert.That(seen.Token).IsEqualTo(token);
+            await Assert.That(seen.WorkflowId).IsEqualTo(workflowId);
+            await Assert.That(seen.StepCount).IsEqualTo(initialStepCount + 1);
+        }
+    }
+}

--- a/src/Strategos.Generators.Behavioral.Tests/ConfidenceBehaviorTests.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/ConfidenceBehaviorTests.cs
@@ -1,0 +1,130 @@
+// -----------------------------------------------------------------------
+// <copyright file="ConfidenceBehaviorTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Generators.Behavioral.Tests.Workflows;
+
+namespace Strategos.Generators.Behavioral.Tests;
+
+/// <summary>
+/// End-to-end behavioral proof (DR-5 T014) that a step's
+/// <c>.RequireConfidence(0.85).OnLowConfidence(alt =&gt; alt.Then&lt;HumanReview&gt;())</c>
+/// is actually honored at runtime: the generated confidence-gated saga handler
+/// compares the step result's confidence to the threshold and routes to the
+/// OnLowConfidence handler step (low case) or proceeds on the primary path
+/// (high case) on a real PostgreSQL-backed host.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two fixtures with distinct step CLR types (avoiding the generator's CS0101
+/// same-name collision) exercise both sides of the gate:
+/// <list type="bullet">
+///   <item><description>
+///     The low-confidence saga's classify step returns confidence 0.5 (below the
+///     0.85 threshold), so the human-review handler MUST run and the primary
+///     finish step MUST NOT.
+///   </description></item>
+///   <item><description>
+///     The high-confidence saga's classify step returns confidence 0.9 (at/above
+///     the threshold), so the primary finish step MUST run and the human-review
+///     handler MUST NOT.
+///   </description></item>
+/// </list>
+/// Before DR-5 the OnLowConfidence branch was not lowered into the saga at all,
+/// so both scenarios took the primary path; asserting that the low case diverts
+/// to the handler — and the high case does not — is the routing proof.
+/// </para>
+/// <para>
+/// Marked <see cref="NotInParallelAttribute"/> because it shares the single
+/// process-wide container + host and observes the process-shared invocation log.
+/// </para>
+/// </remarks>
+[Property("Category", "Integration")]
+[NotInParallel]
+[ClassDataSource<WolverineHostFixture>(Shared = SharedType.PerTestSession)]
+public sealed class ConfidenceBehaviorTests
+{
+    private readonly WolverineHostFixture host;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfidenceBehaviorTests"/>
+    /// class.
+    /// </summary>
+    /// <param name="host">
+    /// The shared Wolverine+Marten host fixture, injected by TUnit and shared
+    /// across the entire test session.
+    /// </param>
+    public ConfidenceBehaviorTests(WolverineHostFixture host)
+    {
+        this.host = host;
+    }
+
+    /// <summary>
+    /// Starts the generated low-confidence workflow saga whose classify step
+    /// returns confidence 0.5 (below the 0.85 threshold). Asserts the saga routed
+    /// to the lowered OnLowConfidence handler step (HumanReviewStepLow ran) and
+    /// the primary finish step did NOT run.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Saga_LowConfidence_RoutesToOnLowConfidenceBranch()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+
+        var initialState = new ConfidenceState { WorkflowId = workflowId };
+        var startCommand = new StartLowConfidenceCommand(workflowId, initialState);
+
+        var completed = await this.host.RunWorkflowAsync<LowConfidenceSaga>(workflowId, startCommand);
+
+        // The saga reached its terminal phase: the single-step OnLowConfidence
+        // handler calls MarkCompleted(), removing the persisted saga document.
+        await Assert.That(completed).IsTrue();
+
+        // The prepare and classify steps each ran exactly once.
+        await Assert.That(this.host.Invocations.CountFor(nameof(ConfPrepareStepLow))).IsEqualTo(1);
+        await Assert.That(this.host.Invocations.CountFor(nameof(ClassifyStepLow))).IsEqualTo(1);
+
+        // Routing proof: confidence 0.5 < 0.85 → the human-review handler ran...
+        await Assert.That(this.host.Invocations.CountFor(nameof(HumanReviewStepLow))).IsEqualTo(1);
+
+        // ...and the primary finish step was skipped (the gate diverted before it).
+        await Assert.That(this.host.Invocations.CountFor(nameof(ConfFinishStepLow))).IsEqualTo(0);
+    }
+
+    /// <summary>
+    /// Starts the generated high-confidence workflow saga whose classify step
+    /// returns confidence 0.9 (at/above the 0.85 threshold). Asserts the saga
+    /// proceeded on the primary path (the finish step ran) and did NOT route to
+    /// the OnLowConfidence handler step.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Saga_HighConfidence_ProceedsOnPrimaryPath()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+
+        var initialState = new ConfidenceState { WorkflowId = workflowId };
+        var startCommand = new StartHighConfidenceCommand(workflowId, initialState);
+
+        var completed = await this.host.RunWorkflowAsync<HighConfidenceSaga>(workflowId, startCommand);
+
+        // The saga reached its terminal phase via the primary finish step's
+        // MarkCompleted().
+        await Assert.That(completed).IsTrue();
+
+        // The prepare and classify steps each ran exactly once.
+        await Assert.That(this.host.Invocations.CountFor(nameof(ConfPrepareStepHigh))).IsEqualTo(1);
+        await Assert.That(this.host.Invocations.CountFor(nameof(ClassifyStepHigh))).IsEqualTo(1);
+
+        // Routing proof: confidence 0.9 >= 0.85 → the primary finish step ran...
+        await Assert.That(this.host.Invocations.CountFor(nameof(ConfFinishStepHigh))).IsEqualTo(1);
+
+        // ...and the human-review handler did NOT run.
+        await Assert.That(this.host.Invocations.CountFor(nameof(HumanReviewStepHigh))).IsEqualTo(0);
+    }
+}

--- a/src/Strategos.Generators.Behavioral.Tests/ContextBehaviorTests.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/ContextBehaviorTests.cs
@@ -1,0 +1,124 @@
+// -----------------------------------------------------------------------
+// <copyright file="ContextBehaviorTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Agents.Models;
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Generators.Behavioral.Tests.Workflows;
+
+namespace Strategos.Generators.Behavioral.Tests;
+
+/// <summary>
+/// End-to-end behavioral proof (DR-6 T016) that a step's <c>.WithContext(...)</c>
+/// declaration is actually honored at runtime: the generated
+/// <c>EnrichStepContextAssembler</c> is wired into the step's worker handler, so
+/// when the saga runs on a real PostgreSQL-backed host the handler assembles the
+/// declared context (state value, ontology retrieval, literal) BEFORE the step
+/// executes, runs the lowered <c>SimilarityExpression</c> through the registered
+/// <c>IObjectSetProvider</c>, and delivers the assembled context to the
+/// context-aware step.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Before the DR-6 wire-in the <c>ContextAssemblerEmitter</c> was never invoked
+/// by the generator, so no assembler reached the compilation: the step ran with
+/// no assembled context and the object-set provider was never called. Asserting
+/// that the stub provider's <c>ExecuteSimilarityAsync</c> was invoked with the
+/// declared <c>TopK</c>/<c>MinRelevance</c>, and that the step received a
+/// state + retrieval + literal context, is the wire-in proof.
+/// </para>
+/// <para>
+/// Ontology-wired, not RAG (INV-2): the assembler's only retrieval dependency is
+/// <c>IObjectSetProvider</c> (Strategos.Ontology.ObjectSets), backed here by the
+/// recording <see cref="StubObjectSetProvider"/>.
+/// </para>
+/// <para>
+/// Marked <see cref="NotInParallelAttribute"/> because it shares the single
+/// process-wide container + host and observes process-shared probes.
+/// </para>
+/// </remarks>
+[Property("Category", "Integration")]
+[NotInParallel]
+[ClassDataSource<ContextHostFixture>(Shared = SharedType.PerTestSession)]
+public sealed class ContextBehaviorTests
+{
+    private readonly ContextHostFixture host;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ContextBehaviorTests"/> class.
+    /// </summary>
+    /// <param name="host">
+    /// The shared Wolverine+Marten host fixture, injected by TUnit and shared
+    /// across the entire test session.
+    /// </param>
+    public ContextBehaviorTests(ContextHostFixture host)
+    {
+        this.host = host;
+    }
+
+    /// <summary>
+    /// Runs the generated context workflow saga whose enrich step declares
+    /// <c>.WithContext(...)</c>. Asserts the generated assembler assembled the
+    /// step's context (state + retrieval + literal segments) and delivered it to
+    /// the step, and that the lowered retrieval ran through the stub
+    /// <c>IObjectSetProvider</c> with the declared <c>TopK</c>/<c>MinRelevance</c>.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Saga_StepWithContext_AssemblesContextAndInvokesExecuteSimilarity()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+        this.host.Probe.Reset();
+
+        var initialState = new ContextState { WorkflowId = workflowId };
+        var startCommand = new StartContextFlowCommand(workflowId, initialState);
+
+        var completed = await this.host.RunWorkflowAsync<ContextFlowSaga>(workflowId, startCommand);
+
+        // The saga reached its terminal phase via the finish step's MarkCompleted().
+        await Assert.That(completed).IsTrue();
+
+        // Every step ran exactly once, including the context-declaring enrich step.
+        await Assert.That(this.host.Invocations.CountFor(nameof(ContextPrepareStep))).IsEqualTo(1);
+        await Assert.That(this.host.Invocations.CountFor(nameof(EnrichStep))).IsEqualTo(1);
+        await Assert.That(this.host.Invocations.CountFor(nameof(ContextFinishStep))).IsEqualTo(1);
+
+        // Retrieval proof: the lowered SimilarityExpression reached the provider
+        // with the declared TopK / MinRelevance / query exactly once.
+        await Assert.That(this.host.Probe.SimilarityCallCount).IsEqualTo(1);
+        var similarity = this.host.Probe.LastSimilarity;
+        await Assert.That(similarity).IsNotNull();
+        await Assert.That(similarity!.TopK).IsEqualTo(5);
+        await Assert.That(similarity.MinRelevance).IsEqualTo(0.8);
+        await Assert.That(similarity.QueryText).IsEqualTo("recommended widgets");
+
+        // Assembly proof: the worker handler assembled context BEFORE the step ran
+        // and delivered it to the context-aware step.
+        var assembled = this.host.Probe.LastAssembledContext;
+        await Assert.That(assembled).IsNotNull();
+        await Assert.That(assembled!.IsEmpty).IsFalse();
+
+        // All three declared sources are present, in order: state, retrieval, literal.
+        await Assert.That(assembled.Segments.Count).IsEqualTo(3);
+        await Assert.That(assembled.Segments[0]).IsTypeOf<StateContextSegment>();
+        await Assert.That(assembled.Segments[1]).IsTypeOf<RetrievalContextSegment>();
+        await Assert.That(assembled.Segments[2]).IsTypeOf<LiteralContextSegment>();
+
+        // State segment carries the value the prepare step folded into state.
+        var stateSegment = (StateContextSegment)assembled.Segments[0];
+        await Assert.That(stateSegment.Value as string).IsEqualTo("Ada Lovelace");
+
+        // Retrieval segment carries the single canned stub document.
+        var retrievalSegment = (RetrievalContextSegment)assembled.Segments[1];
+        await Assert.That(retrievalSegment.CollectionName).IsEqualTo(nameof(ProductCatalog));
+        await Assert.That(retrievalSegment.Results.Count).IsEqualTo(1);
+        await Assert.That(retrievalSegment.Results[0].Score).IsEqualTo(StubObjectSetProvider.StubScore);
+
+        // Literal segment carries the declared brand-guidelines literal.
+        var literalSegment = (LiteralContextSegment)assembled.Segments[2];
+        await Assert.That(literalSegment.Value).IsEqualTo("Follow brand guidelines.");
+    }
+}

--- a/src/Strategos.Generators.Behavioral.Tests/GlobalUsings.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/GlobalUsings.cs
@@ -1,0 +1,15 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using System;
+global using System.Collections.Generic;
+global using System.Linq;
+global using System.Threading;
+global using System.Threading.Tasks;
+
+global using TUnit.Assertions;
+global using TUnit.Core;
+global using TUnit.Core.Interfaces;

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/CompensationHostFixture.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/CompensationHostFixture.cs
@@ -1,0 +1,183 @@
+// -----------------------------------------------------------------------
+// <copyright file="CompensationHostFixture.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Diagnostics;
+
+using JasperFx.Resources;
+
+using Marten;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Strategos.Generators.Behavioral.Tests.Workflows;
+
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+
+namespace Strategos.Generators.Behavioral.Tests.Infrastructure;
+
+/// <summary>
+/// Runtime host fixture for the compensation behavioral proof (DR-3). Stands up a
+/// real PostgreSQL container and a Wolverine+Marten host wired with the generated
+/// <c>AddCompensationProofWorkflow()</c> registration, then runs the generated saga
+/// end-to-end to observe the lowered <c>.Compensate&lt;T&gt;()</c> path firing after
+/// retry exhaustion.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This mirrors <see cref="TimeoutHostFixture"/>: the compensation trigger is
+/// published from the failing step's Wolverine error chain
+/// (<c>CompensatingAction</c>) once retries are exhausted, and is released through
+/// the durable inbox/outbox by Wolverine's durability agent rather than being
+/// awaited synchronously by <c>TrackActivity()</c>. The fixture therefore publishes
+/// the start command, awaits the synchronously-cascaded activity, then polls
+/// saga-document absence until the compensation chain settles into the terminal
+/// Failed phase.
+/// </para>
+/// <para>
+/// Lifecycle is driven by TUnit via <see cref="IAsyncInitializer"/> /
+/// <see cref="IAsyncDisposable"/>. Share one instance for the whole session with
+/// <c>[ClassDataSource&lt;CompensationHostFixture&gt;(Shared = SharedType.PerTestSession)]</c>.
+/// </para>
+/// </remarks>
+public sealed class CompensationHostFixture : IAsyncInitializer, IAsyncDisposable
+{
+    private readonly PostgresFixture postgres = new();
+
+    private IHost? host;
+
+    /// <summary>
+    /// Gets the shared step-invocation log. Instrumented workflow steps push their
+    /// name here so a test can assert which steps ran and how many times.
+    /// </summary>
+    public WorkflowInvocationLog Invocations { get; } = new();
+
+    /// <summary>
+    /// Starts the shared Postgres container, then builds and starts the Wolverine
+    /// host with Marten-backed saga storage and the generated compensation-workflow
+    /// registration.
+    /// </summary>
+    /// <returns>A task that completes when the host is running.</returns>
+    public async Task InitializeAsync()
+    {
+        await this.postgres.InitializeAsync();
+
+        this.host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services
+                    .AddMarten(storeOptions =>
+                    {
+                        storeOptions.Connection(this.postgres.ConnectionString);
+                        storeOptions.AutoCreateSchemaObjects = JasperFx.AutoCreate.All;
+                    })
+                    .IntegrateWithWolverine()
+                    .ApplyAllDatabaseChangesOnStartup();
+
+                // The generated compensation workflow: its CompensatedFailingStepHandler
+                // carries the static Configure(HandlerChain) retry + compensation policy
+                // lowered from .WithRetry(2).Compensate<RollbackStep>() (DR-3).
+                opts.Services.AddCompensationProofWorkflow();
+
+                opts.Services.AddSingleton(this.Invocations);
+                opts.Services.AddResourceSetupOnStartup();
+            })
+            .StartAsync();
+    }
+
+    /// <summary>
+    /// Publishes a generated start command, awaits all synchronously-tracked
+    /// cascaded activity, then polls until the saga reaches its terminal phase
+    /// (its document is removed by <c>MarkCompleted()</c>) or the budget elapses.
+    /// </summary>
+    /// <typeparam name="TSaga">
+    /// The generated saga document type whose persistence is polled for terminal
+    /// completion (its absence signals the saga finished).
+    /// </typeparam>
+    /// <param name="workflowId">The workflow/saga identity to wait on.</param>
+    /// <param name="startCommand">The generated start command.</param>
+    /// <param name="terminalBudget">
+    /// Total budget to wait for the terminal phase, covering retry exhaustion, the
+    /// outbox-released compensation trigger, the rollback worker, and completion.
+    /// Defaults to 60 seconds.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when the saga reached its terminal phase within the
+    /// budget; otherwise <see langword="false"/>.
+    /// </returns>
+    public async Task<bool> RunToTerminalAsync<TSaga>(
+        Guid workflowId,
+        object startCommand,
+        TimeSpan? terminalBudget = null)
+        where TSaga : class
+    {
+        ArgumentNullException.ThrowIfNull(startCommand, nameof(startCommand));
+
+        var runtime = this.RequireHost();
+        var budget = terminalBudget ?? TimeSpan.FromSeconds(60);
+
+        // Publish the start command. The failing step throws and Wolverine retries
+        // it; the error chain's CompensatingAction publishes the trigger via the
+        // outbox once retries are exhausted. That trigger + the rollback worker +
+        // completion are released by the durability agent and polled for below, so
+        // the tracked publish is allowed to settle without requiring the whole
+        // compensation cascade to be synchronous.
+        try
+        {
+            await runtime
+                .TrackActivity()
+                .Timeout(budget)
+                .DoNotAssertOnExceptionsDetected()
+                .PublishMessageAndWaitAsync(startCommand);
+        }
+        catch (TimeoutException)
+        {
+            // The retry/dead-letter machinery may keep the tracked session busy past
+            // the point the saga has already routed to compensation; fall through to
+            // the saga-absence poll, which is the authoritative terminal signal.
+        }
+
+        var store = runtime.Services.GetRequiredService<IDocumentStore>();
+        var sw = Stopwatch.StartNew();
+
+        while (sw.Elapsed < budget)
+        {
+            await using var query = store.QuerySession();
+            var saga = await query.LoadAsync<TSaga>(workflowId);
+            if (saga is null)
+            {
+                // MarkCompleted() removed the saga document: terminal Failed reached
+                // after the compensation step ran.
+                return true;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100), CancellationToken.None);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Stops and disposes the host and the shared Postgres container.
+    /// </summary>
+    /// <returns>A value task that completes when teardown finishes.</returns>
+    public async ValueTask DisposeAsync()
+    {
+        if (this.host is not null)
+        {
+            await this.host.StopAsync();
+            this.host.Dispose();
+        }
+
+        await this.postgres.DisposeAsync();
+    }
+
+    private IHost RequireHost() =>
+        this.host ?? throw new InvalidOperationException(
+            "Host not initialized. Ensure InitializeAsync ran (TUnit IAsyncInitializer).");
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/CompositionHostFixture.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/CompositionHostFixture.cs
@@ -1,0 +1,201 @@
+// -----------------------------------------------------------------------
+// <copyright file="CompositionHostFixture.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Diagnostics;
+
+using JasperFx.Resources;
+
+using Marten;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Strategos.Generators.Behavioral.Tests.Workflows;
+
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+
+namespace Strategos.Generators.Behavioral.Tests.Infrastructure;
+
+/// <summary>
+/// Runtime host fixture for the composition behavioral proofs (epic #135, DR-10,
+/// T019/T020/T021). Stands up a real PostgreSQL container and a Wolverine+Marten
+/// host wired with the generated composition-workflow registrations, then runs the
+/// generated sagas end-to-end to observe how all four lowered resilience
+/// capabilities (retry, timeout, compensation, confidence) COMPOSE on a single
+/// step and behave at the edges.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the union of the per-capability fixtures: some composition scenarios
+/// complete on the synchronously-tracked cascade (transient-then-success,
+/// low-confidence route), while others (always-throws -> compensation; timeout
+/// firing mid-retry) complete via a durably-released message (the
+/// outbox-published compensation trigger, or the scheduled timeout) that
+/// <c>TrackActivity()</c> does not await. The fixture therefore publishes the
+/// start command (tolerating detected exceptions from the failure paths), then
+/// polls saga-document absence — the authoritative terminal signal, because the
+/// generated terminal handlers call <c>MarkCompleted()</c> which removes the saga
+/// document.
+/// </para>
+/// <para>
+/// Lifecycle is driven by TUnit via <see cref="IAsyncInitializer"/> /
+/// <see cref="IAsyncDisposable"/>. Share one instance for the whole session with
+/// <c>[ClassDataSource&lt;CompositionHostFixture&gt;(Shared = SharedType.PerTestSession)]</c>.
+/// </para>
+/// </remarks>
+public sealed class CompositionHostFixture : IAsyncInitializer, IAsyncDisposable
+{
+    private readonly PostgresFixture postgres = new();
+
+    private IHost? host;
+
+    /// <summary>
+    /// Gets the shared step-invocation log. Instrumented workflow steps push their
+    /// name here so a test can assert which steps ran and how many times.
+    /// </summary>
+    public WorkflowInvocationLog Invocations { get; } = new();
+
+    /// <summary>
+    /// Gets the shared timeout-vs-retry race probe (T020). The slow retried step
+    /// records each attempt-start timestamp here so a test can confirm the deadline
+    /// fired mid-retry.
+    /// </summary>
+    public CompositionRaceProbe Race { get; } = new();
+
+    /// <summary>
+    /// Gets the shared immutable-input probe (T021). The retried step records the
+    /// input state instance it received on each attempt so a test can assert INV-7.
+    /// </summary>
+    public CompositionImmutableProbe Immutable { get; } = new();
+
+    /// <summary>
+    /// Starts the shared Postgres container, then builds and starts the Wolverine
+    /// host with Marten-backed saga storage and the generated composition-workflow
+    /// registrations.
+    /// </summary>
+    /// <returns>A task that completes when the host is running.</returns>
+    public async Task InitializeAsync()
+    {
+        await this.postgres.InitializeAsync();
+
+        this.host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services
+                    .AddMarten(storeOptions =>
+                    {
+                        storeOptions.Connection(this.postgres.ConnectionString);
+                        storeOptions.AutoCreateSchemaObjects = JasperFx.AutoCreate.All;
+                    })
+                    .IntegrateWithWolverine()
+                    .ApplyAllDatabaseChangesOnStartup();
+
+                // The three T019 precedence workflows: each generated saga carries
+                // all four lowered capabilities on its middle step (retry +
+                // compensation on the worker chain, timeout cascade + saga handler,
+                // confidence gate in the completed handler).
+                opts.Services.AddCompositionTransientWorkflow();
+                opts.Services.AddCompositionLowConfidenceWorkflow();
+                opts.Services.AddCompositionFailWorkflow();
+
+                // The T020 race + T021 immutable-input workflows.
+                opts.Services.AddCompositionRaceWorkflow();
+                opts.Services.AddCompositionImmutableWorkflow();
+
+                opts.Services.AddSingleton(this.Invocations);
+                opts.Services.AddSingleton(this.Race);
+                opts.Services.AddSingleton(this.Immutable);
+                opts.Services.AddResourceSetupOnStartup();
+            })
+            .StartAsync();
+    }
+
+    /// <summary>
+    /// Publishes a generated start command, awaits all synchronously-tracked
+    /// cascaded activity (tolerating detected exceptions from the compensation /
+    /// timeout failure paths), then polls until the saga reaches its terminal phase
+    /// (its document is removed by <c>MarkCompleted()</c>) or the budget elapses.
+    /// </summary>
+    /// <typeparam name="TSaga">
+    /// The generated saga document type whose persistence is polled for terminal
+    /// completion (its absence signals the saga finished).
+    /// </typeparam>
+    /// <param name="workflowId">The workflow/saga identity to wait on.</param>
+    /// <param name="startCommand">The generated start command.</param>
+    /// <param name="terminalBudget">
+    /// Total budget to wait for the terminal phase, covering retry exhaustion, the
+    /// outbox-released compensation trigger, the scheduled timeout, the rollback
+    /// worker, and completion. Defaults to 60 seconds.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when the saga reached its terminal phase within the
+    /// budget; otherwise <see langword="false"/>.
+    /// </returns>
+    public async Task<bool> RunToTerminalAsync<TSaga>(
+        Guid workflowId,
+        object startCommand,
+        TimeSpan? terminalBudget = null)
+        where TSaga : class
+    {
+        ArgumentNullException.ThrowIfNull(startCommand, nameof(startCommand));
+
+        var runtime = this.RequireHost();
+        var budget = terminalBudget ?? TimeSpan.FromSeconds(60);
+
+        try
+        {
+            await runtime
+                .TrackActivity()
+                .Timeout(budget)
+                .DoNotAssertOnExceptionsDetected()
+                .PublishMessageAndWaitAsync(startCommand);
+        }
+        catch (TimeoutException)
+        {
+            // The retry / scheduled-timeout machinery may keep the tracked session
+            // busy past the point the saga has already routed to its terminal phase;
+            // fall through to the saga-absence poll, which is authoritative.
+        }
+
+        var store = runtime.Services.GetRequiredService<IDocumentStore>();
+        var sw = Stopwatch.StartNew();
+
+        while (sw.Elapsed < budget)
+        {
+            await using var query = store.QuerySession();
+            var saga = await query.LoadAsync<TSaga>(workflowId);
+            if (saga is null)
+            {
+                return true;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100), CancellationToken.None);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Stops and disposes the host and the shared Postgres container.
+    /// </summary>
+    /// <returns>A value task that completes when teardown finishes.</returns>
+    public async ValueTask DisposeAsync()
+    {
+        if (this.host is not null)
+        {
+            await this.host.StopAsync();
+            this.host.Dispose();
+        }
+
+        await this.postgres.DisposeAsync();
+    }
+
+    private IHost RequireHost() =>
+        this.host ?? throw new InvalidOperationException(
+            "Host not initialized. Ensure InitializeAsync ran (TUnit IAsyncInitializer).");
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/ContextHostFixture.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/ContextHostFixture.cs
@@ -1,0 +1,162 @@
+// -----------------------------------------------------------------------
+// <copyright file="ContextHostFixture.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using JasperFx.Resources;
+
+using Marten;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Strategos.Generators.Behavioral.Tests.Workflows;
+using Strategos.Ontology.ObjectSets;
+
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+
+namespace Strategos.Generators.Behavioral.Tests.Infrastructure;
+
+/// <summary>
+/// Runtime host fixture for the context-assembly behavioral proof (DR-6 T016).
+/// Stands up a real PostgreSQL container and a Wolverine+Marten host wired with
+/// the generated <c>AddContextFlowWorkflow()</c> registration, then runs the
+/// generated saga end-to-end so the lowered <c>{Step}ContextAssembler</c> is
+/// exercised on the real container.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Dedicated rather than reusing <see cref="WolverineHostFixture"/> because the
+/// generated <c>EnrichStepContextAssembler</c> takes an
+/// <c>IObjectSetProvider</c> dependency; this fixture registers the recording
+/// <see cref="StubObjectSetProvider"/> (and the shared <see cref="ContextProbe"/>)
+/// so the assembler resolves and its <c>ExecuteSimilarityAsync</c> call is
+/// observable. The generated DI registration only wires the assembler type
+/// itself; the provider is the host's responsibility, exactly as a real ontology
+/// host would register its backend.
+/// </para>
+/// <para>
+/// Lifecycle is driven by TUnit via <see cref="IAsyncInitializer"/> /
+/// <see cref="IAsyncDisposable"/>. Share one instance for the whole session with
+/// <c>[ClassDataSource&lt;ContextHostFixture&gt;(Shared = SharedType.PerTestSession)]</c>.
+/// </para>
+/// </remarks>
+public sealed class ContextHostFixture : IAsyncInitializer, IAsyncDisposable
+{
+    private readonly PostgresFixture postgres = new();
+
+    private IHost? host;
+
+    /// <summary>
+    /// Gets the shared step-invocation log. Instrumented workflow steps push their
+    /// name here so a test can assert which steps ran and how many times.
+    /// </summary>
+    public WorkflowInvocationLog Invocations { get; } = new();
+
+    /// <summary>
+    /// Gets the shared observation probe. The stub provider records its
+    /// <c>ExecuteSimilarityAsync</c> expression here and the context-aware step
+    /// records the assembled context it received.
+    /// </summary>
+    public ContextProbe Probe { get; } = new();
+
+    /// <summary>
+    /// Starts the shared Postgres container, then builds and starts the Wolverine
+    /// host with Marten-backed saga storage, the generated context workflow, and
+    /// the stub object-set provider that backs the generated assembler.
+    /// </summary>
+    /// <returns>A task that completes when the host is running.</returns>
+    public async Task InitializeAsync()
+    {
+        await this.postgres.InitializeAsync();
+
+        this.host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services
+                    .AddMarten(storeOptions =>
+                    {
+                        storeOptions.Connection(this.postgres.ConnectionString);
+                        storeOptions.AutoCreateSchemaObjects = JasperFx.AutoCreate.All;
+                    })
+                    .IntegrateWithWolverine()
+                    .ApplyAllDatabaseChangesOnStartup();
+
+                // The generated context workflow: AddContextFlowWorkflow() registers
+                // the steps, worker handlers, AND the lowered EnrichStepContextAssembler
+                // (DR-6). The assembler's IObjectSetProvider dependency is the host's
+                // to supply — here the recording stub below.
+                opts.Services.AddContextFlowWorkflow();
+
+                // The recording object-set provider that backs the generated
+                // assembler's retrieval source, plus the shared probe both it and the
+                // context-aware step write their observations to.
+                opts.Services.AddSingleton(this.Probe);
+                opts.Services.AddSingleton<IObjectSetProvider>(_ => new StubObjectSetProvider(this.Probe));
+
+                // The shared invocation log injected into instrumented steps.
+                opts.Services.AddSingleton(this.Invocations);
+
+                opts.Services.AddResourceSetupOnStartup();
+            })
+            .StartAsync();
+    }
+
+    /// <summary>
+    /// Runs the generated context workflow saga to completion against the real
+    /// host, awaiting all cascaded saga + worker activity via Wolverine's
+    /// message-tracking API.
+    /// </summary>
+    /// <typeparam name="TSaga">
+    /// The generated saga document type whose persistence is polled to confirm
+    /// terminal completion (its absence signals the saga finished).
+    /// </typeparam>
+    /// <param name="workflowId">The workflow/saga identity to wait on.</param>
+    /// <param name="startCommand">The generated start command.</param>
+    /// <param name="timeout">Optional wait budget. Defaults to 30 seconds.</param>
+    /// <returns>
+    /// <see langword="true"/> when the saga reached its terminal phase.
+    /// </returns>
+    public async Task<bool> RunWorkflowAsync<TSaga>(
+        Guid workflowId,
+        object startCommand,
+        TimeSpan? timeout = null)
+        where TSaga : class
+    {
+        ArgumentNullException.ThrowIfNull(startCommand, nameof(startCommand));
+
+        var runtime = this.RequireHost();
+
+        await runtime
+            .TrackActivity()
+            .Timeout(timeout ?? TimeSpan.FromSeconds(30))
+            .PublishMessageAndWaitAsync(startCommand);
+
+        await using var query = runtime.Services.GetRequiredService<IDocumentStore>().QuerySession();
+        var saga = await query.LoadAsync<TSaga>(workflowId);
+
+        return saga is null;
+    }
+
+    /// <summary>
+    /// Stops and disposes the host and the shared Postgres container.
+    /// </summary>
+    /// <returns>A value task that completes when teardown finishes.</returns>
+    public async ValueTask DisposeAsync()
+    {
+        if (this.host is not null)
+        {
+            await this.host.StopAsync();
+            this.host.Dispose();
+        }
+
+        await this.postgres.DisposeAsync();
+    }
+
+    private IHost RequireHost() =>
+        this.host ?? throw new InvalidOperationException(
+            "Host not initialized. Ensure InitializeAsync ran (TUnit IAsyncInitializer).");
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/ContextProbe.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/ContextProbe.cs
@@ -25,25 +25,70 @@ public sealed class ContextProbe
 {
     private readonly object gate = new();
 
+    private SimilarityExpression? lastSimilarity;
+    private int similarityCallCount;
+    private AssembledContext? lastAssembledContext;
+
     /// <summary>
     /// Gets the similarity expression captured from the stub provider's most
     /// recent <c>ExecuteSimilarityAsync</c> call, or <see langword="null"/> if it
     /// has not been invoked since the last <see cref="Reset"/>.
     /// </summary>
-    public SimilarityExpression? LastSimilarity { get; private set; }
+    /// <remarks>
+    /// The getter acquires the same <c>gate</c> lock the writers hold, so a test
+    /// assertion (reader) never observes torn/stale state written by the stub
+    /// provider (writer) on another thread — this is a DI singleton shared across
+    /// both roles.
+    /// </remarks>
+    public SimilarityExpression? LastSimilarity
+    {
+        get
+        {
+            lock (this.gate)
+            {
+                return this.lastSimilarity;
+            }
+        }
+    }
 
     /// <summary>
     /// Gets the number of times the stub provider's <c>ExecuteSimilarityAsync</c>
     /// was invoked since the last <see cref="Reset"/>.
     /// </summary>
-    public int SimilarityCallCount { get; private set; }
+    /// <remarks>
+    /// Read under the same <c>gate</c> lock the writers hold so the count is
+    /// synchronized with the write that incremented it.
+    /// </remarks>
+    public int SimilarityCallCount
+    {
+        get
+        {
+            lock (this.gate)
+            {
+                return this.similarityCallCount;
+            }
+        }
+    }
 
     /// <summary>
     /// Gets the assembled context the generated worker handler delivered to the
     /// context-aware step, or <see langword="null"/> if the step has not received
     /// context since the last <see cref="Reset"/>.
     /// </summary>
-    public AssembledContext? LastAssembledContext { get; private set; }
+    /// <remarks>
+    /// Read under the same <c>gate</c> lock the writers hold so the reader never
+    /// observes a half-published reference.
+    /// </remarks>
+    public AssembledContext? LastAssembledContext
+    {
+        get
+        {
+            lock (this.gate)
+            {
+                return this.lastAssembledContext;
+            }
+        }
+    }
 
     /// <summary>
     /// Records the similarity expression the stub provider was asked to execute.
@@ -55,8 +100,8 @@ public sealed class ContextProbe
 
         lock (this.gate)
         {
-            this.LastSimilarity = expression;
-            this.SimilarityCallCount++;
+            this.lastSimilarity = expression;
+            this.similarityCallCount++;
         }
     }
 
@@ -70,7 +115,7 @@ public sealed class ContextProbe
 
         lock (this.gate)
         {
-            this.LastAssembledContext = context;
+            this.lastAssembledContext = context;
         }
     }
 
@@ -81,9 +126,9 @@ public sealed class ContextProbe
     {
         lock (this.gate)
         {
-            this.LastSimilarity = null;
-            this.SimilarityCallCount = 0;
-            this.LastAssembledContext = null;
+            this.lastSimilarity = null;
+            this.similarityCallCount = 0;
+            this.lastAssembledContext = null;
         }
     }
 }

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/ContextProbe.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/ContextProbe.cs
@@ -1,0 +1,89 @@
+// -----------------------------------------------------------------------
+// <copyright file="ContextProbe.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Agents.Models;
+using Strategos.Ontology.ObjectSets;
+
+namespace Strategos.Generators.Behavioral.Tests.Infrastructure;
+
+/// <summary>
+/// Process-shared observation sink for the DR-6 context-assembly behavioral proof
+/// (T016). The stub <see cref="StubObjectSetProvider"/> records the
+/// <c>SimilarityExpression</c> it received on <see cref="LastSimilarity"/>; the
+/// context-aware enrich step records the <see cref="AssembledContext"/> the
+/// generated worker handler delivered on <see cref="LastAssembledContext"/>.
+/// </summary>
+/// <remarks>
+/// Registered as a DI singleton on the host so the stub provider and the step
+/// share one instance. Reset at the start of each test to isolate it from prior
+/// runs on the session-scoped host.
+/// </remarks>
+public sealed class ContextProbe
+{
+    private readonly object gate = new();
+
+    /// <summary>
+    /// Gets the similarity expression captured from the stub provider's most
+    /// recent <c>ExecuteSimilarityAsync</c> call, or <see langword="null"/> if it
+    /// has not been invoked since the last <see cref="Reset"/>.
+    /// </summary>
+    public SimilarityExpression? LastSimilarity { get; private set; }
+
+    /// <summary>
+    /// Gets the number of times the stub provider's <c>ExecuteSimilarityAsync</c>
+    /// was invoked since the last <see cref="Reset"/>.
+    /// </summary>
+    public int SimilarityCallCount { get; private set; }
+
+    /// <summary>
+    /// Gets the assembled context the generated worker handler delivered to the
+    /// context-aware step, or <see langword="null"/> if the step has not received
+    /// context since the last <see cref="Reset"/>.
+    /// </summary>
+    public AssembledContext? LastAssembledContext { get; private set; }
+
+    /// <summary>
+    /// Records the similarity expression the stub provider was asked to execute.
+    /// </summary>
+    /// <param name="expression">The similarity expression.</param>
+    public void RecordSimilarity(SimilarityExpression expression)
+    {
+        ArgumentNullException.ThrowIfNull(expression, nameof(expression));
+
+        lock (this.gate)
+        {
+            this.LastSimilarity = expression;
+            this.SimilarityCallCount++;
+        }
+    }
+
+    /// <summary>
+    /// Records the assembled context delivered to the context-aware step.
+    /// </summary>
+    /// <param name="context">The assembled context.</param>
+    public void RecordAssembledContext(AssembledContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context, nameof(context));
+
+        lock (this.gate)
+        {
+            this.LastAssembledContext = context;
+        }
+    }
+
+    /// <summary>
+    /// Clears all captured observations. Called at the start of each test.
+    /// </summary>
+    public void Reset()
+    {
+        lock (this.gate)
+        {
+            this.LastSimilarity = null;
+            this.SimilarityCallCount = 0;
+            this.LastAssembledContext = null;
+        }
+    }
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/HostFixtureTests.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/HostFixtureTests.cs
@@ -1,0 +1,78 @@
+// -----------------------------------------------------------------------
+// <copyright file="HostFixtureTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Behavioral.Tests.Workflows;
+
+namespace Strategos.Generators.Behavioral.Tests.Infrastructure;
+
+/// <summary>
+/// End-to-end behavioral test that compiles a Strategos workflow (the source
+/// generator emits its Wolverine+Marten saga) and RUNS it against a real
+/// PostgreSQL container, asserting happy-path completion.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the acceptance test for the reusable runtime host fixture
+/// (<see cref="WolverineHostFixture"/>) that later behavioral tasks
+/// (retry/timeout/compensation/confidence) build on. It proves a generated
+/// saga runs to completion on a real host with real Marten-backed saga
+/// storage and inbox/outbox.
+/// </para>
+/// <para>
+/// Marked <see cref="NotInParallelAttribute"/> because it shares a single
+/// process-wide container + host and observes a process-shared invocation
+/// log.
+/// </para>
+/// </remarks>
+[Property("Category", "Integration")]
+[NotInParallel]
+[ClassDataSource<WolverineHostFixture>(Shared = SharedType.PerTestSession)]
+public sealed class HostFixtureTests
+{
+    private readonly WolverineHostFixture host;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HostFixtureTests"/> class.
+    /// </summary>
+    /// <param name="host">
+    /// The shared Wolverine+Marten host fixture, injected by TUnit and shared
+    /// across the entire test session.
+    /// </param>
+    public HostFixtureTests(WolverineHostFixture host)
+    {
+        this.host = host;
+    }
+
+    /// <summary>
+    /// Starts the generated happy-path workflow saga and awaits completion,
+    /// asserting that every step ran exactly once and the saga reached its
+    /// terminal/completed phase (the saga document is removed by
+    /// <c>MarkCompleted()</c>).
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Host_FixtureWorkflow_StartsAndCompletesHappyPath()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+
+        var initialState = new HappyPathState { WorkflowId = workflowId };
+        var startCommand = new StartHappyPathCommand(workflowId, initialState);
+
+        var completed = await this.host.RunWorkflowAsync(workflowId, startCommand);
+
+        // The saga reached its terminal phase: MarkCompleted() removed the
+        // persisted saga document, which the host observes as completion.
+        await Assert.That(completed).IsTrue();
+
+        // Each instrumented step ran exactly once.
+        await Assert.That(this.host.Invocations.CountFor(nameof(RecordFirstStep))).IsEqualTo(1);
+        await Assert.That(this.host.Invocations.CountFor(nameof(RecordSecondStep))).IsEqualTo(1);
+
+        // Total step invocations across the run is exactly two (no replays).
+        await Assert.That(this.host.Invocations.TotalCount).IsEqualTo(2);
+    }
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/PostgresFixture.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/PostgresFixture.cs
@@ -1,0 +1,164 @@
+// -----------------------------------------------------------------------
+// <copyright file="PostgresFixture.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Testcontainers.PostgreSql;
+
+namespace Strategos.Generators.Behavioral.Tests.Infrastructure;
+
+/// <summary>
+/// Owns the single PostgreSQL container shared across the behavioral-test
+/// suite. Later DR-9 tasks compile the generated Wolverine+Marten saga and
+/// run it against this database to assert runtime behavior; this fixture is
+/// the harness backbone that proves a real database can be stood up.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Lifecycle is driven by TUnit: <see cref="InitializeAsync"/> (from
+/// <see cref="IAsyncInitializer"/>) starts exactly one container and
+/// <see cref="DisposeAsync"/> tears it down. Share a single instance across
+/// the whole session by injecting it with
+/// <c>[ClassDataSource&lt;PostgresFixture&gt;(Shared = SharedType.PerTestSession)]</c>.
+/// </para>
+/// <para>
+/// The Docker provider on the target environment is <b>podman</b> (rootless).
+/// Testcontainers .NET talks the Docker API, so the fixture points it at the
+/// active rootless podman socket and disables Ryuk (the resource-reaper
+/// sidecar Ryuk is unreliable under rootless podman). These are set as
+/// process environment variables before the container is built so the harness
+/// is self-configuring regardless of how the test host is launched. Both are
+/// only applied when not already supplied by the surrounding environment, so a
+/// CI runner with real Docker (or an explicit override) is respected.
+/// </para>
+/// </remarks>
+public sealed class PostgresFixture : IAsyncInitializer, IAsyncDisposable
+{
+    /// <summary>
+    /// Default rootless podman API socket path. Derived from the current user
+    /// id so it resolves to <c>/run/user/&lt;uid&gt;/podman/podman.sock</c>,
+    /// matching <c>podman info --format '{{.Host.RemoteSocket.Path}}'</c>.
+    /// </summary>
+    private static readonly string DefaultPodmanSocket =
+        $"unix:///run/user/{GetCurrentUserId()}/podman/podman.sock";
+
+    private readonly PostgreSqlContainer container;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PostgresFixture"/> class,
+    /// configuring the Docker provider for rootless podman and building (but
+    /// not yet starting) the PostgreSQL container.
+    /// </summary>
+    public PostgresFixture()
+    {
+        ConfigurePodmanProvider();
+
+        // Ryuk (the reaper sidecar) is disabled under rootless podman (see
+        // ConfigurePodmanProvider), so cleanup is driven by WithCleanUp(true)
+        // + the explicit DisposeAsync below. WithAutoRemove(true) is NOT used:
+        // under podman the daemon removes the container on stop and then
+        // Testcontainers' own remove-on-dispose races it ("no such container",
+        // HTTP 500) — a noisy teardown error. A cleanly stopped (Exited)
+        // container is the harmless, standard Ryuk-disabled tradeoff.
+        this.container = new PostgreSqlBuilder("postgres:16-alpine")
+            .WithCleanUp(true)
+            .Build();
+    }
+
+    /// <summary>
+    /// Gets the connection string for the running container's database. Only
+    /// valid after <see cref="InitializeAsync"/> has completed.
+    /// </summary>
+    public string ConnectionString => this.container.GetConnectionString();
+
+    /// <summary>
+    /// Starts the single shared PostgreSQL container.
+    /// </summary>
+    /// <returns>A task that completes when the container is ready.</returns>
+    public Task InitializeAsync() => this.container.StartAsync();
+
+    /// <summary>
+    /// Stops and disposes the shared container.
+    /// </summary>
+    /// <returns>A value task that completes when the container is disposed.</returns>
+    public ValueTask DisposeAsync() => this.container.DisposeAsync();
+
+    /// <summary>
+    /// Points Testcontainers at the rootless podman socket and disables Ryuk,
+    /// unless the environment already provides these settings.
+    /// </summary>
+    private static void ConfigurePodmanProvider()
+    {
+        SetIfAbsent("DOCKER_HOST", DefaultPodmanSocket);
+
+        // Ryuk (the Testcontainers resource reaper) commonly fails to start
+        // under rootless podman; disable it so the run is not blocked. The
+        // container's own WithCleanUp(true) still removes the container on
+        // dispose.
+        SetIfAbsent("TESTCONTAINERS_RYUK_DISABLED", "true");
+    }
+
+    /// <summary>
+    /// Sets an environment variable for the current process only if it is not
+    /// already set (so an explicit override or CI Docker config wins).
+    /// </summary>
+    /// <param name="name">The environment variable name.</param>
+    /// <param name="value">The value to apply when absent.</param>
+    private static void SetIfAbsent(string name, string value)
+    {
+        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(name)))
+        {
+            Environment.SetEnvironmentVariable(name, value);
+        }
+    }
+
+    /// <summary>
+    /// Resolves the current effective user id for the rootless podman socket
+    /// path. Falls back to <c>1000</c> when the platform does not expose it.
+    /// </summary>
+    /// <returns>The numeric user id as a string.</returns>
+    private static string GetCurrentUserId()
+    {
+        if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+        {
+            var uid = Libc.GetEffectiveUserId();
+            if (uid >= 0)
+            {
+                return uid.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            }
+        }
+
+        return "1000";
+    }
+
+    /// <summary>
+    /// Minimal interop for the POSIX effective user id, used to build the
+    /// rootless podman socket path.
+    /// </summary>
+    private static class Libc
+    {
+        /// <summary>
+        /// Returns the effective user id, or <c>-1</c> if interop fails.
+        /// </summary>
+        /// <returns>The effective user id, or <c>-1</c> on failure.</returns>
+        public static int GetEffectiveUserId()
+        {
+            try
+            {
+                return Geteuid();
+            }
+            catch (DllNotFoundException)
+            {
+                return -1;
+            }
+            catch (EntryPointNotFoundException)
+            {
+                return -1;
+            }
+        }
+
+        [System.Runtime.InteropServices.DllImport("libc", EntryPoint = "geteuid")]
+        private static extern int Geteuid();
+    }
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/PostgresFixture.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/PostgresFixture.cs
@@ -28,20 +28,48 @@ namespace Strategos.Generators.Behavioral.Tests.Infrastructure;
 /// active rootless podman socket and disables Ryuk (the resource-reaper
 /// sidecar Ryuk is unreliable under rootless podman). These are set as
 /// process environment variables before the container is built so the harness
-/// is self-configuring regardless of how the test host is launched. Both are
-/// only applied when not already supplied by the surrounding environment, so a
-/// CI runner with real Docker (or an explicit override) is respected.
+/// is self-configuring regardless of how the test host is launched.
+/// </para>
+/// <para>
+/// The podman redirect is applied only when ALL of the following hold, so a
+/// Docker-only host using Testcontainers' default discovery is never broken:
+/// <list type="number">
+///   <item><description>
+///     <c>DOCKER_HOST</c> is not already set — an explicit override or a CI
+///     runner's Docker config always wins.
+///   </description></item>
+///   <item><description>
+///     The rootless podman socket actually exists on disk — otherwise the
+///     redirect would point Testcontainers at a non-existent socket and break
+///     a Docker-only runner.
+///   </description></item>
+///   <item><description>
+///     The host is Linux — the rootless <c>/run/user/&lt;uid&gt;/podman</c>
+///     socket layout is Linux-specific.
+///   </description></item>
+/// </list>
+/// When the redirect is skipped, Testcontainers' own provider discovery
+/// (default Docker socket / <c>DOCKER_HOST</c>) is left untouched.
 /// </para>
 /// </remarks>
 public sealed class PostgresFixture : IAsyncInitializer, IAsyncDisposable
 {
     /// <summary>
-    /// Default rootless podman API socket path. Derived from the current user
-    /// id so it resolves to <c>/run/user/&lt;uid&gt;/podman/podman.sock</c>,
-    /// matching <c>podman info --format '{{.Host.RemoteSocket.Path}}'</c>.
+    /// Default rootless podman API socket path on disk. Derived from the current
+    /// user id so it resolves to <c>/run/user/&lt;uid&gt;/podman/podman.sock</c>,
+    /// matching <c>podman info --format '{{.Host.RemoteSocket.Path}}'</c>. Used
+    /// both to probe for the socket's existence and to build the
+    /// <c>DOCKER_HOST</c> URI.
     /// </summary>
-    private static readonly string DefaultPodmanSocket =
-        $"unix:///run/user/{GetCurrentUserId()}/podman/podman.sock";
+    private static readonly string DefaultPodmanSocketPath =
+        $"/run/user/{GetCurrentUserId()}/podman/podman.sock";
+
+    /// <summary>
+    /// The <c>unix://</c> <c>DOCKER_HOST</c> URI for the rootless podman socket
+    /// at <see cref="DefaultPodmanSocketPath"/>.
+    /// </summary>
+    private static readonly string DefaultPodmanSocketUri =
+        $"unix://{DefaultPodmanSocketPath}";
 
     private readonly PostgreSqlContainer container;
 
@@ -85,17 +113,35 @@ public sealed class PostgresFixture : IAsyncInitializer, IAsyncDisposable
     public ValueTask DisposeAsync() => this.container.DisposeAsync();
 
     /// <summary>
-    /// Points Testcontainers at the rootless podman socket and disables Ryuk,
-    /// unless the environment already provides these settings.
+    /// Points Testcontainers at the rootless podman socket and disables Ryuk —
+    /// but only on a host that actually has a rootless podman socket and no
+    /// pre-existing <c>DOCKER_HOST</c>. A Docker-only host (or an explicit
+    /// override) is left entirely to Testcontainers' default discovery so the
+    /// redirect cannot point it at a non-existent socket.
     /// </summary>
     private static void ConfigurePodmanProvider()
     {
-        SetIfAbsent("DOCKER_HOST", DefaultPodmanSocket);
+        // Guard (a): an explicit override or a CI runner's Docker config wins.
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOCKER_HOST")))
+        {
+            return;
+        }
+
+        // Guard (c): the rootless /run/user/<uid>/podman socket layout is
+        // Linux-specific. (b): only redirect if that socket actually exists, so
+        // a Docker-only Linux runner using default discovery is untouched.
+        if (!OperatingSystem.IsLinux() || !File.Exists(DefaultPodmanSocketPath))
+        {
+            return;
+        }
+
+        Environment.SetEnvironmentVariable("DOCKER_HOST", DefaultPodmanSocketUri);
 
         // Ryuk (the Testcontainers resource reaper) commonly fails to start
-        // under rootless podman; disable it so the run is not blocked. The
-        // container's own WithCleanUp(true) still removes the container on
-        // dispose.
+        // under rootless podman; disable it so the run is not blocked. Only
+        // applied alongside the podman redirect (and only when not already set),
+        // so a Docker host keeps its default Ryuk behavior. The container's own
+        // WithCleanUp(true) still removes the container on dispose.
         SetIfAbsent("TESTCONTAINERS_RYUK_DISABLED", "true");
     }
 

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/PostgresFixtureSmokeTests.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/PostgresFixtureSmokeTests.cs
@@ -1,0 +1,65 @@
+// -----------------------------------------------------------------------
+// <copyright file="PostgresFixtureSmokeTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Data;
+
+using Npgsql;
+
+namespace Strategos.Generators.Behavioral.Tests.Infrastructure;
+
+/// <summary>
+/// Smoke test proving the behavioral-test harness can stand up a real
+/// PostgreSQL database via Testcontainers and open a connection to it. This
+/// is the acceptance-unlock for later DR-9 tasks that compile and RUN the
+/// generated Wolverine+Marten saga against this database.
+/// </summary>
+/// <remarks>
+/// Marked <see cref="NotInParallelAttribute"/> because the suite asserts
+/// against a single shared container (a process-shared resource). The
+/// container itself is shared for the whole test session via
+/// <c>[ClassDataSource(Shared = SharedType.PerTestSession)]</c>.
+/// </remarks>
+[Property("Category", "Integration")]
+[NotInParallel]
+[ClassDataSource<PostgresFixture>(Shared = SharedType.PerTestSession)]
+public sealed class PostgresFixtureSmokeTests
+{
+    private readonly PostgresFixture fixture;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PostgresFixtureSmokeTests"/> class.
+    /// </summary>
+    /// <param name="fixture">
+    /// The shared Postgres container fixture, injected by TUnit from the
+    /// class-level <c>[ClassDataSource]</c> and shared across the entire test
+    /// session.
+    /// </param>
+    public PostgresFixtureSmokeTests(PostgresFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    /// <summary>
+    /// Verifies the fixture's container starts and a connection can be opened
+    /// against its connection string: <c>SELECT 1</c> returns <c>1</c> and the
+    /// connection reaches the <see cref="ConnectionState.Open"/> state.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task PostgresFixture_StartsContainer_ConnectionOpens()
+    {
+        await using var connection = new NpgsqlConnection(this.fixture.ConnectionString);
+
+        await connection.OpenAsync();
+
+        await Assert.That(connection.State).IsEqualTo(ConnectionState.Open);
+
+        await using var command = new NpgsqlCommand("SELECT 1;", connection);
+        var result = await command.ExecuteScalarAsync();
+
+        await Assert.That(result).IsEqualTo(1);
+    }
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/StubObjectSetProvider.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/StubObjectSetProvider.cs
@@ -1,0 +1,64 @@
+// -----------------------------------------------------------------------
+// <copyright file="StubObjectSetProvider.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Ontology.ObjectSets;
+
+namespace Strategos.Generators.Behavioral.Tests.Infrastructure;
+
+/// <summary>
+/// A stub <see cref="IObjectSetProvider"/> for the DR-6 context-assembly
+/// behavioral proof (T016). It records every <c>ExecuteSimilarityAsync</c> call's
+/// <c>SimilarityExpression</c> on the shared <see cref="ContextProbe"/> (so the
+/// test can assert the declared <c>TopK</c>/<c>MinRelevance</c> reached the
+/// provider) and returns a single canned scored item so the generated assembler
+/// produces a non-empty retrieval segment.
+/// </summary>
+/// <remarks>
+/// Only <see cref="ExecuteSimilarityAsync{T}"/> is exercised by the generated
+/// assembler; the non-similarity members throw because the context-assembly path
+/// never calls them.
+/// </remarks>
+public sealed class StubObjectSetProvider(ContextProbe probe) : IObjectSetProvider
+{
+    /// <summary>The canned relevance score returned for the single stub item.</summary>
+    public const double StubScore = 0.95;
+
+    private readonly ContextProbe probe = probe;
+
+    /// <inheritdoc />
+    public Task<ScoredObjectSetResult<T>> ExecuteSimilarityAsync<T>(
+        SimilarityExpression expression,
+        CancellationToken ct = default)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(expression, nameof(expression));
+
+        // Capture the lowered expression so the test can assert the step's
+        // declared TopK / MinRelevance / query reached the provider.
+        this.probe.RecordSimilarity(expression);
+
+        // Return one canned item. T is the collection marker type (ProductCatalog);
+        // a parameterless instance suffices for the assembler's item.ToString() map.
+        var item = Activator.CreateInstance<T>();
+        var result = new ScoredObjectSetResult<T>(
+            items: [item],
+            totalCount: 1,
+            inclusion: ObjectSetInclusion.Properties,
+            scores: [StubScore]);
+
+        return Task.FromResult(result);
+    }
+
+    /// <inheritdoc />
+    public Task<ObjectSetResult<T>> ExecuteAsync<T>(ObjectSetExpression expression, CancellationToken ct = default)
+        where T : class =>
+        throw new NotSupportedException("The context-assembly path does not call ExecuteAsync.");
+
+    /// <inheritdoc />
+    public IAsyncEnumerable<T> StreamAsync<T>(ObjectSetExpression expression, CancellationToken ct = default)
+        where T : class =>
+        throw new NotSupportedException("The context-assembly path does not call StreamAsync.");
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/TimeoutHostFixture.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/TimeoutHostFixture.cs
@@ -1,0 +1,174 @@
+// -----------------------------------------------------------------------
+// <copyright file="TimeoutHostFixture.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Diagnostics;
+
+using JasperFx.Resources;
+
+using Marten;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Strategos.Generators.Behavioral.Tests.Workflows;
+
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+
+namespace Strategos.Generators.Behavioral.Tests.Infrastructure;
+
+/// <summary>
+/// Runtime host fixture for the timeout behavioral proofs (DR-4). Stands up a real
+/// PostgreSQL container and a Wolverine+Marten host wired with the generated
+/// <c>AddTimeoutSlowWorkflow()</c> and <c>AddTimeoutFastWorkflow()</c> registrations,
+/// then runs the generated sagas end-to-end to observe the saga-level deadline race.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This mirrors <see cref="WolverineHostFixture"/> (which is pinned to the
+/// happy-path workflow) but registers the two timeout workflows and exposes a
+/// terminal-wait helper. The host integrates Marten with Wolverine
+/// (<c>IntegrateWithWolverine()</c>) so the durable inbox/outbox releases the
+/// scheduled <c>TimeoutMessage</c> deliveries that drive the deadline race.
+/// </para>
+/// <para>
+/// Lifecycle is driven by TUnit via <see cref="IAsyncInitializer"/> /
+/// <see cref="IAsyncDisposable"/>. Share one instance for the whole session with
+/// <c>[ClassDataSource&lt;TimeoutHostFixture&gt;(Shared = SharedType.PerTestSession)]</c>.
+/// </para>
+/// </remarks>
+public sealed class TimeoutHostFixture : IAsyncInitializer, IAsyncDisposable
+{
+    private readonly PostgresFixture postgres = new();
+
+    private IHost? host;
+
+    /// <summary>
+    /// Gets the shared step-invocation log. Instrumented workflow steps push their
+    /// name here so a test can assert which steps ran and how many times.
+    /// </summary>
+    public WorkflowInvocationLog Invocations { get; } = new();
+
+    /// <summary>
+    /// Starts the shared Postgres container, then builds and starts the Wolverine
+    /// host with Marten-backed saga storage and the generated timeout-workflow
+    /// registrations.
+    /// </summary>
+    /// <returns>A task that completes when the host is running.</returns>
+    public async Task InitializeAsync()
+    {
+        await this.postgres.InitializeAsync();
+
+        this.host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services
+                    .AddMarten(storeOptions =>
+                    {
+                        storeOptions.Connection(this.postgres.ConnectionString);
+                        storeOptions.AutoCreateSchemaObjects = JasperFx.AutoCreate.All;
+                    })
+                    .IntegrateWithWolverine()
+                    .ApplyAllDatabaseChangesOnStartup();
+
+                // Both generated timeout workflows: the slow scenario (deadline
+                // exceeded → route to failure) and the fast scenario (completes
+                // first → timeout is a no-op).
+                opts.Services.AddTimeoutSlowWorkflow();
+                opts.Services.AddTimeoutFastWorkflow();
+
+                opts.Services.AddSingleton(this.Invocations);
+                opts.Services.AddResourceSetupOnStartup();
+            })
+            .StartAsync();
+    }
+
+    /// <summary>
+    /// Publishes a generated start command, awaits all synchronously-tracked
+    /// cascaded activity, then polls until the saga reaches its terminal phase
+    /// (its document is removed by <c>MarkCompleted()</c>) or the budget elapses.
+    /// </summary>
+    /// <typeparam name="TSaga">
+    /// The generated saga document type whose persistence is polled for terminal
+    /// completion (its absence signals the saga finished).
+    /// </typeparam>
+    /// <param name="workflowId">The workflow/saga identity to wait on.</param>
+    /// <param name="startCommand">The generated start command.</param>
+    /// <param name="terminalBudget">
+    /// Total budget to wait for the terminal phase, covering the scheduled
+    /// <c>TimeoutMessage</c> delivery and its handling. Defaults to 30 seconds.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when the saga reached its terminal phase within the
+    /// budget; otherwise <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    /// The deadline-race timeout is a durable scheduled message released by
+    /// Wolverine's background durability agent, which is NOT awaited by
+    /// <c>TrackActivity()</c>. The fixture therefore polls saga-document absence
+    /// after the tracked publish settles, so both the "timeout fires and routes to
+    /// failure" path and the "step completes first" path are observed
+    /// deterministically.
+    /// </remarks>
+    public async Task<bool> RunToTerminalAsync<TSaga>(
+        Guid workflowId,
+        object startCommand,
+        TimeSpan? terminalBudget = null)
+        where TSaga : class
+    {
+        ArgumentNullException.ThrowIfNull(startCommand, nameof(startCommand));
+
+        var runtime = this.RequireHost();
+        var budget = terminalBudget ?? TimeSpan.FromSeconds(30);
+
+        // Publish + await the synchronously-cascaded chain (saga start → step start
+        // → worker → step completed → ...). The scheduled timeout message is
+        // released later by the durability agent and is polled for below.
+        await runtime
+            .TrackActivity()
+            .Timeout(budget)
+            .PublishMessageAndWaitAsync(startCommand);
+
+        var store = runtime.Services.GetRequiredService<IDocumentStore>();
+        var sw = Stopwatch.StartNew();
+
+        while (sw.Elapsed < budget)
+        {
+            await using var query = store.QuerySession();
+            var saga = await query.LoadAsync<TSaga>(workflowId);
+            if (saga is null)
+            {
+                // MarkCompleted() removed the saga document: terminal reached
+                // (Completed for the fast path, or Failed for the timed-out path).
+                return true;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(50), CancellationToken.None);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Stops and disposes the host and the shared Postgres container.
+    /// </summary>
+    /// <returns>A value task that completes when teardown finishes.</returns>
+    public async ValueTask DisposeAsync()
+    {
+        if (this.host is not null)
+        {
+            await this.host.StopAsync();
+            this.host.Dispose();
+        }
+
+        await this.postgres.DisposeAsync();
+    }
+
+    private IHost RequireHost() =>
+        this.host ?? throw new InvalidOperationException(
+            "Host not initialized. Ensure InitializeAsync ran (TUnit IAsyncInitializer).");
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/WolverineHostFixture.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/WolverineHostFixture.cs
@@ -1,0 +1,199 @@
+// -----------------------------------------------------------------------
+// <copyright file="WolverineHostFixture.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using JasperFx.Resources;
+
+using Marten;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Strategos.Generators.Behavioral.Tests.Workflows;
+
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+
+namespace Strategos.Generators.Behavioral.Tests.Infrastructure;
+
+/// <summary>
+/// Reusable runtime host fixture that compiles a Strategos workflow (the
+/// source generator emits its Wolverine+Marten saga) and RUNS it end-to-end
+/// against a real PostgreSQL container.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the engine that later behavioral tasks (retry/timeout/compensation/
+/// confidence) build on. It owns:
+/// <list type="bullet">
+///   <item><description>
+///     A single shared <see cref="PostgresFixture"/> container for the session.
+///   </description></item>
+///   <item><description>
+///     A single Wolverine host wired with Marten-backed saga storage and the
+///     durable inbox/outbox (via <c>IntegrateWithWolverine()</c>), plus the
+///     generated <c>AddHappyPathWorkflow()</c> registration.
+///   </description></item>
+///   <item><description>
+///     A shared <see cref="WorkflowInvocationLog"/> singleton so instrumented
+///     steps can be observed at runtime.
+///   </description></item>
+/// </list>
+/// </para>
+/// <para>
+/// Lifecycle is driven by TUnit via <see cref="IAsyncInitializer"/> /
+/// <see cref="IAsyncDisposable"/>. Share one instance for the whole session
+/// with
+/// <c>[ClassDataSource&lt;WolverineHostFixture&gt;(Shared = SharedType.PerTestSession)]</c>.
+/// </para>
+/// </remarks>
+public sealed class WolverineHostFixture : IAsyncInitializer, IAsyncDisposable
+{
+    private readonly PostgresFixture postgres = new();
+
+    private IHost? host;
+
+    /// <summary>
+    /// Gets the shared step-invocation log. Instrumented workflow steps push
+    /// their name here so a test can assert which steps ran and how many times.
+    /// </summary>
+    public WorkflowInvocationLog Invocations { get; } = new();
+
+    /// <summary>
+    /// Starts the shared Postgres container, then builds and starts the
+    /// Wolverine host with Marten-backed saga storage and the generated
+    /// workflow registration.
+    /// </summary>
+    /// <returns>A task that completes when the host is running.</returns>
+    public async Task InitializeAsync()
+    {
+        await this.postgres.InitializeAsync();
+
+        this.host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // Marten owns saga storage + the durable inbox/outbox. The
+                // generated AddHappyPathWorkflow() registers the saga's step
+                // types, worker handlers, and the workflow definition; the
+                // saga document type itself is discovered by Wolverine's type
+                // scanning of the assembly under test.
+                opts.Services
+                    .AddMarten(storeOptions =>
+                    {
+                        storeOptions.Connection(this.postgres.ConnectionString);
+
+                        // Dev-style schema provisioning: create the saga +
+                        // Wolverine envelope tables on first use.
+                        storeOptions.AutoCreateSchemaObjects = JasperFx.AutoCreate.All;
+                    })
+                    .IntegrateWithWolverine()
+                    .ApplyAllDatabaseChangesOnStartup();
+
+                opts.Services.AddHappyPathWorkflow();
+
+                // The shared invocation log injected into instrumented steps.
+                opts.Services.AddSingleton(this.Invocations);
+
+                // Provision Wolverine's own durable storage objects on startup.
+                opts.Services.AddResourceSetupOnStartup();
+            })
+            .StartAsync();
+    }
+
+    /// <summary>
+    /// Runs the happy-path fixture workflow saga to completion against the real
+    /// host. Convenience overload pinned to <see cref="HappyPathSaga"/>.
+    /// </summary>
+    /// <param name="workflowId">The workflow/saga identity to wait on.</param>
+    /// <param name="startCommand">
+    /// The generated start command (<c>StartHappyPathCommand</c>) that kicks off
+    /// the saga.
+    /// </param>
+    /// <param name="timeout">
+    /// Optional wait budget for the cascading saga + worker activity to settle.
+    /// Defaults to 30 seconds.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when the saga reached its terminal phase.
+    /// </returns>
+    public Task<bool> RunWorkflowAsync(
+        Guid workflowId,
+        object startCommand,
+        TimeSpan? timeout = null) =>
+        this.RunWorkflowAsync<HappyPathSaga>(workflowId, startCommand, timeout);
+
+    /// <summary>
+    /// Runs a generated workflow saga to completion against the real host.
+    /// Reusable by later behavioral tasks (retry/timeout/compensation/
+    /// confidence) over any generated saga type.
+    /// </summary>
+    /// <typeparam name="TSaga">
+    /// The generated saga document type (e.g. <c>HappyPathSaga</c>) whose
+    /// persistence is polled to confirm terminal completion.
+    /// </typeparam>
+    /// <param name="workflowId">The workflow/saga identity to wait on.</param>
+    /// <param name="startCommand">
+    /// The generated start command (e.g. <c>StartHappyPathCommand</c>) that
+    /// kicks off the saga.
+    /// </param>
+    /// <param name="timeout">
+    /// Optional wait budget for the cascading saga + worker activity to settle.
+    /// Defaults to 30 seconds.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when the saga reached its terminal phase — the
+    /// generated final-step handler calls <c>MarkCompleted()</c>, which removes
+    /// the persisted saga document; an absent document after the run is the
+    /// completion signal.
+    /// </returns>
+    /// <remarks>
+    /// Uses Wolverine's message-tracking API to deterministically await all
+    /// cascaded processing (saga start → step start → worker → step completed →
+    /// next step → … → MarkCompleted) rather than sleeping on a poll loop.
+    /// </remarks>
+    public async Task<bool> RunWorkflowAsync<TSaga>(
+        Guid workflowId,
+        object startCommand,
+        TimeSpan? timeout = null)
+        where TSaga : class
+    {
+        ArgumentNullException.ThrowIfNull(startCommand, nameof(startCommand));
+
+        var runtime = this.RequireHost();
+
+        await runtime
+            .TrackActivity()
+            .Timeout(timeout ?? TimeSpan.FromSeconds(30))
+            .PublishMessageAndWaitAsync(startCommand);
+
+        // The saga document is deleted by MarkCompleted() on the terminal
+        // step, so its absence after the tracked run settles means the workflow
+        // reached its Completed phase.
+        await using var query = runtime.Services.GetRequiredService<IDocumentStore>().QuerySession();
+        var saga = await query.LoadAsync<TSaga>(workflowId);
+
+        return saga is null;
+    }
+
+    /// <summary>
+    /// Stops and disposes the host and the shared Postgres container.
+    /// </summary>
+    /// <returns>A value task that completes when teardown finishes.</returns>
+    public async ValueTask DisposeAsync()
+    {
+        if (this.host is not null)
+        {
+            await this.host.StopAsync();
+            this.host.Dispose();
+        }
+
+        await this.postgres.DisposeAsync();
+    }
+
+    private IHost RequireHost() =>
+        this.host ?? throw new InvalidOperationException(
+            "Host not initialized. Ensure InitializeAsync ran (TUnit IAsyncInitializer).");
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/WolverineHostFixture.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/WolverineHostFixture.cs
@@ -94,6 +94,13 @@ public sealed class WolverineHostFixture : IAsyncInitializer, IAsyncDisposable
 
                 opts.Services.AddHappyPathWorkflow();
 
+                // The retry-proof workflow (DR-2 T011): its generated
+                // RetryFlakyStepHandler carries the static Configure(HandlerChain)
+                // retry policy lowered from .WithRetry(2). Registered alongside the
+                // happy-path workflow on the same host; both share the singleton
+                // invocation log below.
+                opts.Services.AddRetryProofWorkflow();
+
                 // The shared invocation log injected into instrumented steps.
                 opts.Services.AddSingleton(this.Invocations);
 

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/WolverineHostFixture.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/WolverineHostFixture.cs
@@ -101,6 +101,15 @@ public sealed class WolverineHostFixture : IAsyncInitializer, IAsyncDisposable
                 // invocation log below.
                 opts.Services.AddRetryProofWorkflow();
 
+                // The confidence-gate workflows (DR-5 T014). Each generated saga
+                // carries the confidence-gated completed handler that compares the
+                // step result confidence to the 0.85 threshold and either routes to
+                // the lowered OnLowConfidence handler step (low-confidence case) or
+                // proceeds on the primary path (high-confidence case). Both share the
+                // singleton invocation log below.
+                opts.Services.AddLowConfidenceWorkflow();
+                opts.Services.AddHighConfidenceWorkflow();
+
                 // The shared invocation log injected into instrumented steps.
                 opts.Services.AddSingleton(this.Invocations);
 

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/WorkflowInvocationLog.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/WorkflowInvocationLog.cs
@@ -1,0 +1,75 @@
+// -----------------------------------------------------------------------
+// <copyright file="WorkflowInvocationLog.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Collections.Concurrent;
+
+namespace Strategos.Generators.Behavioral.Tests.Infrastructure;
+
+/// <summary>
+/// Thread-safe, process-shared record of step invocations for behavioral
+/// tests. Instrumented workflow steps push their name here when executed so a
+/// test can observe runtime behavior (which steps ran, how many times, in what
+/// order) without mocking the saga or the message bus.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Registered as a DI singleton on the host so every step resolved by the
+/// generated <c>Add{Name}Workflow()</c> registration shares the same instance.
+/// Later behavioral tasks (retry/timeout/compensation/confidence) reuse this to
+/// assert invocation counts (e.g. a flaky step retried N times).
+/// </para>
+/// <para>
+/// A single host is shared for the whole test session, so
+/// <see cref="Reset"/> clears the log at the start of each test to isolate it
+/// from prior runs.
+/// </para>
+/// </remarks>
+public sealed class WorkflowInvocationLog
+{
+    private readonly ConcurrentQueue<string> invocations = new();
+
+    /// <summary>
+    /// Gets the ordered sequence of step names recorded so far.
+    /// </summary>
+    public IReadOnlyList<string> Invocations => this.invocations.ToArray();
+
+    /// <summary>
+    /// Gets the total number of step invocations recorded.
+    /// </summary>
+    public int TotalCount => this.invocations.Count;
+
+    /// <summary>
+    /// Records that the named step executed.
+    /// </summary>
+    /// <param name="stepName">The step name (typically <c>nameof(TStep)</c>).</param>
+    public void Record(string stepName)
+    {
+        ArgumentNullException.ThrowIfNull(stepName, nameof(stepName));
+
+        this.invocations.Enqueue(stepName);
+    }
+
+    /// <summary>
+    /// Counts how many times the named step has been recorded.
+    /// </summary>
+    /// <param name="stepName">The step name to count.</param>
+    /// <returns>The number of recorded invocations for that step.</returns>
+    public int CountFor(string stepName)
+    {
+        ArgumentNullException.ThrowIfNull(stepName, nameof(stepName));
+
+        return this.invocations.Count(name => string.Equals(name, stepName, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Clears all recorded invocations. Called at the start of each test to
+    /// isolate it from runs that shared the same session-scoped host.
+    /// </summary>
+    public void Reset()
+    {
+        this.invocations.Clear();
+    }
+}

--- a/src/Strategos.Generators.Behavioral.Tests/RetryBehaviorTests.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/RetryBehaviorTests.cs
@@ -1,0 +1,84 @@
+// -----------------------------------------------------------------------
+// <copyright file="RetryBehaviorTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Generators.Behavioral.Tests.Workflows;
+
+namespace Strategos.Generators.Behavioral.Tests;
+
+/// <summary>
+/// End-to-end behavioral proof (DR-2 T011) that a step's <c>.WithRetry(2)</c>
+/// is actually honored at runtime: the generated
+/// <c>Configure(HandlerChain)</c> per-handler policy causes Wolverine to retry
+/// a transiently-failing step on a real PostgreSQL-backed host.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The flaky step throws on attempts 1 and 2 and succeeds on attempt 3. Without
+/// the generated retry policy the saga would dead-letter after the first
+/// failure and never complete; with it, the step is retried until it succeeds
+/// and the saga reaches its terminal phase (the saga document is removed by
+/// <c>MarkCompleted()</c>). Asserting exactly three invocations plus completion
+/// proves the retry lowering, not just that the saga eventually ran.
+/// </para>
+/// <para>
+/// Marked <see cref="NotInParallelAttribute"/> because it shares the single
+/// process-wide container + host and observes the process-shared invocation
+/// log.
+/// </para>
+/// </remarks>
+[Property("Category", "Integration")]
+[NotInParallel]
+[ClassDataSource<WolverineHostFixture>(Shared = SharedType.PerTestSession)]
+public sealed class RetryBehaviorTests
+{
+    private readonly WolverineHostFixture host;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RetryBehaviorTests"/> class.
+    /// </summary>
+    /// <param name="host">
+    /// The shared Wolverine+Marten host fixture, injected by TUnit and shared
+    /// across the entire test session.
+    /// </param>
+    public RetryBehaviorTests(WolverineHostFixture host)
+    {
+        this.host = host;
+    }
+
+    /// <summary>
+    /// Starts the generated retry-proof workflow saga whose middle step declares
+    /// <c>.WithRetry(2)</c> and throws on its first two invocations. Asserts the
+    /// flaky step was invoked exactly three times (initial + two retries) and
+    /// the saga reached its terminal/completed phase.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Saga_StepWithWithRetry2_InvokesStepExactlyTwiceThenSucceeds()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+
+        var initialState = new RetryState { WorkflowId = workflowId };
+        var startCommand = new StartRetryProofCommand(workflowId, initialState);
+
+        var completed = await this.host.RunWorkflowAsync<RetryProofSaga>(workflowId, startCommand);
+
+        // The saga reached its terminal phase: it only gets past the flaky step
+        // (and on to the terminal finish step + MarkCompleted) if the retry
+        // policy carried the step through its two transient failures.
+        await Assert.That(completed).IsTrue();
+
+        // The flaky step ran exactly three times: the initial attempt plus the
+        // two retries lowered from .WithRetry(2). This is the retry proof.
+        await Assert.That(this.host.Invocations.CountFor(nameof(RetryFlakyStep))).IsEqualTo(3);
+
+        // The deterministic prepare and finish steps each ran exactly once (the
+        // saga, not the retry policy, drives them).
+        await Assert.That(this.host.Invocations.CountFor(nameof(RetryPrepareStep))).IsEqualTo(1);
+        await Assert.That(this.host.Invocations.CountFor(nameof(RetryFinishStep))).IsEqualTo(1);
+    }
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Strategos.Generators.Behavioral.Tests.csproj
+++ b/src/Strategos.Generators.Behavioral.Tests/Strategos.Generators.Behavioral.Tests.csproj
@@ -44,6 +44,13 @@
          (WorkflowTelemetry) for OpenTelemetry step spans, so the generated
          saga only compiles with Strategos.Agents on the reference graph. -->
     <ProjectReference Include="..\Strategos.Agents\Strategos.Agents.csproj" />
+    <!-- DR-6 context wire-in (T016): a step's .WithContext(...) lowers a
+         {Step}ContextAssembler whose retrieval source depends on
+         IObjectSetProvider (Strategos.Ontology.ObjectSets), so the generated
+         saga only compiles — and the ContextWorkflow fixture's stub provider
+         can be registered — with Strategos.Ontology on the reference graph.
+         Ontology-wired, not RAG (INV-2): no Strategos.Rag reference. -->
+    <ProjectReference Include="..\Strategos.Ontology\Strategos.Ontology.csproj" />
     <ProjectReference Include="..\Strategos.Identity.Abstractions\Strategos.Identity.Abstractions.csproj" />
   </ItemGroup>
 

--- a/src/Strategos.Generators.Behavioral.Tests/Strategos.Generators.Behavioral.Tests.csproj
+++ b/src/Strategos.Generators.Behavioral.Tests/Strategos.Generators.Behavioral.Tests.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TUnit" />
+    <PackageReference Include="NSubstitute" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Used now: the Postgres Testcontainers fixture + smoke test. -->
+    <PackageReference Include="Npgsql" />
+    <PackageReference Include="Testcontainers.PostgreSql" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Referenced now, *used* by a later DR-9 host-wiring task that compiles
+         and runs the generated Wolverine+Marten saga. Kept here so the
+         package backbone is in place; no host wiring lives in this project
+         yet. -->
+    <PackageReference Include="WolverineFx" />
+    <PackageReference Include="WolverineFx.Marten" />
+    <PackageReference Include="Marten" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Strategos.Generators\Strategos.Generators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="true" />
+    <ProjectReference Include="..\Strategos\Strategos.csproj" />
+    <ProjectReference Include="..\Strategos.Identity.Abstractions\Strategos.Identity.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Strategos.Generators.Behavioral.Tests/Strategos.Generators.Behavioral.Tests.csproj
+++ b/src/Strategos.Generators.Behavioral.Tests/Strategos.Generators.Behavioral.Tests.csproj
@@ -3,6 +3,10 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <!-- Persist the generated Wolverine+Marten saga/handlers to disk so the
+         generated start command + saga shape can be inspected (DR-9 T006). -->
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)generated</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,13 +21,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Referenced now, *used* by a later DR-9 host-wiring task that compiles
-         and runs the generated Wolverine+Marten saga. Kept here so the
-         package backbone is in place; no host wiring lives in this project
-         yet. -->
+    <!-- DR-9 host-wiring (T006): the generated Wolverine+Marten saga is built
+         in THIS project (the generator runs as an Analyzer below) and RUN on a
+         real host backed by Marten/Postgres. UseWolverine() lives on
+         IHostBuilder from Microsoft.Extensions.Hosting (flows transitively from
+         WolverineFx, referenced explicitly here for Host.CreateDefaultBuilder). -->
     <PackageReference Include="WolverineFx" />
     <PackageReference Include="WolverineFx.Marten" />
+    <!-- Compiles the generated saga/handler glue at runtime (WolverineFx 6.x
+         no longer ships the in-box compiler). Auto-registers when referenced. -->
+    <PackageReference Include="WolverineFx.RuntimeCompilation" />
     <PackageReference Include="Marten" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
 
   <ItemGroup>
@@ -31,6 +40,10 @@
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="true" />
     <ProjectReference Include="..\Strategos\Strategos.csproj" />
+    <!-- The generated worker handlers reference Strategos.Agents.Telemetry
+         (WorkflowTelemetry) for OpenTelemetry step spans, so the generated
+         saga only compiles with Strategos.Agents on the reference graph. -->
+    <ProjectReference Include="..\Strategos.Agents\Strategos.Agents.csproj" />
     <ProjectReference Include="..\Strategos.Identity.Abstractions\Strategos.Identity.Abstractions.csproj" />
   </ItemGroup>
 

--- a/src/Strategos.Generators.Behavioral.Tests/TimeoutBehaviorTests.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/TimeoutBehaviorTests.cs
@@ -1,0 +1,118 @@
+// -----------------------------------------------------------------------
+// <copyright file="TimeoutBehaviorTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Generators.Behavioral.Tests.Workflows;
+
+namespace Strategos.Generators.Behavioral.Tests;
+
+/// <summary>
+/// End-to-end behavioral proof that a step's <c>.WithTimeout(t)</c> lowers into a
+/// working Wolverine saga deadline race (DR-4), run against a real PostgreSQL
+/// container.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is a saga-level deadline race, not hard cancellation of an in-flight
+/// handler: the slow step runs to completion; what is proven is that the saga
+/// routes to its timeout/failure path because the scheduled timeout message
+/// reached the saga before the step's completion event.
+/// </para>
+/// <para>
+/// Marked <see cref="NotInParallelAttribute"/> because it shares a single
+/// process-wide container + host and observes a process-shared invocation log.
+/// </para>
+/// </remarks>
+[Property("Category", "Integration")]
+[NotInParallel]
+[ClassDataSource<TimeoutHostFixture>(Shared = SharedType.PerTestSession)]
+public sealed class TimeoutBehaviorTests
+{
+    private readonly TimeoutHostFixture host;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TimeoutBehaviorTests"/> class.
+    /// </summary>
+    /// <param name="host">
+    /// The shared Wolverine+Marten timeout host fixture, injected by TUnit and
+    /// shared across the entire test session.
+    /// </param>
+    public TimeoutBehaviorTests(TimeoutHostFixture host)
+    {
+        this.host = host;
+    }
+
+    /// <summary>
+    /// Proves that when a step exceeds its timeout, the saga routes to the
+    /// timeout/failure path while the slow step is still in flight: the step after
+    /// the timed step (<see cref="NeverReachedStep"/>) never executes, because the
+    /// timeout drove the saga to Failed + <c>MarkCompleted()</c> before its start
+    /// command could be cascaded.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Saga_StepExceedsTimeout_RoutesToTimeoutPath()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+
+        var initialState = new TimeoutState { WorkflowId = workflowId };
+        var startCommand = new StartTimeoutSlowCommand(workflowId, initialState);
+
+        var reachedTerminal = await this.host.RunToTerminalAsync<TimeoutSlowSaga>(
+            workflowId,
+            startCommand);
+
+        // The saga reached a terminal phase (its document was removed by
+        // MarkCompleted on the timeout/failure route).
+        await Assert.That(reachedTerminal).IsTrue();
+
+        // The kickoff and the slow step both ran (the slow step runs to completion
+        // — this is a deadline race, not hard cancellation).
+        await Assert.That(this.host.Invocations.CountFor(nameof(SlowKickoffStep))).IsEqualTo(1);
+        await Assert.That(this.host.Invocations.CountFor(nameof(SlowTimedStep))).IsEqualTo(1);
+
+        // The decisive observation: the step AFTER the timed step never ran. The
+        // timeout routed the saga away from the happy path before its start
+        // command could be cascaded.
+        await Assert.That(this.host.Invocations.CountFor(nameof(NeverReachedStep))).IsEqualTo(0);
+    }
+
+    /// <summary>
+    /// Proves that when a step completes before its (generous) timeout, the saga
+    /// chains forward normally and the later timeout message is a harmless no-op:
+    /// the follow-on step runs and the workflow reaches its terminal phase without
+    /// being double-failed.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Saga_StepCompletesBeforeTimeout_TimeoutHandlerIsNoOp()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+
+        var initialState = new TimeoutState { WorkflowId = workflowId };
+        var startCommand = new StartTimeoutFastCommand(workflowId, initialState);
+
+        var reachedTerminal = await this.host.RunToTerminalAsync<TimeoutFastSaga>(
+            workflowId,
+            startCommand);
+
+        // The saga reached its terminal Completed phase (document removed).
+        await Assert.That(reachedTerminal).IsTrue();
+
+        // Every step ran exactly once: the fast step completed before its deadline
+        // and the saga chained forward to the follow-on step.
+        await Assert.That(this.host.Invocations.CountFor(nameof(FastKickoffStep))).IsEqualTo(1);
+        await Assert.That(this.host.Invocations.CountFor(nameof(FastTimedStep))).IsEqualTo(1);
+        await Assert.That(this.host.Invocations.CountFor(nameof(FollowOnStep))).IsEqualTo(1);
+
+        // No replays / double-runs: the late timeout message was a no-op (the saga
+        // was already gone, so Wolverine ignored the TimeoutMessage), and nothing
+        // re-ran the chain.
+        await Assert.That(this.host.Invocations.TotalCount).IsEqualTo(3);
+    }
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Workflows/CompensationWorkflow.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Workflows/CompensationWorkflow.cs
@@ -1,0 +1,183 @@
+// -----------------------------------------------------------------------
+// <copyright file="CompensationWorkflow.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Abstractions;
+using Strategos.Attributes;
+using Strategos.Builders;
+using Strategos.Definitions;
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Steps;
+
+namespace Strategos.Generators.Behavioral.Tests.Workflows;
+
+/// <summary>
+/// Immutable state for the compensation behavioral fixture (DR-3).
+/// </summary>
+/// <remarks>
+/// Marked <see cref="WorkflowStateAttribute"/> so the source generator emits a
+/// reducer used by the saga to fold each step's returned state.
+/// </remarks>
+[WorkflowState]
+public sealed record CompensationState : IWorkflowState
+{
+    /// <summary>
+    /// Gets the unique identifier for this workflow instance.
+    /// </summary>
+    public Guid WorkflowId { get; init; }
+
+    /// <summary>
+    /// Gets the number of steps that have folded their result into state.
+    /// </summary>
+    public int StepCount { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the compensation (rollback) ran.
+    /// </summary>
+    public bool RolledBack { get; init; }
+}
+
+/// <summary>
+/// Permanent failure raised by <see cref="CompensatedFailingStep"/> on EVERY
+/// invocation, so the generated <c>.WithRetry(2)</c> policy exhausts its retries
+/// and the lowered compensation path fires.
+/// </summary>
+public sealed class CompensatedStepException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CompensatedStepException"/>
+    /// class with the supplied message.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    public CompensatedStepException(string message)
+        : base(message)
+    {
+    }
+}
+
+/// <summary>
+/// Entry step of the compensation fixture workflow. Deterministic (never throws);
+/// records its invocation so the test can confirm the saga actually started.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class CompensationPrepareStep(WorkflowInvocationLog log) : IWorkflowStep<CompensationState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompensationState>> ExecuteAsync(
+        CompensationState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(CompensationPrepareStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<CompensationState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The compensated middle step. It declares <c>.WithRetry(2).Compensate&lt;RollbackStep&gt;()</c>
+/// and throws on EVERY invocation, so Wolverine retries it three times total
+/// (initial + two retries) and then the lowered compensation path publishes the
+/// trigger that runs <see cref="RollbackStep"/>. Records every attempt so the
+/// test can prove the retries happened before compensation.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class CompensatedFailingStep(WorkflowInvocationLog log) : IWorkflowStep<CompensationState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompensationState>> ExecuteAsync(
+        CompensationState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(CompensatedFailingStep));
+
+        throw new CompensatedStepException(
+            "CompensatedFailingStep always fails to force retry exhaustion and compensation.");
+    }
+}
+
+/// <summary>
+/// The compensation (rollback) step run when <see cref="CompensatedFailingStep"/>
+/// exhausts its retries. Records its invocation exactly once per failed step so
+/// the test can assert the compensation ran exactly once. Per INV-7 it returns
+/// NEW state (sets <see cref="CompensationState.RolledBack"/>) rather than
+/// mutating the input.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class RollbackStep(WorkflowInvocationLog log) : IWorkflowStep<CompensationState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompensationState>> ExecuteAsync(
+        CompensationState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(RollbackStep));
+
+        var updated = state with { RolledBack = true };
+        return Task.FromResult(StepResult<CompensationState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// A step that must NOT run when the preceding <see cref="CompensatedFailingStep"/>
+/// fails: once compensation fires, the saga routes to Failed and
+/// <c>MarkCompleted()</c> before ever cascading this step's start command. Its
+/// invocation count being zero is the observable proof that the failure routed
+/// away from the happy path.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class CompensationNeverReachedStep(WorkflowInvocationLog log) : IWorkflowStep<CompensationState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompensationState>> ExecuteAsync(
+        CompensationState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(CompensationNeverReachedStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<CompensationState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The compensation-proof fixture workflow definition. The
+/// <see cref="WorkflowAttribute"/> drives the Strategos source generator to emit,
+/// at build time, the Wolverine saga (<c>CompensationProofSaga</c>), the worker
+/// handler for <see cref="CompensatedFailingStep"/> carrying the generated
+/// <c>Configure(HandlerChain)</c> retry + compensation policy (DR-3), the worker
+/// handler for <see cref="RollbackStep"/> (folded in so it can RUN), the saga
+/// compensation chain, the start command (<c>StartCompensationProofCommand</c>),
+/// and the <c>AddCompensationProofWorkflow()</c> DI extension consumed by the host
+/// fixture.
+/// </summary>
+[Workflow("compensation-proof")]
+public static partial class CompensationProofWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent workflow definition: a prepare step, a middle step
+    /// declaring <c>.WithRetry(2).Compensate&lt;RollbackStep&gt;()</c> that always
+    /// throws, and a terminal step that must never be reached.
+    /// </summary>
+    public static WorkflowDefinition<CompensationState> Definition => Workflow<CompensationState>
+        .Create("compensation-proof")
+        .StartWith<CompensationPrepareStep>()
+        .Then<CompensatedFailingStep>(step => step
+            .WithRetry(2)
+            .Compensate<RollbackStep>())
+        .Finally<CompensationNeverReachedStep>();
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Workflows/CompositionEdgeWorkflow.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Workflows/CompositionEdgeWorkflow.cs
@@ -179,6 +179,7 @@ public static partial class CompositionRaceWorkflowDefinition
 public sealed class CompositionImmutableProbe
 {
     private readonly ConcurrentQueue<CompositionState> seenInputs = new();
+    private readonly ConcurrentDictionary<Guid, int> attemptsByRun = new();
 
     /// <summary>
     /// Gets the ordered sequence of input state instances seen across attempts.
@@ -196,9 +197,30 @@ public sealed class CompositionImmutableProbe
     }
 
     /// <summary>
+    /// Atomically increments and returns the per-run attempt number for the given
+    /// workflow run, keyed by <paramref name="workflowId"/>.
+    /// </summary>
+    /// <remarks>
+    /// This is the per-run replacement for deriving the attempt count from the
+    /// session-shared <see cref="WorkflowInvocationLog"/>: keying by the run's
+    /// fresh <see cref="CompositionState.WorkflowId"/> (reset to zero each test via
+    /// <see cref="Reset"/>) makes the count start from one for every run, so the
+    /// retried step's success threshold is order-independent and unaffected by any
+    /// prior run/test that recorded the same step name.
+    /// </remarks>
+    /// <param name="workflowId">The run identity to count attempts for.</param>
+    /// <returns>The 1-based attempt number for this run after incrementing.</returns>
+    public int NextAttempt(Guid workflowId) =>
+        this.attemptsByRun.AddOrUpdate(workflowId, 1, (_, current) => current + 1);
+
+    /// <summary>
     /// Clears the probe at the start of each test to isolate it from prior runs.
     /// </summary>
-    public void Reset() => this.seenInputs.Clear();
+    public void Reset()
+    {
+        this.seenInputs.Clear();
+        this.attemptsByRun.Clear();
+    }
 }
 
 /// <summary>Leading kickoff step for the immutable-input scenario. Seeds the
@@ -249,7 +271,14 @@ public sealed class ImmutableRetriedStep(WorkflowInvocationLog log, CompositionI
         // probe captures the input on every attempt (including the failing ones).
         this.probe.RecordInput(state);
 
-        var attempt = this.log.CountFor(nameof(ImmutableRetriedStep));
+        // Derive the attempt number from the PER-RUN probe keyed by this run's
+        // WorkflowId, NOT the session-shared invocation log. The log persists
+        // across runs/tests on the session-scoped host, so a prior run that
+        // recorded this step name would start `attempt` at 3+ here — the step
+        // would then succeed immediately and stop proving retry/INV-7. Keying by
+        // WorkflowId (the probe is Reset() each test) starts every run at 1, so
+        // the threshold is order-independent.
+        var attempt = this.probe.NextAttempt(state.WorkflowId);
         if (attempt < 3)
         {
             throw new CompositionTransientException(

--- a/src/Strategos.Generators.Behavioral.Tests/Workflows/CompositionEdgeWorkflow.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Workflows/CompositionEdgeWorkflow.cs
@@ -1,0 +1,300 @@
+// -----------------------------------------------------------------------
+// <copyright file="CompositionEdgeWorkflow.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Collections.Concurrent;
+
+using Strategos.Abstractions;
+using Strategos.Attributes;
+using Strategos.Builders;
+using Strategos.Definitions;
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Steps;
+
+namespace Strategos.Generators.Behavioral.Tests.Workflows;
+
+// =============================================================================
+// Composition edge-case fixtures (epic #135, DR-10).
+//
+//   T020 — timeout-vs-retry race + late-completion idempotency.
+//   T021 — INV-7: the same immutable input flows to every retry attempt.
+//
+// These reuse CompositionState (defined in CompositionWorkflow.cs) but get their
+// own distinct step CLR types (the generator emits per-step-TYPE handlers within
+// one compilation; reusing a type across [Workflow]s would emit duplicate
+// generated types -> CS0101).
+// =============================================================================
+
+/// <summary>
+/// Process-shared probe for the timeout-vs-retry race (T020). Counts how many
+/// times the saga's timeout handler routed the workflow to its Failed terminal
+/// (the saga must fail-by-timeout exactly ONCE even though retry/late-completion
+/// machinery keeps firing), and whether a late step-completed event tried to
+/// resurrect the already-terminated saga.
+/// </summary>
+/// <remarks>
+/// Registered as a DI singleton on the host. The probe is a side channel to the
+/// invocation log: the timeout-failure terminal is observed by saga-document
+/// absence (the standard signal), and this probe additionally records the raw
+/// attempt timeline so the test can confirm the deadline fired mid-retry.
+/// </remarks>
+public sealed class CompositionRaceProbe
+{
+    private readonly ConcurrentQueue<DateTimeOffset> attemptStarts = new();
+
+    /// <summary>
+    /// Gets the ordered attempt-start timestamps recorded by the slow retried step.
+    /// </summary>
+    public IReadOnlyList<DateTimeOffset> AttemptStarts => this.attemptStarts.ToArray();
+
+    /// <summary>
+    /// Records that the slow retried step began an attempt.
+    /// </summary>
+    public void RecordAttemptStart() => this.attemptStarts.Enqueue(DateTimeOffset.UtcNow);
+
+    /// <summary>
+    /// Clears the probe at the start of each test to isolate it from prior runs.
+    /// </summary>
+    public void Reset() => this.attemptStarts.Clear();
+}
+
+// -----------------------------------------------------------------------------
+// T020 — race workflow.
+// -----------------------------------------------------------------------------
+
+/// <summary>Leading kickoff step for the race scenario.</summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class RaceKickoffStep(WorkflowInvocationLog log) : IWorkflowStep<CompositionState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompositionState>> ExecuteAsync(
+        CompositionState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(RaceKickoffStep));
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<CompositionState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// A slow retried step (T020): declares <c>.WithRetry(3, 200ms cooldown)</c> and
+/// <c>.WithTimeout(50ms)</c>, and each attempt sleeps ~100ms — longer than the
+/// 50ms deadline — so the scheduled saga timeout fires while the step is still
+/// retrying. Each attempt eventually throws so Wolverine keeps retrying until the
+/// timeout has long since routed the saga to Failed; the LATE completion / retry
+/// activity must NOT resurrect the terminated saga (the timeout race guard + the
+/// saga's absence are the idempotency proof).
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+/// <param name="probe">The shared race probe injected by the host.</param>
+public sealed class RaceSlowStep(WorkflowInvocationLog log, CompositionRaceProbe probe)
+    : IWorkflowStep<CompositionState>
+{
+    private readonly WorkflowInvocationLog log = log;
+    private readonly CompositionRaceProbe probe = probe;
+
+    /// <inheritdoc />
+    public async Task<StepResult<CompositionState>> ExecuteAsync(
+        CompositionState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(RaceSlowStep));
+        this.probe.RecordAttemptStart();
+
+        // Each attempt outlasts the 50ms deadline. Do NOT honour the cancellation
+        // token: the saga-level deadline race does not hard-cancel the in-flight
+        // handler — what matters is that the scheduled timeout message reaches the
+        // saga first while the step is still mid-retry.
+        await Task.Delay(TimeSpan.FromMilliseconds(100), CancellationToken.None);
+
+        // Throw so Wolverine retries (per .WithRetry(3)). This keeps the step
+        // re-firing AFTER the 50ms timeout has already terminated the saga, so a
+        // late completion / retry must not be able to resurrect or re-fail it.
+        throw new CompositionTransientException(
+            "RaceSlowStep always throws so retries keep firing past the already-fired timeout deadline.");
+    }
+}
+
+/// <summary>A step that must NOT run when the slow step times out: the timeout
+/// routes the saga to Failed + <c>MarkCompleted()</c> before this step's start
+/// command could be cascaded.</summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class RaceNeverReachedStep(WorkflowInvocationLog log) : IWorkflowStep<CompositionState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompositionState>> ExecuteAsync(
+        CompositionState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(RaceNeverReachedStep));
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<CompositionState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// T020 race workflow: the slow step's per-attempt sleep (~100ms) outlasts its
+/// 50ms timeout while <c>.WithRetry(3, 200ms)</c> keeps it firing, so the
+/// scheduled saga timeout wins the race mid-retry and routes the saga to Failed
+/// exactly once; late completions / retries must not resurrect it.
+/// </summary>
+[Workflow("composition-race")]
+public static partial class CompositionRaceWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent definition: kickoff -> slow retried+timed step
+    /// (<c>.WithRetry(3, 200ms).WithTimeout(50ms)</c>, each attempt ~100ms) ->
+    /// a step that must not be reached once the timeout fires.
+    /// </summary>
+    public static WorkflowDefinition<CompositionState> Definition => Workflow<CompositionState>
+        .Create("composition-race")
+        .StartWith<RaceKickoffStep>()
+        .Then<RaceSlowStep>(step => step
+            .WithRetry(3, TimeSpan.FromMilliseconds(200))
+            .WithTimeout(TimeSpan.FromMilliseconds(50)))
+        .Finally<RaceNeverReachedStep>();
+}
+
+// -----------------------------------------------------------------------------
+// T021 — immutable-input workflow.
+// -----------------------------------------------------------------------------
+
+/// <summary>
+/// Process-shared probe for INV-7 (T021): records the input
+/// <see cref="CompositionState"/> instance a retried step received on each
+/// attempt, so the test can confirm Wolverine re-delivers the SAME immutable
+/// value across attempts (no mutation-across-attempts).
+/// </summary>
+/// <remarks>Registered as a DI singleton on the host.</remarks>
+public sealed class CompositionImmutableProbe
+{
+    private readonly ConcurrentQueue<CompositionState> seenInputs = new();
+
+    /// <summary>
+    /// Gets the ordered sequence of input state instances seen across attempts.
+    /// </summary>
+    public IReadOnlyList<CompositionState> SeenInputs => this.seenInputs.ToArray();
+
+    /// <summary>
+    /// Records the input state instance an attempt received.
+    /// </summary>
+    /// <param name="input">The input state the step was handed this attempt.</param>
+    public void RecordInput(CompositionState input)
+    {
+        ArgumentNullException.ThrowIfNull(input, nameof(input));
+        this.seenInputs.Enqueue(input);
+    }
+
+    /// <summary>
+    /// Clears the probe at the start of each test to isolate it from prior runs.
+    /// </summary>
+    public void Reset() => this.seenInputs.Clear();
+}
+
+/// <summary>Leading kickoff step for the immutable-input scenario. Seeds the
+/// state token forward (folded into state) so the retried step's input carries a
+/// stable, per-run-identifiable value.</summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class ImmutableKickoffStep(WorkflowInvocationLog log) : IWorkflowStep<CompositionState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompositionState>> ExecuteAsync(
+        CompositionState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(ImmutableKickoffStep));
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<CompositionState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// A transient retried step (T021): declares <c>.WithRetry(2)</c>, throws on its
+/// first two attempts and succeeds on the third. On EVERY attempt it records the
+/// input state instance it received into the shared
+/// <see cref="CompositionImmutableProbe"/>, so the test can assert INV-7: each
+/// retry attempt receives the SAME immutable input value (Wolverine re-delivers
+/// the same envelope; the saga never mutates the input across attempts).
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+/// <param name="probe">The shared immutable-input probe injected by the host.</param>
+public sealed class ImmutableRetriedStep(WorkflowInvocationLog log, CompositionImmutableProbe probe)
+    : IWorkflowStep<CompositionState>
+{
+    private readonly WorkflowInvocationLog log = log;
+    private readonly CompositionImmutableProbe probe = probe;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompositionState>> ExecuteAsync(
+        CompositionState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(ImmutableRetriedStep));
+
+        // Record the input this attempt received BEFORE deciding to throw, so the
+        // probe captures the input on every attempt (including the failing ones).
+        this.probe.RecordInput(state);
+
+        var attempt = this.log.CountFor(nameof(ImmutableRetriedStep));
+        if (attempt < 3)
+        {
+            throw new CompositionTransientException(
+                $"ImmutableRetriedStep transient failure on attempt {attempt}.");
+        }
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<CompositionState>.FromState(updated));
+    }
+}
+
+/// <summary>Terminal step for the immutable-input scenario; its completion drives
+/// the saga to its terminal Completed phase once the retried step succeeds.</summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class ImmutableFinishStep(WorkflowInvocationLog log) : IWorkflowStep<CompositionState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompositionState>> ExecuteAsync(
+        CompositionState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(ImmutableFinishStep));
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<CompositionState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// T021 immutable-input workflow: the retried step throws twice then succeeds,
+/// recording its input on each attempt so the test can assert every attempt
+/// received the same immutable <see cref="CompositionState"/> value (INV-7).
+/// </summary>
+[Workflow("composition-immutable")]
+public static partial class CompositionImmutableWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent definition: kickoff -> transient retried step
+    /// (<c>.WithRetry(2)</c>, throws twice then succeeds) -> terminal finish.
+    /// </summary>
+    public static WorkflowDefinition<CompositionState> Definition => Workflow<CompositionState>
+        .Create("composition-immutable")
+        .StartWith<ImmutableKickoffStep>()
+        .Then<ImmutableRetriedStep>(step => step.WithRetry(2))
+        .Finally<ImmutableFinishStep>();
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Workflows/CompositionWorkflow.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Workflows/CompositionWorkflow.cs
@@ -1,0 +1,522 @@
+// -----------------------------------------------------------------------
+// <copyright file="CompositionWorkflow.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Abstractions;
+using Strategos.Attributes;
+using Strategos.Builders;
+using Strategos.Definitions;
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Steps;
+
+namespace Strategos.Generators.Behavioral.Tests.Workflows;
+
+// =============================================================================
+// Composition fixtures (epic #135, DR-10, T019/T020/T021).
+//
+// These workflows are the FIRST time all four lowered step-resilience
+// capabilities are declared together on a SINGLE step:
+//
+//     .WithRetry(n).WithTimeout(t).Compensate<TRollback>()
+//         .RequireConfidence(x).OnLowConfidence(alt => alt.Then<THandler>())
+//
+// The four capabilities lower onto DISJOINT generated surfaces (so they compose
+// without a duplicate-Handle CS0111 collision):
+//   * retry + compensation  -> worker handler's static Configure(HandlerChain)
+//   * timeout               -> StepStart cascade of {Phase}Timeout + saga Handle
+//   * confidence            -> StepCompleted handler routing on evt.Confidence
+//
+// The three precedence scenarios (T019) need DISTINCT runtime behavior, so each
+// lives in its own [Workflow] definition with its own distinct step CLR types
+// (the generator emits worker handlers / commands / events per step TYPE within
+// one compilation, so reusing a step type across two [Workflow]s would emit
+// duplicate generated types -> CS0101).
+//
+// T020 (timeout-vs-retry race) and T021 (immutable input across retries) get
+// their own dedicated workflows further down.
+// =============================================================================
+
+/// <summary>
+/// Immutable state shared by the composition fixtures (DR-10). A step that
+/// always throws records nothing in state; the deterministic steps fold a
+/// monotonically increasing <see cref="StepCount"/> so a test can confirm how
+/// far the saga progressed. <see cref="LastSeenInput"/> records the input state
+/// instance each retried attempt received (T021 / INV-7).
+/// </summary>
+/// <remarks>
+/// Marked <see cref="WorkflowStateAttribute"/> so the source generator emits a
+/// reducer the saga uses to fold each step's returned state.
+/// </remarks>
+[WorkflowState]
+public sealed record CompositionState : IWorkflowState
+{
+    /// <summary>
+    /// Gets the unique identifier for this workflow instance.
+    /// </summary>
+    public Guid WorkflowId { get; init; }
+
+    /// <summary>
+    /// Gets the number of steps that have folded their result into state.
+    /// </summary>
+    public int StepCount { get; init; }
+
+    /// <summary>
+    /// Gets an opaque token (T021): a per-run marker the test sets so a retried
+    /// step can confirm Wolverine re-delivers the SAME immutable input envelope
+    /// across attempts rather than a mutated one.
+    /// </summary>
+    public string Token { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// Permanent failure raised by the always-throwing composition step on every
+/// invocation, so its <c>.WithRetry(2)</c> exhausts and the lowered compensation
+/// path fires.
+/// </summary>
+public sealed class CompositionPermanentException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CompositionPermanentException"/>
+    /// class with the supplied message.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    public CompositionPermanentException(string message)
+        : base(message)
+    {
+    }
+}
+
+/// <summary>
+/// Transient failure raised by the transient-then-success composition step on its
+/// first two attempts to exercise the lowered retry policy under composition.
+/// </summary>
+public sealed class CompositionTransientException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CompositionTransientException"/>
+    /// class with the supplied message.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    public CompositionTransientException(string message)
+        : base(message)
+    {
+    }
+}
+
+// =============================================================================
+// SCENARIO 1 (T019) — transient-then-success, HIGH confidence.
+// The all-four step throws on attempts 1-2, then on attempt 3 succeeds with HIGH
+// confidence (0.9 >= 0.85). Expected precedence: retry carries it through, then
+// the completed handler sees acceptable confidence and proceeds on the primary
+// path. No compensation, no low-confidence route.
+// =============================================================================
+
+/// <summary>Leading kickoff step for the transient scenario (timed steps need a
+/// preceding step because <c>StartWith</c> has no configure overload).</summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class TransientKickoffStep(WorkflowInvocationLog log) : IWorkflowStep<CompositionState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompositionState>> ExecuteAsync(
+        CompositionState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(TransientKickoffStep));
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<CompositionState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The all-four-resilience step for scenario 1. Throws a transient exception on
+/// attempts 1 and 2, then succeeds on attempt 3 with HIGH confidence (0.9). The
+/// recorded invocation count therefore equals the number of attempts Wolverine
+/// made under the composed retry policy.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class TransientAllResilienceStep(WorkflowInvocationLog log) : IWorkflowStep<CompositionState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompositionState>> ExecuteAsync(
+        CompositionState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(TransientAllResilienceStep));
+        var attempt = this.log.CountFor(nameof(TransientAllResilienceStep));
+
+        if (attempt < 3)
+        {
+            throw new CompositionTransientException(
+                $"TransientAllResilienceStep transient failure on attempt {attempt}.");
+        }
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+
+        // High confidence (>= 0.85): the completed handler must proceed on the
+        // primary path, NOT route to the low-confidence handler.
+        return Task.FromResult(StepResult<CompositionState>.WithConfidence(updated, 0.9));
+    }
+}
+
+/// <summary>The low-confidence handler for scenario 1. Must NOT run (the step
+/// succeeds with high confidence). Its zero invocation count proves the
+/// confidence gate did not divert.</summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class TransientReviewStep(WorkflowInvocationLog log) : IWorkflowStep<CompositionState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompositionState>> ExecuteAsync(
+        CompositionState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(TransientReviewStep));
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<CompositionState>.FromState(updated));
+    }
+}
+
+/// <summary>The rollback (compensation) step for scenario 1. Must NOT run (the
+/// step eventually succeeds). Its zero invocation count proves compensation did
+/// not fire on a successful step.</summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class TransientRollbackStep(WorkflowInvocationLog log) : IWorkflowStep<CompositionState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompositionState>> ExecuteAsync(
+        CompositionState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(TransientRollbackStep));
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<CompositionState>.FromState(updated));
+    }
+}
+
+/// <summary>The terminal step for scenario 1. Runs on the primary path once the
+/// transient step finally succeeds with acceptable confidence; its completion
+/// drives the saga to its terminal Completed phase.</summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class TransientFinishStep(WorkflowInvocationLog log) : IWorkflowStep<CompositionState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompositionState>> ExecuteAsync(
+        CompositionState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(TransientFinishStep));
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<CompositionState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// Scenario 1 composition workflow: the all-four-resilience step is
+/// transient-then-success with HIGH confidence, so retry carries it through and
+/// the saga proceeds on the primary path to <see cref="TransientFinishStep"/>.
+/// </summary>
+[Workflow("composition-transient")]
+public static partial class CompositionTransientWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent definition: kickoff -> all-four step
+    /// (<c>.WithRetry(2).WithTimeout(30s).Compensate&lt;TransientRollbackStep&gt;()
+    /// .RequireConfidence(0.85).OnLowConfidence(alt =&gt; alt.Then&lt;TransientReviewStep&gt;())</c>)
+    /// -> terminal finish.
+    /// </summary>
+    public static WorkflowDefinition<CompositionState> Definition => Workflow<CompositionState>
+        .Create("composition-transient")
+        .StartWith<TransientKickoffStep>()
+        .Then<TransientAllResilienceStep>(step => step
+            .WithRetry(2)
+            .WithTimeout(TimeSpan.FromSeconds(30))
+            .Compensate<TransientRollbackStep>()
+            .RequireConfidence(0.85)
+            .OnLowConfidence(alt => alt.Then<TransientReviewStep>()))
+        .Finally<TransientFinishStep>();
+}
+
+// =============================================================================
+// SCENARIO 2 (T019) — first-try success, LOW confidence (0.5).
+// The all-four step succeeds on its first attempt but returns LOW confidence
+// (0.5 < 0.85). Expected precedence: success-but-low-confidence is NOT a failure,
+// so compensation must NOT run; the completed handler routes to the
+// OnLowConfidence handler step instead.
+// =============================================================================
+
+/// <summary>Leading kickoff step for the low-confidence scenario.</summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class LowConfKickoffStep(WorkflowInvocationLog log) : IWorkflowStep<CompositionState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompositionState>> ExecuteAsync(
+        CompositionState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(LowConfKickoffStep));
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<CompositionState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The all-four-resilience step for scenario 2. Succeeds on the FIRST attempt
+/// (never throws) but returns LOW confidence (0.5 &lt; 0.85). Proves that a
+/// successful-but-low-confidence result routes to the OnLowConfidence handler and
+/// does NOT trip the compensation (failure) path.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class LowConfAllResilienceStep(WorkflowInvocationLog log) : IWorkflowStep<CompositionState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompositionState>> ExecuteAsync(
+        CompositionState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(LowConfAllResilienceStep));
+        var updated = state with { StepCount = state.StepCount + 1 };
+
+        // Low confidence (< 0.85): the completed handler must route to the
+        // OnLowConfidence handler. The step still SUCCEEDED, so compensation must
+        // not run.
+        return Task.FromResult(StepResult<CompositionState>.WithConfidence(updated, 0.5));
+    }
+}
+
+/// <summary>The low-confidence handler for scenario 2. As a single-step
+/// OnLowConfidence handler it terminates the workflow (the generated handler
+/// calls <c>MarkCompleted()</c>). Its single invocation is the routing proof.</summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class LowConfReviewStep(WorkflowInvocationLog log) : IWorkflowStep<CompositionState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompositionState>> ExecuteAsync(
+        CompositionState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(LowConfReviewStep));
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<CompositionState>.FromState(updated));
+    }
+}
+
+/// <summary>The rollback step for scenario 2. Must NOT run: the step succeeded
+/// (low confidence is not a failure), so the compensation path never fires.</summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class LowConfRollbackStep(WorkflowInvocationLog log) : IWorkflowStep<CompositionState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompositionState>> ExecuteAsync(
+        CompositionState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(LowConfRollbackStep));
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<CompositionState>.FromState(updated));
+    }
+}
+
+/// <summary>The primary finish step for scenario 2. Must NOT run: the gate
+/// diverts to the handler branch (which completes the saga) before this step is
+/// reached.</summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class LowConfFinishStep(WorkflowInvocationLog log) : IWorkflowStep<CompositionState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompositionState>> ExecuteAsync(
+        CompositionState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(LowConfFinishStep));
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<CompositionState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// Scenario 2 composition workflow: the all-four-resilience step succeeds first
+/// try with LOW confidence, so the saga routes to <see cref="LowConfReviewStep"/>
+/// (NOT compensation) and the primary finish step is skipped.
+/// </summary>
+[Workflow("composition-low-confidence")]
+public static partial class CompositionLowConfidenceWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent definition: kickoff -> all-four step (succeeds first try,
+    /// confidence 0.5) -> terminal finish (skipped via the low-confidence route).
+    /// </summary>
+    public static WorkflowDefinition<CompositionState> Definition => Workflow<CompositionState>
+        .Create("composition-low-confidence")
+        .StartWith<LowConfKickoffStep>()
+        .Then<LowConfAllResilienceStep>(step => step
+            .WithRetry(2)
+            .WithTimeout(TimeSpan.FromSeconds(30))
+            .Compensate<LowConfRollbackStep>()
+            .RequireConfidence(0.85)
+            .OnLowConfidence(alt => alt.Then<LowConfReviewStep>()))
+        .Finally<LowConfFinishStep>();
+}
+
+// =============================================================================
+// SCENARIO 3 (T019) — always throws.
+// The all-four step throws on EVERY attempt, so the retry policy exhausts and the
+// lowered compensation path fires. Expected precedence: retries exhaust ->
+// compensation (rollback) runs -> terminal Failed. No low-confidence route (the
+// completed event never fires).
+// =============================================================================
+
+/// <summary>Leading kickoff step for the always-fail scenario.</summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class FailKickoffStep(WorkflowInvocationLog log) : IWorkflowStep<CompositionState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompositionState>> ExecuteAsync(
+        CompositionState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(FailKickoffStep));
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<CompositionState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The all-four-resilience step for scenario 3. Throws on EVERY invocation, so
+/// the composed <c>.WithRetry(2)</c> exhausts (initial + two retries = three
+/// attempts) and the lowered compensation path fires. Its recorded count is the
+/// retry-exhaustion proof under composition.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class FailAllResilienceStep(WorkflowInvocationLog log) : IWorkflowStep<CompositionState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompositionState>> ExecuteAsync(
+        CompositionState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(FailAllResilienceStep));
+
+        throw new CompositionPermanentException(
+            "FailAllResilienceStep always fails to force retry exhaustion and compensation under composition.");
+    }
+}
+
+/// <summary>The low-confidence handler for scenario 3. Must NOT run: the step
+/// never produces a completed event (it always throws), so the confidence gate is
+/// never reached.</summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class FailReviewStep(WorkflowInvocationLog log) : IWorkflowStep<CompositionState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompositionState>> ExecuteAsync(
+        CompositionState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(FailReviewStep));
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<CompositionState>.FromState(updated));
+    }
+}
+
+/// <summary>The rollback (compensation) step for scenario 3. Runs exactly once
+/// when the failing step exhausts its retries. INV-7: returns NEW state rather
+/// than mutating the input.</summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class FailRollbackStep(WorkflowInvocationLog log) : IWorkflowStep<CompositionState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompositionState>> ExecuteAsync(
+        CompositionState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(FailRollbackStep));
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<CompositionState>.FromState(updated));
+    }
+}
+
+/// <summary>The terminal step for scenario 3. Must NOT run: compensation routes
+/// the saga to Failed before the happy path is reached.</summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class FailFinishStep(WorkflowInvocationLog log) : IWorkflowStep<CompositionState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompositionState>> ExecuteAsync(
+        CompositionState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(FailFinishStep));
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<CompositionState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// Scenario 3 composition workflow: the all-four-resilience step always throws,
+/// so retries exhaust and the compensation (<see cref="FailRollbackStep"/>) runs,
+/// routing the saga to its terminal Failed phase.
+/// </summary>
+[Workflow("composition-fail")]
+public static partial class CompositionFailWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent definition: kickoff -> all-four step (always throws) ->
+    /// terminal finish (never reached; compensation routes to Failed).
+    /// </summary>
+    public static WorkflowDefinition<CompositionState> Definition => Workflow<CompositionState>
+        .Create("composition-fail")
+        .StartWith<FailKickoffStep>()
+        .Then<FailAllResilienceStep>(step => step
+            .WithRetry(2)
+            .WithTimeout(TimeSpan.FromSeconds(30))
+            .Compensate<FailRollbackStep>()
+            .RequireConfidence(0.85)
+            .OnLowConfidence(alt => alt.Then<FailReviewStep>()))
+        .Finally<FailFinishStep>();
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Workflows/ConfidenceWorkflow.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Workflows/ConfidenceWorkflow.cs
@@ -1,0 +1,285 @@
+// -----------------------------------------------------------------------
+// <copyright file="ConfidenceWorkflow.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Abstractions;
+using Strategos.Attributes;
+using Strategos.Builders;
+using Strategos.Definitions;
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Steps;
+
+namespace Strategos.Generators.Behavioral.Tests.Workflows;
+
+/// <summary>
+/// Immutable state shared by the confidence-gate fixture workflows (DR-5 T014).
+/// </summary>
+/// <remarks>
+/// Marked <see cref="WorkflowStateAttribute"/> so the source generator emits a
+/// reducer used by each saga to fold every step's returned state.
+/// </remarks>
+[WorkflowState]
+public sealed record ConfidenceState : IWorkflowState
+{
+    /// <summary>
+    /// Gets the unique identifier for this workflow instance.
+    /// </summary>
+    public Guid WorkflowId { get; init; }
+
+    /// <summary>
+    /// Gets the number of steps that have folded their result into state.
+    /// </summary>
+    public int StepCount { get; init; }
+}
+
+// =============================================================================
+// Low-confidence scenario: the classify step returns Confidence = 0.5, below
+// the 0.85 threshold, so the saga must route to the OnLowConfidence handler
+// (HumanReviewStepLow) instead of the primary finish step. Distinct CLR types
+// per [Workflow] definition avoid the generator's CS0101 same-name collision.
+// =============================================================================
+
+/// <summary>
+/// Entry step of the low-confidence fixture workflow. Deterministic; records
+/// its invocation so the test can confirm the saga started.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class ConfPrepareStepLow(WorkflowInvocationLog log) : IWorkflowStep<ConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ConfidenceState>> ExecuteAsync(
+        ConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(ConfPrepareStepLow));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ConfidenceState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The confidence-gated step of the low-confidence fixture. Returns a step
+/// result whose <c>Confidence</c> is 0.5 — below the 0.85 threshold — so the
+/// generated saga's confidence gate must route to
+/// <see cref="HumanReviewStepLow"/> rather than the primary finish step.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class ClassifyStepLow(WorkflowInvocationLog log) : IWorkflowStep<ConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ConfidenceState>> ExecuteAsync(
+        ConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(ClassifyStepLow));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ConfidenceState>.WithConfidence(updated, 0.5));
+    }
+}
+
+/// <summary>
+/// The low-confidence handler step. It only runs when the confidence gate
+/// routes to it (confidence below threshold). As a single-step OnLowConfidence
+/// handler it terminates the workflow (the generated handler calls
+/// <c>MarkCompleted()</c>).
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class HumanReviewStepLow(WorkflowInvocationLog log) : IWorkflowStep<ConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ConfidenceState>> ExecuteAsync(
+        ConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(HumanReviewStepLow));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ConfidenceState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The primary finish step of the low-confidence fixture. It must NOT run when
+/// confidence is low, because the gate diverts to the handler branch before
+/// this step is reached. Records its invocation so the test can assert it was
+/// skipped.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class ConfFinishStepLow(WorkflowInvocationLog log) : IWorkflowStep<ConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ConfidenceState>> ExecuteAsync(
+        ConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(ConfFinishStepLow));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ConfidenceState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The low-confidence fixture workflow definition. The classify step declares
+/// <c>.RequireConfidence(0.85).OnLowConfidence(alt =&gt; alt.Then&lt;HumanReviewStepLow&gt;())</c>
+/// and returns confidence 0.5, so the generated saga must route to the human
+/// review handler. Drives the generator to emit <c>LowConfidenceSaga</c>,
+/// <c>StartLowConfidenceCommand</c>, and <c>AddLowConfidenceWorkflow()</c>.
+/// </summary>
+[Workflow("low-confidence")]
+public static partial class LowConfidenceWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent definition: a prepare step, a confidence-gated classify
+    /// step (returns 0.5, below the 0.85 threshold) whose <c>OnLowConfidence</c>
+    /// branch runs <see cref="HumanReviewStepLow"/>, and a primary finish step
+    /// that should be skipped when confidence is low.
+    /// </summary>
+    public static WorkflowDefinition<ConfidenceState> Definition => Workflow<ConfidenceState>
+        .Create("low-confidence")
+        .StartWith<ConfPrepareStepLow>()
+        .Then<ClassifyStepLow>(step => step
+            .RequireConfidence(0.85)
+            .OnLowConfidence(alt => alt.Then<HumanReviewStepLow>()))
+        .Finally<ConfFinishStepLow>();
+}
+
+// =============================================================================
+// High-confidence scenario: the classify step returns Confidence = 0.9, at/above
+// the 0.85 threshold, so the saga must proceed on the primary path to the finish
+// step and the human review handler must NOT run. Distinct CLR types again.
+// =============================================================================
+
+/// <summary>
+/// Entry step of the high-confidence fixture workflow. Deterministic; records
+/// its invocation.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class ConfPrepareStepHigh(WorkflowInvocationLog log) : IWorkflowStep<ConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ConfidenceState>> ExecuteAsync(
+        ConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(ConfPrepareStepHigh));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ConfidenceState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The confidence-gated step of the high-confidence fixture. Returns a step
+/// result whose <c>Confidence</c> is 0.9 — at/above the 0.85 threshold — so the
+/// generated saga's confidence gate must proceed down the primary path and NOT
+/// route to <see cref="HumanReviewStepHigh"/>.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class ClassifyStepHigh(WorkflowInvocationLog log) : IWorkflowStep<ConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ConfidenceState>> ExecuteAsync(
+        ConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(ClassifyStepHigh));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ConfidenceState>.WithConfidence(updated, 0.9));
+    }
+}
+
+/// <summary>
+/// The low-confidence handler step for the high-confidence fixture. It must NOT
+/// run, because confidence is at/above the threshold. Records its invocation so
+/// the test can assert it was skipped.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class HumanReviewStepHigh(WorkflowInvocationLog log) : IWorkflowStep<ConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ConfidenceState>> ExecuteAsync(
+        ConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(HumanReviewStepHigh));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ConfidenceState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The primary finish step of the high-confidence fixture. As the workflow's
+/// <c>Finally</c> step, its completion drives the saga to its terminal phase and
+/// <c>MarkCompleted()</c>. It must run on the primary path (high confidence).
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class ConfFinishStepHigh(WorkflowInvocationLog log) : IWorkflowStep<ConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ConfidenceState>> ExecuteAsync(
+        ConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(ConfFinishStepHigh));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ConfidenceState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The high-confidence fixture workflow definition. The classify step declares
+/// the same confidence gate but returns confidence 0.9, so the generated saga
+/// must proceed on the primary path to <see cref="ConfFinishStepHigh"/> and the
+/// human review handler must NOT run. Drives the generator to emit
+/// <c>HighConfidenceSaga</c>, <c>StartHighConfidenceCommand</c>, and
+/// <c>AddHighConfidenceWorkflow()</c>.
+/// </summary>
+[Workflow("high-confidence")]
+public static partial class HighConfidenceWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent definition: a prepare step, a confidence-gated classify
+    /// step (returns 0.9, at/above the 0.85 threshold) whose
+    /// <c>OnLowConfidence</c> branch (<see cref="HumanReviewStepHigh"/>) must be
+    /// skipped, and a primary finish step that should run.
+    /// </summary>
+    public static WorkflowDefinition<ConfidenceState> Definition => Workflow<ConfidenceState>
+        .Create("high-confidence")
+        .StartWith<ConfPrepareStepHigh>()
+        .Then<ClassifyStepHigh>(step => step
+            .RequireConfidence(0.85)
+            .OnLowConfidence(alt => alt.Then<HumanReviewStepHigh>()))
+        .Finally<ConfFinishStepHigh>();
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Workflows/ContextWorkflow.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Workflows/ContextWorkflow.cs
@@ -1,0 +1,160 @@
+// -----------------------------------------------------------------------
+// <copyright file="ContextWorkflow.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Abstractions;
+using Strategos.Agents.Abstractions;
+using Strategos.Agents.Models;
+using Strategos.Attributes;
+using Strategos.Builders;
+using Strategos.Definitions;
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Steps;
+
+namespace Strategos.Generators.Behavioral.Tests.Workflows;
+
+/// <summary>
+/// Immutable state for the context-assembly fixture workflow (DR-6 T016).
+/// </summary>
+/// <remarks>
+/// Marked <see cref="WorkflowStateAttribute"/> so the source generator emits a
+/// reducer used by the saga to fold every step's returned state.
+/// </remarks>
+[WorkflowState]
+public sealed record ContextState : IWorkflowState
+{
+    /// <summary>
+    /// Gets the unique identifier for this workflow instance.
+    /// </summary>
+    public Guid WorkflowId { get; init; }
+
+    /// <summary>
+    /// Gets the customer name folded into the assembled state context.
+    /// </summary>
+    public string CustomerName { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// Marker type for the ontology collection the enrich step retrieves from. The
+/// generated assembler dispatches a <c>SimilarityExpression</c> rooted on this
+/// type through <c>IObjectSetProvider.ExecuteSimilarityAsync&lt;ProductCatalog&gt;</c>;
+/// the stub provider ignores the root and returns a canned scored result.
+/// </summary>
+public sealed class ProductCatalog
+{
+    /// <summary>
+    /// Gets a stub document body; the assembler maps each item via
+    /// <c>item.ToString()</c> into a retrieval segment.
+    /// </summary>
+    public string Text { get; init; } = string.Empty;
+
+    /// <inheritdoc />
+    public override string ToString() => this.Text;
+}
+
+/// <summary>
+/// Entry step of the context fixture. Deterministic; records its invocation so
+/// the test can confirm the saga started.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class ContextPrepareStep(WorkflowInvocationLog log) : IWorkflowStep<ContextState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ContextState>> ExecuteAsync(
+        ContextState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(ContextPrepareStep));
+
+        // Seed a state value so the assembler's FromState source has content.
+        var updated = state with { CustomerName = "Ada Lovelace" };
+        return Task.FromResult(StepResult<ContextState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The context-declaring step. Its <c>.WithContext(...)</c> declaration lowers a
+/// generated <c>EnrichStepContextAssembler</c> whose retrieval source runs
+/// through the stub <c>IObjectSetProvider</c>. Implements
+/// <see cref="IContextAwareStep"/> so the generated worker handler delivers the
+/// assembled context here, where it is captured on the shared
+/// <see cref="ContextProbe"/> for the test to assert.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+/// <param name="probe">The shared observation probe injected by the host.</param>
+public sealed class EnrichStep(WorkflowInvocationLog log, ContextProbe probe)
+    : IWorkflowStep<ContextState>, IContextAwareStep
+{
+    private readonly WorkflowInvocationLog log = log;
+    private readonly ContextProbe probe = probe;
+
+    /// <inheritdoc />
+    public void ReceiveContext(AssembledContext context)
+    {
+        // The handler assembles context BEFORE ExecuteAsync and delivers it here.
+        this.probe.RecordAssembledContext(context);
+    }
+
+    /// <inheritdoc />
+    public Task<StepResult<ContextState>> ExecuteAsync(
+        ContextState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(EnrichStep));
+        return Task.FromResult(StepResult<ContextState>.FromState(state));
+    }
+}
+
+/// <summary>
+/// Terminal step of the context fixture. As the <c>Finally</c> step its
+/// completion drives the saga to its terminal phase and <c>MarkCompleted()</c>.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class ContextFinishStep(WorkflowInvocationLog log) : IWorkflowStep<ContextState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ContextState>> ExecuteAsync(
+        ContextState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(ContextFinishStep));
+        return Task.FromResult(StepResult<ContextState>.FromState(state));
+    }
+}
+
+/// <summary>
+/// The context fixture workflow definition. The enrich step declares
+/// <c>.WithContext(ctx =&gt; ctx.FromState(...).FromRetrieval&lt;ProductCatalog&gt;(...).FromLiteral(...))</c>,
+/// driving the generator to emit <c>EnrichStepContextAssembler</c>, wire it into
+/// <c>EnrichStepHandler</c>, and register it via <c>AddContextFlowWorkflow()</c>.
+/// </summary>
+[Workflow("context-flow")]
+public static partial class ContextFlowWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent definition: a prepare step, a context-declaring enrich
+    /// step whose assembled context draws from state, ontology retrieval
+    /// (TopK 5, MinRelevance 0.8) and a literal, and a terminal finish step.
+    /// </summary>
+    public static WorkflowDefinition<ContextState> Definition => Workflow<ContextState>
+        .Create("context-flow")
+        .StartWith<ContextPrepareStep>()
+        .Then<EnrichStep>(step => step
+            .WithContext(ctx => ctx
+                .FromState(s => s.CustomerName)
+                .FromRetrieval<ProductCatalog>(r => r
+                    .Query("recommended widgets")
+                    .TopK(5)
+                    .MinRelevance(0.8m))
+                .FromLiteral("Follow brand guidelines.")))
+        .Finally<ContextFinishStep>();
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Workflows/HappyPathWorkflow.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Workflows/HappyPathWorkflow.cs
@@ -1,0 +1,105 @@
+// -----------------------------------------------------------------------
+// <copyright file="HappyPathWorkflow.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Abstractions;
+using Strategos.Attributes;
+using Strategos.Builders;
+using Strategos.Definitions;
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Steps;
+
+namespace Strategos.Generators.Behavioral.Tests.Workflows;
+
+/// <summary>
+/// Immutable state for the happy-path fixture workflow.
+/// </summary>
+/// <remarks>
+/// Marked <see cref="WorkflowStateAttribute"/> so the source generator emits a
+/// reducer (<c>HappyPathStateReducer</c>) used by the saga to fold each step's
+/// returned state. <see cref="StepCount"/> is appended to by each step so a
+/// test can confirm state actually flows through the generated saga.
+/// </remarks>
+[WorkflowState]
+public sealed record HappyPathState : IWorkflowState
+{
+    /// <summary>
+    /// Gets the unique identifier for this workflow instance.
+    /// </summary>
+    public Guid WorkflowId { get; init; }
+
+    /// <summary>
+    /// Gets the number of steps that have folded their result into state.
+    /// </summary>
+    public int StepCount { get; init; }
+}
+
+/// <summary>
+/// First instrumented step of the happy-path fixture workflow. Deterministic
+/// (never throws) for this happy-path task; records its invocation and
+/// increments the state step counter.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class RecordFirstStep(WorkflowInvocationLog log) : IWorkflowStep<HappyPathState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<HappyPathState>> ExecuteAsync(
+        HappyPathState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(RecordFirstStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<HappyPathState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// Final instrumented step of the happy-path fixture workflow. Deterministic
+/// (never throws); records its invocation and increments the state step
+/// counter. As the workflow's <c>Finally</c> step, its completion drives the
+/// saga to its terminal <c>Completed</c> phase and <c>MarkCompleted()</c>.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class RecordSecondStep(WorkflowInvocationLog log) : IWorkflowStep<HappyPathState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<HappyPathState>> ExecuteAsync(
+        HappyPathState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(RecordSecondStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<HappyPathState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The happy-path fixture workflow definition. The
+/// <see cref="WorkflowAttribute"/> drives the Strategos source generator to
+/// emit, at build time, the Wolverine saga (<c>HappyPathSaga</c>), the worker
+/// handlers, the command records (notably <c>StartHappyPathCommand</c>), the
+/// <c>HappyPathPhase</c> enum, and the <c>AddHappyPathWorkflow()</c> DI
+/// extension consumed by <see cref="WolverineHostFixture"/>.
+/// </summary>
+[Workflow("happy-path")]
+public static partial class HappyPathWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent workflow definition: a single linear chain of two
+    /// deterministic, instrumented steps.
+    /// </summary>
+    public static WorkflowDefinition<HappyPathState> Definition => Workflow<HappyPathState>
+        .Create("happy-path")
+        .StartWith<RecordFirstStep>()
+        .Finally<RecordSecondStep>();
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Workflows/RetryWorkflow.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Workflows/RetryWorkflow.cs
@@ -1,0 +1,158 @@
+// -----------------------------------------------------------------------
+// <copyright file="RetryWorkflow.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Abstractions;
+using Strategos.Attributes;
+using Strategos.Builders;
+using Strategos.Definitions;
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Steps;
+
+namespace Strategos.Generators.Behavioral.Tests.Workflows;
+
+/// <summary>
+/// Immutable state for the retry-proof fixture workflow.
+/// </summary>
+/// <remarks>
+/// Marked <see cref="WorkflowStateAttribute"/> so the source generator emits a
+/// reducer used by the saga to fold each step's returned state.
+/// </remarks>
+[WorkflowState]
+public sealed record RetryState : IWorkflowState
+{
+    /// <summary>
+    /// Gets the unique identifier for this workflow instance.
+    /// </summary>
+    public Guid WorkflowId { get; init; }
+
+    /// <summary>
+    /// Gets the number of steps that have folded their result into state.
+    /// </summary>
+    public int StepCount { get; init; }
+}
+
+/// <summary>
+/// Transient failure raised by <see cref="RetryFlakyStep"/> on its first two
+/// invocations to exercise the generated Wolverine per-handler retry policy.
+/// </summary>
+public sealed class TransientStepException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TransientStepException"/>
+    /// class with the supplied message.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    public TransientStepException(string message)
+        : base(message)
+    {
+    }
+}
+
+/// <summary>
+/// Entry step of the retry-proof fixture workflow. Deterministic (never throws);
+/// records its invocation so the test can confirm the saga actually started.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class RetryPrepareStep(WorkflowInvocationLog log) : IWorkflowStep<RetryState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<RetryState>> ExecuteAsync(
+        RetryState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(RetryPrepareStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<RetryState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// A deliberately flaky instrumented step. It records every invocation in the
+/// shared <see cref="WorkflowInvocationLog"/> and throws a transient exception
+/// on attempts 1 and 2, succeeding only on attempt 3. The recorded invocation
+/// count therefore equals the number of attempts Wolverine made, which the
+/// behavioral test asserts to prove the generated retry policy actually retried.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class RetryFlakyStep(WorkflowInvocationLog log) : IWorkflowStep<RetryState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<RetryState>> ExecuteAsync(
+        RetryState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        // Record FIRST, then decide based on this invocation's attempt number.
+        // CountFor reflects all prior recordings plus this one.
+        this.log.Record(nameof(RetryFlakyStep));
+        var attempt = this.log.CountFor(nameof(RetryFlakyStep));
+
+        if (attempt < 3)
+        {
+            throw new TransientStepException(
+                $"RetryFlakyStep transient failure on attempt {attempt}.");
+        }
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<RetryState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// Terminal step of the retry-proof fixture workflow. Deterministic (never
+/// throws); records its invocation. As the workflow's <c>Finally</c> step, its
+/// completion drives the saga to its terminal phase and <c>MarkCompleted()</c>,
+/// so the test only observes it once the flaky step has finally succeeded.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class RetryFinishStep(WorkflowInvocationLog log) : IWorkflowStep<RetryState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<RetryState>> ExecuteAsync(
+        RetryState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(RetryFinishStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<RetryState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The retry-proof fixture workflow definition. The
+/// <see cref="WorkflowAttribute"/> drives the Strategos source generator to
+/// emit, at build time, the Wolverine saga (<c>RetryProofSaga</c>), the worker
+/// handler for <see cref="RetryFlakyStep"/> (carrying the generated
+/// <c>Configure(HandlerChain)</c> retry policy from DR-2 T007), the start
+/// command (<c>StartRetryProofCommand</c>), and the
+/// <c>AddRetryProofWorkflow()</c> DI extension consumed by
+/// <see cref="WolverineHostFixture"/>.
+/// </summary>
+[Workflow("retry-proof")]
+public static partial class RetryProofWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent workflow definition: a prepare step, a flaky middle step
+    /// declaring <c>.WithRetry(2)</c> (two retries after the initial attempt,
+    /// i.e. up to three total invocations), and a terminal finish step whose
+    /// completion the test waits on.
+    /// </summary>
+    public static WorkflowDefinition<RetryState> Definition => Workflow<RetryState>
+        .Create("retry-proof")
+        .StartWith<RetryPrepareStep>()
+        .Then<RetryFlakyStep>(step => step.WithRetry(2))
+        .Finally<RetryFinishStep>();
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Workflows/TimeoutWorkflow.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Workflows/TimeoutWorkflow.cs
@@ -1,0 +1,231 @@
+// -----------------------------------------------------------------------
+// <copyright file="TimeoutWorkflow.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Abstractions;
+using Strategos.Attributes;
+using Strategos.Builders;
+using Strategos.Definitions;
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Steps;
+
+namespace Strategos.Generators.Behavioral.Tests.Workflows;
+
+/// <summary>
+/// Immutable state for the timeout behavioral fixtures (DR-4).
+/// </summary>
+/// <remarks>
+/// Marked <see cref="WorkflowStateAttribute"/> so the source generator emits a
+/// reducer the saga uses to fold each step's returned state. <see cref="StepCount"/>
+/// is appended to by each step so a test can confirm how far the workflow actually
+/// progressed through the generated saga.
+/// </remarks>
+[WorkflowState]
+public sealed record TimeoutState : IWorkflowState
+{
+    /// <summary>
+    /// Gets the unique identifier for this workflow instance.
+    /// </summary>
+    public Guid WorkflowId { get; init; }
+
+    /// <summary>
+    /// Gets the number of steps that have folded their result into state.
+    /// </summary>
+    public int StepCount { get; init; }
+}
+
+// NOTE: The slow and fast workflows deliberately share NO step types. The source
+// generator emits worker handlers / commands / events per step TYPE within the
+// same compilation, so a step type reused across two [Workflow] definitions would
+// produce duplicate generated types (CS0101). Each workflow therefore gets its own
+// kickoff/timed/follow-on step classes.
+
+/// <summary>
+/// Instant kickoff step for the slow scenario (no timeout). Exists because the
+/// timed step must be a <c>.Then&lt;T&gt;(configure)</c> — <c>StartWith</c> has no
+/// configure overload — so a workflow needs a leading non-timed step before the
+/// timed one.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class SlowKickoffStep(WorkflowInvocationLog log) : IWorkflowStep<TimeoutState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<TimeoutState>> ExecuteAsync(
+        TimeoutState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(SlowKickoffStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<TimeoutState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// A deliberately slow step (sleeps ~500 ms) configured with a 50 ms timeout. The
+/// saga's deadline-race timeout message therefore arrives long before this step's
+/// <c>Completed</c> event, so the saga must route to its failure path while this
+/// step is still in flight.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class SlowTimedStep(WorkflowInvocationLog log) : IWorkflowStep<TimeoutState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public async Task<StepResult<TimeoutState>> ExecuteAsync(
+        TimeoutState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(SlowTimedStep));
+
+        // Exceed the configured 50 ms deadline. This is an honest deadline race,
+        // not hard cancellation: the step runs to completion; what matters is the
+        // timeout message reaches the saga first. Do NOT honour the cancellation
+        // token here — the saga-level deadline race does not cancel the in-flight
+        // handler, and the test must observe the step running to completion.
+        await Task.Delay(TimeSpan.FromMilliseconds(500), CancellationToken.None);
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return StepResult<TimeoutState>.FromState(updated);
+    }
+}
+
+/// <summary>
+/// A step that must NOT run when the preceding <see cref="SlowTimedStep"/> times
+/// out: if the timeout fires, the saga routes to Failed and <c>MarkCompleted()</c>
+/// before ever cascading this step's start command. Its invocation count being
+/// zero is the observable proof that the timeout routed away from the happy path.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class NeverReachedStep(WorkflowInvocationLog log) : IWorkflowStep<TimeoutState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<TimeoutState>> ExecuteAsync(
+        TimeoutState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(NeverReachedStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<TimeoutState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// Instant kickoff step for the fast scenario (no timeout). Distinct from
+/// <see cref="SlowKickoffStep"/> so the two workflows share no step type.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class FastKickoffStep(WorkflowInvocationLog log) : IWorkflowStep<TimeoutState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<TimeoutState>> ExecuteAsync(
+        TimeoutState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(FastKickoffStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<TimeoutState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// A fast step (~10 ms) configured with a generous 5 s timeout. It completes well
+/// before its deadline, so its <c>Completed</c> event wins the race and the saga
+/// chains forward; the timeout message arrives later as a no-op.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class FastTimedStep(WorkflowInvocationLog log) : IWorkflowStep<TimeoutState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public async Task<StepResult<TimeoutState>> ExecuteAsync(
+        TimeoutState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(FastTimedStep));
+
+        await Task.Delay(TimeSpan.FromMilliseconds(10), cancellationToken);
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return StepResult<TimeoutState>.FromState(updated);
+    }
+}
+
+/// <summary>
+/// The follow-on step after <see cref="FastTimedStep"/> in the fast scenario. It
+/// runs only because the fast step completed before its deadline; its completion
+/// drives the saga to its terminal <c>Completed</c> phase.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class FollowOnStep(WorkflowInvocationLog log) : IWorkflowStep<TimeoutState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<TimeoutState>> ExecuteAsync(
+        TimeoutState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(FollowOnStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<TimeoutState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// Workflow whose middle step exceeds its timeout: the saga must route to the
+/// timeout/failure path while the slow step is still running, so the final
+/// <see cref="NeverReachedStep"/> never executes.
+/// </summary>
+[Workflow("timeout-slow")]
+public static partial class TimeoutSlowWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent definition: kickoff → slow step (50 ms timeout, sleeps
+    /// 500 ms) → a step that must not be reached if the timeout fires.
+    /// </summary>
+    public static WorkflowDefinition<TimeoutState> Definition => Workflow<TimeoutState>
+        .Create("timeout-slow")
+        .StartWith<SlowKickoffStep>()
+        .Then<SlowTimedStep>(step => step
+            .WithTimeout(TimeSpan.FromMilliseconds(50)))
+        .Finally<NeverReachedStep>();
+}
+
+/// <summary>
+/// Workflow whose timed step completes well within its (generous) deadline, so
+/// the saga chains forward to completion and the later timeout message is a no-op.
+/// </summary>
+[Workflow("timeout-fast")]
+public static partial class TimeoutFastWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent definition: kickoff → fast step (5 s timeout, ~10 ms) →
+    /// follow-on step that drives the saga to completion.
+    /// </summary>
+    public static WorkflowDefinition<TimeoutState> Definition => Workflow<TimeoutState>
+        .Create("timeout-fast")
+        .StartWith<FastKickoffStep>()
+        .Then<FastTimedStep>(step => step
+            .WithTimeout(TimeSpan.FromSeconds(5)))
+        .Finally<FollowOnStep>();
+}

--- a/src/Strategos.Generators.Tests/Builders/BranchFailureConfigExpressibilityTests.cs
+++ b/src/Strategos.Generators.Tests/Builders/BranchFailureConfigExpressibilityTests.cs
@@ -4,8 +4,11 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using Strategos.Generators.Helpers;
 using Strategos.Generators.Models;
 using Strategos.Generators.Tests.Fixtures;
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Strategos.Generators.Tests.Builders;
 
@@ -57,22 +60,65 @@ public sealed class BranchFailureConfigExpressibilityTests
     }
 
     /// <summary>
-    /// Verifies that <c>.WithRetry(2)</c> declared via the new failure-handler-builder configure
+    /// Verifies that <c>.WithRetry(2)</c> declared via the failure-handler-builder configure
     /// overload (<c>OnFailure(f =&gt; f.Then&lt;TStep&gt;(step =&gt; step.WithRetry(2)))</c>) populates
     /// the failure-handler step's <see cref="StepModel.Retry"/>.
     /// </summary>
+    /// <remarks>
+    /// The recovery step lives inside the <c>OnFailure(...)</c> handler lambda, so it is owned by
+    /// <see cref="FailureHandlerExtractor"/> — NOT by the main-chain <c>ExtractStepModels</c> walk.
+    /// (Before the F1 nested-lambda-boundary fix, the fork-path walk leaked the handler-nested
+    /// <c>Then&lt;RefundPayment&gt;</c> into the fork-path step models, which is the very bug F1
+    /// closes; the correct assertion is against the failure-handler model.)
+    /// </remarks>
     [Test]
     public async Task FailureHandlerBuilder_ThenWithConfig_StepModelCarriesRetry()
     {
         // Arrange
-        var stepModels = ParserTestHelper.ExtractStepModels(FailureHandlerConfigWorkflow);
+        var context = CreateWorkflowParseContext(FailureHandlerConfigWorkflow, "failure-config");
 
         // Act
-        var recoveryStep = stepModels.Single(s => s.StepName == "RefundPayment");
+        var handlers = FailureHandlerExtractor.Extract(context);
+        var recoveryStep = handlers
+            .SelectMany(h => h.Steps ?? [])
+            .Single(s => s.StepName == "RefundPayment");
 
         // Assert
         await Assert.That(recoveryStep.Retry).IsNotNull();
         await Assert.That(recoveryStep.Retry!.MaxAttempts).IsEqualTo(2);
+    }
+
+    /// <summary>
+    /// Compiles <paramref name="source"/> and builds a <see cref="FluentDslParseContext"/>
+    /// anchored on the <c>[Workflow]</c>-attributed class so chain invocations such as
+    /// <c>OnFailure</c> are in scope (the first type declaration is a record state).
+    /// </summary>
+    private static FluentDslParseContext CreateWorkflowParseContext(string source, string workflowName)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var references = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(a => !a.IsDynamic && !string.IsNullOrEmpty(a.Location))
+            .Select(a => (MetadataReference)MetadataReference.CreateFromFile(a.Location))
+            .Append(MetadataReference.CreateFromFile(
+                typeof(Strategos.Abstractions.IWorkflowState).Assembly.Location))
+            .ToList();
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: [syntaxTree],
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var semanticModel = compilation.GetSemanticModel(syntaxTree);
+
+        var workflowClass = syntaxTree.GetRoot()
+            .DescendantNodes()
+            .OfType<TypeDeclarationSyntax>()
+            .First(t => t.AttributeLists
+                .SelectMany(al => al.Attributes)
+                .Any(a => a.Name.ToString().Contains("Workflow", StringComparison.Ordinal)));
+
+        return FluentDslParseContext.Create(workflowClass, semanticModel, workflowName, CancellationToken.None);
     }
 
     // =========================================================================

--- a/src/Strategos.Generators.Tests/Builders/BranchFailureConfigExpressibilityTests.cs
+++ b/src/Strategos.Generators.Tests/Builders/BranchFailureConfigExpressibilityTests.cs
@@ -1,0 +1,222 @@
+// -----------------------------------------------------------------------
+// <copyright file="BranchFailureConfigExpressibilityTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Models;
+using Strategos.Generators.Tests.Fixtures;
+
+namespace Strategos.Generators.Tests.Builders;
+
+/// <summary>
+/// Tests that resilience configuration declared via the
+/// <c>Then&lt;TStep&gt;(step =&gt; step.WithRetry(...))</c> configure-lambda overload on the
+/// <see cref="Strategos.Builders.IBranchBuilder{TState}"/> branch builder and the
+/// <see cref="Strategos.Builders.IFailureBuilder{TState}"/> failure-handler builder reaches the
+/// generator's <see cref="StepModel"/> IR (epic #135, DR-7).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The configure overload (carrying <c>.WithRetry/.WithTimeout/.Compensate/.RequireConfidence/
+/// .OnLowConfidence/.ValidateState/.WithContext</c>) already exists on the top-level
+/// <see cref="Strategos.Builders.IWorkflowBuilder{TState}"/>, the loop-body
+/// <see cref="Strategos.Builders.ILoopBuilder{TState}"/>, and (via #134) the fork-path
+/// <see cref="Strategos.Builders.IForkPathBuilder{TState}"/> builder. DR-7 closes the
+/// expressibility gap by adding it to the branch and failure-handler builders too.
+/// </para>
+/// <para>
+/// These tests drive a workflow snippet through <see cref="ParserTestHelper.ExtractStepModels"/>,
+/// which routes through <c>FluentDslParser.ExtractStepModels</c> →
+/// <see cref="StepExtractor.ExtractStepModels"/>. The shared <c>TryGetStepModel</c> path invokes
+/// <c>ExtractConfiguredResilience</c> on each <c>Then</c> invocation, so config declared in any
+/// context the walker descends into is captured as a populated <see cref="RetryModel"/> on the
+/// step's <see cref="StepModel"/>.
+/// </para>
+/// </remarks>
+[Property("Category", "Unit")]
+public sealed class BranchFailureConfigExpressibilityTests
+{
+    /// <summary>
+    /// Verifies that <c>.WithRetry(2)</c> declared via the new branch-builder configure overload
+    /// (<c>Then&lt;TStep&gt;(step =&gt; step.WithRetry(2))</c>) populates the branch step's
+    /// <see cref="StepModel.Retry"/>.
+    /// </summary>
+    [Test]
+    public async Task BranchBuilder_ThenWithConfig_StepModelCarriesRetry()
+    {
+        // Arrange
+        var stepModels = ParserTestHelper.ExtractStepModels(BranchConfigWorkflow);
+
+        // Act
+        var branchStep = stepModels.Single(s => s.StepName == "EscalateClaim");
+
+        // Assert
+        await Assert.That(branchStep.Retry).IsNotNull();
+        await Assert.That(branchStep.Retry!.MaxAttempts).IsEqualTo(2);
+    }
+
+    /// <summary>
+    /// Verifies that <c>.WithRetry(2)</c> declared via the new failure-handler-builder configure
+    /// overload (<c>OnFailure(f =&gt; f.Then&lt;TStep&gt;(step =&gt; step.WithRetry(2)))</c>) populates
+    /// the failure-handler step's <see cref="StepModel.Retry"/>.
+    /// </summary>
+    [Test]
+    public async Task FailureHandlerBuilder_ThenWithConfig_StepModelCarriesRetry()
+    {
+        // Arrange
+        var stepModels = ParserTestHelper.ExtractStepModels(FailureHandlerConfigWorkflow);
+
+        // Act
+        var recoveryStep = stepModels.Single(s => s.StepName == "RefundPayment");
+
+        // Assert
+        await Assert.That(recoveryStep.Retry).IsNotNull();
+        await Assert.That(recoveryStep.Retry!.MaxAttempts).IsEqualTo(2);
+    }
+
+    // =========================================================================
+    // Test source workflows
+    // =========================================================================
+
+    /// <summary>
+    /// A workflow whose branch case declares a step's retry via the configure lambda,
+    /// exercising the new branch-builder <c>Then&lt;TStep&gt;(Action&lt;IStepConfiguration&lt;TState&gt;&gt;)</c>
+    /// overload.
+    /// </summary>
+    private const string BranchConfigWorkflow = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record ClaimState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+            public bool RequiresEscalation { get; init; }
+        }
+
+        public class IntakeClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class EscalateClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class AutoApproveClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class SettleClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        [Workflow("branch-config")]
+        public static partial class BranchConfigWorkflow
+        {
+            public static WorkflowDefinition<ClaimState> Definition => Workflow<ClaimState>
+                .Create("branch-config")
+                .StartWith<IntakeClaim>()
+                .Branch(state => state.RequiresEscalation,
+                    BranchCase.When(true, path => path
+                        .Then<EscalateClaim>(step => step.WithRetry(2))),
+                    BranchCase.Otherwise(path => path
+                        .Then<AutoApproveClaim>()))
+                .Finally<SettleClaim>();
+        }
+        """;
+
+    /// <summary>
+    /// A workflow whose fork-path failure handler declares a recovery step's retry via the
+    /// configure lambda, exercising the new failure-handler-builder
+    /// <c>Then&lt;TStep&gt;(Action&lt;IStepConfiguration&lt;TState&gt;&gt;)</c> overload.
+    /// </summary>
+    private const string FailureHandlerConfigWorkflow = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record CheckoutState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class ValidateCart : IWorkflowStep<CheckoutState>
+        {
+            public Task<StepResult<CheckoutState>> ExecuteAsync(
+                CheckoutState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<CheckoutState>.FromState(state));
+        }
+
+        public class ChargeCard : IWorkflowStep<CheckoutState>
+        {
+            public Task<StepResult<CheckoutState>> ExecuteAsync(
+                CheckoutState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<CheckoutState>.FromState(state));
+        }
+
+        public class RefundPayment : IWorkflowStep<CheckoutState>
+        {
+            public Task<StepResult<CheckoutState>> ExecuteAsync(
+                CheckoutState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<CheckoutState>.FromState(state));
+        }
+
+        public class ReserveStock : IWorkflowStep<CheckoutState>
+        {
+            public Task<StepResult<CheckoutState>> ExecuteAsync(
+                CheckoutState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<CheckoutState>.FromState(state));
+        }
+
+        public class FinalizeOrder : IWorkflowStep<CheckoutState>
+        {
+            public Task<StepResult<CheckoutState>> ExecuteAsync(
+                CheckoutState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<CheckoutState>.FromState(state));
+        }
+
+        public class CompleteCheckout : IWorkflowStep<CheckoutState>
+        {
+            public Task<StepResult<CheckoutState>> ExecuteAsync(
+                CheckoutState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<CheckoutState>.FromState(state));
+        }
+
+        [Workflow("failure-config")]
+        public static partial class FailureHandlerConfigWorkflow
+        {
+            public static WorkflowDefinition<CheckoutState> Definition => Workflow<CheckoutState>
+                .Create("failure-config")
+                .StartWith<ValidateCart>()
+                .Fork(
+                    path => path.Then<ChargeCard>()
+                        .OnFailure(f => f.Then<RefundPayment>(step => step.WithRetry(2))),
+                    path => path.Then<ReserveStock>())
+                .Join<FinalizeOrder>()
+                .Finally<CompleteCheckout>();
+        }
+        """;
+}

--- a/src/Strategos.Generators.Tests/Diagnostics/ResilienceDiagnosticsTests.cs
+++ b/src/Strategos.Generators.Tests/Diagnostics/ResilienceDiagnosticsTests.cs
@@ -1,0 +1,340 @@
+// -----------------------------------------------------------------------
+// <copyright file="ResilienceDiagnosticsTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Tests.Fixtures;
+
+namespace Strategos.Generators.Tests.Diagnostics;
+
+/// <summary>
+/// DR-8 (epic #135, INV-5) — compile-time diagnostics for invalid step-resilience
+/// configuration, surfaced from <c>WorkflowIncrementalGenerator</c> at the earliest
+/// (emitter) tier. Each fires a stable next-free <c>AGWF0xx</c> id (≥ AGWF017) so
+/// consumers can suppress it; the pre-existing builder-runtime throws
+/// (<c>RequireConfidence</c> ∉ [0,1], retry <c>&lt; 1</c>) are mirrored as ids here.
+/// </summary>
+/// <remarks>
+/// The diagnostic codes asserted below are the next-free ids verified against the
+/// live AGWF ceiling (AGWF016) at GREEN time:
+/// <list type="bullet">
+///   <item>AGWF017 — <c>Compensate&lt;T&gt;</c> where T is not a registered step.</item>
+///   <item>AGWF018 — <c>RequireConfidence(x)</c> with x outside [0.0, 1.0].</item>
+///   <item>AGWF019 — <c>RequireConfidence</c> without a corresponding <c>OnLowConfidence</c>.</item>
+///   <item>AGWF020 — retry <c>maxAttempts &lt; 1</c>.</item>
+///   <item>AGWF021 — non-positive <c>WithTimeout</c>.</item>
+/// </list>
+/// </remarks>
+[Property("Category", "Integration")]
+public sealed class ResilienceDiagnosticsTests
+{
+    private const string CompensateNonStepId = "AGWF017";
+    private const string ConfidenceOutOfRangeId = "AGWF018";
+    private const string ConfidenceWithoutHandlerId = "AGWF019";
+    private const string RetryBelowOneId = "AGWF020";
+    private const string NonPositiveTimeoutId = "AGWF021";
+
+    // =========================================================================
+    // A. Compensate<T> where T is not a registered IWorkflowStep<TState> step.
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that <c>Compensate&lt;T&gt;</c> where <c>T</c> does not implement
+    /// <c>IWorkflowStep&lt;TState&gt;</c> fires the next-free AGWF id (AGWF017).
+    /// </summary>
+    [Test]
+    public async Task Analyze_CompensateNonStepType_FiresNextFreeAgwf()
+    {
+        var source = WorkflowWithStepConfig(
+            stepConfig: "step => step.Compensate<NotAStep>()",
+            extraTypes: "public class NotAStep { }");
+
+        var result = GeneratorTestHelper.RunGenerator(source);
+
+        var diagnostic = result.Diagnostics.FirstOrDefault(d => d.Id == CompensateNonStepId);
+        await Assert.That(diagnostic).IsNotNull();
+        await Assert.That(diagnostic!.Severity).IsEqualTo(DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
+    /// Verifies that <c>Compensate&lt;T&gt;</c> with a genuine step type does NOT
+    /// fire AGWF017 (conformant-negative).
+    /// </summary>
+    [Test]
+    public async Task Analyze_CompensateRegisteredStep_DoesNotFire()
+    {
+        var source = WorkflowWithStepConfig(
+            stepConfig: "step => step.Compensate<RollbackStep>()",
+            extraTypes: StepClass("RollbackStep"));
+
+        var result = GeneratorTestHelper.RunGenerator(source);
+
+        await Assert.That(result.Diagnostics.Any(d => d.Id == CompensateNonStepId)).IsFalse();
+    }
+
+    // =========================================================================
+    // B. RequireConfidence(x) with x outside [0.0, 1.0].
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that <c>RequireConfidence</c> with a threshold above 1.0 fires AGWF018.
+    /// </summary>
+    [Test]
+    public async Task Analyze_RequireConfidenceOutOfRange_Fires()
+    {
+        var source = WorkflowWithStepConfig(
+            stepConfig: "step => step.RequireConfidence(1.5).OnLowConfidence(alt => alt.Then<HumanReview>())",
+            extraTypes: StepClass("HumanReview"));
+
+        var result = GeneratorTestHelper.RunGenerator(source);
+
+        var diagnostic = result.Diagnostics.FirstOrDefault(d => d.Id == ConfidenceOutOfRangeId);
+        await Assert.That(diagnostic).IsNotNull();
+        await Assert.That(diagnostic!.Severity).IsEqualTo(DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
+    /// Verifies that <c>RequireConfidence</c> with a negative threshold fires AGWF018.
+    /// </summary>
+    [Test]
+    public async Task Analyze_RequireConfidenceNegative_Fires()
+    {
+        var source = WorkflowWithStepConfig(
+            stepConfig: "step => step.RequireConfidence(-0.1).OnLowConfidence(alt => alt.Then<HumanReview>())",
+            extraTypes: StepClass("HumanReview"));
+
+        var result = GeneratorTestHelper.RunGenerator(source);
+
+        await Assert.That(result.Diagnostics.Any(d => d.Id == ConfidenceOutOfRangeId)).IsTrue();
+    }
+
+    /// <summary>
+    /// Verifies that an in-range <c>RequireConfidence</c> does NOT fire AGWF018
+    /// (conformant-negative — boundary 1.0 is valid).
+    /// </summary>
+    [Test]
+    public async Task Analyze_RequireConfidenceInRange_DoesNotFire()
+    {
+        var source = WorkflowWithStepConfig(
+            stepConfig: "step => step.RequireConfidence(1.0).OnLowConfidence(alt => alt.Then<HumanReview>())",
+            extraTypes: StepClass("HumanReview"));
+
+        var result = GeneratorTestHelper.RunGenerator(source);
+
+        await Assert.That(result.Diagnostics.Any(d => d.Id == ConfidenceOutOfRangeId)).IsFalse();
+    }
+
+    // =========================================================================
+    // C. RequireConfidence without a corresponding OnLowConfidence handler.
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that <c>RequireConfidence</c> declared without a corresponding
+    /// <c>OnLowConfidence</c> handler fires AGWF019.
+    /// </summary>
+    [Test]
+    public async Task Analyze_RequireConfidenceWithoutOnLowConfidence_Fires()
+    {
+        var source = WorkflowWithStepConfig(
+            stepConfig: "step => step.RequireConfidence(0.85)",
+            extraTypes: string.Empty);
+
+        var result = GeneratorTestHelper.RunGenerator(source);
+
+        var diagnostic = result.Diagnostics.FirstOrDefault(d => d.Id == ConfidenceWithoutHandlerId);
+        await Assert.That(diagnostic).IsNotNull();
+    }
+
+    /// <summary>
+    /// Verifies that <c>RequireConfidence</c> WITH an <c>OnLowConfidence</c> handler
+    /// does NOT fire AGWF019 (conformant-negative).
+    /// </summary>
+    [Test]
+    public async Task Analyze_RequireConfidenceWithOnLowConfidence_DoesNotFire()
+    {
+        var source = WorkflowWithStepConfig(
+            stepConfig: "step => step.RequireConfidence(0.85).OnLowConfidence(alt => alt.Then<HumanReview>())",
+            extraTypes: StepClass("HumanReview"));
+
+        var result = GeneratorTestHelper.RunGenerator(source);
+
+        await Assert.That(result.Diagnostics.Any(d => d.Id == ConfidenceWithoutHandlerId)).IsFalse();
+    }
+
+    // =========================================================================
+    // D. Retry maxAttempts < 1.
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that a retry policy with <c>maxAttempts &lt; 1</c> fires AGWF020.
+    /// </summary>
+    [Test]
+    public async Task Analyze_RetryMaxAttemptsBelowOne_Fires()
+    {
+        var source = WorkflowWithStepConfig(
+            stepConfig: "step => step.WithRetry(0)",
+            extraTypes: string.Empty);
+
+        var result = GeneratorTestHelper.RunGenerator(source);
+
+        var diagnostic = result.Diagnostics.FirstOrDefault(d => d.Id == RetryBelowOneId);
+        await Assert.That(diagnostic).IsNotNull();
+        await Assert.That(diagnostic!.Severity).IsEqualTo(DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
+    /// Verifies that a valid retry count does NOT fire AGWF020 (conformant-negative).
+    /// </summary>
+    [Test]
+    public async Task Analyze_RetryMaxAttemptsValid_DoesNotFire()
+    {
+        var source = WorkflowWithStepConfig(
+            stepConfig: "step => step.WithRetry(3)",
+            extraTypes: string.Empty);
+
+        var result = GeneratorTestHelper.RunGenerator(source);
+
+        await Assert.That(result.Diagnostics.Any(d => d.Id == RetryBelowOneId)).IsFalse();
+    }
+
+    // =========================================================================
+    // E. Non-positive WithTimeout.
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that a non-positive timeout (<c>TimeSpan.Zero</c>) fires AGWF021.
+    /// </summary>
+    [Test]
+    public async Task Analyze_NonPositiveTimeout_Fires()
+    {
+        var source = WorkflowWithStepConfig(
+            stepConfig: "step => step.WithTimeout(TimeSpan.Zero)",
+            extraTypes: string.Empty);
+
+        var result = GeneratorTestHelper.RunGenerator(source);
+
+        var diagnostic = result.Diagnostics.FirstOrDefault(d => d.Id == NonPositiveTimeoutId);
+        await Assert.That(diagnostic).IsNotNull();
+        await Assert.That(diagnostic!.Severity).IsEqualTo(DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
+    /// Verifies that a positive timeout does NOT fire AGWF021 (conformant-negative).
+    /// </summary>
+    [Test]
+    public async Task Analyze_PositiveTimeout_DoesNotFire()
+    {
+        var source = WorkflowWithStepConfig(
+            stepConfig: "step => step.WithTimeout(TimeSpan.FromSeconds(30))",
+            extraTypes: string.Empty);
+
+        var result = GeneratorTestHelper.RunGenerator(source);
+
+        await Assert.That(result.Diagnostics.Any(d => d.Id == NonPositiveTimeoutId)).IsFalse();
+    }
+
+    // =========================================================================
+    // F. Fully conformant workflow — none of the resilience diagnostics fire.
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that a fully conformant resilience configuration fires none of the
+    /// AGWF017–AGWF021 resilience diagnostics.
+    /// </summary>
+    [Test]
+    public async Task Analyze_FullyConformantResilience_FiresNoResilienceDiagnostics()
+    {
+        var source = WorkflowWithStepConfig(
+            stepConfig: "step => step"
+                + ".WithRetry(3, TimeSpan.FromSeconds(5))"
+                + ".WithTimeout(TimeSpan.FromMinutes(2))"
+                + ".RequireConfidence(0.85)"
+                + ".OnLowConfidence(alt => alt.Then<HumanReview>())"
+                + ".Compensate<RollbackStep>()",
+            extraTypes: StepClass("HumanReview") + "\n" + StepClass("RollbackStep"));
+
+        var result = GeneratorTestHelper.RunGenerator(source);
+
+        var ids = new[]
+        {
+            CompensateNonStepId,
+            ConfidenceOutOfRangeId,
+            ConfidenceWithoutHandlerId,
+            RetryBelowOneId,
+            NonPositiveTimeoutId,
+        };
+
+        var fired = result.Diagnostics.Where(d => ids.Contains(d.Id)).Select(d => d.Id).ToList();
+        await Assert.That(fired).IsEmpty();
+    }
+
+    // =========================================================================
+    // Source builder helpers
+    // =========================================================================
+
+    private static string StepClass(string name) => $$"""
+        public class {{name}} : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+        """;
+
+    /// <summary>
+    /// Builds a single-step workflow whose <c>AssessClaim</c> step carries the
+    /// supplied resilience <paramref name="stepConfig"/> configure lambda, plus any
+    /// <paramref name="extraTypes"/> the config references.
+    /// </summary>
+    private static string WorkflowWithStepConfig(string stepConfig, string extraTypes) => $$"""
+        using System;
+        using System.Threading;
+        using System.Threading.Tasks;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record ClaimState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class IntakeClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class AssessClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class SettleClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        {{extraTypes}}
+
+        [Workflow("resilience-claim")]
+        public static partial class ResilienceClaimWorkflow
+        {
+            public static WorkflowDefinition<ClaimState> Definition => Workflow<ClaimState>
+                .Create("resilience-claim")
+                .StartWith<IntakeClaim>()
+                .Then<AssessClaim>({{stepConfig}})
+                .Finally<SettleClaim>();
+        }
+        """;
+}

--- a/src/Strategos.Generators.Tests/Diagnostics/ResilienceDiagnosticsTests.cs
+++ b/src/Strategos.Generators.Tests/Diagnostics/ResilienceDiagnosticsTests.cs
@@ -184,6 +184,26 @@ public sealed class ResilienceDiagnosticsTests
     }
 
     /// <summary>
+    /// CodeRabbit F2 (PR #137): a unary-minus retry literal (<c>WithRetry(-1)</c>) must reach
+    /// the IR so AGWF020 fires. The retry parser previously accepted only a direct numeric
+    /// literal, so a negative literal never parsed and the diagnostic silently vanished —
+    /// violating INV-5 (invalid config must surface, not disappear).
+    /// </summary>
+    [Test]
+    public async Task Analyze_RetryMaxAttemptsNegativeLiteral_Fires()
+    {
+        var source = WorkflowWithStepConfig(
+            stepConfig: "step => step.WithRetry(-1)",
+            extraTypes: string.Empty);
+
+        var result = GeneratorTestHelper.RunGenerator(source);
+
+        var diagnostic = result.Diagnostics.FirstOrDefault(d => d.Id == RetryBelowOneId);
+        await Assert.That(diagnostic).IsNotNull();
+        await Assert.That(diagnostic!.Severity).IsEqualTo(DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
     /// Verifies that a valid retry count does NOT fire AGWF020 (conformant-negative).
     /// </summary>
     [Test]

--- a/src/Strategos.Generators.Tests/Emitters/CompensationLoweringTests.cs
+++ b/src/Strategos.Generators.Tests/Emitters/CompensationLoweringTests.cs
@@ -1,0 +1,229 @@
+// -----------------------------------------------------------------------
+// <copyright file="CompensationLoweringTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Tests.Fixtures;
+
+namespace Strategos.Generators.Tests.Emitters;
+
+/// <summary>
+/// Shape/regression tests for lowering a step's <c>.Compensate&lt;T&gt;()</c>
+/// rollback into a runnable compensation path (DR-3).
+/// </summary>
+/// <remarks>
+/// <para>
+/// These tests run the FULL workflow generator pipeline (not just one emitter)
+/// so they double as a golden/shape regression check. A step configured with a
+/// compensation must lower into:
+/// <list type="bullet">
+///   <item><description>
+///     a worker <c>Configure(HandlerChain)</c> error chain that, on terminal
+///     failure (after any retries), PUBLISHES the
+///     <c>Trigger{Pascal}FailureHandlerCommand</c> via
+///     <c>.Then.CompensatingAction&lt;Execute{Step}WorkerCommand&gt;(...)</c>;
+///   </description></item>
+///   <item><description>
+///     a saga trigger handler that, on receiving that command, dispatches the
+///     compensation step's worker command (so the rollback step actually RUNS);
+///   </description></item>
+///   <item><description>
+///     a worker handler for the compensation step type (it is folded into the
+///     emitted step types so its proven main-flow worker dispatch is reused);
+///   </description></item>
+///   <item><description>
+///     a saga completion handler that, when the compensation step completes,
+///     transitions the saga to its terminal <c>Failed</c> phase.
+///   </description></item>
+/// </list>
+/// A step WITHOUT compensation must lower none of these artifacts.
+/// </para>
+/// </remarks>
+[Property("Category", "Integration")]
+public class CompensationLoweringTests
+{
+    /// <summary>
+    /// A linear workflow whose middle step declares <c>.WithRetry(2)</c> and
+    /// <c>.Compensate&lt;RollbackPayment&gt;()</c> via the step-configure lambda.
+    /// The first and last steps declare no resilience.
+    /// </summary>
+    private const string WorkflowWithStepCompensation = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record OrderState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class ValidateOrder : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class ProcessPayment : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class RollbackPayment : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class SendConfirmation : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        [Workflow("process-order")]
+        public static partial class ProcessOrderWorkflow
+        {
+            public static WorkflowDefinition<OrderState> Definition => Workflow<OrderState>
+                .Create("process-order")
+                .StartWith<ValidateOrder>()
+                .Then<ProcessPayment>(step => step
+                    .WithRetry(2)
+                    .Compensate<RollbackPayment>())
+                .Finally<SendConfirmation>();
+        }
+        """;
+
+    /// <summary>
+    /// A linear workflow with NO compensation configured on any step.
+    /// </summary>
+    private const string WorkflowWithoutCompensation = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record OrderState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class ValidateOrder : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class ProcessPayment : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class SendConfirmation : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        [Workflow("process-order")]
+        public static partial class ProcessOrderWorkflow
+        {
+            public static WorkflowDefinition<OrderState> Definition => Workflow<OrderState>
+                .Create("process-order")
+                .StartWith<ValidateOrder>()
+                .Then<ProcessPayment>()
+                .Finally<SendConfirmation>();
+        }
+        """;
+
+    /// <summary>
+    /// A step with <c>.Compensate&lt;T&gt;()</c> lowers, onto the compensated
+    /// step's worker <c>Configure(HandlerChain)</c>, an error chain that PUBLISHES
+    /// the trigger failure-handler command via
+    /// <c>.Then.CompensatingAction&lt;Execute{Step}WorkerCommand&gt;(...)</c> after
+    /// retries are exhausted. This closes the dead path: the previously
+    /// never-published trigger command now reaches the saga at runtime.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Emit_StepWithCompensate_ConfigureChainPublishesTriggerFailureHandlerCommand()
+    {
+        // Arrange & Act
+        var result = GeneratorTestHelper.RunGenerator(WorkflowWithStepCompensation);
+        var handlersSource = GeneratorTestHelper.GetGeneratedSource(result, "Handlers.g.cs");
+
+        // Assert — the compensated step's handler carries a Configure chain that,
+        // after the retry policy, publishes the trigger command on terminal failure.
+        await Assert.That(handlersSource).Contains("public static void Configure(HandlerChain");
+        await Assert.That(handlersSource).Contains(".Then");
+        await Assert.That(handlersSource).Contains("CompensatingAction<ExecuteProcessPaymentWorkerCommand>");
+        await Assert.That(handlersSource).Contains("TriggerProcessOrderFailureHandlerCommand");
+        await Assert.That(handlersSource).Contains("InvokeResult.Stop");
+
+        // The retry policy is still lowered (the prefix of the same chain).
+        await Assert.That(handlersSource).Contains("RetryTimes(2)");
+    }
+
+    /// <summary>
+    /// The compensation step is REACHABLE: the saga's trigger handler dispatches
+    /// the rollback step's worker command, a worker handler exists for the
+    /// rollback step type, and the rollback's completion routes the saga to its
+    /// terminal <c>Failed</c> phase.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Emit_StepWithCompensate_CompensationStepIsReachableAndRoutesToFailed()
+    {
+        // Arrange & Act
+        var result = GeneratorTestHelper.RunGenerator(WorkflowWithStepCompensation);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+        var handlersSource = GeneratorTestHelper.GetGeneratedSource(result, "Handlers.g.cs");
+
+        // The saga handles the trigger command and dispatches the rollback worker.
+        await Assert.That(sagaSource).Contains("TriggerProcessOrderFailureHandlerCommand cmd");
+        await Assert.That(sagaSource).Contains("new ExecuteRollbackPaymentWorkerCommand(WorkflowId");
+
+        // A worker handler exists for the compensation step type so it actually runs.
+        await Assert.That(handlersSource).Contains("class RollbackPaymentHandler");
+
+        // The rollback's completion routes the saga to its terminal Failed phase.
+        await Assert.That(sagaSource).Contains("RollbackPaymentCompleted evt");
+        await Assert.That(sagaSource).Contains("Phase = ProcessOrderPhase.Failed");
+    }
+
+    /// <summary>
+    /// A workflow with no compensation on any step lowers no compensation
+    /// artifacts whatsoever: no <c>CompensatingAction</c>, and no rollback worker.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Emit_StepWithoutCompensate_GeneratesNoCompensationArtifacts()
+    {
+        // Arrange & Act
+        var result = GeneratorTestHelper.RunGenerator(WorkflowWithoutCompensation);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+        var handlersSource = GeneratorTestHelper.GetGeneratedSource(result, "Handlers.g.cs");
+
+        // Assert — no CompensatingAction publish, no trigger command, no rollback worker.
+        await Assert.That(handlersSource).DoesNotContain("CompensatingAction");
+        await Assert.That(sagaSource).DoesNotContain("FailureHandlerCommand");
+    }
+}

--- a/src/Strategos.Generators.Tests/Emitters/CompensationLoweringTests.cs
+++ b/src/Strategos.Generators.Tests/Emitters/CompensationLoweringTests.cs
@@ -170,6 +170,83 @@ public class CompensationLoweringTests
         """;
 
     /// <summary>
+    /// A linear workflow with TWO distinct compensation step types, so the saga
+    /// trigger handler lowers MULTI-compensation routing (a <c>FailedStepName</c>
+    /// branch per compensated step). Used to prove the routing has a terminal
+    /// fallback for an unmatched <c>FailedStepName</c> (F2).
+    /// </summary>
+    private const string WorkflowWithTwoCompensations = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record OrderState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class ValidateOrder : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class ReserveInventory : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class ReleaseInventory : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class ProcessPayment : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class RollbackPayment : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class SendConfirmation : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        [Workflow("process-order")]
+        public static partial class ProcessOrderWorkflow
+        {
+            public static WorkflowDefinition<OrderState> Definition => Workflow<OrderState>
+                .Create("process-order")
+                .StartWith<ValidateOrder>()
+                .Then<ReserveInventory>(step => step
+                    .Compensate<ReleaseInventory>())
+                .Then<ProcessPayment>(step => step
+                    .Compensate<RollbackPayment>())
+                .Finally<SendConfirmation>();
+        }
+        """;
+
+    /// <summary>
     /// A linear workflow with NO compensation configured on any step.
     /// </summary>
     private const string WorkflowWithoutCompensation = """
@@ -275,6 +352,47 @@ public class CompensationLoweringTests
     }
 
     /// <summary>
+    /// F2 (CodeRabbit / epic #135): in multi-compensation routing the saga trigger
+    /// handler emits one <c>if (cmd.FailedStepName == "X") { ... yield break; }</c>
+    /// branch per compensated step, after setting <c>Phase = Compensating</c>. If
+    /// NONE of the branches match an unexpected <c>FailedStepName</c>, the handler
+    /// previously fell off the end yielding no command, stranding the saga in the
+    /// <c>Compensating</c> phase forever. The routing must have a terminal fallback
+    /// (route to <c>Failed</c> + <c>MarkCompleted()</c>) so an unmatched
+    /// <c>FailedStepName</c> cannot deadlock the saga.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Emit_MultiCompensationRouting_HasTerminalFallbackForUnmatchedFailedStep()
+    {
+        // Arrange & Act
+        var result = GeneratorTestHelper.RunGenerator(WorkflowWithTwoCompensations);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+
+        // Isolate the trigger handler region so the fallback assertion is scoped to
+        // this method and not satisfied by an unrelated completed handler.
+        var triggerHandler = ExtractTriggerHandlerRegion(sagaSource);
+
+        // Sanity: this is genuinely the multi-compensation routing form (a branch
+        // per compensated step routing on FailedStepName).
+        await Assert.That(triggerHandler).Contains("cmd.FailedStepName ==");
+        await Assert.That(triggerHandler).Contains("ExecuteReleaseInventoryWorkerCommand");
+        await Assert.That(triggerHandler).Contains("ExecuteRollbackPaymentWorkerCommand");
+
+        // The terminal fallback: when no FailedStepName branch matches, the handler
+        // must transition to Failed and mark the saga completed (no infinite wait).
+        await Assert.That(triggerHandler).Contains("Phase = ProcessOrderPhase.Failed");
+        await Assert.That(triggerHandler).Contains("MarkCompleted()");
+
+        // The fallback must come AFTER the routing branches (it is the else/last
+        // resort), not before them.
+        var lastRouteIndex = triggerHandler.LastIndexOf("cmd.FailedStepName ==", StringComparison.Ordinal);
+        var markCompletedIndex = triggerHandler.IndexOf("MarkCompleted()", StringComparison.Ordinal);
+        await Assert.That(lastRouteIndex).IsGreaterThanOrEqualTo(0);
+        await Assert.That(markCompletedIndex).IsGreaterThan(lastRouteIndex);
+    }
+
+    /// <summary>
     /// A workflow with no compensation on any step lowers no compensation
     /// artifacts whatsoever: no <c>CompensatingAction</c>, and no rollback worker.
     /// </summary>
@@ -339,6 +457,23 @@ public class CompensationLoweringTests
             .ToList();
 
         await Assert.That(cs0111).IsEmpty();
+    }
+
+    /// <summary>
+    /// Slices out the compensation trigger handler body from the generated saga,
+    /// from its <c>Trigger...FailureHandlerCommand cmd,</c> parameter up to the
+    /// next member's XML doc comment, so a test asserts on this handler alone.
+    /// </summary>
+    private static string ExtractTriggerHandlerRegion(string sagaSource)
+    {
+        var start = sagaSource.IndexOf("FailureHandlerCommand cmd,", StringComparison.Ordinal);
+        if (start < 0)
+        {
+            return string.Empty;
+        }
+
+        var next = sagaSource.IndexOf("/// <summary>", start, StringComparison.Ordinal);
+        return next < 0 ? sagaSource.Substring(start) : sagaSource.Substring(start, next - start);
     }
 
     private static int CountOccurrences(string haystack, string needle)

--- a/src/Strategos.Generators.Tests/Emitters/CompensationLoweringTests.cs
+++ b/src/Strategos.Generators.Tests/Emitters/CompensationLoweringTests.cs
@@ -105,6 +105,71 @@ public class CompensationLoweringTests
         """;
 
     /// <summary>
+    /// A linear workflow whose compensation target step type (<c>RollbackStep</c>) is
+    /// ALSO used as a normal main-flow step. The main flow runs
+    /// <c>ValidateOrder → RollbackStep → ProcessPayment → SendConfirmation</c>, and
+    /// <c>ProcessPayment</c> declares <c>.Compensate&lt;RollbackStep&gt;()</c>. Because the
+    /// rollback type is already a main-flow step it must NOT get a second, duplicate
+    /// <c>Handle(RollbackStepCompleted)</c> from the compensation emitter (CS0111).
+    /// </summary>
+    private const string WorkflowWithCompensationStepAlsoInMainFlow = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record OrderState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class ValidateOrder : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class RollbackStep : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class ProcessPayment : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class SendConfirmation : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        [Workflow("process-order")]
+        public static partial class ProcessOrderWorkflow
+        {
+            public static WorkflowDefinition<OrderState> Definition => Workflow<OrderState>
+                .Create("process-order")
+                .StartWith<ValidateOrder>()
+                .Then<RollbackStep>()
+                .Then<ProcessPayment>(step => step
+                    .WithRetry(2)
+                    .Compensate<RollbackStep>())
+                .Finally<SendConfirmation>();
+        }
+        """;
+
+    /// <summary>
     /// A linear workflow with NO compensation configured on any step.
     /// </summary>
     private const string WorkflowWithoutCompensation = """
@@ -225,5 +290,67 @@ public class CompensationLoweringTests
         // Assert — no CompensatingAction publish, no trigger command, no rollback worker.
         await Assert.That(handlersSource).DoesNotContain("CompensatingAction");
         await Assert.That(sagaSource).DoesNotContain("FailureHandlerCommand");
+    }
+
+    /// <summary>
+    /// When a step TYPE is used both as a normal main-flow step AND as another
+    /// step's <c>.Compensate&lt;T&gt;()</c> target, the saga must declare exactly
+    /// ONE <c>Handle({Comp}Completed)</c> overload. The main-flow completed handler
+    /// (emitted from <c>SagaStepHandlersEmitter</c>) already covers it; the
+    /// compensation emitter must NOT emit a second, duplicate overload (CS0111).
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Emit_CompensationStepAlsoInMainFlow_EmitsSingleCompletedHandler()
+    {
+        // Arrange & Act
+        var result = GeneratorTestHelper.RunGenerator(WorkflowWithCompensationStepAlsoInMainFlow);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+
+        // Assert — exactly one `Handle(RollbackStepCompleted evt, ...)` overload.
+        // Both the main-flow completed handler and the (now-suppressed) compensation
+        // completed handler emit a `Handle(` overload taking `RollbackStepCompleted`;
+        // counting that multiline parameter pattern is the duplicate proxy. (The
+        // separate `NotFound(RollbackStepCompleted evt, ...)` method is a different
+        // method name and is excluded by anchoring on `Handle(`.)
+        var occurrences = CountOccurrences(sagaSource, "Handle(\n        RollbackStepCompleted evt,");
+        await Assert.That(occurrences).IsEqualTo(1);
+    }
+
+    /// <summary>
+    /// The generated saga for a workflow that reuses a step type as a compensation
+    /// target must COMPILE without a CS0111 duplicate-method error (the concrete
+    /// failure mode of the duplicate <c>Handle({Comp}Completed)</c> overload).
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Emit_CompensationStepAlsoInMainFlow_GeneratedSagaHasNoCs0111()
+    {
+        // Arrange & Act — compile the source PLUS the generator output together.
+        var diagnostics = GeneratorTestHelper.GetCompilationDiagnostics(
+            WorkflowWithCompensationStepAlsoInMainFlow);
+
+        // Assert — no CS0111 (duplicate member) anywhere in the generated saga.
+        // Other diagnostics (missing Wolverine/Marten runtime types) are expected
+        // in the bare test compilation and are not asserted on.
+        var cs0111 = diagnostics
+            .Where(d => string.Equals(d.Id, "CS0111", StringComparison.Ordinal))
+            .Select(d => d.GetMessage())
+            .ToList();
+
+        await Assert.That(cs0111).IsEmpty();
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+
+        return count;
     }
 }

--- a/src/Strategos.Generators.Tests/Emitters/ConfidenceLoweringTests.cs
+++ b/src/Strategos.Generators.Tests/Emitters/ConfidenceLoweringTests.cs
@@ -103,6 +103,79 @@ public class ConfidenceLoweringTests
         """;
 
     /// <summary>
+    /// A linear workflow whose middle step declares BOTH a confidence gate
+    /// (<c>.RequireConfidence(0.85).OnLowConfidence(alt =&gt; alt.Then&lt;HumanReview&gt;())</c>)
+    /// AND a workflow-level <c>.OnFailure(...)</c> handler. The confidence-gated
+    /// completed handler must still route to the failure path when the reducer
+    /// drives the saga into the <c>Failed</c> phase (F1).
+    /// </summary>
+    private const string WorkflowWithConfidenceAndFailureHandler = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record OrderState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class ValidateOrder : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class ClassifyIntent : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class HumanReview : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class SendConfirmation : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class LogFailure : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        [Workflow("process-order")]
+        public static partial class ProcessOrderWorkflow
+        {
+            public static WorkflowDefinition<OrderState> Definition => Workflow<OrderState>
+                .Create("process-order")
+                .StartWith<ValidateOrder>()
+                .Then<ClassifyIntent>(step => step
+                    .RequireConfidence(0.85)
+                    .OnLowConfidence(alt => alt.Then<HumanReview>()))
+                .Finally<SendConfirmation>()
+                .OnFailure(f => f
+                    .Then<LogFailure>()
+                    .Complete());
+        }
+        """;
+
+    /// <summary>
     /// A linear workflow with NO confidence gate configured on any step.
     /// </summary>
     private const string WorkflowWithoutConfidence = """
@@ -184,6 +257,75 @@ public class ConfidenceLoweringTests
         // The handler step is fully lowered so the branch is runnable: it has its
         // own start command in the generated commands file.
         await Assert.That(commandsSource).Contains("StartHumanReviewCommand");
+    }
+
+    /// <summary>
+    /// F1 (CodeRabbit / epic #135): a step with BOTH a confidence gate AND a
+    /// workflow <c>.OnFailure(...)</c> handler must still route to the failure
+    /// path when the reducer drives the saga into the <c>Failed</c> phase. The
+    /// confidence-gated completed handler previously skipped the
+    /// <c>Phase == Failed</c> route that the phase-aware non-final handler emits,
+    /// so a confidence-gated step that set <c>Phase = Failed</c> would still chain
+    /// to the next step instead of dispatching the failure handler (INV-1: the
+    /// failure route is a Wolverine cascade lowered by the generator).
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Emit_ConfidenceGatedStepWithFailureHandler_RoutesFailedPhaseToFailureHandler()
+    {
+        // Arrange & Act
+        var result = GeneratorTestHelper.RunGenerator(WorkflowWithConfidenceAndFailureHandler);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+
+        // Isolate the ClassifyIntent confidence-gated completed handler region so
+        // the assertions cannot be satisfied spuriously by another step's
+        // phase-aware handler (e.g. ValidateOrder, which also emits the Failed
+        // guard). The region runs from this handler's parameter to the next
+        // member's XML doc comment.
+        var handler = ExtractConfidenceHandlerRegion(sagaSource, "ClassifyIntentCompleted evt,");
+
+        // Assert — the confidence comparison (the gate itself) is intact within
+        // the isolated handler.
+        await Assert.That(handler).Contains("confidenceScore < 0.85");
+        await Assert.That(handler).Contains("StartHumanReviewCommand");
+
+        // Assert — the confidence-gated handler ITSELF guards on the Failed phase
+        // and routes to the lowered failure handler step (LogFailure). Without the
+        // F1 fix this guard is absent from the confidence-gated handler entirely.
+        await Assert.That(handler).Contains("if (Phase == ProcessOrderPhase.Failed)");
+        await Assert.That(handler).Contains("StartLogFailureCommand");
+
+        // The Failed-phase guard must precede the confidence comparison so a step
+        // that BOTH fails AND gates on confidence routes to the failure path, not
+        // the low-confidence handler.
+        var failedGuardIndex = handler.IndexOf(
+            "if (Phase == ProcessOrderPhase.Failed)",
+            StringComparison.Ordinal);
+        var confidenceCompareIndex = handler.IndexOf(
+            "confidenceScore < 0.85",
+            StringComparison.Ordinal);
+        await Assert.That(failedGuardIndex).IsGreaterThanOrEqualTo(0);
+        await Assert.That(confidenceCompareIndex).IsGreaterThanOrEqualTo(0);
+        await Assert.That(failedGuardIndex).IsLessThan(confidenceCompareIndex);
+    }
+
+    /// <summary>
+    /// Slices out a single completed-handler body from the generated saga, from
+    /// the handler's parameter signature up to the next member's XML doc comment.
+    /// Lets a test assert on ONE handler in isolation so cross-handler text cannot
+    /// satisfy an assertion spuriously.
+    /// </summary>
+    private static string ExtractConfidenceHandlerRegion(string sagaSource, string handlerParameter)
+    {
+        var start = sagaSource.IndexOf(handlerParameter, StringComparison.Ordinal);
+        if (start < 0)
+        {
+            return string.Empty;
+        }
+
+        // The next member starts at the following "    /// <summary>" doc block.
+        var next = sagaSource.IndexOf("/// <summary>", start, StringComparison.Ordinal);
+        return next < 0 ? sagaSource.Substring(start) : sagaSource.Substring(start, next - start);
     }
 
     /// <summary>

--- a/src/Strategos.Generators.Tests/Emitters/ConfidenceLoweringTests.cs
+++ b/src/Strategos.Generators.Tests/Emitters/ConfidenceLoweringTests.cs
@@ -1,0 +1,208 @@
+// -----------------------------------------------------------------------
+// <copyright file="ConfidenceLoweringTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Tests.Fixtures;
+
+namespace Strategos.Generators.Tests.Emitters;
+
+/// <summary>
+/// Shape/regression tests for lowering a step's
+/// <c>.RequireConfidence(threshold).OnLowConfidence(alt =&gt; alt.Then&lt;THandler&gt;())</c>
+/// into a Wolverine saga routing decision (DR-5).
+/// </summary>
+/// <remarks>
+/// <para>
+/// These tests run the FULL workflow generator pipeline (not just one emitter)
+/// so they double as a golden/shape regression check. A step configured with a
+/// confidence gate must lower into:
+/// <list type="bullet">
+///   <item><description>
+///     a saga completed-handler that compares the completed event's
+///     <c>Confidence</c> to the configured threshold;
+///   </description></item>
+///   <item><description>
+///     a dispatch to the low-confidence handler step's start command
+///     (<c>Start{Handler}Command</c>) when confidence is below the threshold,
+///     instead of routing to the normal next step;
+///   </description></item>
+///   <item><description>
+///     the low-confidence handler step itself being lowered (its own worker
+///     handler / start command), so the branch is actually runnable.
+///   </description></item>
+/// </list>
+/// A step WITHOUT a confidence gate must lower no threshold comparison — only
+/// the pre-existing telemetry span tag carrying the raw confidence value.
+/// </para>
+/// </remarks>
+[Property("Category", "Integration")]
+public class ConfidenceLoweringTests
+{
+    /// <summary>
+    /// A linear workflow whose middle step declares
+    /// <c>.RequireConfidence(0.85).OnLowConfidence(alt =&gt; alt.Then&lt;HumanReview&gt;())</c>
+    /// via the step-configure lambda. The first and last steps declare no
+    /// resilience.
+    /// </summary>
+    private const string WorkflowWithStepConfidence = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record OrderState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class ValidateOrder : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class ClassifyIntent : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class HumanReview : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class SendConfirmation : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        [Workflow("process-order")]
+        public static partial class ProcessOrderWorkflow
+        {
+            public static WorkflowDefinition<OrderState> Definition => Workflow<OrderState>
+                .Create("process-order")
+                .StartWith<ValidateOrder>()
+                .Then<ClassifyIntent>(step => step
+                    .RequireConfidence(0.85)
+                    .OnLowConfidence(alt => alt.Then<HumanReview>()))
+                .Finally<SendConfirmation>();
+        }
+        """;
+
+    /// <summary>
+    /// A linear workflow with NO confidence gate configured on any step.
+    /// </summary>
+    private const string WorkflowWithoutConfidence = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record OrderState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class ValidateOrder : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class ClassifyIntent : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class SendConfirmation : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        [Workflow("process-order")]
+        public static partial class ProcessOrderWorkflow
+        {
+            public static WorkflowDefinition<OrderState> Definition => Workflow<OrderState>
+                .Create("process-order")
+                .StartWith<ValidateOrder>()
+                .Then<ClassifyIntent>()
+                .Finally<SendConfirmation>();
+        }
+        """;
+
+    /// <summary>
+    /// Verifies a step with a confidence gate lowers into a saga completed
+    /// handler that compares the event's confidence to the configured threshold
+    /// and dispatches to the low-confidence handler step's start command, and
+    /// that the handler step itself is lowered (so the branch is runnable).
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Emit_StepWithRequireConfidence_GeneratesConfidenceThresholdBranchDispatch()
+    {
+        // Arrange & Act
+        var result = GeneratorTestHelper.RunGenerator(WorkflowWithStepConfidence);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+        var commandsSource = GeneratorTestHelper.GetGeneratedSource(result, "Commands.g.cs");
+
+        // Assert — the saga's ClassifyIntent completed handler compares the
+        // event's Confidence to the configured 0.85 threshold (not merely a
+        // telemetry span tag).
+        await Assert.That(sagaSource).Contains("Confidence");
+        await Assert.That(sagaSource).Contains("0.85");
+
+        // When below the threshold the saga routes to the low-confidence handler
+        // step's start command instead of the normal next step.
+        await Assert.That(sagaSource).Contains("StartHumanReviewCommand");
+
+        // When at/above the threshold the gate proceeds down the normal path to
+        // the next step (SendConfirmation), not to the handler.
+        await Assert.That(sagaSource).Contains("StartSendConfirmationCommand");
+
+        // The handler step is fully lowered so the branch is runnable: it has its
+        // own start command in the generated commands file.
+        await Assert.That(commandsSource).Contains("StartHumanReviewCommand");
+    }
+
+    /// <summary>
+    /// Verifies a workflow with no confidence gate on any step lowers no
+    /// threshold comparison and no low-confidence dispatch — only the
+    /// pre-existing telemetry span tag carrying the raw confidence value (emitted
+    /// by the worker handler, not the saga).
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Emit_StepWithoutConfidence_NoThresholdComparison()
+    {
+        // Arrange & Act
+        var result = GeneratorTestHelper.RunGenerator(WorkflowWithoutConfidence);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+
+        // Assert — the saga performs no confidence threshold comparison and no
+        // low-confidence routing.
+        await Assert.That(sagaSource).DoesNotContain("evt.Confidence <");
+        await Assert.That(sagaSource).DoesNotContain("StartHumanReviewCommand");
+    }
+}

--- a/src/Strategos.Generators.Tests/Emitters/ContextAssemblerEmitterTests.cs
+++ b/src/Strategos.Generators.Tests/Emitters/ContextAssemblerEmitterTests.cs
@@ -393,9 +393,11 @@ public class ContextAssemblerEmitterTests
         // Act
         var source = ContextAssemblerEmitter.Emit(model);
 
-        // Assert
-        await Assert.That(source).Contains("new RetrievalResult");
-        await Assert.That(source).Contains("Content = item.ToString()");
+        // Assert — RetrievalResult is a positional record, so the mapping
+        // constructs it positionally (Content, Score) rather than with an object
+        // initializer (which fails: Content is a required ctor parameter).
+        await Assert.That(source).Contains("new RetrievalResult(");
+        await Assert.That(source).Contains("item.ToString() ?? string.Empty");
         await Assert.That(source).Contains(".Scores[i]");
     }
 

--- a/src/Strategos.Generators.Tests/Emitters/ContextOnHandlerStepsTests.cs
+++ b/src/Strategos.Generators.Tests/Emitters/ContextOnHandlerStepsTests.cs
@@ -1,0 +1,256 @@
+// -----------------------------------------------------------------------
+// <copyright file="ContextOnHandlerStepsTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Tests.Fixtures;
+
+namespace Strategos.Generators.Tests.Emitters;
+
+/// <summary>
+/// Integration tests (DR-6, CodeRabbit / epic #135 F3 + F5) proving that a
+/// <c>.WithContext(...)</c> declaration on a step that lives OFF the main linear
+/// flow — a failure-handler step (<c>OnFailure</c>) or a low-confidence handler
+/// step (<c>OnLowConfidence</c>) — is lowered end-to-end:
+/// <list type="bullet">
+///   <item><description>
+///     F5: the context merge in <see cref="WorkflowIncrementalGenerator"/> runs
+///     AFTER the handler/low-confidence step models are appended, so the context
+///     actually attaches to the handler step model and the
+///     <c>ContextAssemblerEmitter</c> emits its <c>{Step}ContextAssembler</c>.
+///   </description></item>
+///   <item><description>
+///     F3: the DI registration in <see cref="Strategos.Generators.Emitters.ExtensionsEmitter"/>
+///     registers the handler step's <c>{Step}ContextAssembler</c> so the worker
+///     handler's constructor dependency resolves at runtime.
+///   </description></item>
+/// </list>
+/// Together they close the gap where context on a handler step was parsed but
+/// never attached, emitted, or registered (runtime missing-dependency).
+/// </summary>
+/// <remarks>
+/// Context assembly is ontology-wired (INV-2): the retrieval source emits a
+/// <c>SimilarityExpression</c> executed through <c>IObjectSetProvider</c>; no
+/// <c>Strategos.Rag</c> type is introduced.
+/// </remarks>
+[Property("Category", "Integration")]
+public class ContextOnHandlerStepsTests
+{
+    /// <summary>
+    /// A workflow whose <c>OnFailure</c> handler step (<c>LogFailure</c>) declares
+    /// <c>.WithContext(...)</c>. The main flow steps declare no context. Drives the
+    /// generator to lower a <c>LogFailureContextAssembler</c> and register it.
+    /// </summary>
+    private const string FailureHandlerContextSource = @"
+using Strategos.Abstractions;
+using Strategos.Attributes;
+using Strategos.Builders;
+using Strategos.Definitions;
+using Strategos.Steps;
+
+namespace TestApp;
+
+[WorkflowState]
+public sealed record OrderState : IWorkflowState
+{
+    public global::System.Guid WorkflowId { get; init; }
+    public string CustomerName { get; init; } = string.Empty;
+}
+
+public sealed class ProductCatalog { }
+
+public sealed class ValidateOrder : IWorkflowStep<OrderState>
+{
+    public global::System.Threading.Tasks.Task<StepResult<OrderState>> ExecuteAsync(
+        OrderState state, StepContext context, global::System.Threading.CancellationToken cancellationToken)
+        => global::System.Threading.Tasks.Task.FromResult(StepResult<OrderState>.FromState(state));
+}
+
+public sealed class ProcessOrder : IWorkflowStep<OrderState>
+{
+    public global::System.Threading.Tasks.Task<StepResult<OrderState>> ExecuteAsync(
+        OrderState state, StepContext context, global::System.Threading.CancellationToken cancellationToken)
+        => global::System.Threading.Tasks.Task.FromResult(StepResult<OrderState>.FromState(state));
+}
+
+public sealed class FinishStep : IWorkflowStep<OrderState>
+{
+    public global::System.Threading.Tasks.Task<StepResult<OrderState>> ExecuteAsync(
+        OrderState state, StepContext context, global::System.Threading.CancellationToken cancellationToken)
+        => global::System.Threading.Tasks.Task.FromResult(StepResult<OrderState>.FromState(state));
+}
+
+public sealed class LogFailure : IWorkflowStep<OrderState>
+{
+    public global::System.Threading.Tasks.Task<StepResult<OrderState>> ExecuteAsync(
+        OrderState state, StepContext context, global::System.Threading.CancellationToken cancellationToken)
+        => global::System.Threading.Tasks.Task.FromResult(StepResult<OrderState>.FromState(state));
+}
+
+[Workflow(""order-flow"")]
+public static partial class OrderFlowWorkflow
+{
+    public static WorkflowDefinition<OrderState> Definition => Workflow<OrderState>
+        .Create(""order-flow"")
+        .StartWith<ValidateOrder>()
+        .Then<ProcessOrder>()
+        .Finally<FinishStep>()
+        .OnFailure(f => f
+            .Then<LogFailure>(step => step
+                .WithContext(ctx => ctx
+                    .FromState(s => s.CustomerName)
+                    .FromRetrieval<ProductCatalog>(r => r.Query(""incident"").TopK(3).MinRelevance(0.7m))
+                    .FromLiteral(""Record the failure cause."")))
+            .Complete());
+}
+";
+
+    /// <summary>
+    /// A workflow whose <c>OnLowConfidence</c> handler step (<c>HumanReview</c>)
+    /// declares <c>.WithContext(...)</c>. Drives the generator to lower a
+    /// <c>HumanReviewContextAssembler</c> and register it.
+    /// </summary>
+    private const string LowConfidenceHandlerContextSource = @"
+using Strategos.Abstractions;
+using Strategos.Attributes;
+using Strategos.Builders;
+using Strategos.Definitions;
+using Strategos.Steps;
+
+namespace TestApp;
+
+[WorkflowState]
+public sealed record OrderState : IWorkflowState
+{
+    public global::System.Guid WorkflowId { get; init; }
+    public string CustomerName { get; init; } = string.Empty;
+}
+
+public sealed class ProductCatalog { }
+
+public sealed class ValidateOrder : IWorkflowStep<OrderState>
+{
+    public global::System.Threading.Tasks.Task<StepResult<OrderState>> ExecuteAsync(
+        OrderState state, StepContext context, global::System.Threading.CancellationToken cancellationToken)
+        => global::System.Threading.Tasks.Task.FromResult(StepResult<OrderState>.FromState(state));
+}
+
+public sealed class ClassifyIntent : IWorkflowStep<OrderState>
+{
+    public global::System.Threading.Tasks.Task<StepResult<OrderState>> ExecuteAsync(
+        OrderState state, StepContext context, global::System.Threading.CancellationToken cancellationToken)
+        => global::System.Threading.Tasks.Task.FromResult(StepResult<OrderState>.FromState(state));
+}
+
+public sealed class HumanReview : IWorkflowStep<OrderState>
+{
+    public global::System.Threading.Tasks.Task<StepResult<OrderState>> ExecuteAsync(
+        OrderState state, StepContext context, global::System.Threading.CancellationToken cancellationToken)
+        => global::System.Threading.Tasks.Task.FromResult(StepResult<OrderState>.FromState(state));
+}
+
+public sealed class FinishStep : IWorkflowStep<OrderState>
+{
+    public global::System.Threading.Tasks.Task<StepResult<OrderState>> ExecuteAsync(
+        OrderState state, StepContext context, global::System.Threading.CancellationToken cancellationToken)
+        => global::System.Threading.Tasks.Task.FromResult(StepResult<OrderState>.FromState(state));
+}
+
+[Workflow(""classify-flow"")]
+public static partial class ClassifyFlowWorkflow
+{
+    public static WorkflowDefinition<OrderState> Definition => Workflow<OrderState>
+        .Create(""classify-flow"")
+        .StartWith<ValidateOrder>()
+        .Then<ClassifyIntent>(step => step
+            .RequireConfidence(0.85)
+            .OnLowConfidence(alt => alt.Then<HumanReview>(h => h
+                .WithContext(ctx => ctx
+                    .FromState(s => s.CustomerName)
+                    .FromLiteral(""Human escalation context."")))))
+        .Finally<FinishStep>();
+}
+";
+
+    /// <summary>
+    /// F5: <c>.WithContext(...)</c> on an <c>OnFailure</c> handler step must
+    /// attach to that handler step model (because the merge now runs after the
+    /// failure-handler step models are appended), so the
+    /// <c>ContextAssemblerEmitter</c> emits its assembler and the worker handler
+    /// wires it in.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Generate_FailureHandlerStepWithContext_EmitsAssemblerAndWiresWorker()
+    {
+        // Act
+        var result = GeneratorTestHelper.RunGenerator(FailureHandlerContextSource);
+        var assemblerSource = GeneratorTestHelper.GetGeneratedSource(result, "OrderFlowAssemblers.g.cs");
+        var handlersSource = GeneratorTestHelper.GetGeneratedSource(result, "OrderFlowHandlers.g.cs");
+
+        // F5: the assembler for the failure-handler step is emitted (the context
+        // attached to the LogFailure step model).
+        await Assert.That(assemblerSource).IsNotNull().And.IsNotEmpty();
+        await Assert.That(assemblerSource).Contains("LogFailureContextAssembler");
+        await Assert.That(assemblerSource).Contains("IObjectSetProvider");
+        await Assert.That(assemblerSource).DoesNotContain("Strategos.Rag");
+
+        // F5: the assembler is wired into the LogFailure worker handler.
+        await Assert.That(handlersSource).Contains("LogFailureContextAssembler");
+        await Assert.That(handlersSource).Contains("AssembleAsync");
+    }
+
+    /// <summary>
+    /// F3: the <c>OnFailure</c> handler step's <c>{Step}ContextAssembler</c> must
+    /// be DI-registered (mirroring the existing main-flow assembler registration),
+    /// or the worker handler's constructor dependency cannot resolve at runtime.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Generate_FailureHandlerStepWithContext_RegistersAssemblerInDi()
+    {
+        // Act
+        var result = GeneratorTestHelper.RunGenerator(FailureHandlerContextSource);
+        var extensionsSource = GeneratorTestHelper.GetGeneratedSource(result, "OrderFlowExtensions.g.cs");
+
+        // F3: the assembler registration covers the failure-handler step.
+        await Assert.That(extensionsSource).Contains(
+            "services.AddTransient<LogFailureContextAssembler>();");
+    }
+
+    /// <summary>
+    /// F5: <c>.WithContext(...)</c> on an <c>OnLowConfidence</c> handler step must
+    /// attach to that handler step model (DR-5 handler steps are appended after the
+    /// initial context merge), so its assembler is emitted and wired.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Generate_LowConfidenceHandlerStepWithContext_EmitsAssemblerAndWiresWorker()
+    {
+        // Act
+        var result = GeneratorTestHelper.RunGenerator(LowConfidenceHandlerContextSource);
+        var assemblerSource = GeneratorTestHelper.GetGeneratedSource(result, "ClassifyFlowAssemblers.g.cs");
+        var handlersSource = GeneratorTestHelper.GetGeneratedSource(result, "ClassifyFlowHandlers.g.cs");
+
+        await Assert.That(assemblerSource).IsNotNull().And.IsNotEmpty();
+        await Assert.That(assemblerSource).Contains("HumanReviewContextAssembler");
+        await Assert.That(handlersSource).Contains("HumanReviewContextAssembler");
+        await Assert.That(handlersSource).Contains("AssembleAsync");
+    }
+
+    /// <summary>
+    /// F3: the <c>OnLowConfidence</c> handler step's assembler must be DI-registered.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Generate_LowConfidenceHandlerStepWithContext_RegistersAssemblerInDi()
+    {
+        // Act
+        var result = GeneratorTestHelper.RunGenerator(LowConfidenceHandlerContextSource);
+        var extensionsSource = GeneratorTestHelper.GetGeneratedSource(result, "ClassifyFlowExtensions.g.cs");
+
+        await Assert.That(extensionsSource).Contains(
+            "services.AddTransient<HumanReviewContextAssembler>();");
+    }
+}

--- a/src/Strategos.Generators.Tests/Emitters/ContextOnHandlerStepsTests.cs
+++ b/src/Strategos.Generators.Tests/Emitters/ContextOnHandlerStepsTests.cs
@@ -174,6 +174,82 @@ public static partial class ClassifyFlowWorkflow
 ";
 
     /// <summary>
+    /// A workflow whose <c>Branch</c> case step (<c>HandleSuccess</c>) declares
+    /// <c>.WithContext(...)</c>. The branch case step lives off the main linear
+    /// flow (its execution context is <c>BranchPath</c>), so it exercises the F3
+    /// concern: a context-bearing branch step must still get its assembler emitted
+    /// AND DI-registered.
+    /// </summary>
+    private const string BranchCaseContextSource = @"
+using Strategos.Abstractions;
+using Strategos.Attributes;
+using Strategos.Builders;
+using Strategos.Definitions;
+using Strategos.Steps;
+
+namespace TestApp;
+
+public enum Outcome { Success, Fail }
+
+[WorkflowState]
+public sealed record OrderState : IWorkflowState
+{
+    public global::System.Guid WorkflowId { get; init; }
+    public string CustomerName { get; init; } = string.Empty;
+    public Outcome Result { get; init; }
+}
+
+public sealed class ValidateOrder : IWorkflowStep<OrderState>
+{
+    public global::System.Threading.Tasks.Task<StepResult<OrderState>> ExecuteAsync(
+        OrderState state, StepContext context, global::System.Threading.CancellationToken cancellationToken)
+        => global::System.Threading.Tasks.Task.FromResult(StepResult<OrderState>.FromState(state));
+}
+
+public sealed class HandleSuccess : IWorkflowStep<OrderState>
+{
+    public global::System.Threading.Tasks.Task<StepResult<OrderState>> ExecuteAsync(
+        OrderState state, StepContext context, global::System.Threading.CancellationToken cancellationToken)
+        => global::System.Threading.Tasks.Task.FromResult(StepResult<OrderState>.FromState(state));
+}
+
+public sealed class HandleFail : IWorkflowStep<OrderState>
+{
+    public global::System.Threading.Tasks.Task<StepResult<OrderState>> ExecuteAsync(
+        OrderState state, StepContext context, global::System.Threading.CancellationToken cancellationToken)
+        => global::System.Threading.Tasks.Task.FromResult(StepResult<OrderState>.FromState(state));
+}
+
+public sealed class FinishStep : IWorkflowStep<OrderState>
+{
+    public global::System.Threading.Tasks.Task<StepResult<OrderState>> ExecuteAsync(
+        OrderState state, StepContext context, global::System.Threading.CancellationToken cancellationToken)
+        => global::System.Threading.Tasks.Task.FromResult(StepResult<OrderState>.FromState(state));
+}
+
+[Workflow(""branch-flow"")]
+public static partial class BranchFlowWorkflow
+{
+    private static Outcome Pick(OrderState s) => s.Result;
+
+    public static WorkflowDefinition<OrderState> Definition => Workflow<OrderState>
+        .Create(""branch-flow"")
+        .StartWith<ValidateOrder>()
+        .Branch(
+            Pick,
+            BranchCase<OrderState, Outcome>.When(
+                Outcome.Success,
+                path => path.Then<HandleSuccess>(s => s
+                    .WithContext(ctx => ctx
+                        .FromState(st => st.CustomerName)
+                        .FromLiteral(""branch escalation context.""))).Complete()),
+            BranchCase<OrderState, Outcome>.Otherwise(
+                path => path.Then<HandleFail>().Complete()))
+        .Finally<FinishStep>();
+}
+";
+
+    /// <summary>
     /// F5: <c>.WithContext(...)</c> on an <c>OnFailure</c> handler step must
     /// attach to that handler step model (because the merge now runs after the
     /// failure-handler step models are appended), so the
@@ -252,5 +328,67 @@ public static partial class ClassifyFlowWorkflow
 
         await Assert.That(extensionsSource).Contains(
             "services.AddTransient<HumanReviewContextAssembler>();");
+    }
+
+    /// <summary>
+    /// F3 (branch case): <c>.WithContext(...)</c> on a <c>Branch</c> case step must
+    /// emit its assembler and wire it into the worker handler. Branch case steps
+    /// are lowered into <c>model.Steps</c> with a <c>BranchPath</c> context, so the
+    /// existing <c>ContextAssemblerEmitter</c> covers them once F5 attaches context.
+    /// This test pins that contract.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Generate_BranchCaseStepWithContext_EmitsAssemblerAndWiresWorker()
+    {
+        // Act
+        var result = GeneratorTestHelper.RunGenerator(BranchCaseContextSource);
+        var assemblerSource = GeneratorTestHelper.GetGeneratedSource(result, "BranchFlowAssemblers.g.cs");
+        var handlersSource = GeneratorTestHelper.GetGeneratedSource(result, "BranchFlowHandlers.g.cs");
+
+        await Assert.That(assemblerSource).IsNotNull().And.IsNotEmpty();
+        await Assert.That(assemblerSource).Contains("HandleSuccessContextAssembler");
+        await Assert.That(handlersSource).Contains("HandleSuccessContextAssembler");
+        await Assert.That(handlersSource).Contains("AssembleAsync");
+    }
+
+    /// <summary>
+    /// F3 (branch case): the <c>Branch</c> case step's <c>{Step}ContextAssembler</c>
+    /// must be DI-registered. The branch step gets its TYPE and worker handler
+    /// registered (the existing 3-source registration covers branch steps), so the
+    /// assembler registration must keep parity — a context-bearing branch step
+    /// whose assembler is unregistered is a runtime missing-dependency.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Generate_BranchCaseStepWithContext_RegistersAssemblerInDi()
+    {
+        // Act
+        var result = GeneratorTestHelper.RunGenerator(BranchCaseContextSource);
+        var extensionsSource = GeneratorTestHelper.GetGeneratedSource(result, "BranchFlowExtensions.g.cs");
+
+        // The branch step type and worker handler are registered...
+        await Assert.That(extensionsSource).Contains("services.AddTransient<HandleSuccess>();");
+        await Assert.That(extensionsSource).Contains("services.AddTransient<HandleSuccessHandler>();");
+
+        // ...so the assembler must be registered too (parity), exactly once.
+        await Assert.That(extensionsSource).Contains(
+            "services.AddTransient<HandleSuccessContextAssembler>();");
+        await Assert.That(CountOccurrences(
+            extensionsSource,
+            "services.AddTransient<HandleSuccessContextAssembler>();")).IsEqualTo(1);
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+
+        return count;
     }
 }

--- a/src/Strategos.Generators.Tests/Emitters/ContextWireInTests.cs
+++ b/src/Strategos.Generators.Tests/Emitters/ContextWireInTests.cs
@@ -1,0 +1,150 @@
+// -----------------------------------------------------------------------
+// <copyright file="ContextWireInTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Tests.Fixtures;
+
+namespace Strategos.Generators.Tests.Emitters;
+
+/// <summary>
+/// Integration tests (DR-6 T015) proving that a step's <c>.WithContext(...)</c>
+/// declaration is actually LOWERED by the full generator pipeline: the
+/// <see cref="Strategos.Generators.Emitters.ContextAssemblerEmitter"/> is
+/// invoked from <see cref="WorkflowIncrementalGenerator"/> so the
+/// <c>{Step}ContextAssembler</c> is emitted AND wired into the step's worker
+/// handler execution path.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Before this task the emitter existed (with unit tests) but was never invoked
+/// by the generator — <c>.WithContext(...)</c> parsed into a
+/// <c>ContextModel</c> that was discarded, so no assembler reached the
+/// compilation and no step ever received assembled context at runtime.
+/// </para>
+/// <para>
+/// The assembler is ontology-wired (INV-2), not RAG: a retrieval source emits a
+/// <c>SimilarityExpression</c> executed through <c>IObjectSetProvider</c>'s
+/// <c>ExecuteSimilarityAsync</c>; no <c>Strategos.Rag</c> type is introduced.
+/// </para>
+/// </remarks>
+[Property("Category", "Integration")]
+public class ContextWireInTests
+{
+    /// <summary>
+    /// A linear workflow whose first step declares <c>.WithContext(...)</c> with
+    /// all three source kinds (state, ontology retrieval, literal). Drives the
+    /// generator to lower a <c>ProcessStepContextAssembler</c> and wire it into
+    /// the <c>ProcessStep</c> worker handler.
+    /// </summary>
+    private const string ContextWorkflowSource = @"
+using Strategos.Abstractions;
+using Strategos.Attributes;
+using Strategos.Builders;
+using Strategos.Definitions;
+using Strategos.Steps;
+
+namespace TestApp;
+
+[WorkflowState]
+public sealed record OrderState : IWorkflowState
+{
+    public global::System.Guid WorkflowId { get; init; }
+    public string CustomerName { get; init; } = string.Empty;
+}
+
+public sealed class ProductCatalog { }
+
+public sealed class ProcessStep : IWorkflowStep<OrderState>
+{
+    public global::System.Threading.Tasks.Task<StepResult<OrderState>> ExecuteAsync(
+        OrderState state, StepContext context, global::System.Threading.CancellationToken cancellationToken)
+        => global::System.Threading.Tasks.Task.FromResult(StepResult<OrderState>.FromState(state));
+}
+
+public sealed class FinishStep : IWorkflowStep<OrderState>
+{
+    public global::System.Threading.Tasks.Task<StepResult<OrderState>> ExecuteAsync(
+        OrderState state, StepContext context, global::System.Threading.CancellationToken cancellationToken)
+        => global::System.Threading.Tasks.Task.FromResult(StepResult<OrderState>.FromState(state));
+}
+
+[Workflow(""context-flow"")]
+public static partial class ContextFlowWorkflow
+{
+    public static WorkflowDefinition<OrderState> Definition => Workflow<OrderState>
+        .Create(""context-flow"")
+        .StartWith<ProcessStep>(step => step
+            .WithContext(ctx => ctx
+                .FromState(s => s.CustomerName)
+                .FromRetrieval<ProductCatalog>(r => r.Query(""widgets"").TopK(5).MinRelevance(0.8m))
+                .FromLiteral(""Follow brand guidelines."")))
+        .Finally<FinishStep>();
+}
+";
+
+    /// <summary>
+    /// The wire-in proof: running the full generator over a workflow whose step
+    /// declares <c>.WithContext(...)</c> must emit the
+    /// <c>ProcessStepContextAssembler</c> with the ontology retrieval path
+    /// (<c>IObjectSetProvider</c> / <c>ExecuteSimilarityAsync</c> /
+    /// <c>SimilarityExpression</c>), AND wire the assembler into the
+    /// <c>ProcessStep</c> worker handler so it assembles context before the step
+    /// executes. No <c>Strategos.Rag</c> type may appear.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Generate_StepWithWithContext_EmitsContextAssembler()
+    {
+        // Act
+        var result = GeneratorTestHelper.RunGenerator(ContextWorkflowSource);
+
+        var assemblerSource = GeneratorTestHelper.GetGeneratedSource(
+            result, "ContextFlowAssemblers.g.cs");
+        var handlersSource = GeneratorTestHelper.GetGeneratedSource(
+            result, "ContextFlowHandlers.g.cs");
+
+        // Assert — the assembler class was emitted with the ontology retrieval
+        // path (INV-2: ontology, not RAG).
+        await Assert.That(assemblerSource).IsNotNull().And.IsNotEmpty();
+        await Assert.That(assemblerSource).Contains("ProcessStepContextAssembler");
+        await Assert.That(assemblerSource).Contains("IObjectSetProvider");
+        await Assert.That(assemblerSource).Contains("ExecuteSimilarityAsync");
+        await Assert.That(assemblerSource).Contains("new SimilarityExpression(");
+        await Assert.That(assemblerSource).DoesNotContain("Strategos.Rag");
+        await Assert.That(assemblerSource).DoesNotContain("IVectorSearchAdapter");
+
+        // Assert — the assembler is WIRED into the ProcessStep worker handler:
+        // the handler depends on the assembler and assembles context before the
+        // step executes.
+        await Assert.That(handlersSource).Contains("ProcessStepContextAssembler");
+        await Assert.That(handlersSource).Contains("AssembleAsync");
+    }
+
+    /// <summary>
+    /// Steps WITHOUT <c>.WithContext(...)</c> must NOT get an assembler and their
+    /// worker handler must keep the no-assembler baseline shape (no assembler
+    /// dependency, no <c>AssembleAsync</c> call). Guards against the wire-in
+    /// leaking assembler wiring onto unrelated steps.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Generate_StepWithoutContext_KeepsNoAssemblerBaseline()
+    {
+        // Act
+        var result = GeneratorTestHelper.RunGenerator(ContextWorkflowSource);
+
+        var assemblerSource = GeneratorTestHelper.GetGeneratedSource(
+            result, "ContextFlowAssemblers.g.cs");
+        var handlersSource = GeneratorTestHelper.GetGeneratedSource(
+            result, "ContextFlowHandlers.g.cs");
+
+        // The context-less FinishStep gets no assembler...
+        await Assert.That(assemblerSource).DoesNotContain("FinishStepContextAssembler");
+
+        // ...and its handler must not reference any assembler nor assemble context.
+        await Assert.That(handlersSource).Contains("FinishStepHandler");
+        await Assert.That(handlersSource).DoesNotContain("FinishStepContextAssembler");
+    }
+}

--- a/src/Strategos.Generators.Tests/Emitters/NoConfigBaselineTests.cs
+++ b/src/Strategos.Generators.Tests/Emitters/NoConfigBaselineTests.cs
@@ -1,0 +1,143 @@
+// -----------------------------------------------------------------------
+// <copyright file="NoConfigBaselineTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Tests.Fixtures;
+
+namespace Strategos.Generators.Tests.Emitters;
+
+/// <summary>
+/// Golden baseline (DR-10): a step with NO resilience configuration must
+/// generate the same saga/handler/commands output as before the step-resilience
+/// epic. Every resilience emit-guard
+/// (retry / timeout / compensation / confidence / context) must correctly emit
+/// NOTHING for a config-free step.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the negative-space counterpart to the per-feature lowering tests
+/// (<see cref="RetryLoweringTests"/>, <see cref="TimeoutLoweringTests"/>,
+/// <see cref="CompensationLoweringTests"/>, <see cref="ConfidenceLoweringTests"/>,
+/// and the context wire-in tests). Each of those proves the artifact appears
+/// when the feature is configured; this proves the WHOLE pipeline stays inert
+/// when nothing is configured, so a future emit-guard regression that leaks a
+/// resilience artifact onto a plain step fails the build mechanically.
+/// </para>
+/// <para>
+/// The workflow exercises every step position (start / middle / finally) with no
+/// <c>.WithRetry</c>, <c>.WithTimeout</c>, <c>.Compensate</c>,
+/// <c>.RequireConfidence</c> or <c>.WithContext</c> anywhere, then asserts the
+/// generated saga, handlers, commands and assemblers carry none of the five
+/// resilience artifact families.
+/// </para>
+/// </remarks>
+[Property("Category", "Integration")]
+public class NoConfigBaselineTests
+{
+    /// <summary>
+    /// A fully config-free linear workflow: start / middle / finally steps, none
+    /// of which declare any resilience policy. This is the golden baseline shape.
+    /// </summary>
+    private const string WorkflowWithoutResilience = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record OrderState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class ValidateOrder : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class ProcessPayment : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class SendConfirmation : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        [Workflow("process-order")]
+        public static partial class ProcessOrderWorkflow
+        {
+            public static WorkflowDefinition<OrderState> Definition => Workflow<OrderState>
+                .Create("process-order")
+                .StartWith<ValidateOrder>()
+                .Then<ProcessPayment>()
+                .Finally<SendConfirmation>();
+        }
+        """;
+
+    /// <summary>
+    /// A config-free workflow lowers NONE of the five resilience artifact
+    /// families: no worker <c>Configure(HandlerChain)</c> (retry), no
+    /// <c>: TimeoutMessage</c>-derived record (timeout), no compensation trigger
+    /// publish / rollback wiring (compensation), no confidence threshold
+    /// comparison or low-confidence branch dispatch (confidence), and no
+    /// <c>{Step}ContextAssembler</c> (context). The generated saga / handlers /
+    /// commands / assemblers are the pre-epic golden baseline.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Emit_StepWithoutResilience_GeneratedOutputHasNoResilienceArtifacts()
+    {
+        // Arrange & Act — run the FULL generator pipeline.
+        var result = GeneratorTestHelper.RunGenerator(WorkflowWithoutResilience);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "Saga.g.cs");
+        var handlersSource = GeneratorTestHelper.GetGeneratedSource(result, "Handlers.g.cs");
+        var commandsSource = GeneratorTestHelper.GetGeneratedSource(result, "Commands.g.cs");
+        var assemblersSource = GeneratorTestHelper.GetGeneratedSource(result, "Assemblers.g.cs");
+
+        // Sanity: the pipeline did produce the core artifacts for a normal
+        // workflow, so the negative assertions below are meaningful (not asserting
+        // against empty strings because generation silently failed).
+        await Assert.That(sagaSource).IsNotEmpty();
+        await Assert.That(handlersSource).IsNotEmpty();
+
+        // Retry guard — no per-handler Wolverine error policy hook.
+        await Assert.That(handlersSource).DoesNotContain("Configure(HandlerChain");
+        await Assert.That(handlersSource).DoesNotContain("RetryTimes(");
+        await Assert.That(handlersSource).DoesNotContain("RetryWithCooldown(");
+
+        // Timeout guard — no TimeoutMessage-derived record, no timeout cascade.
+        await Assert.That(sagaSource).DoesNotContain(": TimeoutMessage");
+        await Assert.That(sagaSource).DoesNotContain("Timeout(");
+
+        // Compensation guard — no failure-handler trigger command, no
+        // CompensatingAction publish, no rollback worker dispatch.
+        await Assert.That(sagaSource).DoesNotContain("FailureHandlerCommand");
+        await Assert.That(handlersSource).DoesNotContain("FailureHandlerCommand");
+        await Assert.That(handlersSource).DoesNotContain("CompensatingAction");
+
+        // Confidence guard — no threshold comparison branch in the saga. The
+        // raw confidence value still flows as a telemetry span tag (emitted by
+        // the worker handler regardless of any gate), so the precise marker is
+        // the threshold-comparison branch the confidence gate lowers:
+        // "if (evt.Confidence is double confidenceScore && confidenceScore < t)".
+        await Assert.That(sagaSource).DoesNotContain("confidenceScore <");
+        await Assert.That(sagaSource).DoesNotContain("below threshold");
+
+        // Context guard — no per-step context assembler emitted or wired in.
+        await Assert.That(assemblersSource).DoesNotContain("ContextAssembler");
+        await Assert.That(handlersSource).DoesNotContain("ContextAssembler");
+    }
+}

--- a/src/Strategos.Generators.Tests/Emitters/RetryLoweringTests.cs
+++ b/src/Strategos.Generators.Tests/Emitters/RetryLoweringTests.cs
@@ -1,0 +1,110 @@
+// -----------------------------------------------------------------------
+// <copyright file="RetryLoweringTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Emitters;
+using Strategos.Generators.Models;
+
+namespace Strategos.Generators.Tests.Emitters;
+
+/// <summary>
+/// Shape tests for lowering a step's <c>.WithRetry(...)</c> policy onto the
+/// generated worker handler as a Wolverine per-handler error policy
+/// (<c>public static void Configure(HandlerChain chain)</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Wolverine discovers a static <c>Configure(HandlerChain)</c> method on the
+/// handler class at codegen time and applies it to that handler's chain,
+/// scoping the error policy to this one step (DR-2). The handler's existing
+/// <c>catch { throw; }</c> re-throw is what feeds the policy, so retry is a
+/// pure additive on top of the happy-path handler body.
+/// </para>
+/// <para>
+/// Maps <see cref="RetryModel"/> to the chain fluent API:
+/// no delay → <c>chain.OnAnyException().RetryTimes(n)</c>;
+/// an <c>InitialDelay</c> → <c>chain.OnAnyException().RetryWithCooldown(...)</c>.
+/// </para>
+/// </remarks>
+[Property("Category", "Unit")]
+public class RetryLoweringTests
+{
+    /// <summary>
+    /// A bare <c>.WithRetry(2)</c> (no delay) lowers to a static
+    /// <c>Configure(HandlerChain ...)</c> method that calls
+    /// <c>RetryTimes(2)</c> on the handler chain.
+    /// </summary>
+    [Test]
+    public async Task Emit_StepWithWithRetry2_GeneratesConfigureWithRetryTimes()
+    {
+        // Arrange
+        var step = StepModel.Create(
+            "FlakyStep",
+            "TestNamespace.FlakyStep",
+            retry: new RetryModel(MaxAttempts: 2));
+
+        var model = ModelWithStep(step);
+
+        // Act
+        var source = WorkerHandlerEmitter.Emit(model);
+
+        // Assert - the FlakyStepHandler carries the per-handler retry policy.
+        await Assert.That(source).Contains("public static void Configure(HandlerChain");
+        await Assert.That(source).Contains("RetryTimes(2)");
+    }
+
+    /// <summary>
+    /// A <c>.WithRetry(n, delay)</c> lowers to <c>RetryWithCooldown(...)</c>
+    /// (a TimeSpan-shaped backoff), not <c>RetryTimes</c>.
+    /// </summary>
+    [Test]
+    public async Task Emit_StepWithWithRetryAndDelay_GeneratesRetryWithCooldown()
+    {
+        // Arrange
+        var step = StepModel.Create(
+            "FlakyStep",
+            "TestNamespace.FlakyStep",
+            retry: new RetryModel(MaxAttempts: 3, InitialDelay: TimeSpan.FromMilliseconds(50)));
+
+        var model = ModelWithStep(step);
+
+        // Act
+        var source = WorkerHandlerEmitter.Emit(model);
+
+        // Assert - a delayed retry uses the cooldown overload, not RetryTimes.
+        await Assert.That(source).Contains("public static void Configure(HandlerChain");
+        await Assert.That(source).Contains("RetryWithCooldown(");
+        await Assert.That(source).DoesNotContain("RetryTimes(");
+    }
+
+    /// <summary>
+    /// A step without any retry policy emits NO <c>Configure</c> method, so the
+    /// generated handler is unchanged from the no-resilience baseline.
+    /// </summary>
+    [Test]
+    public async Task Emit_StepWithoutRetry_GeneratesNoConfigureMethod()
+    {
+        // Arrange
+        var step = StepModel.Create("PlainStep", "TestNamespace.PlainStep");
+        var model = ModelWithStep(step);
+
+        // Act
+        var source = WorkerHandlerEmitter.Emit(model);
+
+        // Assert - no per-handler policy hook is emitted when retry is absent.
+        await Assert.That(source).DoesNotContain("Configure(HandlerChain");
+    }
+
+    private static WorkflowModel ModelWithStep(StepModel step)
+    {
+        return new WorkflowModel(
+            WorkflowName: "resilience-flow",
+            PascalName: "ResilienceFlow",
+            Namespace: "TestNamespace",
+            StepNames: [step.StepName],
+            StateTypeName: "FlowState",
+            Steps: [step]);
+    }
+}

--- a/src/Strategos.Generators.Tests/Emitters/Saga/SagaPropertiesEmitterTests.cs
+++ b/src/Strategos.Generators.Tests/Emitters/Saga/SagaPropertiesEmitterTests.cs
@@ -109,7 +109,10 @@ public class SagaPropertiesEmitterTests
         var result = sb.ToString();
 
         // Assert
-        await Assert.That(result).Contains("[Identity]");
+        // Fully qualified [JasperFx.Identity] (the Marten document-identity
+        // attribute) to avoid a CS0616 collision with the Strategos.Identity
+        // namespace in consumers that reference Strategos.Identity.Abstractions.
+        await Assert.That(result).Contains("[JasperFx.Identity]");
     }
 
     // =============================================================================
@@ -132,7 +135,9 @@ public class SagaPropertiesEmitterTests
         var result = sb.ToString();
 
         // Assert
-        await Assert.That(result).Contains("public new int Version { get; set; }");
+        // long (not int): Marten 9 widened numeric document revisions to long
+        // and rejects an int [Version] property at document-mapping time.
+        await Assert.That(result).Contains("public new long Version { get; set; }");
     }
 
     /// <summary>

--- a/src/Strategos.Generators.Tests/Emitters/TimeoutLoweringTests.cs
+++ b/src/Strategos.Generators.Tests/Emitters/TimeoutLoweringTests.cs
@@ -1,0 +1,186 @@
+// -----------------------------------------------------------------------
+// <copyright file="TimeoutLoweringTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Tests.Fixtures;
+
+namespace Strategos.Generators.Tests.Emitters;
+
+/// <summary>
+/// Shape/regression tests for lowering a step's <c>.WithTimeout(t)</c> into a
+/// Wolverine saga <see cref="global::Wolverine.TimeoutMessage"/> (DR-4).
+/// </summary>
+/// <remarks>
+/// <para>
+/// These tests run the FULL workflow generator pipeline (not just one emitter)
+/// so they double as a golden/shape regression check: a step configured with a
+/// timeout must lower into
+/// <list type="bullet">
+///   <item><description>
+///     a <c>{Step}Timeout</c> record deriving from <c>Wolverine.TimeoutMessage</c>
+///     (Wolverine auto-schedules its delayed delivery from the base ctor's
+///     <see cref="System.TimeSpan"/>);
+///   </description></item>
+///   <item><description>
+///     a cascade of that timeout message from the step-start handler alongside
+///     the worker command (so the deadline race starts when the step starts);
+///   </description></item>
+///   <item><description>
+///     a saga <c>Handle({Step}Timeout)</c> that routes to the failure path only
+///     when the step's phase has not advanced (idempotent race guard).
+///   </description></item>
+/// </list>
+/// A step WITHOUT a timeout must lower no timeout artifacts at all.
+/// </para>
+/// </remarks>
+[Property("Category", "Integration")]
+public class TimeoutLoweringTests
+{
+    /// <summary>
+    /// A linear workflow whose middle step declares <c>.WithTimeout(...)</c> via
+    /// the step-configure lambda. The first and last steps declare no resilience.
+    /// </summary>
+    private const string WorkflowWithStepTimeout = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record OrderState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class ValidateOrder : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class ProcessPayment : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class SendConfirmation : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        [Workflow("process-order")]
+        public static partial class ProcessOrderWorkflow
+        {
+            public static WorkflowDefinition<OrderState> Definition => Workflow<OrderState>
+                .Create("process-order")
+                .StartWith<ValidateOrder>()
+                .Then<ProcessPayment>(step => step
+                    .WithTimeout(TimeSpan.FromSeconds(30)))
+                .Finally<SendConfirmation>();
+        }
+        """;
+
+    /// <summary>
+    /// A linear workflow with NO timeout configured on any step.
+    /// </summary>
+    private const string WorkflowWithoutTimeout = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record OrderState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class ValidateOrder : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class ProcessPayment : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class SendConfirmation : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        [Workflow("process-order")]
+        public static partial class ProcessOrderWorkflow
+        {
+            public static WorkflowDefinition<OrderState> Definition => Workflow<OrderState>
+                .Create("process-order")
+                .StartWith<ValidateOrder>()
+                .Then<ProcessPayment>()
+                .Finally<SendConfirmation>();
+        }
+        """;
+
+    /// <summary>
+    /// Verifies a step with a timeout lowers into a <c>TimeoutMessage</c>-derived
+    /// record, a saga handler for it, and a cascade of that message from the
+    /// step-start handler.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Emit_StepWithTimeout_GeneratesTimeoutMessageRecordAndSagaHandler()
+    {
+        // Arrange & Act
+        var result = GeneratorTestHelper.RunGenerator(WorkflowWithStepTimeout);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+
+        // Assert — the timeout message record derives from Wolverine.TimeoutMessage,
+        // carries the step name, and is scheduled from the configured 30s duration.
+        await Assert.That(sagaSource).Contains("ProcessPaymentTimeout");
+        await Assert.That(sagaSource).Contains(": TimeoutMessage");
+
+        // The step-start handler cascades the timeout message alongside the worker
+        // command so the deadline race begins when the step begins.
+        await Assert.That(sagaSource).Contains("new ProcessPaymentTimeout(");
+
+        // The saga handles the timeout later (race guard / failure routing).
+        await Assert.That(sagaSource).Contains("Handle(");
+        await Assert.That(sagaSource).Contains("ProcessPaymentTimeout t");
+    }
+
+    /// <summary>
+    /// Verifies a workflow with no timeout on any step lowers no timeout
+    /// artifacts whatsoever.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Emit_StepWithoutTimeout_GeneratesNoTimeoutMessage()
+    {
+        // Arrange & Act
+        var result = GeneratorTestHelper.RunGenerator(WorkflowWithoutTimeout);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+
+        // Assert — no timeout message, no derivation, no cascade.
+        await Assert.That(sagaSource).DoesNotContain(": TimeoutMessage");
+        await Assert.That(sagaSource).DoesNotContain("Timeout(");
+    }
+}

--- a/src/Strategos.Generators.Tests/Helpers/NamingHelperTests.cs
+++ b/src/Strategos.Generators.Tests/Helpers/NamingHelperTests.cs
@@ -160,6 +160,85 @@ public class NamingHelperTests
     }
 
     // =============================================================================
+    // G2. GetSimpleTypeName Tests
+    // =============================================================================
+
+    /// <summary>
+    /// Verifies that GetSimpleTypeName strips the namespace from a fully qualified
+    /// (non-generic) type name.
+    /// </summary>
+    [Test]
+    public async Task GetSimpleTypeName_FullyQualified_ReturnsSimpleName()
+    {
+        // Act
+        var result = NamingHelper.GetSimpleTypeName("MyApp.Steps.RollbackStep");
+
+        // Assert
+        await Assert.That(result).IsEqualTo("RollbackStep");
+    }
+
+    /// <summary>
+    /// Verifies that GetSimpleTypeName returns an unqualified name unchanged.
+    /// </summary>
+    [Test]
+    public async Task GetSimpleTypeName_Unqualified_ReturnsInput()
+    {
+        // Act
+        var result = NamingHelper.GetSimpleTypeName("RollbackStep");
+
+        // Assert
+        await Assert.That(result).IsEqualTo("RollbackStep");
+    }
+
+    /// <summary>
+    /// Verifies that GetSimpleTypeName returns a VALID identifier for a fully
+    /// qualified GENERIC type whose type argument is itself qualified. The old
+    /// implementation split on the LAST '.', which fell inside the type argument
+    /// (<c>Ns.Foo&lt;Ns.Bar&gt;</c>) and yielded <c>Bar&gt;</c> — an invalid
+    /// identifier with a trailing '&gt;'.
+    /// </summary>
+    [Test]
+    public async Task GetSimpleTypeName_QualifiedGenericWithQualifiedArg_ReturnsValidOuterName()
+    {
+        // Act
+        var result = NamingHelper.GetSimpleTypeName("Ns.Foo<Ns.Bar>");
+
+        // Assert
+        await Assert.That(result).IsEqualTo("Foo");
+        await Assert.That(result).DoesNotContain(">");
+        await Assert.That(result).DoesNotContain("<");
+        await Assert.That(result).DoesNotContain(".");
+    }
+
+    /// <summary>
+    /// Verifies that GetSimpleTypeName strips the generic-argument suffix from a
+    /// fully qualified generic with an unqualified type argument.
+    /// </summary>
+    [Test]
+    public async Task GetSimpleTypeName_QualifiedGenericWithSimpleArg_ReturnsOuterName()
+    {
+        // Act
+        var result = NamingHelper.GetSimpleTypeName("MyApp.Steps.Wrapper<Payload>");
+
+        // Assert
+        await Assert.That(result).IsEqualTo("Wrapper");
+    }
+
+    /// <summary>
+    /// Verifies that GetSimpleTypeName strips the generic-argument suffix from an
+    /// unqualified generic type name.
+    /// </summary>
+    [Test]
+    public async Task GetSimpleTypeName_UnqualifiedGeneric_ReturnsOuterName()
+    {
+        // Act
+        var result = NamingHelper.GetSimpleTypeName("Wrapper<Payload>");
+
+        // Assert
+        await Assert.That(result).IsEqualTo("Wrapper");
+    }
+
+    // =============================================================================
     // H. Guard Clause Tests
     // =============================================================================
 

--- a/src/Strategos.Generators.Tests/Helpers/NestedLambdaLeakageTests.cs
+++ b/src/Strategos.Generators.Tests/Helpers/NestedLambdaLeakageTests.cs
@@ -1,0 +1,373 @@
+// -----------------------------------------------------------------------
+// <copyright file="NestedLambdaLeakageTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Helpers;
+using Strategos.Generators.Models;
+using Strategos.Generators.Tests.Fixtures;
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Strategos.Generators.Tests.Helpers;
+
+/// <summary>
+/// CodeRabbit F1 (PR #137, epic #135) — regression tests for nested-lambda leakage
+/// across the three step-resilience / step-discovery extraction sites that walk a
+/// configure/handler lambda with <c>DescendantNodes()</c>:
+/// <list type="bullet">
+///   <item>parent-step resilience (<c>StepExtractor.ExtractConfiguredResilience</c>),</item>
+///   <item>branch-path step discovery (<c>StepExtractor.ParseBranchPathStepModels</c>),</item>
+///   <item>failure-handler step discovery (<c>FailureHandlerExtractor.ParseFailureHandlerBody</c>).</item>
+/// </list>
+/// Each site must consider ONLY invocations in its own lambda body, never those captured
+/// from a nested lambda (e.g. an inner <c>OnLowConfidence(alt =&gt; alt.Then&lt;Y&gt;(c =&gt; c.WithTimeout(t)))</c>).
+/// INV-1: lowering stays correct; INV-7: immutability untouched.
+/// </summary>
+[Property("Category", "Unit")]
+public sealed class NestedLambdaLeakageTests
+{
+    // =========================================================================
+    // F1a — parent-step resilience must NOT absorb a nested lambda's resilience.
+    // =========================================================================
+
+    /// <summary>
+    /// The outer step declares <c>WithRetry(2)</c> and an <c>OnLowConfidence</c> whose
+    /// handler step declares <c>WithTimeout(...)</c> via its own configure lambda. The
+    /// outer step must carry the retry but NOT the inner handler's timeout.
+    /// </summary>
+    [Test]
+    public async Task ExtractResilience_NestedOnLowConfidenceTimeout_DoesNotLeakToOuterStep()
+    {
+        // Arrange
+        var stepModels = ParserTestHelper.ExtractStepModels(NestedConfidenceTimeoutWorkflow);
+
+        // Act
+        var outerStep = stepModels.Single(s => s.StepName == "AssessClaim");
+
+        // Assert - outer step keeps its own retry
+        await Assert.That(outerStep.Retry).IsNotNull();
+        await Assert.That(outerStep.Retry!.MaxAttempts).IsEqualTo(2);
+
+        // Assert - the inner handler's WithTimeout must NOT leak onto the outer step
+        await Assert.That(outerStep.Timeout).IsNull();
+    }
+
+    /// <summary>
+    /// The legitimately-nested <c>OnLowConfidence(alt =&gt; alt.Then&lt;HumanReview&gt;(...))</c>
+    /// handler step must still be identified on the outer step's confidence model — the
+    /// nested-lambda boundary fix must not drop config that belongs to the inner handler.
+    /// (Threshold + handler identity survive; the handler step's own resilience extraction
+    /// is a separate concern — DR-5 lowers the handler by name/type, not its retry/timeout.)
+    /// </summary>
+    [Test]
+    public async Task ExtractResilience_NestedOnLowConfidenceTimeout_HandlerStepStillIdentified()
+    {
+        // Arrange
+        var stepModels = ParserTestHelper.ExtractStepModels(NestedConfidenceTimeoutWorkflow);
+        var outerStep = stepModels.Single(s => s.StepName == "AssessClaim");
+
+        // Act - the confidence model + handler step are carried on the outer step
+        var confidence = outerStep.Confidence;
+        var handlerStep = confidence?.OnLowConfidenceHandlerStep;
+
+        // Assert - the threshold and low-confidence handler survive the boundary fix
+        await Assert.That(confidence).IsNotNull();
+        await Assert.That(confidence!.Threshold).IsEqualTo(0.85);
+        await Assert.That(confidence.OnLowConfidenceHandlerId).IsEqualTo("HumanReview");
+        await Assert.That(handlerStep).IsNotNull();
+        await Assert.That(handlerStep!.StepName).IsEqualTo("HumanReview");
+    }
+
+    // =========================================================================
+    // F1b — branch-path step discovery must NOT pick up nested Then<> calls.
+    // =========================================================================
+
+    /// <summary>
+    /// A branch case path step declares an <c>OnLowConfidence(alt =&gt; alt.Then&lt;Inner&gt;())</c>.
+    /// The branch-path step discovery must yield only the outer <c>Then&lt;Outer&gt;</c> step,
+    /// never the nested <c>Then&lt;Inner&gt;</c> handler step (which is lowered via the
+    /// confidence model, not as an outer branch step).
+    /// </summary>
+    [Test]
+    public async Task BranchPath_NestedThenInOnLowConfidence_NotPickedUpAsBranchStep()
+    {
+        // Arrange
+        var stepModels = ParserTestHelper.ExtractStepModels(BranchNestedThenWorkflow);
+
+        // Act
+        var innerOccurrences = stepModels.Count(s => s.StepName == "InnerHandler");
+        var outerOccurrences = stepModels.Count(s => s.StepName == "ProcessAuto");
+
+        // Assert - the outer branch step is discovered once
+        await Assert.That(outerOccurrences).IsEqualTo(1);
+
+        // Assert - the nested Then<InnerHandler> is NOT discovered as a branch-path step
+        await Assert.That(innerOccurrences).IsEqualTo(0);
+    }
+
+    // =========================================================================
+    // F1c — failure-handler step discovery must NOT pick up nested Then<> calls.
+    // =========================================================================
+
+    /// <summary>
+    /// A workflow failure handler declares a step whose configure lambda nests an
+    /// <c>OnLowConfidence(alt =&gt; alt.Then&lt;Nested&gt;())</c>. The failure-handler body
+    /// walk must yield only the outer handler step, never the nested <c>Then&lt;Nested&gt;</c>.
+    /// </summary>
+    [Test]
+    public async Task FailureHandler_NestedThenInConfigLambda_NotPickedUpAsHandlerStep()
+    {
+        // Arrange — build the context from the workflow-attributed class so the
+        // OnFailure invocation is in scope (the first type declaration is a record state).
+        var context = CreateWorkflowParseContext(FailureHandlerNestedThenWorkflow, "nested-failure");
+
+        // Act
+        var handlers = FailureHandlerExtractor.Extract(context);
+        var handler = handlers.Single();
+        var stepNames = (handler.Steps ?? []).Select(s => s.StepName).ToList();
+
+        // Assert - the outer failure-handler step is present
+        await Assert.That(stepNames).Contains("LogFailure");
+
+        // Assert - the nested Then<NestedRecovery> is NOT a failure-handler step
+        await Assert.That(stepNames.Contains("NestedRecovery")).IsFalse();
+    }
+
+    // =========================================================================
+    // Local harness — build a parse context anchored on the workflow class.
+    // =========================================================================
+
+    /// <summary>
+    /// Compiles <paramref name="source"/> and builds a <see cref="FluentDslParseContext"/>
+    /// anchored on the <c>[Workflow]</c>-attributed class (not the first type declaration,
+    /// which is a record state) so chain invocations such as <c>OnFailure</c> are in scope.
+    /// </summary>
+    private static FluentDslParseContext CreateWorkflowParseContext(string source, string workflowName)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var references = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(a => !a.IsDynamic && !string.IsNullOrEmpty(a.Location))
+            .Select(a => (MetadataReference)MetadataReference.CreateFromFile(a.Location))
+            .Append(MetadataReference.CreateFromFile(
+                typeof(Strategos.Abstractions.IWorkflowState).Assembly.Location))
+            .ToList();
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: [syntaxTree],
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var semanticModel = compilation.GetSemanticModel(syntaxTree);
+
+        var workflowClass = syntaxTree.GetRoot()
+            .DescendantNodes()
+            .OfType<TypeDeclarationSyntax>()
+            .First(t => t.AttributeLists
+                .SelectMany(al => al.Attributes)
+                .Any(a => a.Name.ToString().Contains("Workflow", StringComparison.Ordinal)));
+
+        return FluentDslParseContext.Create(workflowClass, semanticModel, workflowName, CancellationToken.None);
+    }
+
+    // =========================================================================
+    // Test source workflows
+    // =========================================================================
+
+    /// <summary>
+    /// An outer step carrying <c>WithRetry(2)</c> plus an <c>OnLowConfidence</c> whose
+    /// handler step declares its own <c>WithTimeout(TimeSpan.FromSeconds(45))</c> via a
+    /// nested configure lambda. Probes parent-step resilience leakage (F1a).
+    /// </summary>
+    private const string NestedConfidenceTimeoutWorkflow = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record ClaimState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class IntakeClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class AssessClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class HumanReview : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class SettleClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        [Workflow("nested-confidence-timeout")]
+        public static partial class NestedConfidenceTimeoutWorkflow
+        {
+            public static WorkflowDefinition<ClaimState> Definition => Workflow<ClaimState>
+                .Create("nested-confidence-timeout")
+                .StartWith<IntakeClaim>()
+                .Then<AssessClaim>(step => step
+                    .WithRetry(2)
+                    .RequireConfidence(0.85)
+                    .OnLowConfidence(alt => alt.Then<HumanReview>(h => h
+                        .WithTimeout(TimeSpan.FromSeconds(45)))))
+                .Finally<SettleClaim>();
+        }
+        """;
+
+    /// <summary>
+    /// A branch case path whose step declares an <c>OnLowConfidence(alt =&gt; alt.Then&lt;InnerHandler&gt;())</c>.
+    /// Probes branch-path step-discovery leakage (F1b).
+    /// </summary>
+    private const string BranchNestedThenWorkflow = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public enum ClaimType { Auto, Home }
+
+        public record ClaimState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+            public ClaimType Type { get; init; }
+        }
+
+        public class ValidateClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class ProcessAuto : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class ProcessHome : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class InnerHandler : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class CompleteClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        [Workflow("branch-nested-then")]
+        public static partial class BranchNestedThenWorkflow
+        {
+            public static WorkflowDefinition<ClaimState> Definition => Workflow<ClaimState>
+                .Create("branch-nested-then")
+                .StartWith<ValidateClaim>()
+                .Branch(state => state.Type,
+                    BranchCase<ClaimState, ClaimType>.When(ClaimType.Auto, path => path.Then<ProcessAuto>(step => step
+                        .RequireConfidence(0.7)
+                        .OnLowConfidence(alt => alt.Then<InnerHandler>()))),
+                    BranchCase<ClaimState, ClaimType>.Otherwise(path => path.Then<ProcessHome>()))
+                .Finally<CompleteClaim>();
+        }
+        """;
+
+    /// <summary>
+    /// A workflow whose failure handler step nests an <c>OnLowConfidence(alt =&gt; alt.Then&lt;NestedRecovery&gt;())</c>.
+    /// Probes failure-handler step-discovery leakage (F1c).
+    /// </summary>
+    private const string FailureHandlerNestedThenWorkflow = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record OrderState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class PlaceOrder : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class LogFailure : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class NestedRecovery : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class CompleteOrder : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        [Workflow("nested-failure")]
+        public static partial class NestedFailureWorkflow
+        {
+            public static WorkflowDefinition<OrderState> Definition => Workflow<OrderState>
+                .Create("nested-failure")
+                .StartWith<PlaceOrder>()
+                .OnFailure(f => f.Then<LogFailure>(step => step
+                    .RequireConfidence(0.6)
+                    .OnLowConfidence(alt => alt.Then<NestedRecovery>())).Complete())
+                .Finally<CompleteOrder>();
+        }
+        """;
+}

--- a/src/Strategos.Generators.Tests/Helpers/StepExtractorResilienceTests.cs
+++ b/src/Strategos.Generators.Tests/Helpers/StepExtractorResilienceTests.cs
@@ -1,0 +1,139 @@
+// -----------------------------------------------------------------------
+// <copyright file="StepExtractorResilienceTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Models;
+using Strategos.Generators.Tests.Fixtures;
+
+namespace Strategos.Generators.Tests.Helpers;
+
+/// <summary>
+/// Tests that <see cref="StepExtractor"/> parses the per-step resilience configuration
+/// declared inside the <c>Then&lt;TStep&gt;(step =&gt; step.WithRetry(...).WithTimeout(...)...)</c>
+/// configure lambda into the step's <see cref="StepModel"/> IR (epic #135, DR-1).
+/// </summary>
+/// <remarks>
+/// These tests drive a workflow snippet through <see cref="ParserTestHelper.ExtractStepModels"/>,
+/// which routes through <c>FluentDslParser.ExtractStepModels</c> →
+/// <see cref="StepExtractor.ExtractStepModels"/>, returning the configured
+/// <see cref="StepModel"/> list. The resilience models
+/// (<see cref="RetryModel"/>, <see cref="TimeoutModel"/>, <see cref="CompensationModel"/>,
+/// <see cref="ConfidenceModel"/>) are internal but visible to this test project.
+/// </remarks>
+[Property("Category", "Unit")]
+public sealed class StepExtractorResilienceTests
+{
+    // =========================================================================
+    // Task 002 — WithRetry / WithTimeout
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that <c>.WithRetry(int, TimeSpan)</c> and <c>.WithTimeout(TimeSpan)</c>
+    /// declared in a step's configure lambda populate the step's
+    /// <see cref="RetryModel"/> and <see cref="TimeoutModel"/>.
+    /// </summary>
+    [Test]
+    public async Task WalkInvocationChain_StepWithWithRetryAndTimeout_PopulatesRetryAndTimeoutModels()
+    {
+        // Arrange
+        var stepModels = ParserTestHelper.ExtractStepModels(ResilienceLinearWorkflow);
+
+        // Act
+        var processStep = stepModels.Single(s => s.StepName == "ProcessPayment");
+
+        // Assert - retry policy
+        await Assert.That(processStep.Retry).IsNotNull();
+        await Assert.That(processStep.Retry!.MaxAttempts).IsEqualTo(3);
+        await Assert.That(processStep.Retry!.InitialDelay).IsEqualTo(TimeSpan.FromSeconds(5));
+
+        // Assert - timeout policy
+        await Assert.That(processStep.Timeout).IsNotNull();
+        await Assert.That(processStep.Timeout!.Timeout).IsEqualTo(TimeSpan.FromMinutes(2));
+    }
+
+    /// <summary>
+    /// Verifies that the single-argument <c>.WithRetry(int)</c> overload populates
+    /// <see cref="RetryModel.MaxAttempts"/> with a null <see cref="RetryModel.InitialDelay"/>.
+    /// </summary>
+    [Test]
+    public async Task WalkInvocationChain_StepWithWithRetryNoDelay_PopulatesMaxAttemptsOnly()
+    {
+        // Arrange
+        var stepModels = ParserTestHelper.ExtractStepModels(ResilienceLinearWorkflow);
+
+        // Act
+        var auditStep = stepModels.Single(s => s.StepName == "AuditPayment");
+
+        // Assert
+        await Assert.That(auditStep.Retry).IsNotNull();
+        await Assert.That(auditStep.Retry!.MaxAttempts).IsEqualTo(2);
+        await Assert.That(auditStep.Retry!.InitialDelay).IsNull();
+        await Assert.That(auditStep.Timeout).IsNull();
+    }
+
+    // =========================================================================
+    // Test source workflows
+    // =========================================================================
+
+    /// <summary>
+    /// A linear workflow whose steps declare retry/timeout via the configure lambda.
+    /// </summary>
+    private const string ResilienceLinearWorkflow = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record PaymentState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class ValidatePayment : IWorkflowStep<PaymentState>
+        {
+            public Task<StepResult<PaymentState>> ExecuteAsync(
+                PaymentState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<PaymentState>.FromState(state));
+        }
+
+        public class ProcessPayment : IWorkflowStep<PaymentState>
+        {
+            public Task<StepResult<PaymentState>> ExecuteAsync(
+                PaymentState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<PaymentState>.FromState(state));
+        }
+
+        public class AuditPayment : IWorkflowStep<PaymentState>
+        {
+            public Task<StepResult<PaymentState>> ExecuteAsync(
+                PaymentState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<PaymentState>.FromState(state));
+        }
+
+        public class SendReceipt : IWorkflowStep<PaymentState>
+        {
+            public Task<StepResult<PaymentState>> ExecuteAsync(
+                PaymentState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<PaymentState>.FromState(state));
+        }
+
+        [Workflow("resilience-linear")]
+        public static partial class ResilienceLinearWorkflow
+        {
+            public static WorkflowDefinition<PaymentState> Definition => Workflow<PaymentState>
+                .Create("resilience-linear")
+                .StartWith<ValidatePayment>()
+                .Then<ProcessPayment>(step => step
+                    .WithRetry(3, TimeSpan.FromSeconds(5))
+                    .WithTimeout(TimeSpan.FromMinutes(2)))
+                .Then<AuditPayment>(step => step.WithRetry(2))
+                .Finally<SendReceipt>();
+        }
+        """;
+}

--- a/src/Strategos.Generators.Tests/Helpers/StepExtractorResilienceTests.cs
+++ b/src/Strategos.Generators.Tests/Helpers/StepExtractorResilienceTests.cs
@@ -73,6 +73,26 @@ public sealed class StepExtractorResilienceTests
         await Assert.That(auditStep.Timeout).IsNull();
     }
 
+    /// <summary>
+    /// CodeRabbit F2 (PR #137): a unary-minus retry literal (<c>WithRetry(-1)</c>) must reach the
+    /// IR as a negative <see cref="RetryModel.MaxAttempts"/>, so the downstream AGWF020 diagnostic
+    /// can fire (INV-5). The retry parser previously accepted only a direct numeric literal, so the
+    /// negative literal silently dropped — the whole <see cref="RetryModel"/> vanished.
+    /// </summary>
+    [Test]
+    public async Task WalkInvocationChain_StepWithNegativeRetryLiteral_CarriesNegativeMaxAttempts()
+    {
+        // Arrange
+        var stepModels = ParserTestHelper.ExtractStepModels(NegativeRetryWorkflow);
+
+        // Act
+        var step = stepModels.Single(s => s.StepName == "ProcessPayment");
+
+        // Assert - the negative retry reaches the IR (not dropped)
+        await Assert.That(step.Retry).IsNotNull();
+        await Assert.That(step.Retry!.MaxAttempts).IsEqualTo(-1);
+    }
+
     // =========================================================================
     // Task 003 — Compensate<T> / RequireConfidence / OnLowConfidence
     // =========================================================================
@@ -225,6 +245,57 @@ public sealed class StepExtractorResilienceTests
                     .WithRetry(3, TimeSpan.FromSeconds(5))
                     .WithTimeout(TimeSpan.FromMinutes(2)))
                 .Then<AuditPayment>(step => step.WithRetry(2))
+                .Finally<SendReceipt>();
+        }
+        """;
+
+    /// <summary>
+    /// A linear workflow whose <c>ProcessPayment</c> step declares a unary-minus retry literal
+    /// (<c>WithRetry(-1)</c>), probing F2 (negative retry literal must reach the IR).
+    /// </summary>
+    private const string NegativeRetryWorkflow = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record PaymentState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class ValidatePayment : IWorkflowStep<PaymentState>
+        {
+            public Task<StepResult<PaymentState>> ExecuteAsync(
+                PaymentState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<PaymentState>.FromState(state));
+        }
+
+        public class ProcessPayment : IWorkflowStep<PaymentState>
+        {
+            public Task<StepResult<PaymentState>> ExecuteAsync(
+                PaymentState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<PaymentState>.FromState(state));
+        }
+
+        public class SendReceipt : IWorkflowStep<PaymentState>
+        {
+            public Task<StepResult<PaymentState>> ExecuteAsync(
+                PaymentState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<PaymentState>.FromState(state));
+        }
+
+        [Workflow("negative-retry")]
+        public static partial class NegativeRetryWorkflow
+        {
+            public static WorkflowDefinition<PaymentState> Definition => Workflow<PaymentState>
+                .Create("negative-retry")
+                .StartWith<ValidatePayment>()
+                .Then<ProcessPayment>(step => step.WithRetry(-1))
                 .Finally<SendReceipt>();
         }
         """;

--- a/src/Strategos.Generators.Tests/Helpers/StepExtractorResilienceTests.cs
+++ b/src/Strategos.Generators.Tests/Helpers/StepExtractorResilienceTests.cs
@@ -74,6 +74,23 @@ public sealed class StepExtractorResilienceTests
     }
 
     /// <summary>
+    /// CodeRabbit F3 (PR #137): an extreme timeout literal (<c>WithTimeout(TimeSpan.FromDays(1e18))</c>)
+    /// must NOT crash the parser. <c>TimeSpan.From*</c> throws <c>OverflowException</c> on an
+    /// out-of-range argument; the parser must catch that and return "not parsed" (no timeout) instead
+    /// of letting the exception escape and abort generation.
+    /// </summary>
+    [Test]
+    public async Task WalkInvocationChain_ExtremeTimeoutLiteral_DoesNotThrowAndDropsTimeout()
+    {
+        // Act — must not throw (the parser swallows the TimeSpan.From* overflow).
+        var stepModels = ParserTestHelper.ExtractStepModels(ExtremeTimeoutWorkflow);
+
+        // Assert — the step is still parsed; the out-of-range timeout is simply not carried.
+        var step = stepModels.Single(s => s.StepName == "ProcessPayment");
+        await Assert.That(step.Timeout).IsNull();
+    }
+
+    /// <summary>
     /// CodeRabbit F2 (PR #137): a unary-minus retry literal (<c>WithRetry(-1)</c>) must reach the
     /// IR as a negative <see cref="RetryModel.MaxAttempts"/>, so the downstream AGWF020 diagnostic
     /// can fire (INV-5). The retry parser previously accepted only a direct numeric literal, so the
@@ -245,6 +262,58 @@ public sealed class StepExtractorResilienceTests
                     .WithRetry(3, TimeSpan.FromSeconds(5))
                     .WithTimeout(TimeSpan.FromMinutes(2)))
                 .Then<AuditPayment>(step => step.WithRetry(2))
+                .Finally<SendReceipt>();
+        }
+        """;
+
+    /// <summary>
+    /// A linear workflow whose <c>ProcessPayment</c> step declares an out-of-range timeout literal
+    /// (<c>WithTimeout(TimeSpan.FromDays(1e18))</c>), probing F3 (TimeSpan.From* overflow must not
+    /// crash the parser).
+    /// </summary>
+    private const string ExtremeTimeoutWorkflow = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record PaymentState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class ValidatePayment : IWorkflowStep<PaymentState>
+        {
+            public Task<StepResult<PaymentState>> ExecuteAsync(
+                PaymentState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<PaymentState>.FromState(state));
+        }
+
+        public class ProcessPayment : IWorkflowStep<PaymentState>
+        {
+            public Task<StepResult<PaymentState>> ExecuteAsync(
+                PaymentState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<PaymentState>.FromState(state));
+        }
+
+        public class SendReceipt : IWorkflowStep<PaymentState>
+        {
+            public Task<StepResult<PaymentState>> ExecuteAsync(
+                PaymentState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<PaymentState>.FromState(state));
+        }
+
+        [Workflow("extreme-timeout")]
+        public static partial class ExtremeTimeoutWorkflow
+        {
+            public static WorkflowDefinition<PaymentState> Definition => Workflow<PaymentState>
+                .Create("extreme-timeout")
+                .StartWith<ValidatePayment>()
+                .Then<ProcessPayment>(step => step.WithTimeout(TimeSpan.FromDays(1e18)))
                 .Finally<SendReceipt>();
         }
         """;

--- a/src/Strategos.Generators.Tests/Helpers/StepExtractorResilienceTests.cs
+++ b/src/Strategos.Generators.Tests/Helpers/StepExtractorResilienceTests.cs
@@ -74,6 +74,51 @@ public sealed class StepExtractorResilienceTests
     }
 
     // =========================================================================
+    // Task 003 — Compensate<T> / RequireConfidence / OnLowConfidence
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that <c>.Compensate&lt;TCompensation&gt;()</c> carries the compensation
+    /// step's identity as its fully qualified type name (INV-8: a string descriptor,
+    /// never a CLR <see cref="System.Type"/>).
+    /// </summary>
+    [Test]
+    public async Task WalkInvocationChain_CompensateOfT_CarriesCompensationStepSymbolKey()
+    {
+        // Arrange
+        var stepModels = ParserTestHelper.ExtractStepModels(ResilienceCompensationConfidenceWorkflow);
+
+        // Act
+        var assessStep = stepModels.Single(s => s.StepName == "AssessClaim");
+
+        // Assert
+        await Assert.That(assessStep.Compensation).IsNotNull();
+        await Assert.That(assessStep.Compensation!.CompensationStepTypeName)
+            .IsEqualTo("TestNamespace.RollbackAssessment");
+        await Assert.That(assessStep.Compensation!.RequiredOnFailure).IsTrue();
+    }
+
+    /// <summary>
+    /// Verifies that <c>.RequireConfidence(double)</c> + <c>.OnLowConfidence(alt =&gt; alt.Then&lt;T&gt;())</c>
+    /// populate the step's <see cref="ConfidenceModel"/> with the threshold and the
+    /// low-confidence handler's step identifier.
+    /// </summary>
+    [Test]
+    public async Task WalkInvocationChain_RequireConfidenceOnLowConfidence_PopulatesConfidenceModel()
+    {
+        // Arrange
+        var stepModels = ParserTestHelper.ExtractStepModels(ResilienceCompensationConfidenceWorkflow);
+
+        // Act
+        var assessStep = stepModels.Single(s => s.StepName == "AssessClaim");
+
+        // Assert
+        await Assert.That(assessStep.Confidence).IsNotNull();
+        await Assert.That(assessStep.Confidence!.Threshold).IsEqualTo(0.85);
+        await Assert.That(assessStep.Confidence!.OnLowConfidenceHandlerId).IsEqualTo("HumanReview");
+    }
+
+    // =========================================================================
     // Test source workflows
     // =========================================================================
 
@@ -134,6 +179,75 @@ public sealed class StepExtractorResilienceTests
                     .WithTimeout(TimeSpan.FromMinutes(2)))
                 .Then<AuditPayment>(step => step.WithRetry(2))
                 .Finally<SendReceipt>();
+        }
+        """;
+
+    /// <summary>
+    /// A workflow whose step declares compensation and confidence gating via the
+    /// configure lambda, exercising <c>Compensate&lt;T&gt;</c> (FQN), <c>RequireConfidence</c>,
+    /// and <c>OnLowConfidence</c>.
+    /// </summary>
+    private const string ResilienceCompensationConfidenceWorkflow = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record ClaimState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class IntakeClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class AssessClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class RollbackAssessment : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class HumanReview : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class SettleClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        [Workflow("resilience-claim")]
+        public static partial class ResilienceClaimWorkflow
+        {
+            public static WorkflowDefinition<ClaimState> Definition => Workflow<ClaimState>
+                .Create("resilience-claim")
+                .StartWith<IntakeClaim>()
+                .Then<AssessClaim>(step => step
+                    .RequireConfidence(0.85)
+                    .OnLowConfidence(alt => alt.Then<HumanReview>())
+                    .Compensate<RollbackAssessment>())
+                .Finally<SettleClaim>();
         }
         """;
 }

--- a/src/Strategos.Generators.Tests/Helpers/StepExtractorResilienceTests.cs
+++ b/src/Strategos.Generators.Tests/Helpers/StepExtractorResilienceTests.cs
@@ -119,6 +119,53 @@ public sealed class StepExtractorResilienceTests
     }
 
     // =========================================================================
+    // Task 004 — loop + fork-path parse parity
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that resilience config declared on a step inside a <c>RepeatUntil</c>
+    /// loop body is parsed identically to a top-level step (loop parse parity).
+    /// </summary>
+    [Test]
+    public async Task WalkInvocationChain_WithRetryInsideLoopStep_PopulatesRetryModel()
+    {
+        // Arrange
+        var stepModels = ParserTestHelper.ExtractStepModels(ResilienceLoopWorkflow);
+
+        // Act - the loop body step is prefixed with its loop name
+        var refineStep = stepModels.Single(s => s.StepName == "RefineDraft");
+
+        // Assert
+        await Assert.That(refineStep.LoopName).IsEqualTo("Refinement");
+        await Assert.That(refineStep.Retry).IsNotNull();
+        await Assert.That(refineStep.Retry!.MaxAttempts).IsEqualTo(4);
+        await Assert.That(refineStep.Retry!.InitialDelay).IsEqualTo(TimeSpan.FromSeconds(3));
+        await Assert.That(refineStep.Timeout).IsNotNull();
+        await Assert.That(refineStep.Timeout!.Timeout).IsEqualTo(TimeSpan.FromMinutes(1));
+    }
+
+    /// <summary>
+    /// Verifies that resilience config declared on a step inside a <c>Fork</c> path
+    /// is parsed identically to a top-level step (fork-path parse parity).
+    /// </summary>
+    [Test]
+    public async Task WalkInvocationChain_WithRetryInsideForkPathStep_PopulatesRetryModel()
+    {
+        // Arrange
+        var stepModels = ParserTestHelper.ExtractStepModels(ResilienceForkWorkflow);
+
+        // Act
+        var paymentStep = stepModels.Single(s => s.StepName == "ChargeCard");
+
+        // Assert
+        await Assert.That(paymentStep.Retry).IsNotNull();
+        await Assert.That(paymentStep.Retry!.MaxAttempts).IsEqualTo(5);
+        await Assert.That(paymentStep.Retry!.InitialDelay).IsEqualTo(TimeSpan.FromSeconds(2));
+        await Assert.That(paymentStep.Timeout).IsNotNull();
+        await Assert.That(paymentStep.Timeout!.Timeout).IsEqualTo(TimeSpan.FromSeconds(30));
+    }
+
+    // =========================================================================
     // Test source workflows
     // =========================================================================
 
@@ -248,6 +295,135 @@ public sealed class StepExtractorResilienceTests
                     .OnLowConfidence(alt => alt.Then<HumanReview>())
                     .Compensate<RollbackAssessment>())
                 .Finally<SettleClaim>();
+        }
+        """;
+
+    /// <summary>
+    /// A workflow with a <c>RepeatUntil</c> loop whose body step declares retry/timeout via
+    /// the configure lambda, exercising loop-body resilience parse parity.
+    /// </summary>
+    private const string ResilienceLoopWorkflow = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record DraftState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+            public decimal QualityScore { get; init; }
+        }
+
+        public class StartDraft : IWorkflowStep<DraftState>
+        {
+            public Task<StepResult<DraftState>> ExecuteAsync(
+                DraftState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<DraftState>.FromState(state));
+        }
+
+        public class RefineDraft : IWorkflowStep<DraftState>
+        {
+            public Task<StepResult<DraftState>> ExecuteAsync(
+                DraftState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<DraftState>.FromState(state));
+        }
+
+        public class PublishDraft : IWorkflowStep<DraftState>
+        {
+            public Task<StepResult<DraftState>> ExecuteAsync(
+                DraftState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<DraftState>.FromState(state));
+        }
+
+        [Workflow("resilience-loop")]
+        public static partial class ResilienceLoopWorkflow
+        {
+            public static WorkflowDefinition<DraftState> Definition => Workflow<DraftState>
+                .Create("resilience-loop")
+                .StartWith<StartDraft>()
+                .RepeatUntil(
+                    condition: state => state.QualityScore >= 0.9m,
+                    loopName: "Refinement",
+                    body: loop => loop
+                        .Then<RefineDraft>(step => step
+                            .WithRetry(4, TimeSpan.FromSeconds(3))
+                            .WithTimeout(TimeSpan.FromMinutes(1))),
+                    maxIterations: 5)
+                .Finally<PublishDraft>();
+        }
+        """;
+
+    /// <summary>
+    /// A workflow with a <c>Fork</c> whose path step declares retry/timeout via the configure
+    /// lambda, exercising fork-path resilience parse parity.
+    /// </summary>
+    private const string ResilienceForkWorkflow = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record CheckoutState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class ValidateCart : IWorkflowStep<CheckoutState>
+        {
+            public Task<StepResult<CheckoutState>> ExecuteAsync(
+                CheckoutState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<CheckoutState>.FromState(state));
+        }
+
+        public class ChargeCard : IWorkflowStep<CheckoutState>
+        {
+            public Task<StepResult<CheckoutState>> ExecuteAsync(
+                CheckoutState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<CheckoutState>.FromState(state));
+        }
+
+        public class ReserveStock : IWorkflowStep<CheckoutState>
+        {
+            public Task<StepResult<CheckoutState>> ExecuteAsync(
+                CheckoutState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<CheckoutState>.FromState(state));
+        }
+
+        public class FinalizeOrder : IWorkflowStep<CheckoutState>
+        {
+            public Task<StepResult<CheckoutState>> ExecuteAsync(
+                CheckoutState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<CheckoutState>.FromState(state));
+        }
+
+        public class CompleteCheckout : IWorkflowStep<CheckoutState>
+        {
+            public Task<StepResult<CheckoutState>> ExecuteAsync(
+                CheckoutState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<CheckoutState>.FromState(state));
+        }
+
+        [Workflow("resilience-fork")]
+        public static partial class ResilienceForkWorkflow
+        {
+            public static WorkflowDefinition<CheckoutState> Definition => Workflow<CheckoutState>
+                .Create("resilience-fork")
+                .StartWith<ValidateCart>()
+                .Fork(
+                    path => path.Then<ChargeCard>(step => step
+                        .WithRetry(5, TimeSpan.FromSeconds(2))
+                        .WithTimeout(TimeSpan.FromSeconds(30))),
+                    path => path.Then<ReserveStock>())
+                .Join<FinalizeOrder>()
+                .Finally<CompleteCheckout>();
         }
         """;
 }

--- a/src/Strategos.Generators.Tests/InvariantGuardTests.cs
+++ b/src/Strategos.Generators.Tests/InvariantGuardTests.cs
@@ -1,0 +1,132 @@
+// -----------------------------------------------------------------------
+// <copyright file="InvariantGuardTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Reflection;
+
+namespace Strategos.Generators.Tests;
+
+/// <summary>
+/// Standing structural regression guards for the generator's load-bearing
+/// invariants. These execute by reflecting over the shipped
+/// <c>Strategos.Generators</c> assembly, so they fail the build the moment a
+/// future change erodes an invariant rather than at some distant integration
+/// point.
+/// </summary>
+public class InvariantGuardTests
+{
+    private static Assembly GeneratorsAssembly => typeof(WorkflowIncrementalGenerator).Assembly;
+
+    /// <summary>
+    /// INV-6 (sealed-by-default), DR-10 step-resilience surface: the resilience
+    /// IR models, the saga resilience-component emitters, and the resilience
+    /// parse helpers introduced by the step-resilience epic (#135) must all be
+    /// sealed. The IR records carry structural equality that the incremental
+    /// generator pipeline relies on for cache-keying, and the emitters/helpers
+    /// are leaf collaborators with no intended subclassing; a future edit that
+    /// unseals one fails the build mechanically.
+    /// </summary>
+    /// <remarks>
+    /// Resolved by name (not <c>typeof</c>) so the <c>internal</c> emitters and
+    /// helpers are covered uniformly — the assembly exposes its internals to this
+    /// test project, but name-resolution keeps the guard list flat and explicit.
+    /// A C# <c>static class</c> compiles to <c>abstract sealed</c>, so the
+    /// <see cref="Type.IsSealed"/> check covers the static helpers too.
+    /// </remarks>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task InvariantGuard_ResilienceIrAndEmitterTypes_AreSealed()
+    {
+        var names = new[]
+        {
+            // Resilience IR models (Models/ResilienceModels.cs) — sealed records.
+            "Strategos.Generators.Models.RetryModel",
+            "Strategos.Generators.Models.TimeoutModel",
+            "Strategos.Generators.Models.CompensationModel",
+            "Strategos.Generators.Models.ConfidenceModel",
+
+            // New saga resilience-component emitters — sealed classes.
+            "Strategos.Generators.Emitters.Saga.SagaTimeoutComponentEmitter",
+            "Strategos.Generators.Emitters.Saga.SagaCompensationComponentEmitter",
+
+            // New resilience parse helpers — sealed (static) classes.
+            "Strategos.Generators.Helpers.ResilienceParser",
+            "Strategos.Generators.Helpers.FailureHandlerExtractor",
+        };
+
+        var offenders = new List<string>();
+        foreach (var name in names)
+        {
+            var type = GeneratorsAssembly.GetType(name);
+            if (type is null)
+            {
+                offenders.Add($"{name} (type not found)");
+                continue;
+            }
+
+            if (!type.IsInterface && !type.IsSealed)
+            {
+                offenders.Add($"{type.FullName} is not sealed");
+            }
+        }
+
+        await Assert.That(offenders).IsEmpty();
+    }
+
+    /// <summary>
+    /// INV-6 (immutable IR half), DR-10: the resilience IR models must expose no
+    /// externally-settable instance property — every writable member must be
+    /// <c>init</c>-only (positional-record params lower to init-only setters).
+    /// A mutable IR member would let a downstream pipeline stage rewrite the IR
+    /// after parse, breaking the deterministic parse → emit contract the
+    /// incremental generator depends on.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task InvariantGuard_ResilienceIrModels_HaveOnlyInitOnlyMembers()
+    {
+        var names = new[]
+        {
+            "Strategos.Generators.Models.RetryModel",
+            "Strategos.Generators.Models.TimeoutModel",
+            "Strategos.Generators.Models.CompensationModel",
+            "Strategos.Generators.Models.ConfidenceModel",
+        };
+
+        var offenders = new List<string>();
+        foreach (var name in names)
+        {
+            var type = GeneratorsAssembly.GetType(name);
+            if (type is null)
+            {
+                offenders.Add($"{name} (type not found)");
+                continue;
+            }
+
+            const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+            foreach (var prop in type.GetProperties(flags).Where(p => p.DeclaringType == type))
+            {
+                var setter = prop.SetMethod;
+                if (setter is null)
+                {
+                    continue;
+                }
+
+                // An init-only setter carries the IsExternalInit modreq on its
+                // return parameter; a plain mutable setter does not.
+                var isInitOnly = setter.ReturnParameter
+                    .GetRequiredCustomModifiers()
+                    .Any(m => m.FullName == "System.Runtime.CompilerServices.IsExternalInit");
+
+                if (!isInitOnly)
+                {
+                    offenders.Add($"{type.FullName}.{prop.Name} has a mutable (non-init) setter");
+                }
+            }
+        }
+
+        await Assert.That(offenders).IsEmpty();
+    }
+}

--- a/src/Strategos.Generators.Tests/Models/StepModelResilienceTests.cs
+++ b/src/Strategos.Generators.Tests/Models/StepModelResilienceTests.cs
@@ -1,0 +1,88 @@
+// -----------------------------------------------------------------------
+// <copyright file="StepModelResilienceTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Models;
+
+namespace Strategos.Generators.Tests.Models;
+
+/// <summary>
+/// Unit tests verifying that <see cref="StepModel"/> carries the resilience IR
+/// (<see cref="RetryModel"/>, <see cref="TimeoutModel"/>, <see cref="CompensationModel"/>,
+/// <see cref="ConfidenceModel"/>) from construction through to emit-time.
+/// </summary>
+[Property("Category", "Unit")]
+public sealed class StepModelResilienceTests
+{
+    /// <summary>
+    /// Verifies that a <see cref="StepModel"/> created with resilience configuration
+    /// carries back the retry, timeout, compensation, and confidence models intact.
+    /// </summary>
+    [Test]
+    public async Task StepModel_WithResilienceConfig_CarriesRetryTimeoutCompensationConfidence()
+    {
+        // Arrange
+        var retry = new RetryModel(
+            MaxAttempts: 3,
+            InitialDelay: TimeSpan.FromSeconds(2),
+            BackoffMultiplier: 2.0,
+            MaxDelay: TimeSpan.FromMinutes(1),
+            UseJitter: true);
+        var timeout = new TimeoutModel(TimeSpan.FromSeconds(30));
+        var compensation = new CompensationModel(
+            CompensationStepTypeName: "MyApp.Steps.RefundPayment",
+            RequiredOnFailure: true);
+        var confidence = new ConfidenceModel(
+            Threshold: 0.8,
+            OnLowConfidenceHandlerId: "EscalateToHuman");
+
+        // Act
+        var model = StepModel.Create(
+            stepName: "ProcessPayment",
+            stepTypeName: "MyApp.Steps.ProcessPayment",
+            retry: retry,
+            timeout: timeout,
+            compensation: compensation,
+            confidence: confidence);
+
+        // Assert
+        await Assert.That(model.Retry).IsEqualTo(retry);
+        await Assert.That(model.Retry!.MaxAttempts).IsEqualTo(3);
+        await Assert.That(model.Retry!.InitialDelay).IsEqualTo(TimeSpan.FromSeconds(2));
+        await Assert.That(model.Retry!.BackoffMultiplier).IsEqualTo(2.0);
+        await Assert.That(model.Retry!.MaxDelay).IsEqualTo(TimeSpan.FromMinutes(1));
+        await Assert.That(model.Retry!.UseJitter).IsTrue();
+
+        await Assert.That(model.Timeout).IsEqualTo(timeout);
+        await Assert.That(model.Timeout!.Timeout).IsEqualTo(TimeSpan.FromSeconds(30));
+
+        await Assert.That(model.Compensation).IsEqualTo(compensation);
+        await Assert.That(model.Compensation!.CompensationStepTypeName).IsEqualTo("MyApp.Steps.RefundPayment");
+        await Assert.That(model.Compensation!.RequiredOnFailure).IsTrue();
+
+        await Assert.That(model.Confidence).IsEqualTo(confidence);
+        await Assert.That(model.Confidence!.Threshold).IsEqualTo(0.8);
+        await Assert.That(model.Confidence!.OnLowConfidenceHandlerId).IsEqualTo("EscalateToHuman");
+    }
+
+    /// <summary>
+    /// Verifies that the four resilience fields default to null when not supplied,
+    /// so existing call sites that omit resilience config are unaffected.
+    /// </summary>
+    [Test]
+    public async Task StepModel_WithoutResilienceConfig_DefaultsToNull()
+    {
+        // Arrange & Act
+        var model = StepModel.Create(
+            stepName: "ProcessPayment",
+            stepTypeName: "MyApp.Steps.ProcessPayment");
+
+        // Assert
+        await Assert.That(model.Retry).IsNull();
+        await Assert.That(model.Timeout).IsNull();
+        await Assert.That(model.Compensation).IsNull();
+        await Assert.That(model.Confidence).IsNull();
+    }
+}

--- a/src/Strategos.Generators.Tests/Models/WorkflowModelFactoryTests.cs
+++ b/src/Strategos.Generators.Tests/Models/WorkflowModelFactoryTests.cs
@@ -236,4 +236,58 @@ public sealed class WorkflowModelFactoryTests
         // Assert
         await Assert.That(exception).IsNotNull();
     }
+
+    /// <summary>
+    /// F4 (CodeRabbit / epic #135): the <see cref="WorkflowModel.Create"/> factory
+    /// must thread <c>confidenceHandlerStepNames</c> (DR-5) so a model built through
+    /// the factory carries the same handler identity as one built via the primary
+    /// constructor. Before the fix the parameter was silently dropped, leaving
+    /// <see cref="WorkflowModel.HasConfidenceHandlers"/> false and
+    /// <see cref="WorkflowModel.IsConfidenceHandlerStep"/> wrong for every
+    /// <c>Create</c>-built model.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Create_WithConfidenceHandlerStepNames_PreservesHandlerMetadata()
+    {
+        // Arrange
+        var stepNames = new[] { "ValidateOrder", "ClassifyIntent", "HumanReview", "SendConfirmation" };
+        var confidenceHandlerStepNames = new[] { "HumanReview" };
+
+        // Act
+        var model = WorkflowModel.Create(
+            workflowName: "process-order",
+            pascalName: "ProcessOrder",
+            @namespace: "MyCompany.Workflows",
+            stepNames: stepNames,
+            confidenceHandlerStepNames: confidenceHandlerStepNames);
+
+        // Assert — the DR-5 handler identity survives the factory.
+        await Assert.That(model.ConfidenceHandlerStepNames).IsNotNull();
+        await Assert.That(model.HasConfidenceHandlers).IsTrue();
+        await Assert.That(model.IsConfidenceHandlerStep("HumanReview")).IsTrue();
+        await Assert.That(model.IsConfidenceHandlerStep("ClassifyIntent")).IsFalse();
+    }
+
+    /// <summary>
+    /// F4 regression guard: with no confidence handler step names supplied a
+    /// <c>Create</c>-built model reports no confidence handlers (the optional
+    /// parameter defaults to null, matching the constructor default).
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Create_WithoutConfidenceHandlerStepNames_ReportsNoConfidenceHandlers()
+    {
+        // Arrange & Act
+        var model = WorkflowModel.Create(
+            workflowName: "process-order",
+            pascalName: "ProcessOrder",
+            @namespace: "MyCompany.Workflows",
+            stepNames: new[] { "ValidateOrder", "SendConfirmation" });
+
+        // Assert
+        await Assert.That(model.ConfidenceHandlerStepNames).IsNull();
+        await Assert.That(model.HasConfidenceHandlers).IsFalse();
+        await Assert.That(model.IsConfidenceHandlerStep("ValidateOrder")).IsFalse();
+    }
 }

--- a/src/Strategos.Generators.Tests/SagaEmitterIntegrationTests.cs
+++ b/src/Strategos.Generators.Tests/SagaEmitterIntegrationTests.cs
@@ -75,7 +75,11 @@ public class SagaEmitterIntegrationTests
         var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
 
         // Assert
-        await Assert.That(sagaSource).Contains("[Identity]");
+        // Fully qualified [JasperFx.Identity] (the Marten document-identity
+        // attribute) to avoid CS0616: the short [Identity] form collides with
+        // the Strategos.Identity namespace in consumers that reference
+        // Strategos.Identity.Abstractions.
+        await Assert.That(sagaSource).Contains("[JasperFx.Identity]");
     }
 
     /// <summary>

--- a/src/Strategos.Generators/Diagnostics/WorkflowDiagnostics.cs
+++ b/src/Strategos.Generators/Diagnostics/WorkflowDiagnostics.cs
@@ -177,4 +177,88 @@ internal static class WorkflowDiagnostics
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description: "Event-sourced workflows require a state type to generate handlers that call State.ApplyEvent(evt). Ensure the workflow uses Workflow<TState>.Create() with a state type that implements IEventSourcedState<TState>.");
+
+    /// <summary>
+    /// Compensation step is not a workflow step (DR-8 / INV-5).
+    /// </summary>
+    /// <remarks>
+    /// Reported when a step's <c>Compensate&lt;T&gt;</c> names a type that does not implement
+    /// <c>IWorkflowStep&lt;TState&gt;</c>. The DSL's generic constraint also rejects this at the
+    /// C# call site; the diagnostic gives a stable, suppressible id with a clearer message.
+    /// </remarks>
+    public static readonly DiagnosticDescriptor CompensateNotAStep = new(
+        id: AgwfCodes.CompensateNotAStep,
+        title: "Compensation step is not a workflow step",
+        messageFormat: "Step '{0}' in workflow '{1}' compensates with '{2}', which does not implement IWorkflowStep<TState>. Compensation types must be a registered workflow step.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "A compensation (rollback) step declared via Compensate<T>() must be a registered workflow step implementing IWorkflowStep<TState> so it can be lowered into the saga compensation chain.");
+
+    /// <summary>
+    /// Confidence threshold out of range (DR-8 / INV-5).
+    /// </summary>
+    /// <remarks>
+    /// Reported when <c>RequireConfidence(x)</c> is called with <c>x</c> outside the inclusive
+    /// range [0.0, 1.0]. Mirrors the builder-runtime <see cref="System.ArgumentOutOfRangeException"/>
+    /// so consumers get the same signal at compile time and can suppress it by id.
+    /// </remarks>
+    public static readonly DiagnosticDescriptor ConfidenceThresholdOutOfRange = new(
+        id: AgwfCodes.ConfidenceThresholdOutOfRange,
+        title: "Confidence threshold out of range",
+        messageFormat: "Step '{0}' in workflow '{1}' calls RequireConfidence({2}). The threshold must be between 0.0 and 1.0 inclusive.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "A confidence threshold expresses a probability and must lie in [0.0, 1.0]. Values outside this range cannot gate step results meaningfully.");
+
+    /// <summary>
+    /// RequireConfidence without OnLowConfidence handler (DR-8 / INV-5).
+    /// </summary>
+    /// <remarks>
+    /// Reported when a step declares <c>RequireConfidence</c> but no corresponding
+    /// <c>OnLowConfidence</c> handler. Without a handler, a low-confidence result has no
+    /// routing path. A warning because some callers may intentionally fail-fast on low confidence.
+    /// </remarks>
+    public static readonly DiagnosticDescriptor RequireConfidenceWithoutHandler = new(
+        id: AgwfCodes.RequireConfidenceWithoutHandler,
+        title: "RequireConfidence without OnLowConfidence handler",
+        messageFormat: "Step '{0}' in workflow '{1}' calls RequireConfidence but declares no OnLowConfidence handler. Add OnLowConfidence(alt => ...) so low-confidence results have a routing path.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A step that gates on confidence should declare an OnLowConfidence handler so that results below the threshold are routed somewhere. This is a warning because a caller may intentionally fail-fast on low confidence.");
+
+    /// <summary>
+    /// Retry maxAttempts below one (DR-8 / INV-5).
+    /// </summary>
+    /// <remarks>
+    /// Reported when <c>WithRetry</c> is configured with <c>maxAttempts &lt; 1</c>. Mirrors the
+    /// builder-runtime <see cref="System.ArgumentOutOfRangeException"/> so consumers get the same
+    /// signal at compile time and can suppress it by id.
+    /// </remarks>
+    public static readonly DiagnosticDescriptor RetryMaxAttemptsBelowOne = new(
+        id: AgwfCodes.RetryMaxAttemptsBelowOne,
+        title: "Retry maxAttempts below one",
+        messageFormat: "Step '{0}' in workflow '{1}' configures WithRetry({2}). The maxAttempts value must be at least 1.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "A retry policy must allow at least one attempt. A maxAttempts value below 1 would prevent the step from ever executing.");
+
+    /// <summary>
+    /// Non-positive timeout (DR-8 / INV-5).
+    /// </summary>
+    /// <remarks>
+    /// Reported when <c>WithTimeout</c> is configured with a non-positive duration
+    /// (zero or negative). A non-positive deadline would expire immediately or never apply.
+    /// </remarks>
+    public static readonly DiagnosticDescriptor NonPositiveTimeout = new(
+        id: AgwfCodes.NonPositiveTimeout,
+        title: "Non-positive timeout",
+        messageFormat: "Step '{0}' in workflow '{1}' configures WithTimeout with a non-positive duration. The timeout must be greater than zero.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "A step timeout must be a positive duration. A zero or negative timeout cannot bound the step's execution meaningfully.");
 }

--- a/src/Strategos.Generators/Emitters/CommandsEmitter.cs
+++ b/src/Strategos.Generators/Emitters/CommandsEmitter.cs
@@ -216,6 +216,17 @@ internal static class CommandsEmitter
         {
             EmitFailureHandlerCommands(sb, model, model.FailureHandlers!);
         }
+        else if (model.HasCompensation)
+        {
+            // Compensation (DR-3) reuses the same Trigger{Pascal}FailureHandlerCommand
+            // as the saga entry point but, unlike OnFailure, emits NO per-handler step
+            // commands here — the compensation step's worker command is produced via
+            // model.Steps (it is folded into the step types). Guarded with 'else' so a
+            // workflow that has BOTH OnFailure and compensation emits the trigger
+            // command exactly once.
+            sb.AppendLine();
+            EmitTriggerFailureHandlerCommand(sb, model);
+        }
 
         return sb.ToString();
     }

--- a/src/Strategos.Generators/Emitters/ContextAssemblerEmitter.cs
+++ b/src/Strategos.Generators/Emitters/ContextAssemblerEmitter.cs
@@ -54,6 +54,7 @@ internal static class ContextAssemblerEmitter
             "System.Linq",
             "System.Threading",
             "System.Threading.Tasks",
+            "Strategos.Agents.Abstractions",
             "Strategos.Agents.Models",
             "Strategos.Ontology.ObjectSets",
             "Strategos.Steps");
@@ -258,12 +259,13 @@ internal static class ContextAssemblerEmitter
 
         sb.AppendLine($"        var {resultsVarName} = await _objectSetProvider.ExecuteSimilarityAsync<{retrieval.CollectionTypeName}>({resultsVarName}Expression, cancellationToken);");
 
-        // Map to RetrievalResult list
-        sb.AppendLine($"        var {resultsVarName}List = {resultsVarName}.Items.Select((item, i) => new RetrievalResult");
-        sb.AppendLine("        {");
-        sb.AppendLine("            Content = item.ToString(),");
-        sb.AppendLine($"            Score = {resultsVarName}.Scores[i],");
-        sb.AppendLine("        }).ToList();");
+        // Map to RetrievalResult list. RetrievalResult is a POSITIONAL record
+        // (Content, Score, ...): construct it positionally, not with an object
+        // initializer (Content is a required ctor parameter). item.ToString() is
+        // string? so coalesce to keep the non-nullable Content satisfied.
+        sb.AppendLine($"        var {resultsVarName}List = {resultsVarName}.Items.Select((item, i) => new RetrievalResult(");
+        sb.AppendLine("            item.ToString() ?? string.Empty,");
+        sb.AppendLine($"            {resultsVarName}.Scores[i])).ToList();");
         sb.AppendLine($"        contextBuilder.AddRetrievalContext(\"{retrieval.CollectionTypeName}\", {resultsVarName}List);");
     }
 

--- a/src/Strategos.Generators/Emitters/ContextAssemblerEmitter.cs
+++ b/src/Strategos.Generators/Emitters/ContextAssemblerEmitter.cs
@@ -32,6 +32,16 @@ internal static class ContextAssemblerEmitter
     {
         ThrowHelper.ThrowIfNull(model, nameof(model));
 
+        // Find steps with context up front: when none declared .WithContext(...)
+        // there is nothing to lower, so return empty and let the generator skip
+        // adding an assembler file entirely (a context-free workflow keeps its
+        // prior generated-file set unchanged).
+        var stepsWithContext = GetStepsWithContext(model);
+        if (stepsWithContext.Count == 0)
+        {
+            return string.Empty;
+        }
+
         var sb = new StringBuilder();
 
         // File header
@@ -51,8 +61,7 @@ internal static class ContextAssemblerEmitter
         // Namespace
         FileHeaderHelper.AppendNamespace(sb, model.Namespace);
 
-        // Find steps with context and generate assemblers for each
-        var stepsWithContext = GetStepsWithContext(model);
+        // Generate an assembler for each step that declared context.
         var isFirst = true;
 
         foreach (var step in stepsWithContext)

--- a/src/Strategos.Generators/Emitters/ExtensionsEmitter.cs
+++ b/src/Strategos.Generators/Emitters/ExtensionsEmitter.cs
@@ -190,20 +190,42 @@ internal static class ExtensionsEmitter
         // .WithContext(...); the step's worker handler takes it as a constructor
         // dependency. A retrieval-bearing assembler additionally depends on
         // IObjectSetProvider, which the ontology host registers separately.
+        //
+        // F3: the step-type + worker-handler registration above explicitly
+        // enumerates branch (model.Branches) steps as a separate source, so the
+        // assembler registration mirrors that source coverage to keep parity and
+        // stay robust if a branch/failure-handler step ever lives ONLY in those
+        // collections. The context flag lives on the StepModel (model.Steps), so we
+        // first build a name -> has-context lookup, then register the assembler for
+        // every context-bearing step reached through ANY source. The shared
+        // registeredAssemblers set guarantees each assembler is registered exactly
+        // once (no duplicate AddTransient), so this is idempotent: a step already
+        // covered by the model.Steps pass is never re-registered from the branch /
+        // failure-handler pass.
         if (model.Steps is not null)
         {
-            var registeredAssemblers = new HashSet<string>(StringComparer.Ordinal);
-            var emittedHeader = false;
+            var stepsWithContext = new HashSet<string>(StringComparer.Ordinal);
             foreach (var step in model.Steps)
             {
-                if (step.Context is null || step.Context.Sources.Count == 0)
+                if (step.Context is not null && step.Context.Sources.Count > 0)
                 {
-                    continue;
+                    stepsWithContext.Add(step.StepName);
+                }
+            }
+
+            var registeredAssemblers = new HashSet<string>(StringComparer.Ordinal);
+            var emittedHeader = false;
+
+            void RegisterAssembler(string stepName)
+            {
+                if (!stepsWithContext.Contains(stepName))
+                {
+                    return;
                 }
 
-                if (!registeredAssemblers.Add(step.StepName))
+                if (!registeredAssemblers.Add(stepName))
                 {
-                    continue;
+                    return;
                 }
 
                 if (!emittedHeader)
@@ -213,7 +235,42 @@ internal static class ExtensionsEmitter
                     emittedHeader = true;
                 }
 
-                sb.AppendLine($"        services.AddTransient<{step.StepName}ContextAssembler>();");
+                sb.AppendLine($"        services.AddTransient<{stepName}ContextAssembler>();");
+            }
+
+            // Primary source: every lowered step model (main flow, branch,
+            // failure-handler, low-confidence, compensation steps are all folded in).
+            foreach (var step in model.Steps)
+            {
+                RegisterAssembler(step.StepName);
+            }
+
+            // Mirror the step-type/worker registration sources so the assembler
+            // registration can never silently drop a context-bearing branch or
+            // failure-handler step (idempotent via registeredAssemblers).
+            if (model.Branches is not null)
+            {
+                foreach (var branch in model.Branches)
+                {
+                    foreach (var branchCase in branch.Cases)
+                    {
+                        foreach (var stepName in branchCase.StepNames)
+                        {
+                            RegisterAssembler(stepName);
+                        }
+                    }
+                }
+            }
+
+            if (model.FailureHandlers is not null)
+            {
+                foreach (var handler in model.FailureHandlers)
+                {
+                    foreach (var stepName in handler.StepNames)
+                    {
+                        RegisterAssembler(stepName);
+                    }
+                }
             }
         }
 

--- a/src/Strategos.Generators/Emitters/ExtensionsEmitter.cs
+++ b/src/Strategos.Generators/Emitters/ExtensionsEmitter.cs
@@ -186,6 +186,37 @@ internal static class ExtensionsEmitter
             }
         }
 
+        // Register context assemblers (DR-6). One per step that declared
+        // .WithContext(...); the step's worker handler takes it as a constructor
+        // dependency. A retrieval-bearing assembler additionally depends on
+        // IObjectSetProvider, which the ontology host registers separately.
+        if (model.Steps is not null)
+        {
+            var registeredAssemblers = new HashSet<string>(StringComparer.Ordinal);
+            var emittedHeader = false;
+            foreach (var step in model.Steps)
+            {
+                if (step.Context is null || step.Context.Sources.Count == 0)
+                {
+                    continue;
+                }
+
+                if (!registeredAssemblers.Add(step.StepName))
+                {
+                    continue;
+                }
+
+                if (!emittedHeader)
+                {
+                    sb.AppendLine();
+                    sb.AppendLine("        // Register context assemblers");
+                    emittedHeader = true;
+                }
+
+                sb.AppendLine($"        services.AddTransient<{step.StepName}ContextAssembler>();");
+            }
+        }
+
         sb.AppendLine();
 
         // Force evaluation of workflow definition to register loop conditions

--- a/src/Strategos.Generators/Emitters/PhaseEnumEmitter.cs
+++ b/src/Strategos.Generators/Emitters/PhaseEnumEmitter.cs
@@ -86,6 +86,15 @@ internal static class PhaseEnumEmitter
             EmitFailureHandlerPhases(sb, model.FailureHandlers!);
         }
 
+        // Compensation phase (DR-3): the in-flight phase while a step's rollback
+        // (.Compensate<T>()) runs, before the saga settles into terminal Failed.
+        if (model.HasCompensation)
+        {
+            sb.AppendLine("    /// <summary>Running a step's compensation (rollback) handler.</summary>");
+            sb.AppendLine("    Compensating,");
+            sb.AppendLine();
+        }
+
         // Standard terminal phases
         sb.AppendLine("    /// <summary>Workflow completed successfully.</summary>");
         sb.AppendLine("    Completed,");

--- a/src/Strategos.Generators/Emitters/Saga/SagaCompensationComponentEmitter.cs
+++ b/src/Strategos.Generators/Emitters/Saga/SagaCompensationComponentEmitter.cs
@@ -56,6 +56,15 @@ namespace Strategos.Generators.Emitters.Saga;
 /// types are declared, the trigger handler routes to the correct rollback worker on
 /// the <c>FailedStepName</c> carried by the trigger command.
 /// </para>
+/// <para>
+/// <b>Reuse of a main-flow step as a compensation target:</b> a compensation step
+/// TYPE may also appear as a normal main-flow step (rolling back to a step the happy
+/// path also runs). The main-flow completed handler (<see cref="SagaStepHandlersEmitter"/>)
+/// already declares that step's <c>Handle({Comp}Completed)</c> overload, so this
+/// emitter SKIPS the duplicate to avoid a CS0111 collision; the trigger/dispatch
+/// path is unaffected because the rollback's worker command is the same one the
+/// folded main-flow step model already produced.
+/// </para>
 /// </remarks>
 internal sealed class SagaCompensationComponentEmitter : ISagaComponentEmitter
 {
@@ -85,12 +94,29 @@ internal sealed class SagaCompensationComponentEmitter : ISagaComponentEmitter
         sb.AppendLine();
         EmitTriggerHandler(sb, model, compensatedSteps);
 
+        // A compensation step TYPE may also be a normal main-flow step (it is valid
+        // to roll back to a step the happy path already runs). In that case the
+        // main-flow completed handler (SagaStepHandlersEmitter) already declares the
+        // Handle({Comp}Completed) overload; emitting ours too would collide (CS0111).
+        // Mirror the HasFailureHandlers no-op above: skip the duplicate handler and
+        // let the existing main-flow one cover it. The trigger/dispatch path needs no
+        // change — it dispatches the rollback's worker command, which the folded
+        // step model already produced (no duplicate member there).
+        var mainFlowStepNames = new HashSet<string>(model.StepNames, StringComparer.Ordinal);
+
         // Deduplicate by compensation step type: two steps rolling back to the same
         // compensation type share a single {Comp}Completed handler.
         var emittedCompletedHandlers = new HashSet<string>(StringComparer.Ordinal);
         foreach (var step in compensatedSteps)
         {
             var compStepName = NamingHelper.GetSimpleTypeName(step.Compensation!.CompensationStepTypeName);
+
+            // Skip if the main flow already declares this step's completed handler.
+            if (mainFlowStepNames.Contains(compStepName))
+            {
+                continue;
+            }
+
             if (emittedCompletedHandlers.Add(compStepName))
             {
                 sb.AppendLine();

--- a/src/Strategos.Generators/Emitters/Saga/SagaCompensationComponentEmitter.cs
+++ b/src/Strategos.Generators/Emitters/Saga/SagaCompensationComponentEmitter.cs
@@ -189,6 +189,24 @@ internal sealed class SagaCompensationComponentEmitter : ISagaComponentEmitter
             }
         }
 
+        // Terminal fallback (F2): in multi-compensation routing an unmatched
+        // FailedStepName would fall through every branch yielding NO command,
+        // stranding the saga in the Compensating phase forever (no further event
+        // ever arrives). Transition to the terminal Failed phase and MarkCompleted()
+        // so an unexpected failed-step name cannot deadlock the saga. The single
+        // case always yields a worker command above, so it needs no fallback.
+        if (!single)
+        {
+            sb.AppendLine("        logger.LogError(");
+            sb.AppendLine("            \"No compensation registered for failed step {FailedStepName} in workflow {WorkflowId}; failing terminally\",");
+            sb.AppendLine("            cmd.FailedStepName,");
+            sb.AppendLine("            WorkflowId);");
+            sb.AppendLine();
+            sb.AppendLine($"        Phase = {model.PhaseEnumName}.Failed;");
+            sb.AppendLine("        MarkCompleted();");
+            sb.AppendLine("        yield break;");
+        }
+
         sb.AppendLine("    }");
     }
 

--- a/src/Strategos.Generators/Emitters/Saga/SagaCompensationComponentEmitter.cs
+++ b/src/Strategos.Generators/Emitters/Saga/SagaCompensationComponentEmitter.cs
@@ -1,0 +1,212 @@
+// -----------------------------------------------------------------------
+// <copyright file="SagaCompensationComponentEmitter.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Linq;
+using System.Text;
+
+using Strategos.Generators.Helpers;
+using Strategos.Generators.Models;
+using Strategos.Generators.Polyfills;
+
+namespace Strategos.Generators.Emitters.Saga;
+
+/// <summary>
+/// Component emitter that lowers a step's <c>.Compensate&lt;T&gt;()</c> rollback
+/// into a runnable saga compensation chain (DR-3).
+/// </summary>
+/// <remarks>
+/// <para>
+/// This closes the long-standing dead path: the worker handler's generated
+/// <c>Configure(HandlerChain)</c> chain now PUBLISHES the
+/// <c>Trigger{Pascal}FailureHandlerCommand</c> on terminal step failure
+/// (see <see cref="WorkerHandlerEmitter"/>); this emitter is what RECEIVES that
+/// command in the saga and actually runs the compensation step. It emits, nested
+/// in the generated saga:
+/// <list type="bullet">
+///   <item><description>
+///     A <c>Handle(Trigger{Pascal}FailureHandlerCommand)</c> that stores the
+///     failure context, transitions to the <c>Compensating</c> phase, and
+///     dispatches the compensation step's <c>Execute{Comp}WorkerCommand</c>. The
+///     compensation step's worker handler is produced by the normal main-flow
+///     path because the compensation step type is folded into <c>model.Steps</c>,
+///     so the proven worker dispatch is reused (it RUNS the rollback step).
+///   </description></item>
+///   <item><description>
+///     A <c>Handle({Comp}Completed)</c> that folds the rollback's returned state
+///     (INV-7: the compensation step returns new state; the saga never mutates the
+///     input), then transitions the saga to its terminal <c>Failed</c> phase and
+///     calls <c>MarkCompleted()</c>.
+///   </description></item>
+/// </list>
+/// </para>
+/// <para>
+/// <b>Mutual exclusion with <see cref="SagaFailureHandlerComponentEmitter"/>:</b>
+/// both emitters would produce a <c>Handle(Trigger{Pascal}FailureHandlerCommand)</c>
+/// overload. To avoid a duplicate-method (CS0111) collision this emitter is a NO-OP
+/// when the workflow ALSO declares an <c>OnFailure</c> block
+/// (<c>model.HasFailureHandlers</c>); in that case the <c>OnFailure</c> path owns the
+/// trigger handler. Compensation + OnFailure interop is a separate, larger concern
+/// tracked outside this vertical.
+/// </para>
+/// <para>
+/// <b>Single-compensation-step scope:</b> when multiple distinct compensation step
+/// types are declared, the trigger handler routes to the correct rollback worker on
+/// the <c>FailedStepName</c> carried by the trigger command.
+/// </para>
+/// </remarks>
+internal sealed class SagaCompensationComponentEmitter : ISagaComponentEmitter
+{
+    /// <inheritdoc />
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="sb"/> or <paramref name="model"/> is null.
+    /// </exception>
+    public void Emit(StringBuilder sb, WorkflowModel model)
+    {
+        ThrowHelper.ThrowIfNull(sb, nameof(sb));
+        ThrowHelper.ThrowIfNull(model, nameof(model));
+
+        if (!model.HasCompensation)
+        {
+            return;
+        }
+
+        // The OnFailure path (SagaFailureHandlerComponentEmitter) owns the trigger
+        // handler when present; emitting ours too would collide (CS0111).
+        if (model.HasFailureHandlers)
+        {
+            return;
+        }
+
+        var compensatedSteps = model.CompensationSteps;
+
+        sb.AppendLine();
+        EmitTriggerHandler(sb, model, compensatedSteps);
+
+        // Deduplicate by compensation step type: two steps rolling back to the same
+        // compensation type share a single {Comp}Completed handler.
+        var emittedCompletedHandlers = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var step in compensatedSteps)
+        {
+            var compStepName = NamingHelper.GetSimpleTypeName(step.Compensation!.CompensationStepTypeName);
+            if (emittedCompletedHandlers.Add(compStepName))
+            {
+                sb.AppendLine();
+                EmitCompensationCompletedHandler(sb, model, compStepName);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Emits the saga handler for the trigger failure-handler command: stores
+    /// failure context, transitions to <c>Compensating</c>, and dispatches the
+    /// compensation step's worker command (routing on the failed step name when
+    /// more than one compensation step is declared).
+    /// </summary>
+    private static void EmitTriggerHandler(
+        StringBuilder sb,
+        WorkflowModel model,
+        IReadOnlyList<StepModel> compensatedSteps)
+    {
+        var triggerCommandName = $"Trigger{model.PascalName}FailureHandlerCommand";
+        var sagaClassName = NamingHelper.GetSagaClassName(model.PascalName, model.Version);
+        var single = compensatedSteps.Count == 1;
+
+        sb.AppendLine("    /// <summary>");
+        sb.AppendLine("    /// Handles the compensation trigger command (DR-3) - stores failure context");
+        sb.AppendLine("    /// and dispatches the failed step's compensation (rollback) worker so the");
+        sb.AppendLine("    /// compensation step actually runs.");
+        sb.AppendLine("    /// </summary>");
+        sb.AppendLine("    /// <param name=\"cmd\">The trigger command carrying the failure context.</param>");
+        sb.AppendLine("    /// <param name=\"logger\">The injected logger.</param>");
+        sb.AppendLine("    /// <returns>The compensation worker command(s) to dispatch.</returns>");
+        sb.AppendLine("    public IEnumerable<object> Handle(");
+        sb.AppendLine($"        {triggerCommandName} cmd,");
+        sb.AppendLine($"        ILogger<{sagaClassName}> logger)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        ArgumentNullException.ThrowIfNull(cmd, nameof(cmd));");
+        sb.AppendLine("        ArgumentNullException.ThrowIfNull(logger, nameof(logger));");
+        sb.AppendLine();
+        sb.AppendLine("        FailedStepName = cmd.FailedStepName;");
+        sb.AppendLine("        FailureExceptionMessage = cmd.ExceptionMessage;");
+        sb.AppendLine("        FailureExceptionType = cmd.ExceptionType;");
+        sb.AppendLine("        FailureStackTrace = cmd.StackTrace;");
+        sb.AppendLine("        FailureTimestamp = DateTimeOffset.UtcNow;");
+        sb.AppendLine($"        Phase = {model.PhaseEnumName}.Compensating;");
+        sb.AppendLine();
+        sb.AppendLine("        logger.LogWarning(");
+        sb.AppendLine("            \"Step {FailedStepName} failed for workflow {WorkflowId}; running compensation\",");
+        sb.AppendLine("            cmd.FailedStepName,");
+        sb.AppendLine("            WorkflowId);");
+        sb.AppendLine();
+
+        foreach (var step in compensatedSteps)
+        {
+            var compStepName = NamingHelper.GetSimpleTypeName(step.Compensation!.CompensationStepTypeName);
+            var workerCommandName = NamingHelper.GetWorkerCommandName(compStepName);
+
+            if (single)
+            {
+                sb.AppendLine($"        yield return new {workerCommandName}(WorkflowId, Guid.NewGuid(), State);");
+            }
+            else
+            {
+                // Route on the failed step name so the correct rollback runs.
+                sb.AppendLine($"        if (cmd.FailedStepName == \"{step.StepName}\")");
+                sb.AppendLine("        {");
+                sb.AppendLine($"            yield return new {workerCommandName}(WorkflowId, Guid.NewGuid(), State);");
+                sb.AppendLine("            yield break;");
+                sb.AppendLine("        }");
+                sb.AppendLine();
+            }
+        }
+
+        sb.AppendLine("    }");
+    }
+
+    /// <summary>
+    /// Emits the saga handler for a compensation step's completed event: folds the
+    /// rollback's returned state, transitions to the terminal <c>Failed</c> phase,
+    /// and marks the saga completed.
+    /// </summary>
+    private static void EmitCompensationCompletedHandler(
+        StringBuilder sb,
+        WorkflowModel model,
+        string compStepName)
+    {
+        var completedEventName = NamingHelper.GetCompletedEventName(compStepName);
+        var sagaClassName = NamingHelper.GetSagaClassName(model.PascalName, model.Version);
+
+        sb.AppendLine("    /// <summary>");
+        sb.AppendLine($"    /// Handles the {completedEventName} event (DR-3) - folds the rollback's");
+        sb.AppendLine("    /// returned state and transitions the saga to its terminal Failed phase.");
+        sb.AppendLine("    /// </summary>");
+        sb.AppendLine($"    /// <param name=\"evt\">The {compStepName} compensation completed event.</param>");
+        StateApplicationHelper.EmitSessionParameterDoc(sb, model);
+        sb.AppendLine("    /// <param name=\"logger\">The injected logger.</param>");
+        sb.AppendLine("    public void Handle(");
+        sb.AppendLine($"        {completedEventName} evt,");
+        StateApplicationHelper.EmitSessionParameter(sb, model);
+        sb.AppendLine($"        ILogger<{sagaClassName}> logger)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        ArgumentNullException.ThrowIfNull(evt, nameof(evt));");
+        StateApplicationHelper.EmitSessionGuard(sb, model);
+        sb.AppendLine("        ArgumentNullException.ThrowIfNull(logger, nameof(logger));");
+        sb.AppendLine();
+
+        // INV-7: the compensation step returns NEW state; the saga only folds it,
+        // never mutates the input. This is the standard reducer application.
+        StateApplicationHelper.EmitStateApplication(sb, model);
+
+        sb.AppendLine($"        Phase = {model.PhaseEnumName}.Failed;");
+        sb.AppendLine();
+        sb.AppendLine("        logger.LogInformation(");
+        sb.AppendLine("            \"Compensation completed for workflow {WorkflowId}; workflow Failed\",");
+        sb.AppendLine("            WorkflowId);");
+        sb.AppendLine();
+        sb.AppendLine("        MarkCompleted();");
+        sb.AppendLine("    }");
+    }
+}

--- a/src/Strategos.Generators/Emitters/Saga/SagaPropertiesEmitter.cs
+++ b/src/Strategos.Generators/Emitters/Saga/SagaPropertiesEmitter.cs
@@ -149,8 +149,10 @@ internal sealed class SagaPropertiesEmitter : ISagaComponentEmitter
             }
         }
 
-        // Failure tracking properties (if failure handlers are defined)
-        if (model.HasFailureHandlers)
+        // Failure tracking properties (if failure handlers OR compensation are
+        // defined). Compensation (DR-3) reuses the same failure-context fields,
+        // populated by the saga's Trigger{Pascal}FailureHandlerCommand handler.
+        if (model.HasFailureHandlers || model.HasCompensation)
         {
             sb.AppendLine("    /// <summary>");
             sb.AppendLine("    /// Gets or sets the name of the step that failed, triggering the failure handler.");

--- a/src/Strategos.Generators/Emitters/Saga/SagaPropertiesEmitter.cs
+++ b/src/Strategos.Generators/Emitters/Saga/SagaPropertiesEmitter.cs
@@ -40,21 +40,30 @@ internal sealed class SagaPropertiesEmitter : ISagaComponentEmitter
 
         var phaseEnumName = model.PhaseEnumName;
 
-        // WorkflowId with both attributes
+        // WorkflowId with both attributes.
+        // The Marten document-identity attribute is JasperFx.IdentityAttribute,
+        // surfaced via `using Marten.Schema;`. It is written fully qualified as
+        // [JasperFx.Identity]: consumers that also reference
+        // Strategos.Identity.Abstractions bring the Strategos.Identity namespace
+        // into scope, and an unqualified [Identity] would bind to that namespace
+        // instead of the attribute (CS0616).
         sb.AppendLine("    /// <summary>");
         sb.AppendLine("    /// Gets or sets the workflow identifier.");
         sb.AppendLine("    /// </summary>");
         sb.AppendLine("    [SagaIdentity]");
-        sb.AppendLine("    [Identity]");
+        sb.AppendLine("    [JasperFx.Identity]");
         sb.AppendLine("    public Guid WorkflowId { get; set; }");
         sb.AppendLine();
 
-        // Version for optimistic concurrency
+        // Version for optimistic concurrency.
+        // Typed as long: Marten 9 widened numeric document revisions from int to
+        // long and rejects an int [Version] property at mapping time. This
+        // shadows the Wolverine Saga.Version (int) base property with `new`.
         sb.AppendLine("    /// <summary>");
         sb.AppendLine("    /// Gets or sets the version for optimistic concurrency control.");
         sb.AppendLine("    /// </summary>");
         sb.AppendLine("    [Version]");
-        sb.AppendLine("    public new int Version { get; set; }");
+        sb.AppendLine("    public new long Version { get; set; }");
         sb.AppendLine();
 
         // Phase property

--- a/src/Strategos.Generators/Emitters/Saga/SagaStepHandlersEmitter.cs
+++ b/src/Strategos.Generators/Emitters/Saga/SagaStepHandlersEmitter.cs
@@ -165,8 +165,30 @@ internal sealed class SagaStepHandlersEmitter : ISagaComponentEmitter
         string stepName,
         int index)
     {
-        var isLastStep = index == ctx.Model.StepNames.Count - 1;
-        var nextStepName = isLastStep ? null : ctx.Model.StepNames[index + 1];
+        // Confidence handler steps (DR-5) are appended to StepNames for full lowering but are NOT
+        // part of the main linear flow. They must not be a "next step" for the main flow, and they
+        // themselves terminate the workflow. Compute main-flow adjacency by skipping over them so the
+        // preceding main-flow step (e.g. a Finally) keeps its terminal status instead of wrongly
+        // chaining into a handler step.
+        var model = ctx.Model;
+        var isConfidenceHandlerStep = model.IsConfidenceHandlerStep(stepName);
+
+        string? nextStepName = null;
+        if (!isConfidenceHandlerStep)
+        {
+            for (var j = index + 1; j < model.StepNames.Count; j++)
+            {
+                if (!model.IsConfidenceHandlerStep(model.StepNames[j]))
+                {
+                    nextStepName = model.StepNames[j];
+                    break;
+                }
+            }
+        }
+
+        // The step is "last in the main flow" when no later main-flow step exists. A confidence
+        // handler step is always treated as terminal (single-step handler ends the workflow).
+        var isLastStep = isConfidenceHandlerStep || nextStepName is null;
 
         ctx.LoopsByLastStep.TryGetValue(stepName, out var loopsAtStep);
         ctx.BranchesByPreviousStep.TryGetValue(stepName, out var branchAtStep);

--- a/src/Strategos.Generators/Emitters/Saga/SagaTimeoutComponentEmitter.cs
+++ b/src/Strategos.Generators/Emitters/Saga/SagaTimeoutComponentEmitter.cs
@@ -1,0 +1,142 @@
+// -----------------------------------------------------------------------
+// <copyright file="SagaTimeoutComponentEmitter.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Globalization;
+using System.Text;
+
+using Strategos.Generators.Helpers;
+using Strategos.Generators.Models;
+using Strategos.Generators.Polyfills;
+
+namespace Strategos.Generators.Emitters.Saga;
+
+/// <summary>
+/// Component emitter that lowers a step's <c>.WithTimeout(t)</c> into a Wolverine
+/// saga deadline race (DR-4).
+/// </summary>
+/// <remarks>
+/// <para>
+/// For each step that declares a timeout, this component emits, nested inside the
+/// generated saga:
+/// <list type="bullet">
+///   <item><description>
+///     A <c>{Phase}Timeout</c> record deriving from <see cref="global::Wolverine.TimeoutMessage"/>.
+///     The base type carries a <see cref="System.TimeSpan"/> and tells Wolverine to
+///     auto-schedule delayed delivery of the message and to silently ignore it if
+///     the saga no longer exists (so the no-op race needs no NotFound handler).
+///   </description></item>
+///   <item><description>
+///     A <c>Handle({Phase}Timeout)</c> method that routes to the failure path only
+///     when the step's phase has not advanced — an idempotent race guard. If the
+///     step already completed, the saga's <c>Phase</c> moved on and the timeout is a
+///     no-op (the step's <c>Completed</c> event won the race).
+///   </description></item>
+/// </list>
+/// </para>
+/// <para>
+/// The cascade of the timeout message (so the deadline race starts when the step
+/// starts) is emitted by <see cref="StepStartHandlerEmitter"/> alongside the worker
+/// command. This mirrors the existing approval-timeout shape
+/// (<see cref="SagaApprovalHandlersEmitter.EmitTimeoutHandler"/>), differing only in
+/// that Wolverine's <c>TimeoutMessage</c> base auto-schedules delivery rather than an
+/// explicit <c>context.ScheduleAsync(...)</c>.
+/// </para>
+/// </remarks>
+internal sealed class SagaTimeoutComponentEmitter : ISagaComponentEmitter
+{
+    /// <inheritdoc />
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="sb"/> or <paramref name="model"/> is null.
+    /// </exception>
+    public void Emit(StringBuilder sb, WorkflowModel model)
+    {
+        ThrowHelper.ThrowIfNull(sb, nameof(sb));
+        ThrowHelper.ThrowIfNull(model, nameof(model));
+
+        var context = SagaEmissionContext.Create(model);
+
+        foreach (var phaseName in model.StepNames)
+        {
+            if (!context.StepsByName.TryGetValue(phaseName, out var stepModel))
+            {
+                continue;
+            }
+
+            if (stepModel.Timeout is null)
+            {
+                continue;
+            }
+
+            sb.AppendLine();
+            EmitTimeoutMessageRecord(sb, phaseName, stepModel.Timeout);
+
+            sb.AppendLine();
+            EmitTimeoutHandler(sb, model, phaseName);
+        }
+    }
+
+    /// <summary>
+    /// Emits the timeout message record that derives from Wolverine's
+    /// <c>TimeoutMessage</c> base. Wolverine auto-schedules its delivery from the
+    /// base constructor's <see cref="System.TimeSpan"/>.
+    /// </summary>
+    private static void EmitTimeoutMessageRecord(StringBuilder sb, string phaseName, TimeoutModel timeout)
+    {
+        // Reconstruct the configured TimeSpan deterministically from ticks so the
+        // emitted literal is exact regardless of how the duration was expressed in
+        // the DSL (seconds, minutes, milliseconds, ...).
+        var ticks = timeout.Timeout.Ticks.ToString(CultureInfo.InvariantCulture);
+
+        sb.AppendLine("    /// <summary>");
+        sb.AppendLine($"    /// Saga timeout message for the {phaseName} step. Derives from");
+        sb.AppendLine("    /// <see cref=\"Wolverine.TimeoutMessage\"/> so Wolverine auto-schedules its");
+        sb.AppendLine("    /// delayed delivery and ignores it if the saga has already completed.");
+        sb.AppendLine("    /// </summary>");
+        sb.AppendLine("    [GeneratedCode(\"Strategos.Generators\", \"1.0.0\")]");
+        sb.AppendLine($"    public sealed record {phaseName}Timeout(");
+        sb.AppendLine("        [property: Wolverine.Persistence.Sagas.SagaIdentity] Guid WorkflowId)");
+        sb.AppendLine($"        : TimeoutMessage(System.TimeSpan.FromTicks({ticks}L));");
+    }
+
+    /// <summary>
+    /// Emits the saga handler for a step's timeout message. The handler routes to the
+    /// failure path only when the step's phase has not advanced (idempotent guard).
+    /// </summary>
+    private static void EmitTimeoutHandler(StringBuilder sb, WorkflowModel model, string phaseName)
+    {
+        var sagaClassName = NamingHelper.GetSagaClassName(model.PascalName, model.Version);
+
+        sb.AppendLine("    /// <summary>");
+        sb.AppendLine($"    /// Handles the {phaseName} step timeout - routes to the failure path");
+        sb.AppendLine("    /// only if the step has not already advanced past its phase.");
+        sb.AppendLine("    /// </summary>");
+        sb.AppendLine($"    /// <param name=\"t\">The {phaseName} timeout message.</param>");
+        sb.AppendLine("    /// <param name=\"logger\">The injected logger.</param>");
+        sb.AppendLine("    public void Handle(");
+        sb.AppendLine($"        {phaseName}Timeout t,");
+        sb.AppendLine($"        ILogger<{sagaClassName}> logger)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        ArgumentNullException.ThrowIfNull(t, nameof(t));");
+        sb.AppendLine("        ArgumentNullException.ThrowIfNull(logger, nameof(logger));");
+        sb.AppendLine();
+        sb.AppendLine("        // Race guard: if the step already completed, the saga's Phase has");
+        sb.AppendLine("        // advanced past this step and the timeout is a no-op (the Completed");
+        sb.AppendLine("        // event won the race).");
+        sb.AppendLine($"        if (Phase != {model.PhaseEnumName}.{phaseName})");
+        sb.AppendLine("        {");
+        sb.AppendLine("            return;");
+        sb.AppendLine("        }");
+        sb.AppendLine();
+        sb.AppendLine("        logger.LogWarning(");
+        sb.AppendLine("            \"Step {StepName} timed out for workflow {WorkflowId}; routing to failure path\",");
+        sb.AppendLine($"            \"{phaseName}\",");
+        sb.AppendLine("            WorkflowId);");
+        sb.AppendLine();
+        sb.AppendLine($"        Phase = {model.PhaseEnumName}.Failed;");
+        sb.AppendLine("        MarkCompleted();");
+        sb.AppendLine("    }");
+    }
+}

--- a/src/Strategos.Generators/Emitters/Saga/StepCompletedHandlerEmitter.cs
+++ b/src/Strategos.Generators/Emitters/Saga/StepCompletedHandlerEmitter.cs
@@ -137,8 +137,39 @@ internal sealed class StepCompletedHandlerEmitter
 
         StateApplicationHelper.EmitStateApplication(sb, model);
 
+        // Failure-phase sync + route (F1): a confidence-gated step can ALSO drive
+        // the saga into the Failed phase via its reducer/state application. The
+        // confidence comparison must not bypass failure-handler dispatch, so when
+        // the workflow declares failure handlers we mirror the phase-aware non-final
+        // handler: sync Phase from the reduced state and emit the same Phase == Failed
+        // guard — BEFORE the confidence comparison — routing to the failure handler's
+        // start command (INV-1: a Wolverine cascade). State types ending in
+        // "WorkflowState" track phase at the saga level only, so they are excluded
+        // from the sync, exactly as EmitPhaseAwareNonFinalStepHandler does.
+        if (model.HasFailureHandlers
+            && !string.IsNullOrEmpty(model.StateTypeName)
+            && !model.StateTypeName.EndsWith("WorkflowState", StringComparison.Ordinal))
+        {
+            sb.AppendLine($"        Phase = State.Phase;");
+        }
+
         if (!string.IsNullOrEmpty(model.StateTypeName))
         {
+            sb.AppendLine();
+        }
+
+        if (model.HasFailureHandlers)
+        {
+            var failedStepCommand = GetFailedStepCommandName(model);
+            sb.AppendLine($"        if (Phase == {model.PhaseEnumName}.Failed)");
+            sb.AppendLine("        {");
+            sb.AppendLine("            logger.LogWarning(");
+            sb.AppendLine("                \"Workflow {WorkflowId} entered Failed phase, routing to failure handler\",");
+            sb.AppendLine("                WorkflowId);");
+            sb.AppendLine();
+            sb.AppendLine($"            yield return new {failedStepCommand}(WorkflowId);");
+            sb.AppendLine("            yield break;");
+            sb.AppendLine("        }");
             sb.AppendLine();
         }
 

--- a/src/Strategos.Generators/Emitters/Saga/StepCompletedHandlerEmitter.cs
+++ b/src/Strategos.Generators/Emitters/Saga/StepCompletedHandlerEmitter.cs
@@ -72,12 +72,24 @@ internal sealed class StepCompletedHandlerEmitter
         sb.AppendLine($"    /// <param name=\"evt\">The {stepName} completed event.</param>");
         StateApplicationHelper.EmitSessionParameterDoc(sb, model);
 
-        // Priority: Approval → Terminal/Final → Non-Final
+        // Priority: Approval → Confidence gate → Terminal/Final → Non-Final
         // Terminal steps (CompleteStep, FailedStep, TerminateStep, AutoFailStep) should always
         // call MarkCompleted() regardless of their position in the workflow.
+        //
+        // The confidence gate (DR-5) takes precedence over the terminal/non-final split because
+        // it must compare the completed event's confidence to the threshold before deciding the
+        // route — either to the low-confidence handler step (a Wolverine cascade, INV-1) or down
+        // the normal path. It only applies when the step declared
+        // .RequireConfidence(t).OnLowConfidence(alt => alt.Then<H>()), where H was lowered into its
+        // own start command by the generator.
+        var confidence = context.StepModel?.Confidence;
         if (context.ApprovalAtStep is not null)
         {
             EmitApprovalWaitingHandler(sb, model, eventName, context.ApprovalAtStep);
+        }
+        else if (confidence?.OnLowConfidenceHandlerStep is not null)
+        {
+            EmitConfidenceGatedHandler(sb, model, eventName, confidence, context);
         }
         else if (context.IsTerminalStep || context.IsLastStep)
         {
@@ -87,6 +99,90 @@ internal sealed class StepCompletedHandlerEmitter
         {
             EmitNonFinalStepHandler(sb, model, eventName, context.NextStepName!);
         }
+    }
+
+    /// <summary>
+    /// Emits a confidence-gated completed handler (DR-5). After applying the
+    /// reducer, it compares the completed event's <c>Confidence</c> to the
+    /// configured threshold: when below, it cascades the low-confidence handler
+    /// step's start command (routing the saga to the OnLowConfidence branch);
+    /// when at or above (or when the result carried no confidence), it proceeds
+    /// down the normal path — to the next step, or to completion if this step is
+    /// terminal/last.
+    /// </summary>
+    private static void EmitConfidenceGatedHandler(
+        StringBuilder sb,
+        WorkflowModel model,
+        string eventName,
+        ConfidenceModel confidence,
+        HandlerContext context)
+    {
+        var sagaClassName = NamingHelper.GetSagaClassName(model.PascalName, model.Version);
+        var handlerStepName = confidence.OnLowConfidenceHandlerStep!.StepName;
+        var lowConfidenceCommand = $"Start{handlerStepName}Command";
+        var thresholdLiteral = confidence.Threshold.ToString("R", System.Globalization.CultureInfo.InvariantCulture);
+        var proceedsToCompletion = context.IsTerminalStep || context.IsLastStep;
+
+        sb.AppendLine($"    /// <returns>The low-confidence handler start command when below the");
+        sb.AppendLine($"    /// confidence threshold; otherwise the normal next-step command.</returns>");
+        sb.AppendLine("    public IEnumerable<object> Handle(");
+        sb.AppendLine($"        {eventName} evt,");
+        StateApplicationHelper.EmitSessionParameter(sb, model);
+        sb.AppendLine($"        ILogger<{sagaClassName}> logger)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        ArgumentNullException.ThrowIfNull(evt, nameof(evt));");
+        StateApplicationHelper.EmitSessionGuard(sb, model);
+        sb.AppendLine("        ArgumentNullException.ThrowIfNull(logger, nameof(logger));");
+        sb.AppendLine();
+
+        StateApplicationHelper.EmitStateApplication(sb, model);
+
+        if (!string.IsNullOrEmpty(model.StateTypeName))
+        {
+            sb.AppendLine();
+        }
+
+        // Confidence gate: route to the low-confidence handler when the step's
+        // result confidence is present and below the configured threshold.
+        sb.AppendLine($"        if (evt.Confidence is double confidenceScore && confidenceScore < {thresholdLiteral})");
+        sb.AppendLine("        {");
+        sb.AppendLine($"            Phase = {model.PhaseEnumName}.{handlerStepName};");
+        sb.AppendLine();
+        sb.AppendLine("            logger.LogWarning(");
+        sb.AppendLine("                \"Step confidence {Confidence} below threshold {Threshold} for workflow {WorkflowId}, routing to {Handler}\",");
+        sb.AppendLine("                confidenceScore,");
+        sb.AppendLine($"                {thresholdLiteral},");
+        sb.AppendLine("                WorkflowId,");
+        sb.AppendLine($"                nameof({lowConfidenceCommand}));");
+        sb.AppendLine();
+        sb.AppendLine($"            yield return new {lowConfidenceCommand}(WorkflowId);");
+        sb.AppendLine("            yield break;");
+        sb.AppendLine("        }");
+        sb.AppendLine();
+
+        if (proceedsToCompletion)
+        {
+            sb.AppendLine($"        Phase = {model.PhaseEnumName}.Completed;");
+            sb.AppendLine();
+            sb.AppendLine("        logger.LogInformation(");
+            sb.AppendLine("            \"Workflow {WorkflowId} completed\",");
+            sb.AppendLine("            WorkflowId);");
+            sb.AppendLine();
+            sb.AppendLine("        MarkCompleted();");
+            sb.AppendLine("        yield break;");
+        }
+        else
+        {
+            var nextStartCommand = $"Start{context.NextStepName}Command";
+            sb.AppendLine("        logger.LogDebug(");
+            sb.AppendLine("            \"Step confidence acceptable, chaining to {NextStep} for workflow {WorkflowId}\",");
+            sb.AppendLine($"            nameof({nextStartCommand}),");
+            sb.AppendLine("            WorkflowId);");
+            sb.AppendLine();
+            sb.AppendLine($"        yield return new {nextStartCommand}(WorkflowId);");
+        }
+
+        sb.AppendLine("    }");
     }
 
     private static void EmitFinalStepHandler(

--- a/src/Strategos.Generators/Emitters/Saga/StepStartHandlerEmitter.cs
+++ b/src/Strategos.Generators/Emitters/Saga/StepStartHandlerEmitter.cs
@@ -75,13 +75,19 @@ internal sealed class StepStartHandlerEmitter
         sb.AppendLine("    /// </summary>");
         sb.AppendLine($"    /// <param name=\"command\">The start {stepName} command.</param>");
 
+        // When the step declares a timeout, the start handler also cascades a
+        // {Phase}Timeout (a Wolverine TimeoutMessage) alongside the worker command,
+        // so the deadline race begins when the step begins. The timeout type is
+        // named per PHASE so reused step types in distinct phases don't collide.
+        var hasTimeout = stepModel?.Timeout is not null;
+
         if (stepModel?.HasValidation == true)
         {
-            EmitValidationHandler(sb, model, stepName, stepModel, commandName, workerCommandName);
+            EmitValidationHandler(sb, model, stepName, stepModel, commandName, workerCommandName, hasTimeout);
         }
         else
         {
-            EmitStandardHandler(sb, model, stepName, commandName, workerCommandName);
+            EmitStandardHandler(sb, model, stepName, commandName, workerCommandName, hasTimeout);
         }
     }
 
@@ -91,7 +97,8 @@ internal sealed class StepStartHandlerEmitter
         string stepName,
         StepModel stepModel,
         string commandName,
-        string workerCommandName)
+        string workerCommandName,
+        bool hasTimeout)
     {
         var sagaClassName = NamingHelper.GetSagaClassName(model.PascalName, model.Version);
 
@@ -138,6 +145,16 @@ internal sealed class StepStartHandlerEmitter
         sb.AppendLine("            WorkflowId);");
         sb.AppendLine();
         sb.AppendLine($"        yield return new {workerCommandName}(WorkflowId, Guid.NewGuid(), State);");
+
+        if (hasTimeout)
+        {
+            // Cascade the timeout message: Wolverine auto-schedules its delayed
+            // delivery from the TimeoutMessage base and re-enters the saga later.
+            sb.AppendLine();
+            sb.AppendLine("        // Start the timeout deadline race for this step.");
+            sb.AppendLine($"        yield return new {stepName}Timeout(WorkflowId);");
+        }
+
         sb.AppendLine("    }");
     }
 
@@ -146,9 +163,16 @@ internal sealed class StepStartHandlerEmitter
         WorkflowModel model,
         string stepName,
         string commandName,
-        string workerCommandName)
+        string workerCommandName,
+        bool hasTimeout)
     {
         var sagaClassName = NamingHelper.GetSagaClassName(model.PascalName, model.Version);
+
+        if (hasTimeout)
+        {
+            EmitTimeoutCascadingStandardHandler(sb, model, stepName, commandName, workerCommandName, sagaClassName);
+            return;
+        }
 
         // Return the worker command directly - this is the standard saga cascading pattern
         // Uses method injection for ILogger to work with Wolverine's saga rehydration pattern
@@ -168,6 +192,40 @@ internal sealed class StepStartHandlerEmitter
         sb.AppendLine("            WorkflowId);");
         sb.AppendLine();
         sb.AppendLine($"        return new {workerCommandName}(WorkflowId, Guid.NewGuid(), State);");
+        sb.AppendLine("    }");
+    }
+
+    private static void EmitTimeoutCascadingStandardHandler(
+        StringBuilder sb,
+        WorkflowModel model,
+        string stepName,
+        string commandName,
+        string workerCommandName,
+        string sagaClassName)
+    {
+        // Yield-based handler so the start handler can cascade BOTH the worker
+        // command and the {Phase}Timeout (Wolverine TimeoutMessage) that begins the
+        // deadline race. Uses method injection for ILogger to work with Wolverine's
+        // saga rehydration pattern.
+        sb.AppendLine($"    /// <returns>The worker command and the timeout deadline message.</returns>");
+        sb.AppendLine($"    public IEnumerable<object> Handle(");
+        sb.AppendLine($"        {commandName} command,");
+        sb.AppendLine($"        ILogger<{sagaClassName}> logger)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        ArgumentNullException.ThrowIfNull(command, nameof(command));");
+        sb.AppendLine("        ArgumentNullException.ThrowIfNull(logger, nameof(logger));");
+        sb.AppendLine();
+        sb.AppendLine($"        Phase = {model.PhaseEnumName}.{stepName};");
+        sb.AppendLine();
+        sb.AppendLine($"        logger.LogDebug(");
+        sb.AppendLine($"            \"Dispatching {{CommandType}} for workflow {{WorkflowId}}\",");
+        sb.AppendLine($"            nameof({workerCommandName}),");
+        sb.AppendLine("            WorkflowId);");
+        sb.AppendLine();
+        sb.AppendLine($"        yield return new {workerCommandName}(WorkflowId, Guid.NewGuid(), State);");
+        sb.AppendLine();
+        sb.AppendLine("        // Start the timeout deadline race for this step.");
+        sb.AppendLine($"        yield return new {stepName}Timeout(WorkflowId);");
         sb.AppendLine("    }");
     }
 

--- a/src/Strategos.Generators/Emitters/SagaEmitter.cs
+++ b/src/Strategos.Generators/Emitters/SagaEmitter.cs
@@ -46,6 +46,7 @@ internal static class SagaEmitter
         new SagaLoopConditionsEmitter(),
         new SagaStartMethodEmitter(),
         new SagaStepHandlersEmitter(),
+        new SagaTimeoutComponentEmitter(),
         new SagaApprovalComponentEmitter(),
         new SagaFailureHandlerComponentEmitter(),
         new SagaNotFoundHandlersEmitter(),

--- a/src/Strategos.Generators/Emitters/SagaEmitter.cs
+++ b/src/Strategos.Generators/Emitters/SagaEmitter.cs
@@ -49,6 +49,7 @@ internal static class SagaEmitter
         new SagaTimeoutComponentEmitter(),
         new SagaApprovalComponentEmitter(),
         new SagaFailureHandlerComponentEmitter(),
+        new SagaCompensationComponentEmitter(),
         new SagaNotFoundHandlersEmitter(),
     ];
 

--- a/src/Strategos.Generators/Emitters/WorkerHandlerEmitter.cs
+++ b/src/Strategos.Generators/Emitters/WorkerHandlerEmitter.cs
@@ -50,6 +50,18 @@ internal static class WorkerHandlerEmitter
             "Microsoft.Extensions.Logging",
         };
 
+        // Wolverine per-handler error policy (DR-2): only pulled in when at least
+        // one step lowers a retry onto its handler chain, so a workflow with no
+        // resilience keeps its handler file byte-identical to the prior baseline.
+        // HandlerChain lives in Wolverine.Runtime.Handlers; the fluent
+        // OnAnyException()/RetryTimes()/RetryWithCooldown()/WithExponentialJitter()
+        // extensions live in Wolverine.ErrorHandling.
+        if (model.Steps is not null && model.Steps.Any(s => s.Retry is not null))
+        {
+            usings.Add("Wolverine.ErrorHandling");
+            usings.Add("Wolverine.Runtime.Handlers");
+        }
+
         // Add step type namespaces from the model
         if (model.Steps is not null)
         {
@@ -130,15 +142,15 @@ internal static class WorkerHandlerEmitter
 
     private static void EmitHandlerClass(StringBuilder sb, WorkflowModel model, StepModel step)
     {
-        EmitHandlerClassCore(sb, model, step.StepName);
+        EmitHandlerClassCore(sb, model, step.StepName, step);
     }
 
     private static void EmitHandlerClassFromName(StringBuilder sb, WorkflowModel model, string stepName)
     {
-        EmitHandlerClassCore(sb, model, stepName);
+        EmitHandlerClassCore(sb, model, stepName, step: null);
     }
 
-    private static void EmitHandlerClassCore(StringBuilder sb, WorkflowModel model, string stepName)
+    private static void EmitHandlerClassCore(StringBuilder sb, WorkflowModel model, string stepName, StepModel? step)
     {
         var workerCommandName = $"Execute{stepName}WorkerCommand";
         var completedEventName = $"{stepName}Completed";
@@ -175,7 +187,104 @@ internal static class WorkerHandlerEmitter
         // Handle method
         EmitHandleMethod(sb, model, stepName, workerCommandName, completedEventName, stateType);
 
+        // Per-handler Wolverine error policy (DR-2). Emitted ONLY when the step
+        // declared resilience that lowers onto the handler's chain (retry). The
+        // re-throw in the Handle catch block is what feeds this policy. Guarded so
+        // a step with no resilience keeps the no-policy baseline handler shape.
+        if (step?.Retry is not null)
+        {
+            sb.AppendLine();
+            EmitConfigureMethod(sb, step.Retry);
+        }
+
         sb.AppendLine("}");
+    }
+
+    /// <summary>
+    /// Emits a static <c>Configure(HandlerChain)</c> method that lowers the
+    /// step's <see cref="RetryModel"/> onto the handler's Wolverine chain as an
+    /// <c>OnAnyException</c> retry policy. Wolverine discovers this method by
+    /// convention at codegen time and scopes the policy to this one handler.
+    /// </summary>
+    private static void EmitConfigureMethod(StringBuilder sb, RetryModel retry)
+    {
+        sb.AppendLine("    /// <summary>");
+        sb.AppendLine("    /// Configures this handler's Wolverine error policy. Lowered from the");
+        sb.AppendLine("    /// step's <c>.WithRetry(...)</c> declaration; Wolverine discovers this");
+        sb.AppendLine("    /// static method by convention and scopes the retry to this handler.");
+        sb.AppendLine("    /// </summary>");
+        sb.AppendLine("    /// <param name=\"chain\">The handler chain to apply the retry policy to.</param>");
+        sb.AppendLine("    public static void Configure(HandlerChain chain)");
+        sb.AppendLine("    {");
+
+        if (retry.InitialDelay is { } initialDelay)
+        {
+            // A configured delay lowers to a per-attempt cooldown schedule.
+            var cooldowns = BuildCooldownSchedule(retry, initialDelay);
+            sb.Append("        chain.OnAnyException()");
+            sb.AppendLine();
+            sb.Append($"            .RetryWithCooldown({cooldowns})");
+
+            if (retry.UseJitter)
+            {
+                sb.AppendLine();
+                sb.Append("            .WithExponentialJitter()");
+            }
+
+            sb.AppendLine(";");
+        }
+        else
+        {
+            // No delay configured: a simple fixed retry count.
+            sb.AppendLine("        chain.OnAnyException()");
+            sb.AppendLine($"            .RetryTimes({retry.MaxAttempts});");
+        }
+
+        sb.AppendLine("    }");
+    }
+
+    /// <summary>
+    /// Builds the comma-separated <see cref="System.TimeSpan"/> argument list for
+    /// <c>RetryWithCooldown</c>, one cooldown per retry attempt. The schedule
+    /// starts at <paramref name="initialDelay"/> and, when a backoff multiplier
+    /// is configured, grows geometrically, capped by <c>MaxDelay</c> if present.
+    /// </summary>
+    private static string BuildCooldownSchedule(RetryModel retry, System.TimeSpan initialDelay)
+    {
+        var attempts = retry.MaxAttempts < 1 ? 1 : retry.MaxAttempts;
+        var multiplier = retry.BackoffMultiplier ?? 1.0;
+        var maxDelay = retry.MaxDelay;
+
+        var parts = new List<string>(attempts);
+        var current = initialDelay;
+        for (var i = 0; i < attempts; i++)
+        {
+            var effective = current;
+            if (maxDelay is { } cap && effective > cap)
+            {
+                effective = cap;
+            }
+
+            parts.Add(FormatTimeSpan(effective));
+
+            if (multiplier != 1.0)
+            {
+                current = System.TimeSpan.FromMilliseconds(current.TotalMilliseconds * multiplier);
+            }
+        }
+
+        return string.Join(", ", parts);
+    }
+
+    /// <summary>
+    /// Renders a <see cref="System.TimeSpan"/> as a
+    /// <c>TimeSpan.FromMilliseconds(...)</c> factory call for the generated
+    /// source, preserving sub-second precision used by short retry cooldowns.
+    /// </summary>
+    private static string FormatTimeSpan(System.TimeSpan value)
+    {
+        var ms = value.TotalMilliseconds;
+        return $"System.TimeSpan.FromMilliseconds({ms.ToString("R", System.Globalization.CultureInfo.InvariantCulture)})";
     }
 
     private static void EmitHandleMethod(

--- a/src/Strategos.Generators/Emitters/WorkerHandlerEmitter.cs
+++ b/src/Strategos.Generators/Emitters/WorkerHandlerEmitter.cs
@@ -50,13 +50,14 @@ internal static class WorkerHandlerEmitter
             "Microsoft.Extensions.Logging",
         };
 
-        // Wolverine per-handler error policy (DR-2): only pulled in when at least
-        // one step lowers a retry onto its handler chain, so a workflow with no
-        // resilience keeps its handler file byte-identical to the prior baseline.
-        // HandlerChain lives in Wolverine.Runtime.Handlers; the fluent
-        // OnAnyException()/RetryTimes()/RetryWithCooldown()/WithExponentialJitter()
-        // extensions live in Wolverine.ErrorHandling.
-        if (model.Steps is not null && model.Steps.Any(s => s.Retry is not null))
+        // Wolverine per-handler error policy (DR-2 retry, DR-3 compensation): only
+        // pulled in when at least one step lowers a retry OR a compensation onto its
+        // handler chain, so a workflow with no resilience keeps its handler file
+        // byte-identical to the prior baseline. HandlerChain and InvokeResult live in
+        // Wolverine.Runtime.Handlers; the fluent OnAnyException()/RetryTimes()/
+        // RetryWithCooldown()/WithExponentialJitter()/CompensatingAction() extensions
+        // live in Wolverine.ErrorHandling.
+        if (model.Steps is not null && model.Steps.Any(s => s.Retry is not null || s.Compensation is not null))
         {
             usings.Add("Wolverine.ErrorHandling");
             usings.Add("Wolverine.Runtime.Handlers");
@@ -187,14 +188,15 @@ internal static class WorkerHandlerEmitter
         // Handle method
         EmitHandleMethod(sb, model, stepName, workerCommandName, completedEventName, stateType);
 
-        // Per-handler Wolverine error policy (DR-2). Emitted ONLY when the step
-        // declared resilience that lowers onto the handler's chain (retry). The
-        // re-throw in the Handle catch block is what feeds this policy. Guarded so
-        // a step with no resilience keeps the no-policy baseline handler shape.
-        if (step?.Retry is not null)
+        // Per-handler Wolverine error policy (DR-2 retry, DR-3 compensation).
+        // Emitted ONLY when the step declared resilience that lowers onto the
+        // handler's chain (retry and/or compensation). The re-throw in the Handle
+        // catch block is what feeds this policy. Guarded so a step with no
+        // resilience keeps the no-policy baseline handler shape.
+        if (step is not null && (step.Retry is not null || step.Compensation is not null))
         {
             sb.AppendLine();
-            EmitConfigureMethod(sb, step.Retry);
+            EmitConfigureMethod(sb, model, step, workerCommandName);
         }
 
         sb.AppendLine("}");
@@ -202,42 +204,106 @@ internal static class WorkerHandlerEmitter
 
     /// <summary>
     /// Emits a static <c>Configure(HandlerChain)</c> method that lowers the
-    /// step's <see cref="RetryModel"/> onto the handler's Wolverine chain as an
-    /// <c>OnAnyException</c> retry policy. Wolverine discovers this method by
-    /// convention at codegen time and scopes the policy to this one handler.
+    /// step's <see cref="RetryModel"/> and/or <see cref="CompensationModel"/> onto
+    /// the handler's Wolverine chain as an <c>OnAnyException</c> error policy.
+    /// Wolverine discovers this method by convention at codegen time and scopes the
+    /// policy to this one handler.
     /// </summary>
-    private static void EmitConfigureMethod(StringBuilder sb, RetryModel retry)
+    /// <remarks>
+    /// <para>
+    /// The chain composes additively: a retry prefix
+    /// (<c>RetryTimes</c>/<c>RetryWithCooldown</c>) is followed, when the step also
+    /// declares <c>.Compensate&lt;T&gt;()</c>, by
+    /// <c>.Then.CompensatingAction&lt;{WorkerCommand}&gt;(...)</c> that PUBLISHES the
+    /// trigger failure-handler command on terminal failure (after retries are
+    /// exhausted), with <c>InvokeResult.Stop</c> so the message is not retried again.
+    /// This is what makes the previously-never-published trigger command reach the
+    /// saga at runtime (DR-3), so the compensation step actually runs.
+    /// </para>
+    /// <para>
+    /// When only compensation is declared (no retry), the compensating action
+    /// applies directly to <c>chain.OnAnyException()</c> with no retry prefix.
+    /// </para>
+    /// </remarks>
+    private static void EmitConfigureMethod(
+        StringBuilder sb,
+        WorkflowModel model,
+        StepModel step,
+        string workerCommandName)
     {
+        var retry = step.Retry;
+        var compensation = step.Compensation;
+
         sb.AppendLine("    /// <summary>");
         sb.AppendLine("    /// Configures this handler's Wolverine error policy. Lowered from the");
-        sb.AppendLine("    /// step's <c>.WithRetry(...)</c> declaration; Wolverine discovers this");
-        sb.AppendLine("    /// static method by convention and scopes the retry to this handler.");
+        sb.AppendLine("    /// step's <c>.WithRetry(...)</c> and/or <c>.Compensate&lt;T&gt;()</c>");
+        sb.AppendLine("    /// declaration; Wolverine discovers this static method by convention and");
+        sb.AppendLine("    /// scopes the policy to this handler.");
         sb.AppendLine("    /// </summary>");
-        sb.AppendLine("    /// <param name=\"chain\">The handler chain to apply the retry policy to.</param>");
+        sb.AppendLine("    /// <param name=\"chain\">The handler chain to apply the error policy to.</param>");
         sb.AppendLine("    public static void Configure(HandlerChain chain)");
         sb.AppendLine("    {");
 
-        if (retry.InitialDelay is { } initialDelay)
-        {
-            // A configured delay lowers to a per-attempt cooldown schedule.
-            var cooldowns = BuildCooldownSchedule(retry, initialDelay);
-            sb.Append("        chain.OnAnyException()");
-            sb.AppendLine();
-            sb.Append($"            .RetryWithCooldown({cooldowns})");
+        // Open the error chain. The retry prefix (if any) is emitted WITHOUT a
+        // terminating ';' so a compensating action can be chained after it.
+        sb.Append("        chain.OnAnyException()");
 
-            if (retry.UseJitter)
+        if (retry is not null)
+        {
+            if (retry.InitialDelay is { } initialDelay)
+            {
+                // A configured delay lowers to a per-attempt cooldown schedule.
+                var cooldowns = BuildCooldownSchedule(retry, initialDelay);
+                sb.AppendLine();
+                sb.Append($"            .RetryWithCooldown({cooldowns})");
+
+                if (retry.UseJitter)
+                {
+                    sb.AppendLine();
+                    sb.Append("            .WithExponentialJitter()");
+                }
+            }
+            else
+            {
+                // No delay configured: a simple fixed retry count.
+                sb.AppendLine();
+                sb.Append($"            .RetryTimes({retry.MaxAttempts})");
+            }
+        }
+
+        if (compensation is not null)
+        {
+            // On terminal failure (after any retries), publish the trigger
+            // failure-handler command so the saga runs the compensation step.
+            // ".Then" is only needed to bridge from a retry continuation back to a
+            // failure-action surface; with no retry, OnAnyException() already is one.
+            if (retry is not null)
             {
                 sb.AppendLine();
-                sb.Append("            .WithExponentialJitter()");
+                sb.Append("            .Then");
             }
 
-            sb.AppendLine(";");
+            var triggerCommandName = $"Trigger{model.PascalName}FailureHandlerCommand";
+            var compStepName = NamingHelper.GetSimpleTypeName(compensation.CompensationStepTypeName);
+
+            sb.AppendLine();
+            sb.AppendLine($"            .CompensatingAction<{workerCommandName}>(");
+            sb.AppendLine($"                (cmd, ex, bus) => bus.PublishAsync(new {triggerCommandName}(");
+            sb.AppendLine("                    cmd.WorkflowId,");
+            sb.AppendLine($"                    \"{step.StepName}\",");
+            sb.AppendLine("                    ex.Message,");
+            sb.AppendLine("                    ex.GetType().Name,");
+            sb.AppendLine("                    ex.StackTrace)),");
+            sb.Append("                InvokeResult.Stop)");
+
+            // Reference the compensation step name in a comment so the lowering is
+            // traceable in the generated source.
+            sb.AppendLine($"; // runs {compStepName}");
         }
         else
         {
-            // No delay configured: a simple fixed retry count.
-            sb.AppendLine("        chain.OnAnyException()");
-            sb.AppendLine($"            .RetryTimes({retry.MaxAttempts});");
+            // Retry-only chain: terminate the statement.
+            sb.AppendLine(";");
         }
 
         sb.AppendLine("    }");

--- a/src/Strategos.Generators/Emitters/WorkerHandlerEmitter.cs
+++ b/src/Strategos.Generators/Emitters/WorkerHandlerEmitter.cs
@@ -63,6 +63,17 @@ internal static class WorkerHandlerEmitter
             usings.Add("Wolverine.Runtime.Handlers");
         }
 
+        // Context assembler wiring (DR-6): only pulled in when at least one step
+        // declared .WithContext(...). IContextAwareStep is the opt-in delivery
+        // contract a step implements to receive AssembledContext; both live in
+        // Strategos.Agents. Guarded so a context-free workflow keeps its prior
+        // handler file unchanged.
+        if (model.Steps is not null && model.Steps.Any(s => s.Context is not null && s.Context.Sources.Count > 0))
+        {
+            usings.Add("Strategos.Agents.Abstractions");
+            usings.Add("Strategos.Agents.Models");
+        }
+
         // Add step type namespaces from the model
         if (model.Steps is not null)
         {
@@ -158,6 +169,13 @@ internal static class WorkerHandlerEmitter
         var handlerClassName = $"{stepName}Handler";
         var stateType = model.StateTypeName ?? "object";
 
+        // A step that declared .WithContext(...) gets its generated
+        // {Step}ContextAssembler injected and invoked before execution (DR-6).
+        var hasContext = step is not null
+            && step.Context is not null
+            && step.Context.Sources.Count > 0;
+        var assemblerTypeName = $"{stepName}ContextAssembler";
+
         // XML documentation
         sb.AppendLine("/// <summary>");
         sb.AppendLine($"/// Worker handler for the {stepName} step.");
@@ -177,16 +195,28 @@ internal static class WorkerHandlerEmitter
         sb.AppendLine("[GeneratedCode(\"Strategos.Generators\", \"1.0.0\")]");
         sb.AppendLine($"public sealed partial class {handlerClassName}(");
         sb.AppendLine($"    {stepName} step,");
+        if (hasContext)
+        {
+            // The assembler is registered in DI (see ExtensionsEmitter) so
+            // Wolverine can resolve it for this handler's primary constructor.
+            sb.AppendLine($"    {assemblerTypeName} contextAssembler,");
+        }
+
         sb.AppendLine($"    ILogger<{handlerClassName}> logger)");
         sb.AppendLine("{");
 
         // Private fields from primary constructor
         sb.AppendLine($"    private readonly {stepName} _step = step;");
+        if (hasContext)
+        {
+            sb.AppendLine($"    private readonly {assemblerTypeName} _contextAssembler = contextAssembler;");
+        }
+
         sb.AppendLine($"    private readonly ILogger<{handlerClassName}> _logger = logger;");
         sb.AppendLine();
 
         // Handle method
-        EmitHandleMethod(sb, model, stepName, workerCommandName, completedEventName, stateType);
+        EmitHandleMethod(sb, model, stepName, workerCommandName, completedEventName, stateType, hasContext);
 
         // Per-handler Wolverine error policy (DR-2 retry, DR-3 compensation).
         // Emitted ONLY when the step declared resilience that lowers onto the
@@ -359,7 +389,8 @@ internal static class WorkerHandlerEmitter
         string stepName,
         string workerCommandName,
         string completedEventName,
-        string stateType)
+        string stateType,
+        bool hasContext)
     {
         sb.AppendLine("    /// <summary>");
         sb.AppendLine($"    /// Handles the {workerCommandName} by executing the step.");
@@ -385,6 +416,22 @@ internal static class WorkerHandlerEmitter
         sb.AppendLine("        try");
         sb.AppendLine("        {");
         sb.AppendLine($"            var stepContext = StepContext.Create(command.WorkflowId, \"{stepName}\", \"{stepName}\");");
+
+        if (hasContext)
+        {
+            // DR-6 wire-in: assemble the step's declared context (state values,
+            // ontology retrieval via IObjectSetProvider, literals) BEFORE the
+            // step runs, then deliver it to the step if it opted into the
+            // IContextAwareStep side channel. The AssembleAsync call is what
+            // actually executes the lowered SimilarityExpression at runtime.
+            sb.AppendLine("            var assembledContext = await _contextAssembler.AssembleAsync(command.State, stepContext, ct);");
+            sb.AppendLine("            if (_step is IContextAwareStep contextAwareStep)");
+            sb.AppendLine("            {");
+            sb.AppendLine("                contextAwareStep.ReceiveContext(assembledContext);");
+            sb.AppendLine("            }");
+            sb.AppendLine();
+        }
+
         sb.AppendLine("            var result = await _step.ExecuteAsync(command.State, stepContext, ct);");
         sb.AppendLine();
         sb.AppendLine("            sw.Stop();");

--- a/src/Strategos.Generators/FluentDslParser.cs
+++ b/src/Strategos.Generators/FluentDslParser.cs
@@ -141,6 +141,30 @@ internal static class FluentDslParser
     }
 
     /// <summary>
+    /// Extracts per-step context models from the workflow DSL so the
+    /// <c>.WithContext(...)</c> declaration can be lowered into a generated
+    /// <c>{Step}ContextAssembler</c> (DR-6).
+    /// </summary>
+    /// <param name="typeDeclaration">The type declaration containing the workflow definition.</param>
+    /// <param name="semanticModel">The semantic model for type resolution.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The (step name, context model) pairs for every step that declared
+    /// <c>.WithContext(...)</c>. Steps without context are omitted.
+    /// </returns>
+    public static IReadOnlyList<(string StepName, ContextModel Context)> ExtractContextModels(
+        SyntaxNode typeDeclaration,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        ThrowHelper.ThrowIfNull(typeDeclaration, nameof(typeDeclaration));
+        ThrowHelper.ThrowIfNull(semanticModel, nameof(semanticModel));
+
+        var context = FluentDslParseContext.Create(typeDeclaration, semanticModel, null, cancellationToken);
+        return ContextModelExtractor.Extract(context);
+    }
+
+    /// <summary>
     /// Extracts branch models from the workflow DSL for saga handler generation.
     /// </summary>
     /// <param name="typeDeclaration">The type declaration containing the workflow definition.</param>

--- a/src/Strategos.Generators/Helpers/ContextModelExtractor.cs
+++ b/src/Strategos.Generators/Helpers/ContextModelExtractor.cs
@@ -118,11 +118,13 @@ internal static class ContextModelExtractor
     {
         var sources = new List<ContextSourceModel>();
 
-        // Find all method invocations within the lambda
-        var allInvocations = configLambda
-            .DescendantNodes()
-            .OfType<InvocationExpressionSyntax>()
-            .ToList();
+        // Collect the top-level FromState/FromRetrieval/FromLiteral invocations in
+        // SOURCE (declaration) order. CollectInvocationsInLambda excludes calls
+        // nested inside lambdas — so a FromRetrieval's inner Query/TopK/... do not
+        // leak in — and reverses the outer-to-inner DescendantNodes order back to
+        // left-to-right, preserving the order the author declared sources in
+        // (assembled segments are order-sensitive for prompt construction).
+        var allInvocations = InvocationChainWalker.CollectInvocationsInLambda(configLambda);
 
         foreach (var inv in allInvocations)
         {
@@ -215,8 +217,11 @@ internal static class ContextModelExtractor
         var typeInfo = semanticModel.GetTypeInfo(body);
         var propertyType = typeInfo.Type?.ToDisplayString() ?? "object";
 
-        // Build the access expression (e.g., "state.CustomerName")
-        var accessExpression = BuildAccessExpression(selectorLambda, body);
+        // Build the access expression against the assembler's "state" parameter
+        // (e.g., "state.CustomerName"). The lambda parameter name (s/x/...) is
+        // discarded so the emitted expression always binds to the generated
+        // AssembleAsync(TState state, ...) parameter, not the author's lambda var.
+        var accessExpression = $"state.{propertyPath}";
 
         stateSource = new StateContextSourceModel(propertyPath, propertyType, accessExpression);
         return true;
@@ -602,19 +607,5 @@ internal static class ContextModelExtractor
         }
 
         return string.Empty;
-    }
-
-    private static string BuildAccessExpression(LambdaExpressionSyntax lambda, SyntaxNode body)
-    {
-        // Get the parameter name from the lambda
-        var parameterName = lambda switch
-        {
-            SimpleLambdaExpressionSyntax simple => simple.Parameter.Identifier.Text,
-            ParenthesizedLambdaExpressionSyntax parens => parens.ParameterList.Parameters.FirstOrDefault()?.Identifier.Text ?? "state",
-            _ => "state"
-        };
-
-        // Build the full expression
-        return body.ToString();
     }
 }

--- a/src/Strategos.Generators/Helpers/ContextModelExtractor.cs
+++ b/src/Strategos.Generators/Helpers/ContextModelExtractor.cs
@@ -468,36 +468,73 @@ internal static class ContextModelExtractor
     {
         stepName = string.Empty;
 
-        // WithContext is called on the result of a previous method (StartWith, Then, etc.)
-        if (withContextInvocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+        // Form 1 — chained on the workflow builder:
+        //   .StartWith<Step>().WithContext(c => ...)
+        // WithContext is invoked on the RESULT of the preceding StartWith/Then,
+        // so we walk back through the member-access chain to find it.
+        if (withContextInvocation.Expression is MemberAccessExpressionSyntax memberAccess)
         {
-            return false;
+            var previousExpression = memberAccess.Expression;
+
+            while (previousExpression is InvocationExpressionSyntax previousInvocation)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (SyntaxHelper.IsMethodCall(previousInvocation, "StartWith") ||
+                    SyntaxHelper.IsMethodCall(previousInvocation, "Then"))
+                {
+                    if (TryGetStepTypeName(previousInvocation, semanticModel, out stepName))
+                    {
+                        return true;
+                    }
+                }
+
+                // Continue walking back
+                if (previousInvocation.Expression is MemberAccessExpressionSyntax prevMemberAccess)
+                {
+                    previousExpression = prevMemberAccess.Expression;
+                }
+                else
+                {
+                    break;
+                }
+            }
         }
 
-        var previousExpression = memberAccess.Expression;
+        // Form 2 — inside a step-configuration lambda:
+        //   .StartWith<Step>(step => step.WithContext(ctx => ...))
+        // Here WithContext is invoked on the lambda parameter, not on a chain,
+        // so the backward walk above finds nothing. Instead walk UP the syntax
+        // ancestors to the nearest enclosing StartWith/Then invocation whose
+        // generic type argument names the configured step.
+        return TryFindEnclosingStepName(withContextInvocation, semanticModel, out stepName, cancellationToken);
+    }
 
-        // Walk back until we find a StartWith or Then call
-        while (previousExpression is InvocationExpressionSyntax previousInvocation)
+    /// <summary>
+    /// Resolves the step name for a <c>WithContext</c> call written inside a
+    /// step-configuration lambda (<c>StartWith&lt;Step&gt;(s =&gt; s.WithContext(...))</c>)
+    /// by walking up to the enclosing <c>StartWith</c>/<c>Then</c> invocation and
+    /// reading its generic type argument.
+    /// </summary>
+    private static bool TryFindEnclosingStepName(
+        InvocationExpressionSyntax withContextInvocation,
+        SemanticModel semanticModel,
+        out string stepName,
+        CancellationToken cancellationToken)
+    {
+        stepName = string.Empty;
+
+        foreach (var ancestor in withContextInvocation.Ancestors().OfType<InvocationExpressionSyntax>())
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (SyntaxHelper.IsMethodCall(previousInvocation, "StartWith") ||
-                SyntaxHelper.IsMethodCall(previousInvocation, "Then"))
+            if (SyntaxHelper.IsMethodCall(ancestor, "StartWith") ||
+                SyntaxHelper.IsMethodCall(ancestor, "Then"))
             {
-                if (TryGetStepTypeName(previousInvocation, semanticModel, out stepName))
+                if (TryGetStepTypeName(ancestor, semanticModel, out stepName))
                 {
                     return true;
                 }
-            }
-
-            // Continue walking back
-            if (previousInvocation.Expression is MemberAccessExpressionSyntax prevMemberAccess)
-            {
-                previousExpression = prevMemberAccess.Expression;
-            }
-            else
-            {
-                break;
             }
         }
 

--- a/src/Strategos.Generators/Helpers/FailureHandlerExtractor.cs
+++ b/src/Strategos.Generators/Helpers/FailureHandlerExtractor.cs
@@ -182,6 +182,17 @@ internal static class FailureHandlerExtractor
             return false;
         }
 
+        // Prefer the shared configured-step builder so any per-step resilience
+        // (WithRetry/WithTimeout/Compensate/confidence) and ValidateState guard declared via the
+        // Then<TStep>(step => step...) configure-lambda overload (DR-7) threads into the StepModel,
+        // bringing failure-handler steps to parity with the top-level/loop/fork parse paths.
+        if (StepExtractor.TryBuildConfiguredStepModel(invocation, semanticModel, out var configuredStepModel))
+        {
+            stepName = configuredStepModel.StepName;
+            stepModel = configuredStepModel;
+            return true;
+        }
+
         // Try to get the symbol for better naming and full type information
         var symbolInfo = semanticModel.GetSymbolInfo(typeArgument);
         if (symbolInfo.Symbol is INamedTypeSymbol namedType)

--- a/src/Strategos.Generators/Helpers/FailureHandlerExtractor.cs
+++ b/src/Strategos.Generators/Helpers/FailureHandlerExtractor.cs
@@ -126,12 +126,11 @@ internal static class FailureHandlerExtractor
         ref bool isTerminal,
         CancellationToken cancellationToken)
     {
-        // Find all invocations in the handler body, reversed for correct order
-        var allInvocations = handlerLambda
-            .DescendantNodes()
-            .OfType<InvocationExpressionSyntax>()
-            .Reverse()
-            .ToList();
+        // F1: walk only the handler lambda's OWN invocations, in source order. A raw
+        // DescendantNodes() walk captures Then<>/Complete calls from NESTED lambdas — e.g. a
+        // handler step's OnLowConfidence(alt => alt.Then<Recovery>()) configure lambda — which
+        // would surface as phantom/misordered failure-handler steps.
+        var allInvocations = InvocationChainWalker.CollectInvocationsInLambda(handlerLambda);
 
         foreach (var inv in allInvocations)
         {

--- a/src/Strategos.Generators/Helpers/NamingHelper.cs
+++ b/src/Strategos.Generators/Helpers/NamingHelper.cs
@@ -97,4 +97,26 @@ internal static class NamingHelper
         ThrowHelper.ThrowIfNull(stateTypeName, nameof(stateTypeName));
         return $"{stateTypeName}Reducer";
     }
+
+    /// <summary>
+    /// Gets the simple (unqualified) type name from a possibly fully qualified
+    /// type name.
+    /// </summary>
+    /// <param name="typeName">The type name (e.g., "MyApp.Steps.RollbackStep").</param>
+    /// <returns>The simple type name (e.g., "RollbackStep").</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="typeName"/> is null.</exception>
+    /// <remarks>
+    /// Used by the compensation lowering path to derive worker-handler, command,
+    /// and event names from a <c>CompensationModel</c>'s fully qualified
+    /// compensation step type name (which is carried as a descriptor string per
+    /// INV-8, never a CLR <see cref="System.Type"/>).
+    /// </remarks>
+    public static string GetSimpleTypeName(string typeName)
+    {
+        ThrowHelper.ThrowIfNull(typeName, nameof(typeName));
+        var lastDot = typeName.LastIndexOf('.');
+        return lastDot >= 0 && lastDot < typeName.Length - 1
+            ? typeName.Substring(lastDot + 1)
+            : typeName;
+    }
 }

--- a/src/Strategos.Generators/Helpers/NamingHelper.cs
+++ b/src/Strategos.Generators/Helpers/NamingHelper.cs
@@ -106,14 +106,33 @@ internal static class NamingHelper
     /// <returns>The simple type name (e.g., "RollbackStep").</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="typeName"/> is null.</exception>
     /// <remarks>
+    /// <para>
     /// Used by the compensation lowering path to derive worker-handler, command,
     /// and event names from a <c>CompensationModel</c>'s fully qualified
     /// compensation step type name (which is carried as a descriptor string per
     /// INV-8, never a CLR <see cref="System.Type"/>).
+    /// </para>
+    /// <para>
+    /// Any generic-arity suffix is stripped FIRST (everything from the first
+    /// <c>&lt;</c>), so a fully qualified generic such as <c>Ns.Foo&lt;Ns.Bar&gt;</c>
+    /// returns the valid identifier <c>Foo</c> rather than <c>Bar&gt;</c> — without
+    /// the truncation the trailing <c>&gt;</c> (and, for a qualified type argument,
+    /// the WRONG inner name) would leak into the derived command/event identifiers.
+    /// </para>
     /// </remarks>
     public static string GetSimpleTypeName(string typeName)
     {
         ThrowHelper.ThrowIfNull(typeName, nameof(typeName));
+
+        // Strip any generic-arity suffix first so the last-dot split operates only
+        // on the outer type's namespace-qualified name, never on a (possibly
+        // qualified) type argument inside the angle brackets.
+        var angle = typeName.IndexOf('<');
+        if (angle >= 0)
+        {
+            typeName = typeName.Substring(0, angle);
+        }
+
         var lastDot = typeName.LastIndexOf('.');
         return lastDot >= 0 && lastDot < typeName.Length - 1
             ? typeName.Substring(lastDot + 1)

--- a/src/Strategos.Generators/Helpers/ResilienceParser.cs
+++ b/src/Strategos.Generators/Helpers/ResilienceParser.cs
@@ -131,6 +131,17 @@ internal static class ResilienceParser
     {
         value = default;
 
+        // TimeSpan.Zero — a non-invocation member access. Recognized so an explicitly
+        // zero (non-positive) timeout reaches the IR and trips the non-positive-timeout diagnostic.
+        if (expression is MemberAccessExpressionSyntax zeroAccess
+            && zeroAccess.Expression is IdentifierNameSyntax zeroReceiver
+            && zeroReceiver.Identifier.ValueText.Equals("TimeSpan", StringComparison.Ordinal)
+            && zeroAccess.Name.Identifier.ValueText.Equals("Zero", StringComparison.Ordinal))
+        {
+            value = TimeSpan.Zero;
+            return true;
+        }
+
         if (expression is not InvocationExpressionSyntax invocation
             || invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
         {
@@ -177,6 +188,16 @@ internal static class ResilienceParser
     private static bool TryGetDoubleLiteral(ExpressionSyntax expression, out double value)
     {
         value = 0;
+
+        // Unary minus over a numeric literal (e.g. TimeSpan.FromSeconds(-5)) — recognized so
+        // a negative (non-positive) duration reaches the IR and trips the non-positive-timeout diagnostic.
+        if (expression is PrefixUnaryExpressionSyntax unary
+            && unary.IsKind(SyntaxKind.UnaryMinusExpression)
+            && TryGetDoubleLiteral(unary.Operand, out var operand))
+        {
+            value = -operand;
+            return true;
+        }
 
         if (expression is LiteralExpressionSyntax literal
             && literal.IsKind(SyntaxKind.NumericLiteralExpression))

--- a/src/Strategos.Generators/Helpers/ResilienceParser.cs
+++ b/src/Strategos.Generators/Helpers/ResilienceParser.cs
@@ -1,0 +1,203 @@
+// -----------------------------------------------------------------------
+// <copyright file="ResilienceParser.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Models;
+using Strategos.Generators.Polyfills;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Strategos.Generators.Helpers;
+
+/// <summary>
+/// Extracts per-step resilience configuration
+/// (<see cref="RetryModel"/>, <see cref="TimeoutModel"/>) from the
+/// <c>WithRetry</c>/<c>WithTimeout</c> invocations declared inside a step's
+/// <c>Then&lt;TStep&gt;(step =&gt; step.WithRetry(...).WithTimeout(...))</c> configure lambda.
+/// </summary>
+/// <remarks>
+/// Mirrors <see cref="ValidationParser"/>: a stateless syntax-only extractor that
+/// produces generator IR for one configuration concern. Symbol-resolving concerns
+/// (e.g. <c>Compensate&lt;T&gt;</c>) live alongside the chain walk in
+/// <see cref="StepExtractor"/>, where the semantic model is in scope.
+/// </remarks>
+internal static class ResilienceParser
+{
+    /// <summary>
+    /// Extracts a <see cref="RetryModel"/> from a <c>WithRetry(...)</c> invocation.
+    /// </summary>
+    /// <param name="invocation">The <c>WithRetry</c> invocation to analyze.</param>
+    /// <returns>
+    /// The retry model carrying the parsed <c>maxAttempts</c> and optional
+    /// <c>initialDelay</c>, or <c>null</c> if the invocation is not a recognizable
+    /// <c>WithRetry</c> call.
+    /// </returns>
+    /// <remarks>
+    /// Supports both the <c>WithRetry(int)</c> and <c>WithRetry(int, TimeSpan)</c> overloads.
+    /// The remaining <see cref="RetryModel"/> delay-shaping members are left at their IR
+    /// defaults: the DSL surface does not yet expose them, so only what was configured is carried.
+    /// </remarks>
+    public static RetryModel? ExtractRetry(InvocationExpressionSyntax invocation)
+    {
+        ThrowHelper.ThrowIfNull(invocation, nameof(invocation));
+
+        if (!SyntaxHelper.IsMethodCall(invocation, "WithRetry"))
+        {
+            return null;
+        }
+
+        var arguments = invocation.ArgumentList.Arguments;
+        if (arguments.Count == 0)
+        {
+            return null;
+        }
+
+        if (!TryGetIntLiteral(arguments[0].Expression, out var maxAttempts))
+        {
+            return null;
+        }
+
+        TimeSpan? initialDelay = null;
+        if (arguments.Count >= 2 && TryGetTimeSpan(arguments[1].Expression, out var delay))
+        {
+            initialDelay = delay;
+        }
+
+        return new RetryModel(MaxAttempts: maxAttempts, InitialDelay: initialDelay);
+    }
+
+    /// <summary>
+    /// Extracts a <see cref="TimeoutModel"/> from a <c>WithTimeout(TimeSpan)</c> invocation.
+    /// </summary>
+    /// <param name="invocation">The <c>WithTimeout</c> invocation to analyze.</param>
+    /// <returns>
+    /// The timeout model, or <c>null</c> if the invocation is not a recognizable
+    /// <c>WithTimeout</c> call with a parseable <see cref="TimeSpan"/> argument.
+    /// </returns>
+    public static TimeoutModel? ExtractTimeout(InvocationExpressionSyntax invocation)
+    {
+        ThrowHelper.ThrowIfNull(invocation, nameof(invocation));
+
+        if (!SyntaxHelper.IsMethodCall(invocation, "WithTimeout"))
+        {
+            return null;
+        }
+
+        var arguments = invocation.ArgumentList.Arguments;
+        if (arguments.Count == 0)
+        {
+            return null;
+        }
+
+        if (!TryGetTimeSpan(arguments[0].Expression, out var timeout))
+        {
+            return null;
+        }
+
+        return new TimeoutModel(timeout);
+    }
+
+    private static bool TryGetIntLiteral(ExpressionSyntax expression, out int value)
+    {
+        value = 0;
+
+        if (expression is LiteralExpressionSyntax literal
+            && literal.IsKind(SyntaxKind.NumericLiteralExpression)
+            && literal.Token.Value is int intValue)
+        {
+            value = intValue;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Parses a syntactic <c>TimeSpan.From*(...)</c> factory call into a concrete
+    /// <see cref="TimeSpan"/> for the IR.
+    /// </summary>
+    /// <remarks>
+    /// Supported forms mirror the DSL examples: <c>TimeSpan.FromSeconds(n)</c>,
+    /// <c>TimeSpan.FromMinutes(n)</c>, <c>TimeSpan.FromHours(n)</c>,
+    /// <c>TimeSpan.FromMilliseconds(n)</c>, and <c>TimeSpan.FromDays(n)</c>, with a
+    /// numeric-literal argument. Unrecognized expressions yield <c>false</c> so the
+    /// caller can skip the unparseable value rather than emit an incorrect delay.
+    /// </remarks>
+    private static bool TryGetTimeSpan(ExpressionSyntax expression, out TimeSpan value)
+    {
+        value = default;
+
+        if (expression is not InvocationExpressionSyntax invocation
+            || invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+        {
+            return false;
+        }
+
+        // Receiver must be the TimeSpan type (e.g. TimeSpan.FromSeconds(...)).
+        if (memberAccess.Expression is not IdentifierNameSyntax receiver
+            || !receiver.Identifier.ValueText.Equals("TimeSpan", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var factory = memberAccess.Name.Identifier.ValueText;
+
+        var arguments = invocation.ArgumentList.Arguments;
+        if (arguments.Count == 0 || !TryGetDoubleLiteral(arguments[0].Expression, out var amount))
+        {
+            return false;
+        }
+
+        switch (factory)
+        {
+            case "FromMilliseconds":
+                value = TimeSpan.FromMilliseconds(amount);
+                return true;
+            case "FromSeconds":
+                value = TimeSpan.FromSeconds(amount);
+                return true;
+            case "FromMinutes":
+                value = TimeSpan.FromMinutes(amount);
+                return true;
+            case "FromHours":
+                value = TimeSpan.FromHours(amount);
+                return true;
+            case "FromDays":
+                value = TimeSpan.FromDays(amount);
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static bool TryGetDoubleLiteral(ExpressionSyntax expression, out double value)
+    {
+        value = 0;
+
+        if (expression is LiteralExpressionSyntax literal
+            && literal.IsKind(SyntaxKind.NumericLiteralExpression))
+        {
+            switch (literal.Token.Value)
+            {
+                case double d:
+                    value = d;
+                    return true;
+                case int i:
+                    value = i;
+                    return true;
+                case long l:
+                    value = l;
+                    return true;
+                case float f:
+                    value = f;
+                    return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Strategos.Generators/Helpers/ResilienceParser.cs
+++ b/src/Strategos.Generators/Helpers/ResilienceParser.cs
@@ -105,6 +105,18 @@ internal static class ResilienceParser
     {
         value = 0;
 
+        // Unary minus over a numeric literal (e.g. WithRetry(-1)) — recognized so a negative
+        // (below-one) maxAttempts reaches the IR and trips the AGWF020 RetryMaxAttemptsBelowOne
+        // diagnostic (INV-5). Mirrors the unary-minus handling in TryGetDoubleLiteral. Without
+        // this, the negative literal never parsed and the whole RetryModel silently vanished.
+        if (expression is PrefixUnaryExpressionSyntax unary
+            && unary.IsKind(SyntaxKind.UnaryMinusExpression)
+            && TryGetIntLiteral(unary.Operand, out var operand))
+        {
+            value = -operand;
+            return true;
+        }
+
         if (expression is LiteralExpressionSyntax literal
             && literal.IsKind(SyntaxKind.NumericLiteralExpression)
             && literal.Token.Value is int intValue)

--- a/src/Strategos.Generators/Helpers/ResilienceParser.cs
+++ b/src/Strategos.Generators/Helpers/ResilienceParser.cs
@@ -106,7 +106,7 @@ internal static class ResilienceParser
         value = 0;
 
         // Unary minus over a numeric literal (e.g. WithRetry(-1)) — recognized so a negative
-        // (below-one) maxAttempts reaches the IR and trips the AGWF020 RetryMaxAttemptsBelowOne
+        // (below-one) maxAttempts reaches the IR and trips the RetryMaxAttemptsBelowOne
         // diagnostic (INV-5). Mirrors the unary-minus handling in TryGetDoubleLiteral. Without
         // this, the negative literal never parsed and the whole RetryModel silently vanished.
         if (expression is PrefixUnaryExpressionSyntax unary
@@ -175,25 +175,37 @@ internal static class ResilienceParser
             return false;
         }
 
-        switch (factory)
+        // F3: TimeSpan.From* throws OverflowException on an out-of-range argument (e.g.
+        // FromDays(1e18)) and ArgumentException on NaN. Constructing it directly let that escape
+        // and abort generation. Wrap the construction so an unparseable/out-of-range literal yields
+        // false — the caller then skips the value (no timeout) rather than crashing the generator.
+        try
         {
-            case "FromMilliseconds":
-                value = TimeSpan.FromMilliseconds(amount);
-                return true;
-            case "FromSeconds":
-                value = TimeSpan.FromSeconds(amount);
-                return true;
-            case "FromMinutes":
-                value = TimeSpan.FromMinutes(amount);
-                return true;
-            case "FromHours":
-                value = TimeSpan.FromHours(amount);
-                return true;
-            case "FromDays":
-                value = TimeSpan.FromDays(amount);
-                return true;
-            default:
-                return false;
+            switch (factory)
+            {
+                case "FromMilliseconds":
+                    value = TimeSpan.FromMilliseconds(amount);
+                    return true;
+                case "FromSeconds":
+                    value = TimeSpan.FromSeconds(amount);
+                    return true;
+                case "FromMinutes":
+                    value = TimeSpan.FromMinutes(amount);
+                    return true;
+                case "FromHours":
+                    value = TimeSpan.FromHours(amount);
+                    return true;
+                case "FromDays":
+                    value = TimeSpan.FromDays(amount);
+                    return true;
+                default:
+                    return false;
+            }
+        }
+        catch (Exception ex) when (ex is OverflowException or ArgumentException)
+        {
+            value = default;
+            return false;
         }
     }
 

--- a/src/Strategos.Generators/Helpers/StepExtractor.cs
+++ b/src/Strategos.Generators/Helpers/StepExtractor.cs
@@ -1123,7 +1123,7 @@ internal static class StepExtractor
         }
 
         var instanceName = ExtractInstanceName(invocation);
-        var (retry, timeout) = ExtractConfiguredResilience(invocation);
+        var resilience = ExtractConfiguredResilience(invocation, semanticModel);
         stepModel = StepModel.Create(
             stepName,
             stepTypeName,
@@ -1131,37 +1131,47 @@ internal static class StepExtractor
             loopName: loopName,
             validationPredicate: validationPredicate,
             validationErrorMessage: validationErrorMessage,
-            retry: retry,
-            timeout: timeout);
+            retry: resilience.Retry,
+            timeout: resilience.Timeout,
+            compensation: resilience.Compensation,
+            confidence: resilience.Confidence);
         return true;
     }
 
     /// <summary>
     /// Extracts per-step resilience configuration from a step's configure lambda, e.g.
-    /// <c>Then&lt;TStep&gt;(step =&gt; step.WithRetry(3, TimeSpan.FromSeconds(5)).WithTimeout(...))</c>.
+    /// <c>Then&lt;TStep&gt;(step =&gt; step.WithRetry(3, TimeSpan.FromSeconds(5)).WithTimeout(...)
+    /// .Compensate&lt;TRollback&gt;().RequireConfidence(0.85).OnLowConfidence(alt =&gt; alt.Then&lt;THandler&gt;()))</c>.
     /// </summary>
     /// <param name="thenInvocation">The <c>Then</c>/<c>StartWith</c> invocation whose configure lambda is inspected.</param>
+    /// <param name="semanticModel">The semantic model, used to resolve the compensation step's fully qualified name.</param>
     /// <returns>
-    /// The retry/timeout models from the first matching call of each kind found inside the
-    /// configure lambda, or <c>(null, null)</c> if the step declares no resilience.
+    /// The retry/timeout/compensation/confidence models from the first matching call of each kind
+    /// found inside the configure lambda; any concern the step does not declare is left null.
     /// </returns>
     /// <remarks>
     /// Mirrors <see cref="ExtractConfiguredValidation"/>: the resilience calls live in this
     /// invocation's own <c>Action&lt;IStepConfiguration&lt;TState&gt;&gt;</c> configure lambda, so the
     /// lookup is scoped to its arguments. Routing through <see cref="TryGetStepModel"/> threads the
-    /// same extraction uniformly into top-level, loop, and fork-path steps.
+    /// same extraction uniformly into top-level, loop, and fork-path steps. Per INV-8 the
+    /// compensation step is carried as its fully qualified type name (a string descriptor), never a
+    /// CLR <see cref="System.Type"/>.
     /// </remarks>
-    private static (RetryModel? Retry, TimeoutModel? Timeout) ExtractConfiguredResilience(
-        InvocationExpressionSyntax thenInvocation)
+    private static (RetryModel? Retry, TimeoutModel? Timeout, CompensationModel? Compensation, ConfidenceModel? Confidence)
+        ExtractConfiguredResilience(
+            InvocationExpressionSyntax thenInvocation,
+            SemanticModel semanticModel)
     {
         var arguments = thenInvocation.ArgumentList?.Arguments;
         if (arguments is null)
         {
-            return (null, null);
+            return (null, null, null, null);
         }
 
         RetryModel? retry = null;
         TimeoutModel? timeout = null;
+        CompensationModel? compensation = null;
+        ConfidenceModel? confidence = null;
 
         foreach (var arg in arguments.Value)
         {
@@ -1185,10 +1195,123 @@ internal static class StepExtractor
                 {
                     timeout = ResilienceParser.ExtractTimeout(configCall);
                 }
+                else if (compensation is null && SyntaxHelper.IsMethodCall(configCall, "Compensate"))
+                {
+                    compensation = ExtractCompensation(configCall, semanticModel);
+                }
+                else if (SyntaxHelper.IsMethodCall(configCall, "RequireConfidence")
+                    || SyntaxHelper.IsMethodCall(configCall, "OnLowConfidence"))
+                {
+                    confidence = MergeConfidence(confidence, configCall);
+                }
             }
         }
 
-        return (retry, timeout);
+        return (retry, timeout, compensation, confidence);
+    }
+
+    /// <summary>
+    /// Resolves a <c>Compensate&lt;TCompensation&gt;()</c> call into a <see cref="CompensationModel"/>,
+    /// carrying the compensation step's fully qualified type name (INV-8: a string descriptor,
+    /// never a CLR <see cref="System.Type"/>). Mirrors the <c>Join&lt;T&gt;</c> symbol resolution.
+    /// </summary>
+    private static CompensationModel? ExtractCompensation(
+        InvocationExpressionSyntax compensateInvocation,
+        SemanticModel semanticModel)
+    {
+        if (!TryGetGenericTypeArgument(compensateInvocation, "Compensate", out var typeArgument))
+        {
+            return null;
+        }
+
+        if (!ResolveTypeNameAndFullName(typeArgument, semanticModel, out _, out var compensationTypeName))
+        {
+            return null;
+        }
+
+        return new CompensationModel(compensationTypeName);
+    }
+
+    /// <summary>
+    /// Folds a <c>RequireConfidence(double)</c> or <c>OnLowConfidence(alt =&gt; alt.Then&lt;THandler&gt;())</c>
+    /// call into the accumulating <see cref="ConfidenceModel"/>.
+    /// </summary>
+    /// <remarks>
+    /// The two calls are independent fluent members on <see cref="Strategos.Builders.IStepConfiguration{TState}"/>,
+    /// so either may appear without the other; this merges whichever is seen into the same model.
+    /// The low-confidence handler is identified by the first <c>Then&lt;THandler&gt;()</c> step declared
+    /// inside the handler lambda — a string descriptor consistent with INV-8.
+    /// </remarks>
+    private static ConfidenceModel MergeConfidence(
+        ConfidenceModel? existing,
+        InvocationExpressionSyntax confidenceCall)
+    {
+        var threshold = existing?.Threshold ?? 0.0;
+        var handlerId = existing?.OnLowConfidenceHandlerId;
+
+        if (SyntaxHelper.IsMethodCall(confidenceCall, "RequireConfidence"))
+        {
+            var arguments = confidenceCall.ArgumentList.Arguments;
+            if (arguments.Count > 0 && TryGetDoubleLiteral(arguments[0].Expression, out var parsed))
+            {
+                threshold = parsed;
+            }
+        }
+        else if (SyntaxHelper.IsMethodCall(confidenceCall, "OnLowConfidence"))
+        {
+            handlerId = ExtractLowConfidenceHandlerId(confidenceCall) ?? handlerId;
+        }
+
+        return new ConfidenceModel(threshold, handlerId);
+    }
+
+    /// <summary>
+    /// Extracts the low-confidence handler identifier — the first <c>Then&lt;THandler&gt;()</c> step
+    /// type name declared inside an <c>OnLowConfidence(alt =&gt; ...)</c> handler lambda.
+    /// </summary>
+    private static string? ExtractLowConfidenceHandlerId(InvocationExpressionSyntax onLowConfidenceCall)
+    {
+        var arguments = onLowConfidenceCall.ArgumentList.Arguments;
+        if (arguments.Count == 0 || arguments[0].Expression is not LambdaExpressionSyntax handlerLambda)
+        {
+            return null;
+        }
+
+        var firstThen = handlerLambda
+            .DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .FirstOrDefault(inv => SyntaxHelper.IsMethodCall(inv, "Then"));
+
+        if (firstThen is null || !TryGetGenericTypeArgument(firstThen, "Then", out var typeArgument))
+        {
+            return null;
+        }
+
+        return SyntaxHelper.GetTypeNameFromSyntax(typeArgument);
+    }
+
+    private static bool TryGetDoubleLiteral(ExpressionSyntax expression, out double value)
+    {
+        value = 0;
+
+        if (expression is LiteralExpressionSyntax literal
+            && literal.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression))
+        {
+            switch (literal.Token.Value)
+            {
+                case double d:
+                    value = d;
+                    return true;
+                case int i:
+                    value = i;
+                    return true;
+                case float f:
+                    value = f;
+                    return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/Strategos.Generators/Helpers/StepExtractor.cs
+++ b/src/Strategos.Generators/Helpers/StepExtractor.cs
@@ -584,12 +584,9 @@ internal static class StepExtractor
             }
 
             // Find Then<T>() calls in the path lambda
-            var pathInvocations = pathLambda
-                .DescendantNodes()
-                .OfType<InvocationExpressionSyntax>()
-                .Where(inv => SyntaxHelper.IsMethodCall(inv, "Then"))
-                .Reverse()
-                .ToList();
+            // F1: only this path's OWN Then<> steps — never Then<> calls nested inside a step's
+            // configure/OnLowConfidence lambda (which would surface as phantom path steps).
+            var pathInvocations = CollectDirectThenInvocations(pathLambda);
 
             foreach (var inv in pathInvocations)
             {
@@ -631,12 +628,9 @@ internal static class StepExtractor
             }
 
             // Find Then<T>() calls in the path lambda
-            var pathInvocations = pathLambda
-                .DescendantNodes()
-                .OfType<InvocationExpressionSyntax>()
-                .Where(inv => SyntaxHelper.IsMethodCall(inv, "Then"))
-                .Reverse()
-                .ToList();
+            // F1: only this path's OWN Then<> steps — never Then<> calls nested inside a step's
+            // configure/OnLowConfidence lambda (which would surface as phantom path steps).
+            var pathInvocations = CollectDirectThenInvocations(pathLambda);
 
             foreach (var inv in pathInvocations)
             {
@@ -725,6 +719,25 @@ internal static class StepExtractor
     }
 
     /// <summary>
+    /// Collects the <c>Then&lt;T&gt;</c> step invocations declared DIRECTLY in a fork/branch path
+    /// lambda body, in source order — excluding <c>Then</c> calls nested inside an inner lambda
+    /// (e.g. a step's <c>OnLowConfidence(alt =&gt; alt.Then&lt;Inner&gt;())</c> or configure lambda).
+    /// </summary>
+    /// <remarks>
+    /// F1: a raw <c>pathLambda.DescendantNodes()</c> walk captures <c>Then</c> invocations from
+    /// nested lambdas, producing phantom/misordered path steps. Delegating to
+    /// <see cref="InvocationChainWalker.CollectInvocationsInLambda"/> (which stops at nested-lambda
+    /// boundaries and returns source order) keeps each path's step discovery to its own steps.
+    /// </remarks>
+    private static IReadOnlyList<InvocationExpressionSyntax> CollectDirectThenInvocations(
+        LambdaExpressionSyntax pathLambda)
+    {
+        return InvocationChainWalker.CollectInvocationsInLambda(pathLambda)
+            .Where(inv => SyntaxHelper.IsMethodCall(inv, "Then"))
+            .ToList();
+    }
+
+    /// <summary>
     /// Collects Then steps from a path lambda and adds them to the steps list.
     /// </summary>
     private static void CollectStepsFromPathLambda(
@@ -734,12 +747,9 @@ internal static class StepExtractor
         StepContext context,
         List<StepInfo> steps)
     {
-        var pathInvocations = pathLambda
-            .DescendantNodes()
-            .OfType<InvocationExpressionSyntax>()
-            .Where(inv => SyntaxHelper.IsMethodCall(inv, "Then"))
-            .Reverse()
-            .ToList();
+        // F1: only this path's OWN Then<> steps — never Then<> calls nested inside a step's
+        // configure/OnLowConfidence lambda (which would surface as phantom path steps).
+        var pathInvocations = CollectDirectThenInvocations(pathLambda);
 
         foreach (var inv in pathInvocations)
         {
@@ -1039,12 +1049,9 @@ internal static class StepExtractor
                 continue;
             }
 
-            var pathInvocations = pathLambda
-                .DescendantNodes()
-                .OfType<InvocationExpressionSyntax>()
-                .Where(inv => SyntaxHelper.IsMethodCall(inv, "Then"))
-                .Reverse()
-                .ToList();
+            // F1: only this path's OWN Then<> steps — never Then<> calls nested inside a step's
+            // configure/OnLowConfidence lambda (which would surface as phantom path steps).
+            var pathInvocations = CollectDirectThenInvocations(pathLambda);
 
             foreach (var inv in pathInvocations)
             {
@@ -1100,12 +1107,9 @@ internal static class StepExtractor
                 continue;
             }
 
-            var pathInvocations = pathLambda
-                .DescendantNodes()
-                .OfType<InvocationExpressionSyntax>()
-                .Where(inv => SyntaxHelper.IsMethodCall(inv, "Then"))
-                .Reverse()
-                .ToList();
+            // F1: only this path's OWN Then<> steps — never Then<> calls nested inside a step's
+            // configure/OnLowConfidence lambda (which would surface as phantom path steps).
+            var pathInvocations = CollectDirectThenInvocations(pathLambda);
 
             foreach (var inv in pathInvocations)
             {
@@ -1279,14 +1283,16 @@ internal static class StepExtractor
         foreach (var arg in arguments.Value)
         {
             // The configure lambda is the Action<IStepConfiguration<TState>> argument.
-            if (arg.Expression is not LambdaExpressionSyntax)
+            if (arg.Expression is not LambdaExpressionSyntax configureLambda)
             {
                 continue;
             }
 
-            var configInvocations = arg.Expression
-                .DescendantNodes()
-                .OfType<InvocationExpressionSyntax>();
+            // F1: scope the resilience walk to THIS configure lambda's own body. Walking
+            // raw DescendantNodes() would capture WithRetry/WithTimeout/Compensate calls from
+            // a NESTED lambda — e.g. OnLowConfidence(alt => alt.Then<Y>(c => c.WithTimeout(t)))
+            // — and wrongly attach Y's resilience to the parent step.
+            var configInvocations = InvocationChainWalker.CollectInvocationsInLambda(configureLambda);
 
             foreach (var configCall in configInvocations)
             {

--- a/src/Strategos.Generators/Helpers/StepExtractor.cs
+++ b/src/Strategos.Generators/Helpers/StepExtractor.cs
@@ -1202,7 +1202,7 @@ internal static class StepExtractor
                 else if (SyntaxHelper.IsMethodCall(configCall, "RequireConfidence")
                     || SyntaxHelper.IsMethodCall(configCall, "OnLowConfidence"))
                 {
-                    confidence = MergeConfidence(confidence, configCall);
+                    confidence = MergeConfidence(confidence, configCall, semanticModel);
                 }
             }
         }
@@ -1240,14 +1240,18 @@ internal static class StepExtractor
     /// The two calls are independent fluent members on <see cref="Strategos.Builders.IStepConfiguration{TState}"/>,
     /// so either may appear without the other; this merges whichever is seen into the same model.
     /// The low-confidence handler is identified by the first <c>Then&lt;THandler&gt;()</c> step declared
-    /// inside the handler lambda — a string descriptor consistent with INV-8.
+    /// inside the handler lambda — captured both as a simple name descriptor (consistent with INV-8) and
+    /// as a fully-resolved <see cref="StepModel"/> so DR-5 can lower the handler step into the saga and
+    /// route to it via a Wolverine cascade.
     /// </remarks>
     private static ConfidenceModel MergeConfidence(
         ConfidenceModel? existing,
-        InvocationExpressionSyntax confidenceCall)
+        InvocationExpressionSyntax confidenceCall,
+        SemanticModel semanticModel)
     {
         var threshold = existing?.Threshold ?? 0.0;
         var handlerId = existing?.OnLowConfidenceHandlerId;
+        var handlerStep = existing?.OnLowConfidenceHandlerStep;
 
         if (SyntaxHelper.IsMethodCall(confidenceCall, "RequireConfidence"))
         {
@@ -1259,17 +1263,27 @@ internal static class StepExtractor
         }
         else if (SyntaxHelper.IsMethodCall(confidenceCall, "OnLowConfidence"))
         {
-            handlerId = ExtractLowConfidenceHandlerId(confidenceCall) ?? handlerId;
+            var extracted = ExtractLowConfidenceHandlerStep(confidenceCall, semanticModel);
+            if (extracted is not null)
+            {
+                handlerStep = extracted;
+                handlerId = extracted.StepName;
+            }
         }
 
-        return new ConfidenceModel(threshold, handlerId);
+        return new ConfidenceModel(threshold, handlerId, handlerStep);
     }
 
     /// <summary>
-    /// Extracts the low-confidence handler identifier — the first <c>Then&lt;THandler&gt;()</c> step
-    /// type name declared inside an <c>OnLowConfidence(alt =&gt; ...)</c> handler lambda.
+    /// Extracts the low-confidence handler step — the first <c>Then&lt;THandler&gt;()</c> step
+    /// declared inside an <c>OnLowConfidence(alt =&gt; ...)</c> handler lambda — as a fully-resolved
+    /// <see cref="StepModel"/> carrying both its simple name and fully qualified type name. The fully
+    /// qualified name is required so the handler step lowers into a worker handler with correct DI
+    /// usings (DR-5).
     /// </summary>
-    private static string? ExtractLowConfidenceHandlerId(InvocationExpressionSyntax onLowConfidenceCall)
+    private static StepModel? ExtractLowConfidenceHandlerStep(
+        InvocationExpressionSyntax onLowConfidenceCall,
+        SemanticModel semanticModel)
     {
         var arguments = onLowConfidenceCall.ArgumentList.Arguments;
         if (arguments.Count == 0 || arguments[0].Expression is not LambdaExpressionSyntax handlerLambda)
@@ -1287,7 +1301,12 @@ internal static class StepExtractor
             return null;
         }
 
-        return SyntaxHelper.GetTypeNameFromSyntax(typeArgument);
+        if (!ResolveTypeNameAndFullName(typeArgument, semanticModel, out var stepName, out var stepTypeName))
+        {
+            return null;
+        }
+
+        return StepModel.Create(stepName, stepTypeName);
     }
 
     private static bool TryGetDoubleLiteral(ExpressionSyntax expression, out double value)

--- a/src/Strategos.Generators/Helpers/StepExtractor.cs
+++ b/src/Strategos.Generators/Helpers/StepExtractor.cs
@@ -1123,14 +1123,72 @@ internal static class StepExtractor
         }
 
         var instanceName = ExtractInstanceName(invocation);
+        var (retry, timeout) = ExtractConfiguredResilience(invocation);
         stepModel = StepModel.Create(
             stepName,
             stepTypeName,
             instanceName: instanceName,
             loopName: loopName,
             validationPredicate: validationPredicate,
-            validationErrorMessage: validationErrorMessage);
+            validationErrorMessage: validationErrorMessage,
+            retry: retry,
+            timeout: timeout);
         return true;
+    }
+
+    /// <summary>
+    /// Extracts per-step resilience configuration from a step's configure lambda, e.g.
+    /// <c>Then&lt;TStep&gt;(step =&gt; step.WithRetry(3, TimeSpan.FromSeconds(5)).WithTimeout(...))</c>.
+    /// </summary>
+    /// <param name="thenInvocation">The <c>Then</c>/<c>StartWith</c> invocation whose configure lambda is inspected.</param>
+    /// <returns>
+    /// The retry/timeout models from the first matching call of each kind found inside the
+    /// configure lambda, or <c>(null, null)</c> if the step declares no resilience.
+    /// </returns>
+    /// <remarks>
+    /// Mirrors <see cref="ExtractConfiguredValidation"/>: the resilience calls live in this
+    /// invocation's own <c>Action&lt;IStepConfiguration&lt;TState&gt;&gt;</c> configure lambda, so the
+    /// lookup is scoped to its arguments. Routing through <see cref="TryGetStepModel"/> threads the
+    /// same extraction uniformly into top-level, loop, and fork-path steps.
+    /// </remarks>
+    private static (RetryModel? Retry, TimeoutModel? Timeout) ExtractConfiguredResilience(
+        InvocationExpressionSyntax thenInvocation)
+    {
+        var arguments = thenInvocation.ArgumentList?.Arguments;
+        if (arguments is null)
+        {
+            return (null, null);
+        }
+
+        RetryModel? retry = null;
+        TimeoutModel? timeout = null;
+
+        foreach (var arg in arguments.Value)
+        {
+            // The configure lambda is the Action<IStepConfiguration<TState>> argument.
+            if (arg.Expression is not LambdaExpressionSyntax)
+            {
+                continue;
+            }
+
+            var configInvocations = arg.Expression
+                .DescendantNodes()
+                .OfType<InvocationExpressionSyntax>();
+
+            foreach (var configCall in configInvocations)
+            {
+                if (retry is null && SyntaxHelper.IsMethodCall(configCall, "WithRetry"))
+                {
+                    retry = ResilienceParser.ExtractRetry(configCall);
+                }
+                else if (timeout is null && SyntaxHelper.IsMethodCall(configCall, "WithTimeout"))
+                {
+                    timeout = ResilienceParser.ExtractTimeout(configCall);
+                }
+            }
+        }
+
+        return (retry, timeout);
     }
 
     /// <summary>

--- a/src/Strategos.Generators/Helpers/StepExtractor.cs
+++ b/src/Strategos.Generators/Helpers/StepExtractor.cs
@@ -239,6 +239,31 @@ internal static class StepExtractor
     }
 
     /// <summary>
+    /// Tries to build a fully configured <see cref="StepModel"/> for a <c>Then&lt;TStep&gt;()</c>
+    /// invocation, routing through the shared <c>TryGetStepModel</c> path so the step carries any
+    /// per-step resilience (<c>WithRetry</c>/<c>WithTimeout</c>/<c>Compensate</c>/confidence) and
+    /// <c>ValidateState</c> guard declared via the configure-lambda overload.
+    /// </summary>
+    /// <param name="invocation">The <c>Then</c> invocation expression for the step.</param>
+    /// <param name="semanticModel">The semantic model for type resolution.</param>
+    /// <param name="stepModel">The resulting configured step model, if successful.</param>
+    /// <returns>True if the step model was built; otherwise, false.</returns>
+    /// <remarks>
+    /// Unlike <see cref="TryBuildConfiguredForkPathStepModel"/>, the instance name is preserved.
+    /// Used by <see cref="FailureHandlerExtractor"/> so failure-handler steps thread their
+    /// configure-lambda resilience into the <see cref="StepModel"/> IR (DR-7), bringing the
+    /// failure-handler parse path to parity with the top-level/loop/fork parse paths.
+    /// </remarks>
+    internal static bool TryBuildConfiguredStepModel(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        out StepModel stepModel)
+    {
+        var (validationPredicate, validationErrorMessage) = ExtractConfiguredValidation(invocation);
+        return TryGetStepModel(invocation, semanticModel, loopName: null, validationPredicate, validationErrorMessage, out stepModel);
+    }
+
+    /// <summary>
     /// Tries to get the step name and optional instance name from an invocation expression.
     /// </summary>
     /// <param name="invocation">The invocation expression to check.</param>
@@ -831,6 +856,25 @@ internal static class StepExtractor
                 }
             }
         }
+        else if (SyntaxHelper.IsMethodCall(invocation, "Branch"))
+        {
+            // Extract step models from branch case path lambdas. Branch case steps are
+            // routed through the shared TryGetStepModel path so any per-step resilience
+            // declared via the Then<TStep>(step => step.WithRetry(...)) configure-lambda
+            // overload (DR-7) is captured into the StepModel IR, exactly as fork-path steps
+            // are. Branch handler EMISSION is still owned by BranchExtractor/the dedicated
+            // branch loop in SagaStepHandlersEmitter (keyed by step name), so surfacing the
+            // configured StepModel here only enriches the deduplicated step IR; it does not
+            // change which steps are emitted.
+            var branchPathStepModels = new List<StepModel>();
+            ParseBranchPathStepModels(invocation, semanticModel, currentLoopPrefix, branchPathStepModels, cancellationToken);
+
+            // Insert branch path steps at the beginning (deduplication happens in caller)
+            for (var i = branchPathStepModels.Count - 1; i >= 0; i--)
+            {
+                steps.Insert(0, branchPathStepModels[i]);
+            }
+        }
         else if (SyntaxHelper.IsMethodCall(invocation, "ValidateState"))
         {
             // Extract validation info - it will be applied to the next step
@@ -1009,6 +1053,65 @@ internal static class StepExtractor
                 // into the StepModel, so the fork-path step's validation guard lowers into
                 // the saga exactly as a top-level/loop step's does. The validation lives in
                 // this Then call's own configure lambda, so scope the lookup to its arguments.
+                var (validationPredicate, validationErrorMessage) = ExtractConfiguredValidation(inv);
+
+                if (TryGetStepModel(inv, semanticModel, currentPrefix, validationPredicate, validationErrorMessage, out var stepModel))
+                {
+                    stepModels.Add(stepModel);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Parses branch case path step models from a <c>Branch</c> invocation.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Mirrors <see cref="ParseForkPathStepModels"/> for branch cases: it descends into each
+    /// <c>When</c>/<c>Otherwise</c> case's path lambda and routes every <c>Then</c> through the
+    /// shared <see cref="TryGetStepModel"/> path, which threads per-step resilience
+    /// (<c>WithRetry</c>/<c>WithTimeout</c>/<c>Compensate</c>/confidence) declared via the
+    /// <c>Then&lt;TStep&gt;(step =&gt; step...)</c> configure-lambda overload (DR-7) into the
+    /// <see cref="StepModel"/> IR, plus any <c>ValidateState</c> guard.
+    /// </para>
+    /// <para>
+    /// This enriches only the deduplicated step IR consumed for worker-handler/command generation.
+    /// Branch routing/handler EMISSION is owned by <c>BranchExtractor</c> and the dedicated branch
+    /// loop in the saga emitter (keyed by step name), which are intentionally left unchanged.
+    /// </para>
+    /// </remarks>
+    private static void ParseBranchPathStepModels(
+        InvocationExpressionSyntax branchInvocation,
+        SemanticModel semanticModel,
+        string? currentPrefix,
+        List<StepModel> stepModels,
+        CancellationToken cancellationToken)
+    {
+        var arguments = branchInvocation.ArgumentList.Arguments;
+
+        // Skip first argument (discriminator); remaining are BranchCase.When()/Otherwise().
+        for (var i = 1; i < arguments.Count; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!TryExtractBranchCasePathLambda(arguments[i], out var pathLambda))
+            {
+                continue;
+            }
+
+            var pathInvocations = pathLambda
+                .DescendantNodes()
+                .OfType<InvocationExpressionSyntax>()
+                .Where(inv => SyntaxHelper.IsMethodCall(inv, "Then"))
+                .Reverse()
+                .ToList();
+
+            foreach (var inv in pathInvocations)
+            {
+                // Scope the per-step validation lookup to this Then call's own configure lambda,
+                // identically to the fork-path parse, so branch-path steps lower their validation
+                // and resilience config the same way.
                 var (validationPredicate, validationErrorMessage) = ExtractConfiguredValidation(inv);
 
                 if (TryGetStepModel(inv, semanticModel, currentPrefix, validationPredicate, validationErrorMessage, out var stepModel))

--- a/src/Strategos.Generators/Helpers/StepExtractor.cs
+++ b/src/Strategos.Generators/Helpers/StepExtractor.cs
@@ -1229,7 +1229,43 @@ internal static class StepExtractor
             return null;
         }
 
-        return new CompensationModel(compensationTypeName);
+        // DR-8 / INV-5 (CompensateNotAStep): record whether the compensation type resolves to a
+        // type implementing IWorkflowStep<TState>. The DSL's generic constraint also
+        // rejects non-steps at the C# call site, but capturing the verdict lets the
+        // generator surface a clearer, suppressible diagnostic. Unresolved symbols are
+        // treated as valid (true) so the analyzer does not double-report on a type that
+        // simply could not be bound (the C# compiler reports that independently).
+        var symbol = semanticModel.GetSymbolInfo(typeArgument).Symbol as INamedTypeSymbol;
+        var isRegisteredStep = symbol is null || ImplementsWorkflowStep(symbol);
+
+        return new CompensationModel(compensationTypeName, IsRegisteredStep: isRegisteredStep);
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="type"/> implements
+    /// <c>Strategos.Abstractions.IWorkflowStep&lt;TState&gt;</c> (any state type argument).
+    /// </summary>
+    private static bool ImplementsWorkflowStep(INamedTypeSymbol type) =>
+        type.AllInterfaces.Any(IsWorkflowStepInterface);
+
+    /// <summary>
+    /// Determines whether <paramref name="iface"/> is the generic
+    /// <c>Strategos.Abstractions.IWorkflowStep&lt;&gt;</c> interface (matched on its open
+    /// definition's metadata name + containing namespace, robust to display formatting).
+    /// </summary>
+    private static bool IsWorkflowStepInterface(INamedTypeSymbol iface)
+    {
+        if (!iface.IsGenericType)
+        {
+            return false;
+        }
+
+        var original = iface.OriginalDefinition;
+        return string.Equals(original.MetadataName, "IWorkflowStep`1", StringComparison.Ordinal)
+            && string.Equals(
+                original.ContainingNamespace?.ToDisplayString(),
+                "Strategos.Abstractions",
+                StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -1312,6 +1348,16 @@ internal static class StepExtractor
     private static bool TryGetDoubleLiteral(ExpressionSyntax expression, out double value)
     {
         value = 0;
+
+        // Unary minus over a numeric literal (e.g. RequireConfidence(-0.1)) — recognized so a
+        // negative (out-of-range) threshold reaches the IR and trips the out-of-range diagnostic.
+        if (expression is PrefixUnaryExpressionSyntax unary
+            && unary.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.UnaryMinusExpression)
+            && TryGetDoubleLiteral(unary.Operand, out var operand))
+        {
+            value = -operand;
+            return true;
+        }
 
         if (expression is LiteralExpressionSyntax literal
             && literal.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression))

--- a/src/Strategos.Generators/Models/ResilienceModels.cs
+++ b/src/Strategos.Generators/Models/ResilienceModels.cs
@@ -61,8 +61,19 @@ internal sealed record CompensationModel(
 /// </param>
 /// <param name="OnLowConfidenceHandlerId">
 /// The identifier of the handler invoked when confidence falls below
-/// <paramref name="Threshold"/>, or null if no handler is configured.
+/// <paramref name="Threshold"/>, or null if no handler is configured. This is the
+/// simple type name of the first <c>Then&lt;THandler&gt;()</c> step declared inside
+/// the <c>OnLowConfidence(alt =&gt; ...)</c> lambda.
+/// </param>
+/// <param name="OnLowConfidenceHandlerStep">
+/// The fully-resolved <see cref="StepModel"/> for the low-confidence handler step,
+/// or null if no handler is configured. Carries the handler step's fully qualified
+/// type name (needed for DI / worker-handler lowering) in addition to its simple
+/// name. The handler step is lowered into the saga (its own phase, worker handler,
+/// start/completed commands and events) so DR-5 can route to it via a Wolverine
+/// cascade (INV-1).
 /// </param>
 internal sealed record ConfidenceModel(
     double Threshold,
-    string? OnLowConfidenceHandlerId = null);
+    string? OnLowConfidenceHandlerId = null,
+    StepModel? OnLowConfidenceHandlerStep = null);

--- a/src/Strategos.Generators/Models/ResilienceModels.cs
+++ b/src/Strategos.Generators/Models/ResilienceModels.cs
@@ -44,14 +44,22 @@ internal sealed record TimeoutModel(TimeSpan Timeout);
 /// <param name="RequiredOnFailure">
 /// A value indicating whether compensation is required when the step fails.
 /// </param>
+/// <param name="IsRegisteredStep">
+/// A value indicating whether the compensation type resolves to a type implementing
+/// <c>IWorkflowStep&lt;TState&gt;</c>. <see langword="false"/> when the type could not be
+/// resolved as a workflow step (drives the compensate-not-a-step diagnostic; DR-8 / INV-5). Defaults to
+/// <see langword="true"/> so models created without a semantic-model check (e.g. tests, the
+/// compensation step-type fold) are not flagged.
+/// </param>
 /// <remarks>
 /// Per INV-8, the compensation step's identity is carried as a descriptor string
 /// (its fully qualified type name), never as a CLR <see cref="System.Type"/>. Symbol
-/// resolution of this name happens in the later parse task, not here.
+/// resolution of this name happens at parse time; only the boolean verdict is retained.
 /// </remarks>
 internal sealed record CompensationModel(
     string CompensationStepTypeName,
-    bool RequiredOnFailure = true);
+    bool RequiredOnFailure = true,
+    bool IsRegisteredStep = true);
 
 /// <summary>
 /// Generator IR for a step's confidence-gating policy.

--- a/src/Strategos.Generators/Models/ResilienceModels.cs
+++ b/src/Strategos.Generators/Models/ResilienceModels.cs
@@ -1,0 +1,68 @@
+// -----------------------------------------------------------------------
+// <copyright file="ResilienceModels.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+
+namespace Strategos.Generators.Models;
+
+/// <summary>
+/// Generator IR for a step's retry policy.
+/// </summary>
+/// <param name="MaxAttempts">The maximum number of retry attempts.</param>
+/// <param name="InitialDelay">The initial delay between retries, or null if unspecified.</param>
+/// <param name="BackoffMultiplier">The multiplier for exponential backoff, or null if unspecified.</param>
+/// <param name="MaxDelay">The maximum delay cap for backoff, or null if unspecified.</param>
+/// <param name="UseJitter">A value indicating whether random jitter is added to delays.</param>
+/// <remarks>
+/// Mirrors the wire-level <c>RetryConfiguration</c>
+/// (MaxAttempts/InitialDelay/BackoffMultiplier/MaxDelay/UseJitter). The delay-shaping
+/// members are nullable so the IR can carry only the values that were explicitly
+/// configured in the DSL; defaulting is applied at emit-time, not in the IR.
+/// </remarks>
+internal sealed record RetryModel(
+    int MaxAttempts,
+    TimeSpan? InitialDelay = null,
+    double? BackoffMultiplier = null,
+    TimeSpan? MaxDelay = null,
+    bool UseJitter = false);
+
+/// <summary>
+/// Generator IR for a step's timeout policy.
+/// </summary>
+/// <param name="Timeout">The maximum duration the step may run before timing out.</param>
+internal sealed record TimeoutModel(TimeSpan Timeout);
+
+/// <summary>
+/// Generator IR for a step's compensation (rollback) policy.
+/// </summary>
+/// <param name="CompensationStepTypeName">
+/// The fully qualified type name of the compensation step.
+/// </param>
+/// <param name="RequiredOnFailure">
+/// A value indicating whether compensation is required when the step fails.
+/// </param>
+/// <remarks>
+/// Per INV-8, the compensation step's identity is carried as a descriptor string
+/// (its fully qualified type name), never as a CLR <see cref="System.Type"/>. Symbol
+/// resolution of this name happens in the later parse task, not here.
+/// </remarks>
+internal sealed record CompensationModel(
+    string CompensationStepTypeName,
+    bool RequiredOnFailure = true);
+
+/// <summary>
+/// Generator IR for a step's confidence-gating policy.
+/// </summary>
+/// <param name="Threshold">
+/// The minimum confidence score required for the step's result to be accepted.
+/// </param>
+/// <param name="OnLowConfidenceHandlerId">
+/// The identifier of the handler invoked when confidence falls below
+/// <paramref name="Threshold"/>, or null if no handler is configured.
+/// </param>
+internal sealed record ConfidenceModel(
+    double Threshold,
+    string? OnLowConfidenceHandlerId = null);

--- a/src/Strategos.Generators/Models/StepModel.cs
+++ b/src/Strategos.Generators/Models/StepModel.cs
@@ -19,6 +19,10 @@ namespace Strategos.Generators.Models;
 /// <param name="ValidationPredicate">The predicate expression text for state validation guard.</param>
 /// <param name="ValidationErrorMessage">The error message when validation fails.</param>
 /// <param name="Context">The optional context configuration for this step.</param>
+/// <param name="Retry">The optional retry policy for this step.</param>
+/// <param name="Timeout">The optional timeout policy for this step.</param>
+/// <param name="Compensation">The optional compensation (rollback) policy for this step.</param>
+/// <param name="Confidence">The optional confidence-gating policy for this step.</param>
 internal sealed record StepModel(
     string StepName,
     string StepTypeName,
@@ -28,6 +32,26 @@ internal sealed record StepModel(
     string? ValidationErrorMessage = null,
     ContextModel? Context = null)
 {
+    /// <summary>
+    /// Gets the optional retry policy for this step.
+    /// </summary>
+    public RetryModel? Retry { get; init; }
+
+    /// <summary>
+    /// Gets the optional timeout policy for this step.
+    /// </summary>
+    public TimeoutModel? Timeout { get; init; }
+
+    /// <summary>
+    /// Gets the optional compensation (rollback) policy for this step.
+    /// </summary>
+    public CompensationModel? Compensation { get; init; }
+
+    /// <summary>
+    /// Gets the optional confidence-gating policy for this step.
+    /// </summary>
+    public ConfidenceModel? Confidence { get; init; }
+
     /// <summary>
     /// Gets the effective name for this step, used for duplicate detection and phase naming.
     /// </summary>
@@ -71,6 +95,10 @@ internal sealed record StepModel(
     /// <param name="validationPredicate">The optional predicate expression text for state validation guard.</param>
     /// <param name="validationErrorMessage">The optional error message when validation fails.</param>
     /// <param name="context">The optional context configuration for this step.</param>
+    /// <param name="retry">The optional retry policy for this step.</param>
+    /// <param name="timeout">The optional timeout policy for this step.</param>
+    /// <param name="compensation">The optional compensation (rollback) policy for this step.</param>
+    /// <param name="confidence">The optional confidence-gating policy for this step.</param>
     /// <returns>A validated <see cref="StepModel"/> instance.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="stepName"/> or <paramref name="stepTypeName"/> is null.</exception>
     /// <exception cref="ArgumentException">Thrown when validation fails or when predicate and message are mismatched.</exception>
@@ -85,7 +113,11 @@ internal sealed record StepModel(
         string? loopName = null,
         string? validationPredicate = null,
         string? validationErrorMessage = null,
-        ContextModel? context = null)
+        ContextModel? context = null,
+        RetryModel? retry = null,
+        TimeoutModel? timeout = null,
+        CompensationModel? compensation = null,
+        ConfidenceModel? confidence = null)
     {
         // Validate required parameters
         ThrowHelper.ThrowIfNull(stepName, nameof(stepName));
@@ -125,6 +157,12 @@ internal sealed record StepModel(
             LoopName: loopName,
             ValidationPredicate: validationPredicate,
             ValidationErrorMessage: validationErrorMessage,
-            Context: context);
+            Context: context)
+        {
+            Retry = retry,
+            Timeout = timeout,
+            Compensation = compensation,
+            Confidence = confidence,
+        };
     }
 }

--- a/src/Strategos.Generators/Models/WorkflowModel.cs
+++ b/src/Strategos.Generators/Models/WorkflowModel.cs
@@ -198,6 +198,11 @@ internal sealed record WorkflowModel(
     /// <param name="failureHandlers">The optional failure handler constructs in this workflow.</param>
     /// <param name="approvalPoints">The optional approval checkpoints in this workflow.</param>
     /// <param name="forks">The optional fork constructs in this workflow.</param>
+    /// <param name="confidenceHandlerStepNames">
+    /// The optional step names lowered from <c>OnLowConfidence</c> handler branches (DR-5).
+    /// Threaded through so <see cref="HasConfidenceHandlers"/> / <see cref="IsConfidenceHandlerStep"/>
+    /// are correct for factory-built models (consistent with the primary constructor).
+    /// </param>
     /// <returns>A validated <see cref="WorkflowModel"/> instance.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="pascalName"/>, <paramref name="namespace"/>, or <paramref name="stepNames"/> is null.</exception>
     /// <exception cref="ArgumentException">Thrown when any validation fails.</exception>
@@ -215,7 +220,8 @@ internal sealed record WorkflowModel(
         IReadOnlyList<BranchModel>? branches = null,
         IReadOnlyList<FailureHandlerModel>? failureHandlers = null,
         IReadOnlyList<ApprovalModel>? approvalPoints = null,
-        IReadOnlyList<ForkModel>? forks = null)
+        IReadOnlyList<ForkModel>? forks = null,
+        IReadOnlyList<string>? confidenceHandlerStepNames = null)
     {
         // Validate required parameters
         ThrowHelper.ThrowIfNullOrWhiteSpace(workflowName, nameof(workflowName));
@@ -269,6 +275,7 @@ internal sealed record WorkflowModel(
             Branches: branches,
             FailureHandlers: failureHandlers,
             ApprovalPoints: approvalPoints,
-            Forks: forks);
+            Forks: forks,
+            ConfidenceHandlerStepNames: confidenceHandlerStepNames);
     }
 }

--- a/src/Strategos.Generators/Models/WorkflowModel.cs
+++ b/src/Strategos.Generators/Models/WorkflowModel.cs
@@ -29,6 +29,13 @@ namespace Strategos.Generators.Models;
 /// <param name="FailureHandlers">The failure handler constructs in this workflow (OnFailure).</param>
 /// <param name="ApprovalPoints">The approval checkpoints in this workflow (AwaitApproval).</param>
 /// <param name="Forks">The fork constructs in this workflow (Fork/Join).</param>
+/// <param name="ConfidenceHandlerStepNames">
+/// The step names lowered from <c>OnLowConfidence</c> handler branches (DR-5). These steps are
+/// appended to <paramref name="StepNames"/> so they get full lowering (phase, worker handler,
+/// commands, events), but they are NOT part of the main linear flow: they must not displace the
+/// main flow's terminal step nor be chained to as a normal "next" step. Their own completed handler
+/// is terminal (a single-step handler ends the workflow via <c>MarkCompleted()</c>).
+/// </param>
 internal sealed record WorkflowModel(
     string WorkflowName,
     string PascalName,
@@ -42,7 +49,8 @@ internal sealed record WorkflowModel(
     IReadOnlyList<BranchModel>? Branches = null,
     IReadOnlyList<FailureHandlerModel>? FailureHandlers = null,
     IReadOnlyList<ApprovalModel>? ApprovalPoints = null,
-    IReadOnlyList<ForkModel>? Forks = null)
+    IReadOnlyList<ForkModel>? Forks = null,
+    IReadOnlyList<string>? ConfidenceHandlerStepNames = null)
 {
     /// <summary>
     /// Gets the derived phase enum name.
@@ -98,6 +106,26 @@ internal sealed record WorkflowModel(
     /// Gets a value indicating whether this workflow contains any fork constructs.
     /// </summary>
     public bool HasForks => Forks is not null && Forks.Count > 0;
+
+    /// <summary>
+    /// Gets a value indicating whether this workflow lowers any <c>OnLowConfidence</c>
+    /// handler branch (DR-5).
+    /// </summary>
+    public bool HasConfidenceHandlers =>
+        ConfidenceHandlerStepNames is not null && ConfidenceHandlerStepNames.Count > 0;
+
+    /// <summary>
+    /// Determines whether the named step is a lowered <c>OnLowConfidence</c> handler step
+    /// (DR-5) and therefore off the main linear flow.
+    /// </summary>
+    /// <param name="stepName">The step name to test.</param>
+    /// <returns>
+    /// <see langword="true"/> when the step was lowered from an <c>OnLowConfidence</c> branch;
+    /// otherwise <see langword="false"/>.
+    /// </returns>
+    public bool IsConfidenceHandlerStep(string stepName) =>
+        ConfidenceHandlerStepNames is not null
+        && ConfidenceHandlerStepNames.Contains(stepName);
 
     /// <summary>
     /// Gets a value indicating whether any step in this workflow has validation guards.

--- a/src/Strategos.Generators/Models/WorkflowModel.cs
+++ b/src/Strategos.Generators/Models/WorkflowModel.cs
@@ -143,6 +143,7 @@ internal sealed record WorkflowModel(
             return result;
         }
     }
+
     /// <summary>
     /// Gets a value indicating whether this workflow contains any approval checkpoints.
     /// </summary>

--- a/src/Strategos.Generators/Models/WorkflowModel.cs
+++ b/src/Strategos.Generators/Models/WorkflowModel.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using Strategos.Generators.Helpers;
 using Strategos.Generators.Polyfills;
 using Strategos.Generators.Utilities;
 
@@ -88,6 +89,52 @@ internal sealed record WorkflowModel(
     /// Gets a value indicating whether this workflow contains any failure handler constructs.
     /// </summary>
     public bool HasFailureHandlers => FailureHandlers is not null && FailureHandlers.Count > 0;
+
+    /// <summary>
+    /// Gets a value indicating whether any step in this workflow declares a
+    /// <c>.Compensate&lt;T&gt;()</c> rollback policy (DR-3).
+    /// </summary>
+    public bool HasCompensation => Steps?.Any(s => s.Compensation is not null) ?? false;
+
+    /// <summary>
+    /// Gets the distinct set of steps that declare a compensation policy, in
+    /// first-seen order (DR-3). Deduplicated by the compensation step's simple
+    /// type name so two steps rolling back to the same compensation type lower a
+    /// single compensation handler chain.
+    /// </summary>
+    /// <remarks>
+    /// Empty when no step declares compensation. Used by the compensation
+    /// lowering path to drive worker-handler, command, event, and saga-handler
+    /// emission for each rollback step.
+    /// </remarks>
+    public IReadOnlyList<StepModel> CompensationSteps
+    {
+        get
+        {
+            if (Steps is null)
+            {
+                return [];
+            }
+
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            var result = new List<StepModel>();
+            foreach (var step in Steps)
+            {
+                if (step.Compensation is null)
+                {
+                    continue;
+                }
+
+                var compName = NamingHelper.GetSimpleTypeName(step.Compensation.CompensationStepTypeName);
+                if (seen.Add(compName))
+                {
+                    result.Add(step);
+                }
+            }
+
+            return result;
+        }
+    }
 
     /// <summary>
     /// Gets a value indicating whether this workflow contains any approval checkpoints.

--- a/src/Strategos.Generators/WorkflowIncrementalGenerator.cs
+++ b/src/Strategos.Generators/WorkflowIncrementalGenerator.cs
@@ -6,6 +6,7 @@
 
 using Strategos.Generators.Diagnostics;
 using Strategos.Generators.Emitters;
+using Strategos.Generators.Helpers;
 using Strategos.Generators.Models;
 
 namespace Strategos.Generators;
@@ -548,6 +549,43 @@ public sealed class WorkflowIncrementalGenerator : IIncrementalGenerator
         if (hasErrors)
         {
             return new WorkflowGeneratorResult(null, diagnostics);
+        }
+
+        // Fold compensation (rollback) step TYPES into the step-model list so the
+        // emitters that key off model.Steps (worker handler, worker command,
+        // completed event, DI registration) produce the artifacts that let the
+        // rollback step RUN via the proven main-flow worker dispatch (DR-3 T008).
+        //
+        // Crucially the compensation step is folded into the step MODELS only, NOT
+        // into stepNames: stepNames is the saga's linear chain, so adding it there
+        // would run the rollback on the happy path. The compensation step is reached
+        // exclusively via the saga compensation handler chain
+        // (SagaCompensationComponentEmitter), which dispatches its worker command
+        // only when the trigger failure-handler command arrives.
+        if (stepModels.Any(s => s.Compensation is not null))
+        {
+            var allStepModels = new List<StepModel>(stepModels);
+            var existingModelNames = new HashSet<string>(
+                stepModels.Select(s => s.StepName),
+                StringComparer.Ordinal);
+
+            foreach (var step in stepModels)
+            {
+                if (step.Compensation is null)
+                {
+                    continue;
+                }
+
+                var compTypeName = step.Compensation.CompensationStepTypeName;
+                var compStepName = NamingHelper.GetSimpleTypeName(compTypeName);
+
+                if (existingModelNames.Add(compStepName))
+                {
+                    allStepModels.Add(StepModel.Create(compStepName, compTypeName));
+                }
+            }
+
+            stepModels = allStepModels;
         }
 
         var model = new WorkflowModel(

--- a/src/Strategos.Generators/WorkflowIncrementalGenerator.cs
+++ b/src/Strategos.Generators/WorkflowIncrementalGenerator.cs
@@ -443,6 +443,55 @@ public sealed class WorkflowIncrementalGenerator : IIncrementalGenerator
             stepModels = allStepModels;
         }
 
+        // Include low-confidence handler step names and step models in the overall
+        // lists (DR-5). A step's .RequireConfidence(t).OnLowConfidence(alt => alt.Then<H>())
+        // captures the handler step H only as a ConfidenceModel descriptor; lowering it here
+        // (mirroring failure-handler / approval step lowering) gives H its own phase, worker
+        // handler, start/completed commands and events, and a terminal saga completed handler.
+        // The saga's confidence-gated completed handler then routes to Start{H}Command via a
+        // Wolverine cascade when the result confidence is below the threshold (INV-1).
+        var confidenceHandlerSteps = stepModels
+            .Where(s => s.Confidence?.OnLowConfidenceHandlerStep is not null)
+            .Select(s => s.Confidence!.OnLowConfidenceHandlerStep!)
+            .ToList();
+
+        // Track the lowered handler step names so the saga emitter can keep them off the
+        // main linear flow (they must not displace the workflow's terminal step nor be
+        // chained to as a normal "next" step).
+        List<string>? confidenceHandlerStepNames = null;
+
+        if (confidenceHandlerSteps.Count > 0)
+        {
+            confidenceHandlerStepNames = new List<string>(confidenceHandlerSteps.Count);
+            var allStepNames = new List<string>(stepNames.Count + confidenceHandlerSteps.Count);
+            allStepNames.AddRange(stepNames);
+            var allStepModels = new List<StepModel>(stepModels.Count + confidenceHandlerSteps.Count);
+            allStepModels.AddRange(stepModels);
+
+            var existingStepNames = new HashSet<string>(stepNames, StringComparer.Ordinal);
+            var existingStepModelNames = new HashSet<string>(stepModels.Select(s => s.StepName), StringComparer.Ordinal);
+
+            foreach (var handlerStep in confidenceHandlerSteps)
+            {
+                confidenceHandlerStepNames.Add(handlerStep.StepName);
+
+                if (!existingStepNames.Contains(handlerStep.StepName))
+                {
+                    allStepNames.Add(handlerStep.StepName);
+                    existingStepNames.Add(handlerStep.StepName);
+                }
+
+                if (!existingStepModelNames.Contains(handlerStep.StepName))
+                {
+                    allStepModels.Add(handlerStep);
+                    existingStepModelNames.Add(handlerStep.StepName);
+                }
+            }
+
+            stepNames = allStepNames;
+            stepModels = allStepModels;
+        }
+
         // Check for missing steps
         if (stepNames.Count == 0)
         {
@@ -563,7 +612,8 @@ public sealed class WorkflowIncrementalGenerator : IIncrementalGenerator
             Branches: branchModels,
             FailureHandlers: failureHandlerModels,
             Forks: forkModels,
-            ApprovalPoints: approvalModels);
+            ApprovalPoints: approvalModels,
+            ConfidenceHandlerStepNames: confidenceHandlerStepNames);
 
         return new WorkflowGeneratorResult(model, diagnostics);
     }

--- a/src/Strategos.Generators/WorkflowIncrementalGenerator.cs
+++ b/src/Strategos.Generators/WorkflowIncrementalGenerator.cs
@@ -204,40 +204,24 @@ public sealed class WorkflowIncrementalGenerator : IIncrementalGenerator
             context.SemanticModel,
             ct);
 
-        // Extract per-step context models (.WithContext(...)) and fold them onto
-        // the matching step models (DR-6 T015). The parse already builds a
-        // ContextModel per WithContext call; merging it here is what makes the
+        // Extract per-step context models (.WithContext(...)) so they can be folded
+        // onto the matching step models (DR-6 T015). The parse already builds a
+        // ContextModel per WithContext call; the merge (below) is what makes the
         // ContextAssemblerEmitter (previously dead) emit a {Step}ContextAssembler
         // and lets the worker handler assemble ontology-backed context before the
-        // step runs. Keyed by step name so a context binds to its declaring step.
+        // step runs.
+        //
+        // F5: the extraction stays here, but the MERGE is deferred to after ALL
+        // step-model lowering completes (failure-handler steps, low-confidence
+        // handler steps, compensation steps are appended to stepModels later). If
+        // we merged now, .WithContext(...) declared on one of those off-main-flow
+        // handler steps would never attach, because the handler step model is not
+        // in stepModels yet. See the deferred merge just before the WorkflowModel
+        // construction.
         var contextModels = FluentDslParser.ExtractContextModels(
             context.TargetNode,
             context.SemanticModel,
             ct);
-
-        if (contextModels.Count > 0)
-        {
-            var contextByStep = new Dictionary<string, ContextModel>(StringComparer.Ordinal);
-            foreach (var (stepName, contextModel) in contextModels)
-            {
-                contextByStep[stepName] = contextModel;
-            }
-
-            var mergedStepModels = new List<StepModel>(stepModels.Count);
-            foreach (var step in stepModels)
-            {
-                if (step.Context is null && contextByStep.TryGetValue(step.StepName, out var ctxModel))
-                {
-                    mergedStepModels.Add(step with { Context = ctxModel });
-                }
-                else
-                {
-                    mergedStepModels.Add(step);
-                }
-            }
-
-            stepModels = mergedStepModels;
-        }
 
         // Extract loop models for loop handler generation
         // Use original validName (not pascalName) to match runtime condition ID format
@@ -691,6 +675,38 @@ public sealed class WorkflowIncrementalGenerator : IIncrementalGenerator
             }
 
             stepModels = allStepModels;
+        }
+
+        // Deferred context merge (F5): fold each .WithContext(...) ContextModel onto
+        // its declaring step model AFTER all step-model lowering has completed —
+        // failure-handler steps, low-confidence handler steps, and compensation
+        // steps are all in stepModels by now. Merging earlier left context declared
+        // on those off-main-flow handler steps unattached, so the assembler was
+        // never emitted (F5) and never registered (F3, ExtensionsEmitter). The
+        // ContextModel is keyed by the declaring step's name, so it binds to the
+        // matching step regardless of where in the flow the step lives.
+        if (contextModels.Count > 0)
+        {
+            var contextByStep = new Dictionary<string, ContextModel>(StringComparer.Ordinal);
+            foreach (var (stepName, contextModel) in contextModels)
+            {
+                contextByStep[stepName] = contextModel;
+            }
+
+            var mergedStepModels = new List<StepModel>(stepModels.Count);
+            foreach (var step in stepModels)
+            {
+                if (step.Context is null && contextByStep.TryGetValue(step.StepName, out var ctxModel))
+                {
+                    mergedStepModels.Add(step with { Context = ctxModel });
+                }
+                else
+                {
+                    mergedStepModels.Add(step);
+                }
+            }
+
+            stepModels = mergedStepModels;
         }
 
         var model = new WorkflowModel(

--- a/src/Strategos.Generators/WorkflowIncrementalGenerator.cs
+++ b/src/Strategos.Generators/WorkflowIncrementalGenerator.cs
@@ -63,6 +63,18 @@ public sealed class WorkflowIncrementalGenerator : IIncrementalGenerator
                 var sagaSource = SagaEmitter.Emit(result.Model);
                 spc.AddSource($"{sagaClassName}.g.cs", SourceText.From(sagaSource, Encoding.UTF8));
 
+                // Emit Context Assemblers (DR-6). Only steps that declared
+                // .WithContext(...) produce a {Step}ContextAssembler; when no step
+                // has context the emitter returns empty and no file is added, so a
+                // context-free workflow keeps its prior generated-file set
+                // byte-identical. The worker handler below wires each assembler into
+                // its step's execution path.
+                var assemblersSource = ContextAssemblerEmitter.Emit(result.Model);
+                if (!string.IsNullOrWhiteSpace(assemblersSource))
+                {
+                    spc.AddSource($"{result.Model.PascalName}Assemblers.g.cs", SourceText.From(assemblersSource, Encoding.UTF8));
+                }
+
                 // Emit Worker Handlers (Brain & Muscle pattern - Muscle component)
                 var handlersSource = WorkerHandlerEmitter.Emit(result.Model);
                 spc.AddSource($"{result.Model.PascalName}Handlers.g.cs", SourceText.From(handlersSource, Encoding.UTF8));
@@ -191,6 +203,41 @@ public sealed class WorkflowIncrementalGenerator : IIncrementalGenerator
             context.TargetNode,
             context.SemanticModel,
             ct);
+
+        // Extract per-step context models (.WithContext(...)) and fold them onto
+        // the matching step models (DR-6 T015). The parse already builds a
+        // ContextModel per WithContext call; merging it here is what makes the
+        // ContextAssemblerEmitter (previously dead) emit a {Step}ContextAssembler
+        // and lets the worker handler assemble ontology-backed context before the
+        // step runs. Keyed by step name so a context binds to its declaring step.
+        var contextModels = FluentDslParser.ExtractContextModels(
+            context.TargetNode,
+            context.SemanticModel,
+            ct);
+
+        if (contextModels.Count > 0)
+        {
+            var contextByStep = new Dictionary<string, ContextModel>(StringComparer.Ordinal);
+            foreach (var (stepName, contextModel) in contextModels)
+            {
+                contextByStep[stepName] = contextModel;
+            }
+
+            var mergedStepModels = new List<StepModel>(stepModels.Count);
+            foreach (var step in stepModels)
+            {
+                if (step.Context is null && contextByStep.TryGetValue(step.StepName, out var ctxModel))
+                {
+                    mergedStepModels.Add(step with { Context = ctxModel });
+                }
+                else
+                {
+                    mergedStepModels.Add(step);
+                }
+            }
+
+            stepModels = mergedStepModels;
+        }
 
         // Extract loop models for loop handler generation
         // Use original validName (not pascalName) to match runtime condition ID format

--- a/src/Strategos.Generators/WorkflowIncrementalGenerator.cs
+++ b/src/Strategos.Generators/WorkflowIncrementalGenerator.cs
@@ -590,6 +590,15 @@ public sealed class WorkflowIncrementalGenerator : IIncrementalGenerator
                 validName));
         }
 
+        // Validate per-step resilience configuration (DR-8 / INV-5; the resilience AGWF
+        // diagnostics). These are advisory signals over the parsed IR (StepModel.Retry/
+        // Timeout/Compensation/Confidence): some mirror builder-runtime throws (retry < 1,
+        // confidence ∉ [0,1]) so consumers get the same signal at compile time and can
+        // suppress it by id; others (non-positive timeout, RequireConfidence without
+        // OnLowConfidence, Compensate<T> non-step) are net-new. They do not gate code
+        // generation — the builder runtime / C# generic constraint already enforce them.
+        ReportResilienceDiagnostics(stepModels, validName, GetAttributeLocation(context), diagnostics);
+
         // Return null model (no code generation) when there are errors
         var hasErrors = duplicateSteps.Count > 0
             || (!hasStartWith && firstMethodName is not null)
@@ -654,6 +663,80 @@ public sealed class WorkflowIncrementalGenerator : IIncrementalGenerator
             ConfidenceHandlerStepNames: confidenceHandlerStepNames);
 
         return new WorkflowGeneratorResult(model, diagnostics);
+    }
+
+    /// <summary>
+    /// Reports the per-step resilience diagnostics (DR-8 / INV-5) over the parsed step
+    /// models. Each reported diagnostic carries a stable, suppressible AGWF id.
+    /// </summary>
+    /// <param name="stepModels">The parsed step models whose resilience IR is validated.</param>
+    /// <param name="workflowName">The validated workflow name, threaded into messages.</param>
+    /// <param name="location">The diagnostic location (the workflow attribute).</param>
+    /// <param name="diagnostics">The diagnostics accumulator to append to.</param>
+    private static void ReportResilienceDiagnostics(
+        IReadOnlyList<StepModel> stepModels,
+        string workflowName,
+        Location location,
+        List<Diagnostic> diagnostics)
+    {
+        foreach (var step in stepModels)
+        {
+            // CompensateNotAStep — Compensate<T> where T is not a registered IWorkflowStep<TState>.
+            if (step.Compensation is { IsRegisteredStep: false } compensation)
+            {
+                diagnostics.Add(Diagnostic.Create(
+                    WorkflowDiagnostics.CompensateNotAStep,
+                    location,
+                    step.EffectiveName,
+                    workflowName,
+                    compensation.CompensationStepTypeName));
+            }
+
+            if (step.Confidence is { } confidence)
+            {
+                // ConfidenceThresholdOutOfRange — RequireConfidence(x) with x outside [0.0, 1.0].
+                if (confidence.Threshold < 0.0 || confidence.Threshold > 1.0)
+                {
+                    diagnostics.Add(Diagnostic.Create(
+                        WorkflowDiagnostics.ConfidenceThresholdOutOfRange,
+                        location,
+                        step.EffectiveName,
+                        workflowName,
+                        confidence.Threshold));
+                }
+
+                // RequireConfidenceWithoutHandler — RequireConfidence with no OnLowConfidence handler.
+                if (confidence.OnLowConfidenceHandlerStep is null)
+                {
+                    diagnostics.Add(Diagnostic.Create(
+                        WorkflowDiagnostics.RequireConfidenceWithoutHandler,
+                        location,
+                        step.EffectiveName,
+                        workflowName));
+                }
+            }
+
+            // RetryMaxAttemptsBelowOne — retry maxAttempts < 1.
+            if (step.Retry is { } retry && retry.MaxAttempts < 1)
+            {
+                diagnostics.Add(Diagnostic.Create(
+                    WorkflowDiagnostics.RetryMaxAttemptsBelowOne,
+                    location,
+                    step.EffectiveName,
+                    workflowName,
+                    retry.MaxAttempts));
+            }
+
+            // NonPositiveTimeout — non-positive WithTimeout.
+            if (step.Timeout is { } timeout && timeout.Timeout <= TimeSpan.Zero)
+            {
+                diagnostics.Add(Diagnostic.Create(
+                    WorkflowDiagnostics.NonPositiveTimeout,
+                    location,
+                    step.EffectiveName,
+                    workflowName));
+            }
+        }
     }
 
     private static Location GetAttributeLocation(GeneratorAttributeSyntaxContext context)

--- a/src/Strategos/Abstractions/IBranchBuilder.cs
+++ b/src/Strategos/Abstractions/IBranchBuilder.cs
@@ -61,6 +61,39 @@ public interface IBranchBuilder<TState>
         where TStep : class, IWorkflowStep<TState>;
 
     /// <summary>
+    /// Adds a step to this branch path with configuration.
+    /// </summary>
+    /// <typeparam name="TStep">The step implementation type.</typeparam>
+    /// <param name="configure">Action to configure the step.</param>
+    /// <returns>The builder for fluent chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configure"/> is null.</exception>
+    /// <remarks>
+    /// <para>
+    /// Brings branch paths to parity with the top-level <see cref="IWorkflowBuilder{TState}"/>,
+    /// loop-body <see cref="ILoopBuilder{TState}"/>, and fork-path <see cref="IForkPathBuilder{TState}"/>
+    /// sequencing contexts, which already expose this overload. The configure lambda carries the
+    /// full <see cref="IStepConfiguration{TState}"/> surface — <c>.WithRetry</c>, <c>.WithTimeout</c>,
+    /// <c>.Compensate</c>, <c>.RequireConfidence</c>, <c>.OnLowConfidence</c>, <c>.ValidateState</c>,
+    /// and <c>.WithContext</c>:
+    /// <code>
+    /// .Branch(state => state.Outcome,
+    ///     BranchCase.When(Outcome.Escalate, path => path
+    ///         .Then&lt;EscalateClaim&gt;(step => step
+    ///             .WithRetry(2, TimeSpan.FromSeconds(5))
+    ///             .WithTimeout(TimeSpan.FromMinutes(1)))),
+    ///     BranchCase.Otherwise(path => path.Then&lt;AutoApprove&gt;()))
+    /// </code>
+    /// </para>
+    /// <para>
+    /// Enforcement parity is partial today: the configuration is captured in the workflow definition
+    /// and threaded into the generator's step IR, but the source generator does not yet emit Wolverine
+    /// retry/timeout/compensation for branch-path steps (tracked by issue #135).
+    /// </para>
+    /// </remarks>
+    IBranchBuilder<TState> Then<TStep>(Action<IStepConfiguration<TState>> configure)
+        where TStep : class, IWorkflowStep<TState>;
+
+    /// <summary>
     /// Marks this branch as terminal (does not rejoin the main flow).
     /// </summary>
     /// <remarks>

--- a/src/Strategos/Abstractions/IFailureBuilder.cs
+++ b/src/Strategos/Abstractions/IFailureBuilder.cs
@@ -49,6 +49,38 @@ public interface IFailureBuilder<TState>
         where TStep : class, IWorkflowStep<TState>;
 
     /// <summary>
+    /// Adds a step to this failure handler path with configuration.
+    /// </summary>
+    /// <typeparam name="TStep">The step implementation type.</typeparam>
+    /// <param name="configure">Action to configure the step.</param>
+    /// <returns>The builder for fluent chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configure"/> is null.</exception>
+    /// <remarks>
+    /// <para>
+    /// Brings failure-handler paths to parity with the top-level <see cref="IWorkflowBuilder{TState}"/>,
+    /// loop-body <see cref="ILoopBuilder{TState}"/>, and fork-path <see cref="IForkPathBuilder{TState}"/>
+    /// sequencing contexts, which already expose this overload. The configure lambda carries the
+    /// full <see cref="IStepConfiguration{TState}"/> surface — <c>.WithRetry</c>, <c>.WithTimeout</c>,
+    /// <c>.Compensate</c>, <c>.RequireConfidence</c>, <c>.OnLowConfidence</c>, <c>.ValidateState</c>,
+    /// and <c>.WithContext</c>:
+    /// <code>
+    /// .OnFailure(failure => failure
+    ///     .Then&lt;RefundPayment&gt;(step => step
+    ///         .WithRetry(2, TimeSpan.FromSeconds(5))
+    ///         .WithTimeout(TimeSpan.FromMinutes(1)))
+    ///     .Complete())
+    /// </code>
+    /// </para>
+    /// <para>
+    /// Enforcement parity is partial today: the configuration is captured in the workflow definition
+    /// and threaded into the generator's step IR, but the source generator does not yet emit Wolverine
+    /// retry/timeout/compensation for failure-handler steps (tracked by issue #135).
+    /// </para>
+    /// </remarks>
+    IFailureBuilder<TState> Then<TStep>(Action<IStepConfiguration<TState>> configure)
+        where TStep : class, IWorkflowStep<TState>;
+
+    /// <summary>
     /// Marks this failure handler as terminal (does not rejoin the main flow).
     /// </summary>
     /// <remarks>

--- a/src/Strategos/Abstractions/IStepConfiguration.cs
+++ b/src/Strategos/Abstractions/IStepConfiguration.cs
@@ -94,6 +94,21 @@ public interface IStepConfiguration<TState>
     /// </summary>
     /// <param name="timeout">The maximum execution time.</param>
     /// <returns>The builder for fluent chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// Lowered into the generated saga as a Wolverine <c>TimeoutMessage</c> deadline
+    /// <em>race</em>: the timeout is scheduled when the step starts, and the saga routes to
+    /// its failure path only if the step has not already completed (the completion event
+    /// won the race). This is a saga-level deadline, not hard cancellation of an in-flight
+    /// step — the step's <see cref="System.Threading.CancellationToken"/> is provided for
+    /// cooperative cancellation.
+    /// </para>
+    /// <para>
+    /// <b>Durability:</b> cross-restart timeout delivery requires the Marten transactional
+    /// outbox (<c>AddMarten(…).IntegrateWithWolverine()</c>); without it, scheduled timeout
+    /// delivery is in-memory only.
+    /// </para>
+    /// </remarks>
     IStepConfiguration<TState> WithTimeout(TimeSpan timeout);
 
     /// <summary>

--- a/src/Strategos/Builders/BranchBuilder.cs
+++ b/src/Strategos/Builders/BranchBuilder.cs
@@ -52,6 +52,24 @@ internal sealed class BranchBuilder<TState> : IBranchBuilder<TState>
     }
 
     /// <inheritdoc/>
+    public IBranchBuilder<TState> Then<TStep>(Action<IStepConfiguration<TState>> configure)
+        where TStep : class, IWorkflowStep<TState>
+    {
+        ArgumentNullException.ThrowIfNull(configure, nameof(configure));
+
+        // Build the step configuration
+        var configBuilder = new StepConfigurationBuilder<TState>();
+        configure(configBuilder);
+
+        // Create step with configuration
+        var step = StepDefinition.Create(typeof(TStep))
+            .WithConfiguration(configBuilder.Configuration);
+
+        _steps.Add(step);
+        return this;
+    }
+
+    /// <inheritdoc/>
     public void Complete()
     {
         IsTerminal = true;

--- a/src/Strategos/Builders/FailureBuilder.cs
+++ b/src/Strategos/Builders/FailureBuilder.cs
@@ -46,6 +46,24 @@ internal sealed class FailureBuilder<TState> : IFailureBuilder<TState>
     }
 
     /// <inheritdoc/>
+    public IFailureBuilder<TState> Then<TStep>(Action<IStepConfiguration<TState>> configure)
+        where TStep : class, IWorkflowStep<TState>
+    {
+        ArgumentNullException.ThrowIfNull(configure, nameof(configure));
+
+        // Build the step configuration
+        var configBuilder = new StepConfigurationBuilder<TState>();
+        configure(configBuilder);
+
+        // Create step with configuration
+        var step = StepDefinition.Create(typeof(TStep))
+            .WithConfiguration(configBuilder.Configuration);
+
+        _steps.Add(step);
+        return this;
+    }
+
+    /// <inheritdoc/>
     public void Complete()
     {
         IsTerminal = true;

--- a/src/Strategos/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Strategos/PublicAPI/PublicAPI.Shipped.txt
@@ -14,10 +14,12 @@ Strategos.Builders.IBranchBuilder<TState>.AwaitApproval<TApprover>(System.Action
 Strategos.Builders.IBranchBuilder<TState>.Complete() -> void
 Strategos.Builders.IBranchBuilder<TState>.Then<TStep>() -> Strategos.Builders.IBranchBuilder<TState!>!
 Strategos.Builders.IBranchBuilder<TState>.Then<TStep>(string! instanceName) -> Strategos.Builders.IBranchBuilder<TState!>!
+Strategos.Builders.IBranchBuilder<TState>.Then<TStep>(System.Action<Strategos.Builders.IStepConfiguration<TState!>!>! configure) -> Strategos.Builders.IBranchBuilder<TState!>!
 Strategos.Builders.IFailureBuilder<TState>
 Strategos.Builders.IFailureBuilder<TState>.Complete() -> void
 Strategos.Builders.IFailureBuilder<TState>.Then<TStep>() -> Strategos.Builders.IFailureBuilder<TState!>!
 Strategos.Builders.IFailureBuilder<TState>.Then<TStep>(string! instanceName) -> Strategos.Builders.IFailureBuilder<TState!>!
+Strategos.Builders.IFailureBuilder<TState>.Then<TStep>(System.Action<Strategos.Builders.IStepConfiguration<TState!>!>! configure) -> Strategos.Builders.IFailureBuilder<TState!>!
 Strategos.Builders.IForkJoinBuilder<TState>
 Strategos.Builders.IForkJoinBuilder<TState>.Join<TJoinStep>() -> Strategos.Builders.IWorkflowBuilder<TState!>!
 Strategos.Builders.ILoopBuilder<TState>

--- a/src/strategos.sln
+++ b/src/strategos.sln
@@ -65,6 +65,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Strategos.Ontology.MCP.Host
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Strategos.Ontology.MCP.Hosting.Tests", "Strategos.Ontology.MCP.Hosting.Tests\Strategos.Ontology.MCP.Hosting.Tests.csproj", "{5ED77069-6A17-417C-8BCA-27AACA0EFBE0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Strategos.Generators.Behavioral.Tests", "Strategos.Generators.Behavioral.Tests\Strategos.Generators.Behavioral.Tests.csproj", "{3C009EF6-1D39-4FC2-B69D-AC05DD50FBBA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -447,6 +449,18 @@ Global
 		{5ED77069-6A17-417C-8BCA-27AACA0EFBE0}.Release|x64.Build.0 = Release|Any CPU
 		{5ED77069-6A17-417C-8BCA-27AACA0EFBE0}.Release|x86.ActiveCfg = Release|Any CPU
 		{5ED77069-6A17-417C-8BCA-27AACA0EFBE0}.Release|x86.Build.0 = Release|Any CPU
+		{3C009EF6-1D39-4FC2-B69D-AC05DD50FBBA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C009EF6-1D39-4FC2-B69D-AC05DD50FBBA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C009EF6-1D39-4FC2-B69D-AC05DD50FBBA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3C009EF6-1D39-4FC2-B69D-AC05DD50FBBA}.Debug|x64.Build.0 = Debug|Any CPU
+		{3C009EF6-1D39-4FC2-B69D-AC05DD50FBBA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3C009EF6-1D39-4FC2-B69D-AC05DD50FBBA}.Debug|x86.Build.0 = Debug|Any CPU
+		{3C009EF6-1D39-4FC2-B69D-AC05DD50FBBA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C009EF6-1D39-4FC2-B69D-AC05DD50FBBA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3C009EF6-1D39-4FC2-B69D-AC05DD50FBBA}.Release|x64.ActiveCfg = Release|Any CPU
+		{3C009EF6-1D39-4FC2-B69D-AC05DD50FBBA}.Release|x64.Build.0 = Release|Any CPU
+		{3C009EF6-1D39-4FC2-B69D-AC05DD50FBBA}.Release|x86.ActiveCfg = Release|Any CPU
+		{3C009EF6-1D39-4FC2-B69D-AC05DD50FBBA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary

Fixes the core bug in **#135**: step-level resilience — `WithRetry` / `WithTimeout` / `Compensate<T>` / `RequireConfidence` + `OnLowConfidence` — was *declared, documented, and exported* but **never lowered into the emitted Wolverine + Marten saga** (a shipped, non-functional feature). It now lowers end-to-end, each capability **proven against a real Wolverine + Marten + Postgres host** (not shape-only). `WithContext` (the dead `ContextAssemblerEmitter`) is wired in too.

Design: [`docs/designs/2026-06-17-step-resilience-lowering.md`](docs/designs/2026-06-17-step-resilience-lowering.md) · Plan: [`docs/plans/2026-06-17-step-resilience-lowering.md`](docs/plans/2026-06-17-step-resilience-lowering.md)

## What now lowers (each with a real-container behavioral test)

| DR | Capability | Mechanism | Proof |
|----|-----------|-----------|-------|
| DR-2 | **Retry** | per-handler `Configure(HandlerChain)` → `OnAnyException().RetryTimes`/`RetryWithCooldown` | flaky step retried exactly 3× → completes |
| DR-3 | **Compensation** | `.Then.CompensatingAction` publishes the (previously orphaned) `Trigger…FailureHandlerCommand` → dedicated saga compensation chain | rollback runs once after exhaustion → `Failed` |
| DR-4 | **Timeout** | saga `TimeoutMessage` deadline race + idempotent guard | slow step routes to timeout; fast step no-ops |
| DR-5 | **Confidence** | saga `StepCompletedHandler` routes on `evt.Confidence` | 0.5 → `OnLowConfidence`; 0.9 → primary |
| DR-6 | **WithContext** | wire `ContextAssemblerEmitter` → ontology `IObjectSetProvider.ExecuteSimilarityAsync` (no `Strategos.Rag`) | step assembles state+retrieval+literal context |
| DR-7 | Expressibility | `Then<T>(configure)` on branch + failure-handler builders | IR-proven |
| DR-8 | Diagnostics | `AGWF017–021` (invalid retry/timeout/compensate/confidence) via the single-source TypeSpec catalog | 12 tests |
| DR-9 | **Behavioral harness** | new `Strategos.Generators.Behavioral.Tests` (Wolverine + Marten + Testcontainers Postgres) | the acceptance unlock |
| DR-10 | Composition | all four capabilities on one step; timeout/retry race; INV-7 | precedence + immutability proven on a real host |

## Why it matters

The new behavioral harness immediately caught **6 latent generator bugs** the old shape-only suite never could — including 3 that made the generated saga **fail to compile/run on Wolverine 6.x / Marten 9** (`[JasperFx.Identity]`, `long Version`, `WolverineFx.RuntimeCompilation`). Lowering is correctly **guarded**: a config-free step emits zero resilience artifacts (golden-baseline test).

## Verification

- Build: **33 projects, 0 errors, 0 warnings**
- `Strategos.Generators.Tests`: **1226 passed**
- `Strategos.Generators.Behavioral.Tests` (real Postgres): **17 passed**
- Spec + quality review: **APPROVED** (0 HIGH; the two MEDIUM findings — a latent CS0111 on compensation-step reuse, and a generic-type naming edge — were fixed with regression tests)

## Deferred follow-ons (documented in `docs/deferred-features.md`)

- [ ] `StepFailed`/`LowConfidenceRouted` **Marten stream events** (audit currently via queryable saga properties + logs; stream events apply only in EventSourced mode)
- [ ] Multi-step / rejoining `OnLowConfidence` handlers (single-step terminating handler lowered)
- [ ] Workflow-level `OnFailure` handler-chain interop with `Compensate<T>` (that chain was found independently dead)
- [ ] Validation-error-message literal escaping (pre-existing, not introduced here)

> **Note for reviewers:** `Refs` (not `Closes`) #135 — the epic has the tracked follow-ons above, so this PR delivers the core lowering without auto-closing the epic.

Refs #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
