### PR TITLE
feat: v2.9.0 close-out — step-resilience completeness + parity guard + schema bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+**Batch/safe schema-bootstrap API — removes the multi-registration startup
+footgun (#132).** `IObjectSetProvider` gains two new entry points so a host can
+stand up its physical layout at startup without hand-rolling a loop over
+`IOntologyQuery.GetObjectTypeNames<T>()`:
+
+- `Task EnsureSchemaAsync<T>(CancellationToken ct = default)` — the SAFE per-type
+  bootstrap. The existing single-descriptor
+  `PgVectorObjectSetProvider.EnsureSchemaAsync<T>(string? descriptorName = null, ct)`
+  **throws** `InvalidOperationException("… has multiple registrations …")` when a
+  CLR type is registered under more than one descriptor and no name is supplied.
+  The new no-name overload instead resolves the **full** registration set from the
+  ontology graph's reverse index (`OntologyGraph.ObjectTypeNamesByType`) and ensures
+  **every** descriptor's schema, keyed on the resolved descriptor name (INV-8). When
+  no graph is in scope it falls back to the single default-overload ensure, so the
+  pre-#132 behavior is byte-identical for the single-registration case.
+- `Task EnsureAllSchemasAsync(CancellationToken ct = default)` — the GRAPH-WIDE
+  bootstrap. Iterates `OntologyGraph.ObjectTypes` and ensures a vertex table (and
+  the DR-13/R2 key-property unique index) for **every** registered object descriptor
+  in one call.
+
+Implemented in `PgVectorObjectSetProvider` (raw Npgsql/pgvector DDL; INV-2) and, for
+cross-provider parity, in `InMemoryObjectSetProvider` (a no-op — partitions are
+materialized lazily, so there is no physical schema to provision). The
+multi-registration `InvalidOperationException` thrown by the write/default path now
+points callers at the new safe bootstrap API. The new members are **interface**
+additions; `Strategos.Ontology` / `Strategos.Ontology.Npgsql` carry **no** PublicAPI
+baseline (no `Microsoft.CodeAnalysis.PublicApiAnalyzers` reference, no
+`PublicAPI.*.txt`), so no re-baseline is required. The DB-gated parity tests
+(`EnsureSchemaBootstrapTests`) skip without `STRATEGOS_PG_TEST_CONN` and assert clean
+bootstrap of a multi-registered carrier under both entry points when a Postgres lane
+is provisioned.
+
 **Npgsql instance-anchored link traversal, depth-tiered (DR-12, #131).**
 `PgVectorObjectSetProvider.ExecuteAsync<T>` / `StreamAsync<T>` now serve
 `.Where(s => s.Key == id).TraverseLink<TLinked>("link")` expressions, closing the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+**`StartWith`/`Finally` accept a step-config overload (#141).**
+`IWorkflowBuilder<TState>` now exposes `StartWith<TStep>(Action<IStepConfiguration<TState>> configure)`,
+`StartWith<TStep>(string instanceName, Action<IStepConfiguration<TState>> configure)`,
+and `Finally<TStep>(Action<IStepConfiguration<TState>> configure)`, mirroring the
+existing `Then<TStep>(configure)` overload. This closes the expressibility gap where
+the entry (`StartWith`) and terminal (`Finally`) steps could not declare per-step
+resilience (`WithRetry`/`WithTimeout`/`Compensate`/`RequireConfidence`) inline and
+had to be wrapped by an extra non-configured `Then`. The captured config is routed
+through the same `WithConfiguration` path `Then(configure)` uses, so the generator's
+existing per-step IR threading (`StepExtractor.ExtractConfiguredResilience`) populates
+the first/terminal `StepModel` with no new lowering required.
+
 **Npgsql instance-anchored link traversal, depth-tiered (DR-12, #131).**
 `PgVectorObjectSetProvider.ExecuteAsync<T>` / `StreamAsync<T>` now serve
 `.Where(s => s.Key == id).TraverseLink<TLinked>("link")` expressions, closing the
@@ -43,6 +55,18 @@ signature changes, the CI gate fails closed with the message:
 
 Follow it: move the new/changed lines into `PublicAPI.Unshipped.txt` and record
 the change here so the downstream exarchos mirror can re-baseline deliberately.
+
+**`IWorkflowBuilder<TState>` step-config overloads added (#141).** Three new public
+members were added to the `IWorkflowBuilder<TState>` cross-product interface
+(non-breaking — pure additions):
+
+- `StartWith<TStep>(System.Action<IStepConfiguration<TState>> configure)`
+- `StartWith<TStep>(string instanceName, System.Action<IStepConfiguration<TState>> configure)`
+- `Finally<TStep>(System.Action<IStepConfiguration<TState>> configure)`
+
+The matching lines are staged in `PublicAPI.Unshipped.txt`. The exarchos
+`strategos-api-mirror.test.ts` mirror should re-baseline to pick up the new
+entry/terminal step-config overloads.
 
 **Ontology edge-properties surface removed (DR-5, #120, closes #114).** The
 schema-only edge-properties footgun — attaching ad-hoc properties to a *link*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,6 +305,58 @@ stream — no new mutation surface (INV-7).
     (`ContextAssemblerEmitter` / `ContextModelExtractor` are exercised by unit
     tests only, never wired into `WorkflowIncrementalGenerator`).
 
+### Added — Multi-step, rejoining `OnLowConfidence` handler chain (#139)
+
+- **`OnLowConfidence` handler lowering generalized from a single terminal
+  `Then<T>` into an ordered, multi-step chain with explicit exit semantics (#139).**
+  The extractor's `ExtractLowConfidenceHandlerChain` returns an ordered
+  `IReadOnlyList<StepModel>` (ordered by `Span.End` so a fluent
+  `alt.Then<A>().Then<B>()` yields `A` before `B`) plus a `RejoinsMainFlow` flag
+  inferred from a `.RejoinMainFlow()` call. A new sealed init-only IR
+  `LowConfidenceHandlerChainModel(Steps, RejoinsMainFlow)` is threaded onto
+  `ConfidenceModel.OnLowConfidenceHandlerChain` (the first step is still retained
+  as `OnLowConfidenceHandlerStep` for the saga routing surface). The generator
+  lowers **every** chain step: non-last steps chain to the next, and the last step
+  either rejoins the main flow at the step after the gated step
+  (`.RejoinMainFlow()`) or terminates via `MarkCompleted()` (the back-compat
+  default). The DSL adds `IBranchBuilder<TState>.RejoinMainFlow()` as an opt-in
+  marker (PublicAPI shipped baseline updated); terminating remains the default.
+  Proven end-to-end on a real Wolverine+Marten+Postgres host
+  (`LowConfidenceChainTests`: two-step chain runs in order, rejoin resumes the main
+  flow, terminating completes).
+
+### Fixed — Generator step-resilience close-out (#140, #142)
+
+- **`OnFailure` worker-handler chain now executes (previously dead) + `Compensate`↔`OnFailure`
+  interop (#140).** The workflow-level `OnFailure` chain was doubly dead: nothing
+  published the `Trigger{Pascal}FailureHandlerCommand` for a non-compensated failing
+  step, and the saga-dispatched failure-handler worker command had no worker `Handle`,
+  so the handler step never ran. `WorkerHandlerEmitter` now emits a dedicated
+  `FailureHandler_{id}_{step}Handler` per `OnFailure` step (returning the
+  `…Completed` event the saga folds and routes on), every main-flow step in an
+  `OnFailure` workflow lowers a trigger-publishing `Configure(HandlerChain)`
+  (failure-handler steps excluded — they are the recovery path), and the handlers are
+  registered in DI. A step-level `.Compensate<T>()` and a workflow-level `OnFailure`
+  were previously mutually exclusive (the compensation emitter no-op'd whenever
+  `OnFailure` was also declared, to avoid a duplicate `Handle(Trigger…)` CS0111);
+  they now **compose in a fixed order from a single merged trigger site** —
+  compensation rollback runs **first** (Compensating phase), then chains into the
+  `OnFailure` chain, which ends the saga in the Failed phase. The saga
+  `Phase = State.Phase` sync is gated on a mechanically-detected
+  `WorkflowModel.StateHasPhaseProperty` (via `StateTypeExtractor`) so a state type
+  with no `Phase` member no longer emits an uncompilable reference. Proven end-to-end
+  on a real Wolverine+Marten+Postgres host (`CompensateOnFailureInteropTests`:
+  rollback runs once, then `OnFailure` runs once, in order, saga terminal;
+  `FailureHandlerChainTests`), plus golden tests pinning exactly one
+  `Handle(Trigger…)` site (no CS0111).
+- **Escape the validation-error-message literal in the generated start handler (#142).**
+  A `ValidateState` error message containing a double-quote or backslash was
+  interpolated raw (`Token.ValueText`) into the generated start-handler string literal,
+  breaking the emitted source so it failed to compile. The message is now emitted via
+  `SymbolDisplay.FormatLiteral(quote: true)` at both literal sites (the `LogWarning`
+  argument and the `ValidationFailed` event), so the literal is fully escaped and
+  compilable.
+
 ## [2.8.0] - 2026-05-25
 
 The **cross-product schema substrate** release. TypeSpec remains the single

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,18 @@ baseline (no `Microsoft.CodeAnalysis.PublicApiAnalyzers` reference, no
 bootstrap of a multi-registered carrier under both entry points when a Postgres lane
 is provisioned.
 
+**`StartWith`/`Finally` accept a step-config overload (#141).**
+`IWorkflowBuilder<TState>` now exposes `StartWith<TStep>(Action<IStepConfiguration<TState>> configure)`,
+`StartWith<TStep>(string instanceName, Action<IStepConfiguration<TState>> configure)`,
+and `Finally<TStep>(Action<IStepConfiguration<TState>> configure)`, mirroring the
+existing `Then<TStep>(configure)` overload. This closes the expressibility gap where
+the entry (`StartWith`) and terminal (`Finally`) steps could not declare per-step
+resilience (`WithRetry`/`WithTimeout`/`Compensate`/`RequireConfidence`) inline and
+had to be wrapped by an extra non-configured `Then`. The captured config is routed
+through the same `WithConfiguration` path `Then(configure)` uses, so the generator's
+existing per-step IR threading (`StepExtractor.ExtractConfiguredResilience`) populates
+the first/terminal `StepModel` with no new lowering required.
+
 **Npgsql instance-anchored link traversal, depth-tiered (DR-12, #131).**
 `PgVectorObjectSetProvider.ExecuteAsync<T>` / `StreamAsync<T>` now serve
 `.Where(s => s.Key == id).TraverseLink<TLinked>("link")` expressions, closing the
@@ -75,6 +87,18 @@ signature changes, the CI gate fails closed with the message:
 
 Follow it: move the new/changed lines into `PublicAPI.Unshipped.txt` and record
 the change here so the downstream exarchos mirror can re-baseline deliberately.
+
+**`IWorkflowBuilder<TState>` step-config overloads added (#141).** Three new public
+members were added to the `IWorkflowBuilder<TState>` cross-product interface
+(non-breaking — pure additions):
+
+- `StartWith<TStep>(System.Action<IStepConfiguration<TState>> configure)`
+- `StartWith<TStep>(string instanceName, System.Action<IStepConfiguration<TState>> configure)`
+- `Finally<TStep>(System.Action<IStepConfiguration<TState>> configure)`
+
+The matching lines are staged in `PublicAPI.Unshipped.txt`. The exarchos
+`strategos-api-mirror.test.ts` mirror should re-baseline to pick up the new
+entry/terminal step-config overloads.
 
 **Ontology edge-properties surface removed (DR-5, #120, closes #114).** The
 schema-only edge-properties footgun — attaching ad-hoc properties to a *link*

--- a/docs/deferred-features.md
+++ b/docs/deferred-features.md
@@ -27,12 +27,23 @@ This document catalogs all features from the Strategos design specification that
 > terminating** `OnLowConfidence` handler is lowered (multi-step chains + rejoin-to-main
 > are not yet); **workflow-level `OnFailure` handler-chain interop with `Compensate<T>` is
 > deferred** (see §2.1 — the workflow-level failure-handler chain is independently
-> non-functional); **terminal-failure / low-confidence audit is captured as queryable saga
-> document properties + structured logs, not yet as named `StepFailed` / `LowConfidenceRouted`
-> Marten *stream* events** (stream events apply only in EventSourced mode — a tracked
-> follow-on); resilience config is attachable only via `.Then<TStep>(s => …)` (not
+> non-functional); resilience config is attachable only via `.Then<TStep>(s => …)` (not
 > `StartWith`/`Finally`); and a `[Workflow("name")]` name must PascalCase to its
 > partial-class name. See `docs/designs/2026-06-17-step-resilience-lowering.md`.
+
+> **Status update — 2026-06-17 (#138, _audit-event taxonomy / Open Question #1_).** The
+> terminal-failure / low-confidence audit is now ALSO emitted as **named Marten *stream*
+> events** in EventSourced mode (it was previously captured only as queryable saga
+> document properties + structured logs — the document-mode behavior is unchanged). This
+> resolves the step-resilience design's **Open Question #1 (audit-event taxonomy)**:
+> - **`StepFailed`** `(WorkflowId, FailedStepName, ExceptionType?, ExceptionMessage?, Timestamp)` — appended at the single ordered terminal-failure trigger site (the OnFailure trigger handler, and the merged Compensate↔OnFailure trigger) when `Persistence = PersistenceMode.EventSourced`.
+> - **`LowConfidenceRouted`** `(WorkflowId, StepName, Confidence, Threshold, Timestamp)` — appended at the confidence gate when a step's result confidence routes below the configured threshold, in EventSourced mode.
+>
+> Both are `sealed`, init-only records implementing the workflow's `I{Pascal}Event` marker,
+> appended through the saga's existing `IDocumentSession` (INV-1, no parallel runtime).
+> They are emitted **only** in EventSourced mode (stream events apply only there), so
+> SagaDocument-mode output is byte-unchanged. Proven end-to-end on a real
+> Postgres-backed Marten host (`EventSourcedHostFixture` + `EventSourcedAuditEventTests`).
 
 **Total Deferred Features:** 8
 **Deferral Categories:**

--- a/docs/deferred-features.md
+++ b/docs/deferred-features.md
@@ -56,14 +56,23 @@ This document catalogs all features from the Strategos design specification that
 >   new config member forces the author to point it at a behavioral proof or file a deferral.
 > - **`AGWF022` (declared-but-inert)**: a `warning` reported when a step declares a config
 >   concern the generator does **not** lower for that step's kind, so it silently has no
->   effect. The first guarded case is **confidence gating (`RequireConfidence`/
->   `OnLowConfidence`) on a `Fork` path** — the fork-path parse threads the configure lambda
->   into the IR (so an out-of-range threshold still surfaces the threshold-range code), but the
->   saga emitter does not lower fork-path confidence routing. That variant is **deferred to
->   v2.10.0 / DR-17 (#134)**; until then the diagnostic prevents the inert configuration from
->   masquerading as working. (Surfacing 6.1's backfill also fixed two real top-level
->   `ValidateState` lowering gaps — configure-lambda validation was dropped for top-level/loop
->   steps, and the predicate parameter had to be named literally `state` to compile.)
+>   effect. The guarded case is **confidence gating (`RequireConfidence`/`OnLowConfidence`)
+>   on a `Fork` path** — the fork-path parse threads the configure lambda into the IR (so an
+>   out-of-range threshold still surfaces the threshold-range code), but the saga emitter does
+>   not lower fork-path confidence routing. That variant is **deferred to v2.10.0 / DR-17
+>   (#134)**; until then the diagnostic prevents the inert configuration from masquerading as
+>   working. (Surfacing 6.1's backfill also fixed two real top-level `ValidateState` lowering
+>   gaps — configure-lambda validation was dropped for top-level/loop steps, and the predicate
+>   parameter had to be named literally `state` to compile.)
+>
+>   **Scope boundary — loop-body / nested-`RepeatUntil` confidence config is _not_ AGWF022-guarded.**
+>   Confidence configuration declared on a step inside a `RepeatUntil` loop body is **dropped
+>   from the IR entirely** by step extraction, so an IR-based diagnostic structurally **cannot**
+>   see it — there is nothing in the IR for AGWF022 to inspect. It is therefore **silently inert**
+>   (no compile-time warning), distinct from the fork-path case above which *is* threaded into the
+>   IR and *is* diagnosed. Loop-body confidence routing is likewise **deferred to v2.10.0 / DR-17
+>   (#134)**; emitting a diagnostic for it requires the lowering work that brings loop-body config
+>   into the IR in the first place.
 
 **Total Deferred Features:** 8
 **Deferral Categories:**

--- a/docs/deferred-features.md
+++ b/docs/deferred-features.md
@@ -45,6 +45,26 @@ This document catalogs all features from the Strategos design specification that
 > SagaDocument-mode output is byte-unchanged. Proven end-to-end on a real
 > Postgres-backed Marten host (`EventSourcedHostFixture` + `EventSourcedAuditEventTests`).
 
+> **Standing contract — 2026-06-18 (#143, G-6 _declared↔lowered parity_).** A step
+> configuration member is **"done" only with a behavioral proof or a tracked deferral** —
+> a shape/golden test (one that asserts the *emitted source text*, not a *running saga*)
+> does **not** count as proof that a configuration lowers. Two mechanisms enforce this:
+> - **Parity guard** (`StepConfigParityTests`, `Strategos.Generators.Tests/Parity/`): reflects
+>   the full `IStepConfiguration<TState>` surface + the `StepConfigurationDefinition` IR
+>   fields and fails the build if any member is not classified as either **Lowered** (with a
+>   named behavioral compile-run-saga test) or **Deferred** (with a tracking issue). Adding a
+>   new config member forces the author to point it at a behavioral proof or file a deferral.
+> - **`AGWF022` (declared-but-inert)**: a `warning` reported when a step declares a config
+>   concern the generator does **not** lower for that step's kind, so it silently has no
+>   effect. The first guarded case is **confidence gating (`RequireConfidence`/
+>   `OnLowConfidence`) on a `Fork` path** — the fork-path parse threads the configure lambda
+>   into the IR (so an out-of-range threshold still surfaces the threshold-range code), but the
+>   saga emitter does not lower fork-path confidence routing. That variant is **deferred to
+>   v2.10.0 / DR-17 (#134)**; until then the diagnostic prevents the inert configuration from
+>   masquerading as working. (Surfacing 6.1's backfill also fixed two real top-level
+>   `ValidateState` lowering gaps — configure-lambda validation was dropped for top-level/loop
+>   steps, and the predicate parameter had to be named literally `state` to compile.)
+
 **Total Deferred Features:** 8
 **Deferral Categories:**
 - Agent-Specific Patterns (4 features)

--- a/docs/designs/2026-06-17-v290-closeout-bundle.md
+++ b/docs/designs/2026-06-17-v290-closeout-bundle.md
@@ -1,0 +1,156 @@
+# v2.9.0 Close-Out Bundle — step-resilience completeness + schema-bootstrap footgun
+
+**Date:** 2026-06-17 · **Workflow:** `v290-closeout-bundle`
+**Addresses:** #143 (parity guard) · #142 (escape literal) · #141 (StartWith/Finally config) · #140 (OnFailure chain + Compensate interop) · #139 (multi-step OnLowConfidence) · #138 (EventSourced audit events) · #132 (batch schema bootstrap)
+**Builds on:** #135 / PR #137 (step-resilience lowering, `docs/designs/2026-06-17-step-resilience-lowering.md`, DR-1..DR-10) · #129 (v2.9.0 edge layer)
+**Invariant catalog:** `/strategos-design-invariants` (INV-1..INV-8)
+**Defers to v2.10.0:** #128 (chained identity) · #130 R3a/R4/R5/R6/R8 — both already owned by `docs/designs/2026-06-16-edge-layer-v2100-followons.md`
+
+---
+
+## Problem Statement
+
+v2.9.0 is **not yet tagged** (`git describe → v2.8.0-5-g0f5fa2c`); the edge layer (#127/#129/#136) and step-resilience lowering (#135/#137) are committed but unreleased. This is the **last close-out before the tag** — the place for the small completeness/correctness work that shouldn't ship half-done, *not* for the architectural follow-ons (#128/#130-heavy/#131/#126/#125/#113), which already have a v2.10.0 design + plan in the tree.
+
+Two gap clusters remain after #137:
+
+1. **The step-resilience DSL is lowered but not *complete*.** #137 made `WithRetry`/`WithTimeout`/`Compensate`/`RequireConfidence`/`WithContext` lower into the Wolverine+Marten saga and locked the five known capabilities with mutation-proven behavioral tests. But the surrounding surface still has declared-but-incomplete corners: the workflow-level `OnFailure` chain emits a worker command with **no handler** (a dead path, #140); `OnLowConfidence` lowers only a **single terminal** step (#139); `StartWith`/`Finally` can't take step config at all (#141); the terminal-failure / low-confidence **audit events** the design committed to are captured as document properties but **never appended to the Marten stream** (#138, the design's Open Question #1); and a validation-error message with a quote breaks the emitted literal (#142). Above all, the protection against *new* instances of the "declared-but-not-lowered" bug class is still **disciplinary, not structural** (#143).
+
+2. **The schema-bootstrap default is a silent multi-registration footgun (#132).** `EnsureSchemaAsync<T>(descriptorName: null)` is correct until a `T` gains a second descriptor, then it's a hard startup crash — which is exactly how a downstream consumer (Basileus agent-host) crash-looped. There is no batch "ensure schemas for everything" counterpart, so every consumer hand-rolls a cross-service loop.
+
+### What the exploration removed from scope
+
+- **#130 R1 (reverse junction index) and R2 (vertex key-path unique index) are already shipped** (`SqlGenerator.cs:359-366` / `:271-287`, covered by `JunctionIndexTests` / `VertexIndexTests`). The "do the additive DDL while the schema is unreleased" argument is **moot** — there is no pre-tag DDL debt. R1/R2 are closed as already-complete; the remaining #130 items (R3a identifier guard, R4 batch relate, R5 prepared statements, R6 `RelateBatchAsync`, R8 pgvector knobs) stay in v2.10.0, where R3a is a P2 concern anyway.
+
+## The organizing idea
+
+The bundle's keystone is **#143's declared↔lowered parity guard**. Under this (Approach B) scope we *complete* the step-resilience surface rather than defer it, so #143 flips from "track five deferrals" to "**assert the whole `IStepConfiguration` surface is lowered and behaviorally proven**, with its deferred-set pointing only at the genuinely-out-of-scope v2.10.0 fork-path items." It converts "remember to lower + behaviorally test a new config member" from a discipline into a **build failure** — the permanent fix for the bug class #137 only patched five instances of.
+
+---
+
+## Invariant constraints (from `/strategos-design-invariants`, verdict: **conditional**)
+
+| Invariant | Constraint this design adopts |
+|---|---|
+| **INV-1** (HIGH, lowering via SG) | #140/#139/#138 lower **through `SagaEmitter` / the `Saga/*` emitters onto Wolverine+Marten primitives** — no parallel runtime. #140's OnFailure worker handler is a generated saga `Handle`, not a hand-rolled dispatcher; #138's events append via the saga's existing `IDocumentSession`. #143's whole purpose is to *enforce* this seam mechanically. |
+| **INV-5** (HIGH, stable diagnostic IDs) | #143's "declared-but-inert" diagnostic takes the **next-free monotonic `AGWF022`** (live ceiling `AGWF021` in `AgwfCatalog.tsp`; ids single-sourced there → `AgwfCodes.g.cs` + `WorkflowDiagnostics.cs`). No id reused/renumbered. #132 adds no analyzer diagnostic (runtime API only); if one is wanted it takes next-free `AONT213` (live ceiling AONT212). |
+| **INV-6 / INV-7** (HIGH, sealed/immutable) | New IR/config records (#141 per-step config threaded onto `StartWith`/`Finally`; #139 multi-step handler chain model; #138 audit-event records; #132 any bootstrap result) are `sealed` `init`-only; each extends `InvariantGuardTests`. Retry/handler re-delivery keeps the same immutable envelope state (INV-7), unchanged from #137. |
+| **INV-8** (HIGH, polyglot identity) | #132's batch path keys on the **resolved descriptor name** via `IOntologyQuery.GetObjectTypeNames<T>()` / `OntologyGraph.ObjectTypes`, never `typeof`. #140/#139 step references stay FQN-string descriptors (consistent with `StepModel.StepTypeName`), never CLR `Type`. |
+| **INV-2** (HIGH, self-contained ontology) | #132 stays in `Strategos.Ontology` / `Strategos.Ontology.Npgsql`, raw Npgsql only — zero Marten/Wolverine. |
+| **INV-3/INV-4** | Do not bind (no MCP-spec change; no new DSL nomenclature beyond mirroring existing concrete verbs `StartWith`/`Finally`/`Then`). |
+
+---
+
+## Requirements
+
+Each `CL-N` is a close-out requirement; `/exarchos:plan` traces tasks to these anchors. CL-1/CL-2/CL-7 are independent; CL-3/CL-4/CL-5 are the heavier saga-emission items; **CL-6 (#143) lands last** as the closing forcing function over the now-complete surface.
+
+### CL-1 — Escape the validation-error-message literal (#142)
+
+`StepStartHandlerEmitter.cs:128` interpolates `stepModel.ValidationErrorMessage` (raw `Token.ValueText`) straight into a generated C# string literal; a message containing `"` or `\` breaks the emitted source.
+
+**Acceptance criteria:**
+- The message is emitted via `SymbolDisplay.FormatLiteral(msg, quote: true)` (or an escaped verbatim literal); generated source compiles for a message containing a double-quote and a backslash.
+- A generator test asserts a quote/backslash-bearing `ValidateState` message round-trips (regression pin).
+
+### CL-2 — `StartWith` / `Finally` accept step config (#141)
+
+`StartWith<TStep>` (`IWorkflowBuilder.cs:51/74`) and `Finally<TStep>` (`:169`) are the only sequencing contexts lacking the `Action<IStepConfiguration<TState>>` overload, so the first and terminal steps can't declare resilience. The parse path already threads config (`StepExtractor.ExtractConfiguredResilience`), and `StepModel` already carries `Retry/Timeout/Compensation/Confidence` — this is overload + IR-threading, not new lowering.
+
+**Acceptance criteria:**
+- `StartWith<TStep>(Action<IStepConfiguration<TState>>)` and `Finally<TStep>(Action<IStepConfiguration<TState>>)` exist, mirroring `Then(configure)` at `IWorkflowBuilder.cs:129`; the interface stays sealed-by-composition (INV-6).
+- A `StartWith`/`Finally` step declaring `.WithRetry(n)`/`.WithTimeout(t)`/`.Compensate<T>()` is lowered identically to a mid-chain `Then` step (proven by the #137 behavioral harness, extended).
+- `PublicAPI.Unshipped.txt` updated (RS0016/RS0017 break by design — not suppressed); CHANGELOG entry.
+
+### CL-3 — Wire the OnFailure worker handler + define Compensate↔OnFailure interop (#140)
+
+Two coupled defects. (a) The workflow-level `OnFailure(flow => …)` chain's generated `ExecuteFailureHandler_…WorkerCommand` has **no worker handler** (`SagaFailureHandlerComponentEmitter.cs:131` dispatches it; nothing handles it) — the chain is dead. (b) `SagaCompensationComponentEmitter.cs:87` **no-ops when `model.HasFailureHandlers`** to avoid a duplicate `Handle(Trigger…)` (CS0111), so step-level `Compensate<T>` and a workflow-level `OnFailure` are today **mutually exclusive**.
+
+The design call: define their composition explicitly. A step's `Compensate<T>` is **local unwind** of that step's effect; the workflow `OnFailure` chain is **terminal handling** for the workflow. When both are present they compose in a fixed order — **step compensation runs first, then the OnFailure chain** — emitted from a **single** `Handle(Trigger…)` site so there is no CS0111 collision (replacing the mutual-exclusion guard with a merged emission path).
+
+**Acceptance criteria:**
+- A workflow with `OnFailure(flow => flow.Then<NotifyFailure>())` and a failing step runs `NotifyFailure` (behavioral test) — the dead worker command is closed.
+- A workflow with **both** a step `.Compensate<Rollback>()` and a workflow `OnFailure(…)`: on failure, `Rollback.ExecuteAsync` runs once, **then** the OnFailure chain runs; the saga reaches `Failed`; no CS0111 (single `Handle` site).
+- The merged emission keeps phase-enum prefixing + durable checkpointing correct (INV-1); golden test pins the single-`Handle` shape.
+
+### CL-4 — Multi-step and rejoining `OnLowConfidence` handlers (#139)
+
+`StepExtractor.ExtractLowConfidenceHandlerStep` (`:1429-1455`) takes the **first** `Then<T>` and the completed handler is terminal (`MarkCompleted()`). Generalize it to a multi-step chain mirroring the failure-handler emission (`SagaFailureHandlerComponentEmitter.cs:52-72` loops over `model.FailureHandlers`), and support **rejoin-to-main-flow** after the handler (resume at the next main step) instead of always terminating.
+
+**Acceptance criteria:**
+- `OnLowConfidence(alt => alt.Then<A>().Then<B>())` lowers a two-step handler chain; both `A` and `B` execute in order (behavioral test).
+- A rejoining handler (`…rejoin/continue` semantic) resumes the main flow at the step after the gated step; a terminating handler still completes (both shapes tested; the terminal default is unchanged for back-compat).
+- New handler-chain model is `sealed` `init`-only (INV-6); emission goes through the saga emitters (INV-1).
+
+### CL-5 — Emit `StepFailed` / `LowConfidenceRouted` as Marten stream events in EventSourced mode (#138)
+
+#137 captures terminal-failure / low-confidence audit data as queryable saga **document properties + logs** (document mode) but never appends the **named stream events** the design committed to; they're only meaningful in `EventSourced` mode. The mechanism already exists — `StateApplicationHelper.cs:56-64` appends via `session.Events.Append(WorkflowId, evt)`, and the failure/confidence handlers already receive `IDocumentSession` when `IsEventSourced` (`SagaFailureHandlerComponentEmitter.cs:112-120`). This **resolves the step-resilience design's Open Question #1 (audit-event taxonomy)**.
+
+**Acceptance criteria:**
+- When `model.IsEventSourced`, the compensation-trigger handler appends `StepFailed` (failed step name + exception type) and the confidence-gated handler appends `LowConfidenceRouted` (step + score + threshold) to the workflow's Marten stream; document-mode posture is unchanged.
+- Audit-event records are `sealed` `init`-only with a settled shape (resolve OQ#1: names `StepFailed` / `LowConfidenceRouted`; reuse vs. new decided in /plan).
+- A new **EventSourced behavioral fixture** (the existing `WolverineHostFixture` is document-mode only) asserts each event lands in the stream; reverting the append makes it go RED (mutation-proof, per the #143 standard).
+
+### CL-6 — Declared↔lowered parity guard (#143) — keystone, lands last
+
+Make it **impossible to ship an `IStepConfiguration<TState>` member (or `StepConfigurationDefinition` field) that isn't lowered or explicitly, trackably deferred.** Two mechanisms:
+
+- **(A) Parity allowlist test** (forcing function) in `Strategos.Generators.Tests`: reflect over the public surface of `IStepConfiguration<TState>` and the fields of `StepConfigurationDefinition`, asserting every member is in exactly one explicit set — **lowered** (membership backed by an emit assertion *and* a compile-run-saga behavioral test) or **deferred** (annotated with a tracking issue). A new member that is neither fails the build.
+- **(B) Generator "declared-but-inert" diagnostic** (`AGWF022`, INV-5): when the parser populates a `StepModel` config field that **no emitter consumes for that step kind**, report the diagnostic at consumer compile time — turning the silent no-op into the earliest-tier signal.
+
+Under Approach B the **lowered** set is the whole current surface (`WithRetry`/`WithTimeout`/`Compensate`/`RequireConfidence`/`OnLowConfidence`/`ValidateState`/`WithContext`, all lowered by #137 + CL-1..CL-5); the **deferred** set points only at the explicitly-out-of-scope v2.10.0 fork-path items (`RequireConfidence`/`OnLowConfidence` on fork branches, nested `RepeatUntil` in a branch — #134/v2.10.0 DR-17).
+
+**Acceptance criteria:**
+- Adding an `IStepConfiguration` member / `StepConfigurationDefinition` field that is neither lowered-with-behavioral-proof nor deferred-with-issue **fails** the parity test.
+- A `StepModel` config field set by the parser but read by no emitter for a step kind raises `AGWF022` at consumer compile time.
+- Backfill: the current surface passes the parity guard (every member lowered after CL-1..CL-5; deferred set = the v2.10.0 fork-path items only).
+- The guard is documented as the standing contract: *shape-only tests are insufficient for lowering correctness; a config member is "done" only with a behavioral proof or a tracked deferral.*
+
+### CL-7 — Batch / safe schema bootstrap (#132)
+
+`PgVectorObjectSetProvider.EnsureSchemaAsync<T>(descriptorName: null)` throws for a multi-registered `T` (`:145`) — defensible alone, but there's no batch counterpart, so consumers hand-roll a cross-service loop over `IOntologyQuery.GetObjectTypeNames<T>()`. Add a graph-wide bootstrap and make the obvious call the safe one.
+
+**Acceptance criteria:**
+- `IObjectSetProvider` gains `Task EnsureAllSchemasAsync(CancellationToken)` — ensures a table for **every** descriptor in `OntologyGraph.ObjectTypes`; the Npgsql impl iterates the graph (INV-2, raw Npgsql; INV-8, keys on resolved descriptor name).
+- `EnsureSchemaAsync<T>(CancellationToken)` (no descriptor name) ensures **all** descriptors registered for `T` (iterates `GetObjectTypeNames<T>()`) instead of throwing — the zero-arg call becomes the safe one; the existing single-descriptor overload is unchanged.
+- The Basileus multi-registration crash scenario (two `Object<SemanticDocument>("…")` registrations) bootstraps cleanly under both new entry points — used as the validation fixture (design-on-merit; consumer is corpus, not dependency).
+- `PublicAPI.Unshipped.txt` + CHANGELOG updated; any new result type `sealed` (INV-6).
+
+---
+
+## Sequencing & delegation shape
+
+| Track | CL | Issue | Depends on | Notes |
+|---|---|---|---|---|
+| Escape literal | CL-1 | #142 | — | Tiny; parallel from t0 |
+| StartWith/Finally config | CL-2 | #141 | — | Overload + IR thread; parse path exists |
+| Batch schema bootstrap | CL-7 | #132 | — | Ontology; fully independent track |
+| OnFailure + Compensate interop | CL-3 | #140 | — | Saga emission; merged `Handle` site |
+| Multi-step OnLowConfidence | CL-4 | #139 | — | Mirror failure-handler chain + rejoin |
+| EventSourced audit events | CL-5 | #138 | — | New EventSourced behavioral fixture |
+| Parity guard | CL-6 | #143 | CL-1..CL-5 | **Last** — allowlist over the completed surface |
+
+**Critical ordering:** CL-6 lands after CL-1..CL-5 so its allowlist reflects the now-complete surface and its backfill passes. CL-1/CL-2/CL-7 are quick parallel wins; CL-3/CL-4/CL-5 are the saga-emission core. **PR shape** (one stacked PR per CL vs. grouped — e.g. CL-3/CL-4/CL-5 saga-emission together, CL-1/CL-2/CL-6 generator-surface together, CL-7 standalone) is a /plan decision.
+
+## Testing Strategy
+
+- **Behavioral (mandatory, the #143 standard):** every lowering CL (CL-2 StartWith/Finally resilience, CL-3 OnFailure+compensation order, CL-4 multi-step/rejoin OnLowConfidence, CL-5 EventSourced stream events) gets a compile-run-saga test in `Strategos.Generators.Behavioral.Tests`, each **mutation-proven** to go RED when its lowering is removed. CL-5 needs a **new EventSourced host fixture** (current fixtures are document-mode).
+- **Generator/shape:** CL-1 (escaped literal compiles), CL-3 (single-`Handle` golden shape, no CS0111), CL-6 (the parity allowlist + `AGWF022` analyzer positive/negative).
+- **Ontology:** CL-7 against real Postgres+pgvector under `Strategos.Ontology.Npgsql.Tests` (DB-gated like the existing suites so the default build stays green without a database), asserting the two-registration bootstrap.
+- **Sealed-guard (INV-6):** `InvariantGuardTests` extended for every new record.
+- **No-config baseline:** the existing golden test still pins byte-for-byte-unchanged output for steps with no resilience config.
+- TUnit invocation is `-- --treenode-filter`, not `--filter` (repo convention).
+
+## Out of scope (→ v2.10.0, already designed)
+
+- **#128** chained-identity / multi-registration traversal — the P2 junction keystone (v2.10.0 DR-11/G-11).
+- **#130** R3a (identifier guard), R4 (batch relate), R5 (prepared statements), R6 (`RelateBatchAsync`), R8 (pgvector knobs) — v2.10.0 DR-13/G-13. **R1/R2 are already shipped and close as complete.**
+- Fork-path `RequireConfidence`/`OnLowConfidence` and nested `RepeatUntil` in a fork branch — tracked deferrals in CL-6's allowlist (v2.10.0 DR-17 / #134).
+
+## Open Questions
+
+1. **OnFailure ↔ Compensate ordering (CL-3)** — confirm "step compensation, then workflow OnFailure" is the desired precedence (vs. OnFailure-only when both declared). Lean: compose in that order; resolve in /plan against the saga state machine.
+2. **Rejoin semantics for OnLowConfidence (CL-4)** — does "rejoin" resume at the next main step, or re-run the gated step with the handler's output? Lean: resume at next step (handler is corrective, not a retry); confirm against a real low-confidence routing case.
+3. **Audit-event taxonomy (CL-5)** — final names/shapes for `StepFailed` / `LowConfidenceRouted`, and whether `RetryExhausted` joins them now or stays deferred. Resolves step-resilience OQ#1 in /plan.
+4. **#132 surface (CL-7)** — ship both `EnsureAllSchemasAsync` *and* the safe `EnsureSchemaAsync<T>(ct)`, or only the graph-wide bootstrap? Lean: both (the per-`T` safe overload removes the footgun at its source).
+5. **Exact AGWF id** — `AGWF022` assigned against the live `AgwfCatalog.tsp` ceiling (AGWF021) at implementation.

--- a/docs/diagnostics/agwf.md
+++ b/docs/diagnostics/agwf.md
@@ -27,3 +27,4 @@ from the generated `AgwfCode` enum; this table is generated from the same source
 | AGWF019 | warning | RequireConfidence without OnLowConfidence handler | Step '{0}' in workflow '{1}' calls RequireConfidence but declares no OnLowConfidence handler. Add OnLowConfidence(alt => ...) so low-confidence results have a routing path. | 2.10.0 |
 | AGWF020 | error | Retry maxAttempts below one | Step '{0}' in workflow '{1}' configures WithRetry({2}). The maxAttempts value must be at least 1. | 2.10.0 |
 | AGWF021 | error | Non-positive timeout | Step '{0}' in workflow '{1}' configures WithTimeout with a non-positive duration. The timeout must be greater than zero. | 2.10.0 |
+| AGWF022 | warning | Declared-but-inert step configuration | Step '{0}' in workflow '{1}' declares {2}, which the generator does not lower for this step kind, so the configuration is inert. Remove it or move the step to a position where the configuration is lowered. | 2.9.0 |

--- a/docs/plans/2026-06-17-v290-closeout-bundle.md
+++ b/docs/plans/2026-06-17-v290-closeout-bundle.md
@@ -1,0 +1,244 @@
+# Implementation Plan — v2.9.0 Close-Out Bundle
+
+**Design:** `docs/designs/2026-06-17-v290-closeout-bundle.md` · **Workflow:** `v290-closeout-bundle`
+**Scope:** step-resilience completeness (#142/#141/#140/#139/#138) + parity guard (#143) + schema bootstrap (#132). **Defers to v2.10.0:** #128, #130 R3a/R4/R5/R6/R8 (R1/R2 already shipped).
+
+## Iron Law
+
+> **NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST.** Every task is RED → GREEN → REFACTOR.
+
+## Conventions for this plan
+
+- **Test runner (TUnit):** `cd src && dotnet test <proj> -- --treenode-filter "/*/*/*/MethodName"`. Bare `--filter` does **not** work in this repo (`feedback_tunit_test_invocation`).
+- **Assertions awaited:** `await Assert.That(x).IsEqualTo(y);`.
+- **Behavioral suite:** `Strategos.Generators.Behavioral.Tests` (real Wolverine + Marten + Testcontainers Postgres). Lowering correctness is proven here, **mutation-proven** (reverting the lowering makes the test RED) — the #143 standard. Document-mode fixtures: `WolverineHostFixture`, `CompensationHostFixture`. **No EventSourced fixture exists yet** (built in G-5).
+- **DB-gated suites:** `Strategos.Generators.Behavioral.Tests` + `Strategos.Ontology.Npgsql.Tests` need a live Postgres+pgvector; gate them like the existing Node/benchmark suites in publish-verify so default `dotnet build`/`dotnet test` stays green without a database.
+- **Public-API drift:** any builder/provider signature change trips RS0016/RS0017 by design — update `PublicAPI.Unshipped.txt` + CHANGELOG in the same task; do **not** suppress.
+- **Diagnostic ids:** new `AGWF` continue past live ceiling **AGWF021** → **AGWF022**, single-sourced in `Strategos.Contracts/Diagnostics/AgwfCatalog.tsp` (regen `AgwfCodes.g.cs` — TypeSpec compile needs Node 22+, `project_contracts_tests_need_node_job`) + `WorkflowDiagnostics.cs`. Monotonic; never reuse. No `AONT` needed (CL-7 is runtime API only).
+- **Sealed-guard (INV-6):** every new public/internal record is appended to `InvariantGuardTests` (`Strategos.Generators.Tests/InvariantGuardTests.cs:42`) in its REFACTOR step.
+
+## Dependency spine (task groups)
+
+```
+G-1 (#142 escape)      ─┐
+G-2 (#141 StartWith/Finally) ─┤  parallel from t0
+G-7 (#132 schema bootstrap)  ─┘
+
+G-3 (#140 OnFailure+Compensate) ─┐
+G-4 (#139 multi-step OnLowConf)  ─┤─► G-5 (#138 EventSourced events) ─► G-6 (#143 parity guard, LAST)
+                                  ┘     (extends both handlers)          (allowlist over completed surface)
+```
+
+**Critical path:** {G-3, G-4} → G-5 → G-6. **Parallel from t0:** G-1, G-2, G-7. **Worktree-isolation note:** G-3 and G-4 touch *different* emitters (G-3: `SagaFailureHandlerComponentEmitter` + `SagaCompensationComponentEmitter`; G-4: `StepExtractor` confidence + confidence emitter) so they parallelize; G-5 extends both failure and confidence handlers, so it lands **after** both; G-6 reflects the *finished* surface, so it lands **last**.
+
+---
+
+## G-1 — CL-1 (#142): Escape validation-error-message literal
+
+### Task 1.1: Escaped literal compiles
+1. **[RED]** `StepStartHandlerEmitter_ValidationMessageWithQuoteAndBackslash_EmitsCompilableLiteral`
+   - File: `src/Strategos.Generators.Tests/Emitters/StepStartHandlerEmitterTests.cs`
+   - Drive a workflow whose `ValidateState` message is `He said \"go\" \\ stop`; assert the generated source for the start handler compiles (Roslyn `CSharpCompilation` with no `CS1009`/`CS1010`), or that the emitted literal equals the `SymbolDisplay.FormatLiteral` form.
+   - Expected failure: today `StepStartHandlerEmitter.cs:128` interpolates raw `Token.ValueText` → broken literal.
+2. **[GREEN]** Replace the raw interpolation at `src/Strategos.Generators/Emitters/Saga/StepStartHandlerEmitter.cs:128` with `SymbolDisplay.FormatLiteral(stepModel.ValidationErrorMessage, quote: true)`.
+3. **[REFACTOR]** Grep sibling emitters for other raw-message interpolations; factor a `LiteralOf(...)` helper if a second site exists.
+
+**Dependencies:** None · **Parallelizable:** Yes
+
+---
+
+## G-2 — CL-2 (#141): `StartWith` / `Finally` accept step config
+
+### Task 2.1: Builder overloads + IR threading (parse)
+1. **[RED]** `StepExtractor_StartWithConfigure_PopulatesFirstStepResilience` and `StepExtractor_FinallyConfigure_PopulatesTerminalStepResilience`
+   - File: `src/Strategos.Generators.Tests/Helpers/StepExtractorConfigTests.cs`
+   - A workflow declaring `.StartWith<First>(s => s.WithRetry(2))` … `.Finally<Last>(s => s.WithTimeout(t))`; assert the resulting `StepModel`s carry `Retry`/`Timeout` (via the existing `ExtractConfiguredResilience` path).
+   - Expected failure: overloads don't exist — won't compile / config dropped.
+2. **[GREEN]** Add `StartWith<TStep>(Action<IStepConfiguration<TState>> configure)` (and the named-instance variant) and `Finally<TStep>(Action<IStepConfiguration<TState>> configure)` to `src/Strategos/Abstractions/IWorkflowBuilder.cs` (mirror `Then(configure)` at `:129`) + the concrete `WorkflowBuilder` impl; route the captured config through the same path `Then(configure)` uses so `StepExtractor` populates the IR.
+3. **[REFACTOR]** No new record (reuses `StepModel` config). Confirm `ILoopBuilder.cs:100` parity unaffected.
+
+**Dependencies:** None · **Parallelizable:** Yes
+
+### Task 2.2: PublicAPI baseline
+1. **[RED]** Build trips `RS0016` (new public members not in shipped baseline).
+2. **[GREEN]** Add the four signatures to `src/Strategos/PublicAPI.Unshipped.txt`; add a CHANGELOG entry. Do not suppress.
+
+**Dependencies:** Task 2.1 · **Parallelizable:** No
+
+### Task 2.3: Behavioral proof
+1. **[RED]** `Behavioral_StartWithStepWithRetry_RetriesIndependently` (start step throws twice, succeeds on 3rd → `ExecuteAsync` invoked 3×) and `Behavioral_FinallyStepWithTimeout_RoutesToTimeoutPath`
+   - File: `src/Strategos.Generators.Behavioral.Tests/StartWithFinallyResilienceTests.cs` (reuse `WolverineHostFixture`)
+   - Expected failure (pre-2.1): no `Configure` emitted for the first/terminal handler.
+2. **[GREEN]** Verified by Task 2.1's emission; this task adds the mutation-proof (revert 2.1 → RED).
+
+**Dependencies:** Task 2.1 · **Parallelizable:** No
+
+---
+
+## G-3 — CL-3 (#140): OnFailure worker handler + Compensate↔OnFailure interop
+
+### Task 3.1: Close the dead OnFailure worker command
+1. **[RED]** `Behavioral_WorkflowOnFailureChain_RunsHandlerStep`
+   - File: `src/Strategos.Generators.Behavioral.Tests/FailureHandlerChainTests.cs` (new `FailureHandlerHostFixture` or reuse `CompensationHostFixture`)
+   - Workflow `OnFailure(flow => flow.Then<NotifyFailure>())` + a step that always throws; assert `NotifyFailure.ExecuteAsync` runs once and saga reaches `Failed`.
+   - Expected failure: `SagaFailureHandlerComponentEmitter.cs:131` dispatches `ExecuteFailureHandler_{id}_{step}WorkerCommand` but **no worker `Handle`** exists → chain never runs.
+2. **[GREEN]** Emit the missing worker handler for `ExecuteFailureHandler_…WorkerCommand` (in `SagaFailureHandlerComponentEmitter` / the worker-handler emit path) so the dispatched command is handled and the failure-handler step executes.
+3. **[REFACTOR]** Golden shape test for the new `Handle` in `Strategos.Generators.Tests`.
+
+**Dependencies:** None · **Parallelizable:** Yes (vs G-4/G-1/G-2/G-7)
+
+### Task 3.2: Compensate↔OnFailure interop (single Handle, ordered)
+1. **[RED]** `Behavioral_StepCompensateAndWorkflowOnFailure_RunsCompensationThenFailureChain`
+   - File: same fixture as 3.1
+   - Workflow with step `.Compensate<Rollback>()` **and** `OnFailure(flow => flow.Then<NotifyFailure>())`; failing step → `Rollback.ExecuteAsync` runs once, **then** `NotifyFailure` runs; saga `Failed`.
+   - Expected failure: `SagaCompensationComponentEmitter.cs:87` `if (model.HasFailureHandlers) return;` makes them mutually exclusive — compensation is skipped.
+2. **[GREEN]** Replace the no-op guard with a **merged single `Handle(Trigger…)` emission** that dispatches compensation first, then the failure-handler chain — eliminating the CS0111 duplicate-`Handle` collision the guard was avoiding. Phase-enum prefixing + durable checkpoint stay correct.
+3. **[REFACTOR]** Golden test pins exactly one `Handle(Trigger…)` site; confirm no CS0111 in the compile fixture.
+
+**Dependencies:** Task 3.1 · **Parallelizable:** No (same emitters)
+
+---
+
+## G-4 — CL-4 (#139): Multi-step + rejoining `OnLowConfidence`
+
+### Task 4.1: Multi-step handler chain
+1. **[RED]** `Behavioral_OnLowConfidenceTwoStepChain_RunsBothInOrder`
+   - File: `src/Strategos.Generators.Behavioral.Tests/LowConfidenceChainTests.cs`
+   - `RequireConfidence(0.85).OnLowConfidence(alt => alt.Then<A>().Then<B>())` with a step returning `Confidence = 0.5`; assert `A` then `B` execute.
+   - Expected failure: `StepExtractor.ExtractLowConfidenceHandlerStep` (`:1429-1455`) takes only the **first** `Then<T>` and terminates.
+2. **[GREEN]** Generalize to `ExtractLowConfidenceHandlerChain` returning an ordered `IReadOnlyList<StepModel>`; emit the chain mirroring the failure-handler multi-step loop (`SagaFailureHandlerComponentEmitter.cs:52-72`). New `sealed` `init`-only chain model.
+3. **[REFACTOR]** Add the chain model to `InvariantGuardTests`.
+
+**Dependencies:** None · **Parallelizable:** Yes (vs G-3)
+
+### Task 4.2: Rejoin-to-main-flow
+1. **[RED]** `Behavioral_OnLowConfidenceRejoin_ResumesMainFlowAfterGatedStep` and `Behavioral_OnLowConfidenceTerminating_CompletesWorkflow`
+   - File: same fixture
+   - Rejoining handler resumes the main flow at the step **after** the gated step; terminating handler still `MarkCompleted()` (back-compat default).
+   - Expected failure (pre-4.2): handler always terminates.
+2. **[GREEN]** Add rejoin semantics — emit a continuation to the next main step instead of `MarkCompleted()` when the handler is declared rejoining; default stays terminal.
+3. **[REFACTOR]** Golden shape for both routings.
+
+**Dependencies:** Task 4.1 · **Parallelizable:** No
+
+---
+
+## G-5 — CL-5 (#138): EventSourced `StepFailed` / `LowConfidenceRouted` stream events
+
+### Task 5.1: EventSourced behavioral fixture (infra)
+1. **[RED]** `EventSourcedFixture_Smoke_AppendsAndReadsStream` — stand up an EventSourced-mode host (Marten event store) and assert a baseline workflow event round-trips.
+   - File: `src/Strategos.Generators.Behavioral.Tests/Infrastructure/EventSourcedHostFixture.cs` (new; `WolverineHostFixture` is document-mode only)
+   - Expected failure: no EventSourced fixture exists.
+2. **[GREEN]** Build the fixture (Marten `AddMarten(...).IntegrateWithWolverine()`, EventSourced persistence mode, shared Testcontainers Postgres via `[ClassDataSource]`/`IAsyncLifetime`; `[NotInParallel]` where the shared host is asserted).
+3. **[REFACTOR]** Share the Postgres container with the existing fixtures (one container per run).
+
+**Dependencies:** None (infra) · **Parallelizable:** Yes, but **G-5 emit tasks below depend on G-3 + G-4**
+
+### Task 5.2: `StepFailed` on terminal failure
+1. **[RED]** `Behavioral_EventSourcedStepFailure_AppendsStepFailedEvent`
+   - File: `src/Strategos.Generators.Behavioral.Tests/EventSourcedAuditEventTests.cs`
+   - EventSourced workflow, failing step → a `StepFailed` event (failed step name + exception type) lands in the Marten stream.
+   - Expected failure: #137 captures this only as document properties; no stream event.
+2. **[GREEN]** In the compensation-trigger handler emit (`SagaFailureHandlerComponentEmitter`, EventSourced branch `:112-120`), append `StepFailed` via the existing `session.Events.Append(WorkflowId, evt)` mechanism (`StateApplicationHelper.cs:56-64`), guarded by `model.IsEventSourced` (`WorkflowModel.cs:84`). Define `sealed record StepFailed(...)`.
+3. **[REFACTOR]** Document-mode golden output unchanged; add `StepFailed` to `InvariantGuardTests`.
+
+**Dependencies:** Tasks 5.1, 3.2 · **Parallelizable:** No
+
+### Task 5.3: `LowConfidenceRouted` on gated routing
+1. **[RED]** `Behavioral_EventSourcedLowConfidence_AppendsLowConfidenceRoutedEvent`
+   - File: same as 5.2
+   - EventSourced workflow, low-confidence result → a `LowConfidenceRouted` event (step + score + threshold) lands in the stream.
+2. **[GREEN]** In the confidence-gated handler emit, append `LowConfidenceRouted` when `IsEventSourced`. Define `sealed record LowConfidenceRouted(...)`. (Resolves step-resilience design **Open Question #1** audit-event taxonomy.)
+3. **[REFACTOR]** Add `LowConfidenceRouted` to `InvariantGuardTests`; reconcile `docs/deferred-features.md`.
+
+**Dependencies:** Tasks 5.1, 4.2 · **Parallelizable:** No
+
+---
+
+## G-6 — CL-6 (#143): Declared↔lowered parity guard — **LAST**
+
+### Task 6.1: Parity allowlist test (forcing function)
+1. **[RED]** `StepConfigParity_EveryMember_IsLoweredOrDeferred`
+   - File: `src/Strategos.Generators.Tests/Parity/StepConfigParityTests.cs`
+   - Reflect over the public surface of `IStepConfiguration<TState>` (`src/Strategos/Abstractions/IStepConfiguration.cs`) and the fields of `StepConfigurationDefinition` (`src/Strategos/Definitions/StepConfigurationDefinition.cs`); assert every member is in exactly one of two explicit sets — **Lowered** (with a referenced behavioral test) or **Deferred** (with a tracking issue #).
+   - Expected failure: no allowlist exists; the reflection finds members not yet classified.
+2. **[GREEN]** Author the `Lowered` set = the full current surface (`WithRetry`/`WithTimeout`/`Compensate`/`RequireConfidence`/`OnLowConfidence`/`ValidateState`/`WithContext`, all lowered after #137 + G-2..G-5) and the `Deferred` set = fork-path `RequireConfidence`/`OnLowConfidence` + nested `RepeatUntil` (→ #134 / v2.10.0 DR-17). Backfill passes.
+   - **Precondition the guard enforces:** each `Lowered` member must reference a *behavioral* (compile-run-saga) test, not a shape test. If reflection surfaces a member whose only proof is shape-level (likely candidates: `ValidateState` from #134, `WithContext` from #137 DR-6), add the missing behavioral test in this step before the parity assertion can pass — this is the guard's whole point.
+3. **[REFACTOR]** Add a guard that a new member with no classification fails (negative test via a synthetic surface).
+
+**Dependencies:** G-1..G-5 complete (surface finished) · **Parallelizable:** No
+
+### Task 6.2: `AGWF022` declared-but-inert diagnostic
+1. **[RED]** `Generator_StepConfigFieldInertForStepKind_ReportsAgwf022`
+   - File: `src/Strategos.Generators.Tests/Diagnostics/DeclaredButInertTests.cs`
+   - Force a parsed `StepModel` config field that no emitter consumes for a given step kind; assert `AGWF022` is reported at the call site.
+   - Expected failure: no such diagnostic.
+2. **[GREEN]** Add `DeclaredButInert = "AGWF022"` to `src/Strategos.Contracts/Diagnostics/AgwfCatalog.tsp` (regen `AgwfCodes.g.cs` via `npx tsp compile` — Node-gated) + a descriptor in `WorkflowDiagnostics.cs`; emit it from the generator when a parsed config field is inert for the step kind.
+3. **[REFACTOR]** Analyzer positive/negative tests; document the standing contract in `docs/deferred-features.md` (*"a config member is done only with a behavioral proof or a tracked deferral"*).
+
+**Dependencies:** Task 6.1 · **Parallelizable:** No
+
+---
+
+## G-7 — CL-7 (#132): Batch / safe schema bootstrap
+
+### Task 7.1: Safe `EnsureSchemaAsync<T>(ct)` (ensure-all-descriptors-for-T)
+1. **[RED]** `EnsureSchemaAsync_MultiRegisteredType_EnsuresAllDescriptorTables`
+   - File: `src/Strategos.Ontology.Npgsql.Tests/Schema/EnsureSchemaBootstrapTests.cs` (DB-gated)
+   - Register a type under two descriptors (`Object<Doc>("a")`, `Object<Doc>("b")`); call `EnsureSchemaAsync<Doc>(ct)` (no descriptor name); assert **both** tables exist.
+   - Expected failure: `PgVectorObjectSetProvider.cs:145` throws `InvalidOperationException` on multi-registration.
+2. **[GREEN]** Add `EnsureSchemaAsync<T>(CancellationToken)` overload that iterates `GetObjectTypeNames<T>()` (`IOntologyQuery.cs:100`) and ensures each descriptor; the existing single-descriptor overload is unchanged. Keys on resolved descriptor name (INV-8); raw Npgsql (INV-2).
+3. **[REFACTOR]** Mirror in the in-memory provider (trivial loop) for parity.
+
+**Dependencies:** None · **Parallelizable:** Yes
+
+### Task 7.2: Graph-wide `EnsureAllSchemasAsync(ct)`
+1. **[RED]** `EnsureAllSchemasAsync_Graph_CreatesTableForEveryObjectDescriptor`
+   - File: same as 7.1
+   - A graph with several object descriptors → all vertex tables exist after one call.
+   - Expected failure: method does not exist.
+2. **[GREEN]** Add `Task EnsureAllSchemasAsync(CancellationToken)` to `src/Strategos.Ontology/ObjectSets/IObjectSetProvider.cs`; implement in `PgVectorObjectSetProvider` (iterate `OntologyGraph.ObjectTypes`, `OntologyGraph.cs:16`) and the in-memory provider.
+3. **[REFACTOR]** Any new result type `sealed` (INV-6) — likely none.
+
+**Dependencies:** Task 7.1 · **Parallelizable:** No
+
+### Task 7.3: Validation-corpus + PublicAPI
+1. **[RED]** `EnsureAllSchemasAsync_BasileusMultiRegistrationScenario_BootstrapsCleanly`
+   - File: same as 7.1
+   - Reproduce the Basileus scenario (two `SemanticDocument` registrations) and assert clean bootstrap under both new entry points (design-on-merit; consumer = corpus, not dependency).
+2. **[GREEN]** Update `src/Strategos.Ontology/PublicAPI.Unshipped.txt` (+ `.Npgsql` if surfaced there) for the new members; CHANGELOG.
+3. **[REFACTOR]** Update the multi-registration exception message at `:145` to point at the batch API.
+
+**Dependencies:** Tasks 7.1, 7.2 · **Parallelizable:** No
+
+---
+
+## Task summary (delegation units)
+
+| ID | Group | Issue | Title | Depends on | Parallel |
+|---|---|---|---|---|---|
+| 1.1 | G-1 | #142 | Escape validation-error literal | — | ✅ |
+| 2.1 | G-2 | #141 | StartWith/Finally overloads + IR | — | ✅ |
+| 2.2 | G-2 | #141 | PublicAPI baseline | 2.1 | — |
+| 2.3 | G-2 | #141 | Behavioral proof | 2.1 | — |
+| 3.1 | G-3 | #140 | OnFailure worker handler | — | ✅ |
+| 3.2 | G-3 | #140 | Compensate↔OnFailure interop | 3.1 | — |
+| 4.1 | G-4 | #139 | Multi-step OnLowConfidence | — | ✅ |
+| 4.2 | G-4 | #139 | Rejoin-to-main-flow | 4.1 | — |
+| 5.1 | G-5 | #138 | EventSourced fixture | — | ✅ |
+| 5.2 | G-5 | #138 | StepFailed event | 5.1, 3.2 | — |
+| 5.3 | G-5 | #138 | LowConfidenceRouted event | 5.1, 4.2 | — |
+| 6.1 | G-6 | #143 | Parity allowlist test | G-1..G-5 | — |
+| 6.2 | G-6 | #143 | AGWF022 inert diagnostic | 6.1 | — |
+| 7.1 | G-7 | #132 | Safe EnsureSchemaAsync<T>(ct) | — | ✅ |
+| 7.2 | G-7 | #132 | EnsureAllSchemasAsync | 7.1 | — |
+| 7.3 | G-7 | #132 | Corpus + PublicAPI | 7.1, 7.2 | — |
+
+**PR shape (for /delegate):** three natural PRs — **(A)** generator surface G-1/G-2/G-6 (escape + StartWith/Finally + parity guard), **(B)** saga-emission G-3/G-4/G-5 (OnFailure/Compensate + OnLowConfidence + EventSourced events), **(C)** ontology G-7 standalone. G-6 must land after G-1..G-5, so PR-A's parity-guard commit sequences after PR-B merges (or G-6 rides PR-B's tail). Confirm at delegation.
+
+## Risks / call-outs
+
+- **AGWF022 regen needs Node** (`npx tsp compile` on `AgwfCatalog.tsp`) — the implementer task for 6.2 runs in a Node-provisioned context (`project_contracts_tests_need_node_job`).
+- **G-3/G-5 file overlap:** `SagaFailureHandlerComponentEmitter` is touched by 3.1/3.2 and 5.2 — sequence them (G-3 before G-5), don't run as parallel worktrees.
+- **EventSourced durability:** timeout/scheduled-retry correctness needs the Marten outbox; the EventSourced fixture (5.1) enables `IntegrateWithWolverine()` (per the step-resilience design's [S2][S3]).
+- **Open questions to settle in implementation:** OnFailure↔Compensate ordering (3.2), rejoin semantics (4.2), audit-event names/shapes (5.2/5.3) — design Open Questions 1–3.

--- a/src/Strategos.Contracts.Tests/Diagnostics/AgwfCatalogEmitterTests.cs
+++ b/src/Strategos.Contracts.Tests/Diagnostics/AgwfCatalogEmitterTests.cs
@@ -25,6 +25,7 @@ public sealed class AgwfCatalogEmitterTests
         "AGWF001", "AGWF002", "AGWF003", "AGWF004", "AGWF009",
         "AGWF010", "AGWF012", "AGWF014", "AGWF015", "AGWF016",
         "AGWF017", "AGWF018", "AGWF019", "AGWF020", "AGWF021",
+        "AGWF022",
     ];
 
     /// <summary>

--- a/src/Strategos.Contracts.Tests/Diagnostics/AgwfCatalogEmitterTests.cs
+++ b/src/Strategos.Contracts.Tests/Diagnostics/AgwfCatalogEmitterTests.cs
@@ -30,11 +30,11 @@ public sealed class AgwfCatalogEmitterTests
 
     /// <summary>
     /// Regenerates from committed schemas and asserts the emitted catalog JSON
-    /// has a <c>catalog_version</c> manifest field and exactly 15 entries ordered
-    /// by ID, each carrying the full metadata set.
+    /// has a <c>catalog_version</c> manifest field and exactly one entry per
+    /// ground-truth code, ordered by ID, each carrying the full metadata set.
     /// </summary>
     [Test]
-    public async Task AgwfCatalogEmitter_TenEntries_EmitsManifestAndEntries()
+    public async Task AgwfCatalogEmitter_AllEntries_EmitsManifestAndEntries()
     {
         var catalogPath = Path.Combine(
             RepoLayout.ContractsProjectDir, "Generated", "agwf-catalog.json");
@@ -50,7 +50,7 @@ public sealed class AgwfCatalogEmitterTests
 
         var entries = root.GetProperty("entries");
         await Assert.That(entries.GetArrayLength()).IsEqualTo(GroundTruthCodes.Length)
-            .Because("the catalog must enumerate exactly the 15 ground-truth entries.");
+            .Because($"the catalog must enumerate exactly the {GroundTruthCodes.Length} ground-truth entries.");
 
         var ids = new List<string>();
         foreach (var entry in entries.EnumerateArray())

--- a/src/Strategos.Contracts.Tests/Diagnostics/AgwfCatalogSchemaTests.cs
+++ b/src/Strategos.Contracts.Tests/Diagnostics/AgwfCatalogSchemaTests.cs
@@ -21,12 +21,13 @@ namespace Strategos.Contracts.Tests.Diagnostics;
 [NotInParallel("tsp-compile")]
 public sealed class AgwfCatalogSchemaTests
 {
-    /// <summary>The 15 ground-truth AGWF codes (INV-5: gaps stay gaps, no renumber).</summary>
+    /// <summary>The 16 ground-truth AGWF codes (INV-5: gaps stay gaps, no renumber).</summary>
     private static readonly string[] GroundTruthCodes =
     [
         "AGWF001", "AGWF002", "AGWF003", "AGWF004", "AGWF009",
         "AGWF010", "AGWF012", "AGWF014", "AGWF015", "AGWF016",
         "AGWF017", "AGWF018", "AGWF019", "AGWF020", "AGWF021",
+        "AGWF022",
     ];
 
     /// <summary>

--- a/src/Strategos.Contracts.Tests/Diagnostics/AgwfCatalogSchemaTests.cs
+++ b/src/Strategos.Contracts.Tests/Diagnostics/AgwfCatalogSchemaTests.cs
@@ -33,10 +33,10 @@ public sealed class AgwfCatalogSchemaTests
     /// <summary>
     /// Compiles the TypeSpec sources, then asserts each AGWF entry schema carries
     /// the five metadata fields as <c>const</c> literals and the union of their
-    /// <c>id</c> consts equals exactly the 15 ground-truth codes.
+    /// <c>id</c> consts equals exactly the ground-truth codes.
     /// </summary>
     [Test]
-    public async Task AgwfCatalogSchema_TenCodes_EmittedWithMetadata()
+    public async Task AgwfCatalogSchema_AllCodes_EmittedWithMetadata()
     {
         var compile = await TspToolchain.CompileAsync();
         await Assert.That(compile.ExitCode).IsEqualTo(0).Because(compile.Output);
@@ -66,6 +66,6 @@ public sealed class AgwfCatalogSchemaTests
 
         await Assert.That(ids.OrderBy(x => x, StringComparer.Ordinal).ToArray())
             .IsEquivalentTo(GroundTruthCodes.OrderBy(x => x, StringComparer.Ordinal).ToArray())
-            .Because("the catalog must enumerate exactly the 15 ground-truth codes (INV-5: gaps stay gaps).");
+            .Because($"the catalog must enumerate exactly the {GroundTruthCodes.Length} ground-truth codes (INV-5: gaps stay gaps).");
     }
 }

--- a/src/Strategos.Contracts.Tests/Diagnostics/AgwfCodeEnumTests.cs
+++ b/src/Strategos.Contracts.Tests/Diagnostics/AgwfCodeEnumTests.cs
@@ -10,7 +10,7 @@ using System.Text.Json;
 namespace Strategos.Contracts.Tests.Diagnostics;
 
 /// <summary>
-/// T4 — the generated <c>AgwfCode</c> C# enum. Asserts it has exactly 15
+/// T4 — the generated <c>AgwfCode</c> C# enum. Asserts it has exactly 16
 /// members carrying <em>symbolic</em> names (the contract Exarchos round-trips
 /// against by name; INV-5), each serializing to its <c>AGWF0xx</c> wire string
 /// via the <c>[JsonStringEnumMemberName]</c> path.
@@ -36,6 +36,7 @@ public sealed class AgwfCodeEnumTests
         ("RequireConfidenceWithoutHandler", "AGWF019"),
         ("RetryMaxAttemptsBelowOne", "AGWF020"),
         ("NonPositiveTimeout", "AGWF021"),
+        ("DeclaredButInert", "AGWF022"),
     ];
 
     /// <summary>
@@ -43,7 +44,7 @@ public sealed class AgwfCodeEnumTests
     /// member set and the wire round-trip (serialize → <c>AGWF0xx</c>, back).
     /// </summary>
     [Test]
-    public async Task AgwfCodeEnum_FifteenMembers_RoundTripsWireValues()
+    public async Task AgwfCodeEnum_SixteenMembers_RoundTripsWireValues()
     {
         var enumType = typeof(ContractsMarker).Assembly
             .GetTypes()
@@ -56,7 +57,7 @@ public sealed class AgwfCodeEnumTests
 
         var members = Enum.GetNames(enumType!);
         await Assert.That(members.Length).IsEqualTo(Expected.Length)
-            .Because("AgwfCode must have exactly 15 members.");
+            .Because("AgwfCode must have exactly 16 members.");
 
         var options = Strategos.Contracts.ContractsJson.Options;
         foreach (var (name, wire) in Expected)

--- a/src/Strategos.Contracts.Tests/Diagnostics/AgwfMarkdownTests.cs
+++ b/src/Strategos.Contracts.Tests/Diagnostics/AgwfMarkdownTests.cs
@@ -57,7 +57,7 @@ public sealed class AgwfMarkdownTests
             .ToList();
 
         await Assert.That(dataRows.Count).IsEqualTo(GroundTruthCodes.Length)
-            .Because("the table must have exactly 15 data rows, one per code.");
+            .Because($"the table must have exactly {GroundTruthCodes.Length} data rows, one per code.");
 
         var rowIds = dataRows
             .Select(r => GroundTruthCodes.First(c => r.Contains(c, StringComparison.Ordinal)))

--- a/src/Strategos.Contracts.Tests/Diagnostics/AgwfMarkdownTests.cs
+++ b/src/Strategos.Contracts.Tests/Diagnostics/AgwfMarkdownTests.cs
@@ -20,6 +20,7 @@ public sealed class AgwfMarkdownTests
         "AGWF001", "AGWF002", "AGWF003", "AGWF004", "AGWF009",
         "AGWF010", "AGWF012", "AGWF014", "AGWF015", "AGWF016",
         "AGWF017", "AGWF018", "AGWF019", "AGWF020", "AGWF021",
+        "AGWF022",
     ];
 
     /// <summary>

--- a/src/Strategos.Contracts/CHANGELOG.md
+++ b/src/Strategos.Contracts/CHANGELOG.md
@@ -11,6 +11,16 @@ the wire contracts (JSON Schema + emitted C# records) are the public surface, so
 a **breaking schema change requires a major bump** (additive-only minors —
 enforced by the T30 structural diff in CI).
 
+## [Unreleased]
+
+### Added
+
+- **Diagnostics family — `AGWF022` (`DeclaredButInert`, severity `warning`):** a new
+  AGWF code for step configuration that is parsed into the IR but not lowered for the
+  step's kind, so it is silently inert (first guarded case: confidence gating on a
+  `Fork` path, deferred to v2.10.0 / DR-17, #134). Additive (a new enum member + a new
+  catalog entry), so it is a minor, non-breaking change (#143, G-6).
+
 ## [0.2.0] - 2026-05-24
 
 First published release of the cross-product schema substrate. **Must not

--- a/src/Strategos.Contracts/Diagnostics/AgwfCatalog.tsp
+++ b/src/Strategos.Contracts/Diagnostics/AgwfCatalog.tsp
@@ -11,7 +11,7 @@ namespace LevelUp.Strategos.Contracts;
  * generated `AgwfCode` C# enum, and the codegen pipeline emits the canonical
  * `agwf-catalog.json` data artifact + `docs/diagnostics/agwf.md` reference.
  *
- * Ground truth = exactly **15 defined codes** with gaps preserved as gaps
+ * Ground truth = exactly **16 defined codes** with gaps preserved as gaps
  * (INV-5: never renumber). Member names are the contract Exarchos's TypeScript
  * enum round-trips against *by name* (not ordinal).
  *
@@ -36,6 +36,7 @@ enum AgwfCode {
   RequireConfidenceWithoutHandler: "AGWF019",
   RetryMaxAttemptsBelowOne: "AGWF020",
   NonPositiveTimeout: "AGWF021",
+  DeclaredButInert: "AGWF022",
 }
 
 /** AGWF001 — Empty workflow name. */
@@ -186,4 +187,14 @@ model AgwfEntryNonPositiveTimeout {
   summary: "Non-positive timeout";
   remediation: "Step '{0}' in workflow '{1}' configures WithTimeout with a non-positive duration. The timeout must be greater than zero.";
   since: "2.10.0";
+}
+
+/** AGWF022 — Declared-but-inert step configuration. */
+@jsonSchema
+model AgwfEntryDeclaredButInert {
+  id: "AGWF022";
+  severity: "warning";
+  summary: "Declared-but-inert step configuration";
+  remediation: "Step '{0}' in workflow '{1}' declares {2}, which the generator does not lower for this step kind, so the configuration is inert. Remove it or move the step to a position where the configuration is lowered.";
+  since: "2.9.0";
 }

--- a/src/Strategos.Contracts/Generated/AgwfCode.g.cs
+++ b/src/Strategos.Contracts/Generated/AgwfCode.g.cs
@@ -78,4 +78,8 @@ public enum AgwfCode
     /// <summary>AGWF021 — Non-positive timeout.</summary>
     [JsonStringEnumMemberName("AGWF021")]
     NonPositiveTimeout,
+
+    /// <summary>AGWF022 — Declared-but-inert step configuration.</summary>
+    [JsonStringEnumMemberName("AGWF022")]
+    DeclaredButInert,
 }

--- a/src/Strategos.Contracts/Generated/AgwfCodes.g.cs
+++ b/src/Strategos.Contracts/Generated/AgwfCodes.g.cs
@@ -59,5 +59,8 @@ namespace Strategos.Contracts.Generated
 
         /// <summary>AGWF021 — Non-positive timeout.</summary>
         public const string NonPositiveTimeout = "AGWF021";
+
+        /// <summary>AGWF022 — Declared-but-inert step configuration.</summary>
+        public const string DeclaredButInert = "AGWF022";
     }
 }

--- a/src/Strategos.Contracts/Generated/agwf-catalog.json
+++ b/src/Strategos.Contracts/Generated/agwf-catalog.json
@@ -1,6 +1,6 @@
 {
   "catalog_version": "0.2.0",
-  "count": 15,
+  "count": 16,
   "entries": [
     {
       "name": "EmptyWorkflowName",
@@ -121,6 +121,14 @@
       "summary": "Non-positive timeout",
       "remediation": "Step '{0}' in workflow '{1}' configures WithTimeout with a non-positive duration. The timeout must be greater than zero.",
       "since": "2.10.0"
+    },
+    {
+      "name": "DeclaredButInert",
+      "id": "AGWF022",
+      "severity": "warning",
+      "summary": "Declared-but-inert step configuration",
+      "remediation": "Step '{0}' in workflow '{1}' declares {2}, which the generator does not lower for this step kind, so the configuration is inert. Remove it or move the step to a position where the configuration is lowered.",
+      "since": "2.9.0"
     }
   ]
 }

--- a/src/Strategos.Contracts/schemas/json-schema/AgwfCode.json
+++ b/src/Strategos.Contracts/schemas/json-schema/AgwfCode.json
@@ -17,7 +17,8 @@
         "AGWF018",
         "AGWF019",
         "AGWF020",
-        "AGWF021"
+        "AGWF021",
+        "AGWF022"
     ],
-    "description": "AGWF — the workflow source-generator diagnostic codes. **Single canonical\nsource** (#52): the codes and their metadata live here in TypeSpec; the\nRoslyn analyzer (`WorkflowDiagnostics`) sources its `id` strings from the\ngenerated `AgwfCode` C# enum, and the codegen pipeline emits the canonical\n`agwf-catalog.json` data artifact + `docs/diagnostics/agwf.md` reference.\n\nGround truth = exactly **15 defined codes** with gaps preserved as gaps\n(INV-5: never renumber). Member names are the contract Exarchos's TypeScript\nenum round-trips against *by name* (not ordinal).\n\nRepresentation = **R-lit** (DR-1): each entry is a literal-typed model whose\nfields emit as JSON Schema `const`, read by `AgwfCatalogEmitter`. Adding a\ncode is a minor bump; renaming/removing one is a major bump."
+    "description": "AGWF — the workflow source-generator diagnostic codes. **Single canonical\nsource** (#52): the codes and their metadata live here in TypeSpec; the\nRoslyn analyzer (`WorkflowDiagnostics`) sources its `id` strings from the\ngenerated `AgwfCode` C# enum, and the codegen pipeline emits the canonical\n`agwf-catalog.json` data artifact + `docs/diagnostics/agwf.md` reference.\n\nGround truth = exactly **16 defined codes** with gaps preserved as gaps\n(INV-5: never renumber). Member names are the contract Exarchos's TypeScript\nenum round-trips against *by name* (not ordinal).\n\nRepresentation = **R-lit** (DR-1): each entry is a literal-typed model whose\nfields emit as JSON Schema `const`, read by `AgwfCatalogEmitter`. Adding a\ncode is a minor bump; renaming/removing one is a major bump."
 }

--- a/src/Strategos.Contracts/schemas/json-schema/AgwfEntryDeclaredButInert.json
+++ b/src/Strategos.Contracts/schemas/json-schema/AgwfEntryDeclaredButInert.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "AgwfEntryDeclaredButInert.json",
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string",
+            "const": "AGWF022"
+        },
+        "severity": {
+            "type": "string",
+            "const": "warning"
+        },
+        "summary": {
+            "type": "string",
+            "const": "Declared-but-inert step configuration"
+        },
+        "remediation": {
+            "type": "string",
+            "const": "Step '{0}' in workflow '{1}' declares {2}, which the generator does not lower for this step kind, so the configuration is inert. Remove it or move the step to a position where the configuration is lowered."
+        },
+        "since": {
+            "type": "string",
+            "const": "2.9.0"
+        }
+    },
+    "required": [
+        "id",
+        "severity",
+        "summary",
+        "remediation",
+        "since"
+    ],
+    "description": "AGWF022 — Declared-but-inert step configuration."
+}

--- a/src/Strategos.Generators.Behavioral.Tests/CompensateOnFailureInteropTests.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/CompensateOnFailureInteropTests.cs
@@ -1,0 +1,93 @@
+// -----------------------------------------------------------------------
+// <copyright file="CompensateOnFailureInteropTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Generators.Behavioral.Tests.Workflows;
+
+namespace Strategos.Generators.Behavioral.Tests;
+
+/// <summary>
+/// End-to-end behavioral proof (#140 Task 3.2) that a workflow declaring BOTH a
+/// step-level <c>.Compensate&lt;T&gt;()</c> AND a workflow-level <c>OnFailure</c>
+/// chain composes them in the fixed order: step compensation runs FIRST, then the
+/// OnFailure chain — all from a single merged saga <c>Handle(Trigger…)</c> site
+/// (no CS0111 collision).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Before this fix the two were mutually exclusive: the
+/// <c>SagaCompensationComponentEmitter</c> no-op'd whenever the workflow also
+/// declared OnFailure, so the compensation step never ran when both were present.
+/// This test asserts the rollback runs exactly once, THEN the OnFailure handler
+/// step runs exactly once, and the saga reaches its terminal phase.
+/// </para>
+/// <para>
+/// Marked <see cref="NotInParallelAttribute"/> because it shares the single
+/// process-wide container + host and observes the process-shared invocation log.
+/// </para>
+/// </remarks>
+[Property("Category", "Integration")]
+[NotInParallel]
+[ClassDataSource<CompensateOnFailureHostFixture>(Shared = SharedType.PerTestSession)]
+public sealed class CompensateOnFailureInteropTests
+{
+    private readonly CompensateOnFailureHostFixture host;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CompensateOnFailureInteropTests"/>
+    /// class.
+    /// </summary>
+    /// <param name="host">
+    /// The shared Wolverine+Marten host fixture, injected by TUnit and shared
+    /// across the entire test session.
+    /// </param>
+    public CompensateOnFailureInteropTests(CompensateOnFailureHostFixture host)
+    {
+        this.host = host;
+    }
+
+    /// <summary>
+    /// Starts the generated interop workflow saga whose middle step declares
+    /// <c>.Compensate&lt;CofRollbackStep&gt;()</c> and always throws, with a
+    /// workflow-level <c>OnFailure</c> chain. Asserts the compensation rollback ran
+    /// exactly once, the OnFailure handler step ran exactly once AFTER the rollback,
+    /// the terminal step never ran, and the saga reached its terminal (Failed) phase.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Behavioral_StepCompensateAndWorkflowOnFailure_RunsCompensationThenFailureChain()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+
+        var initialState = new CompensateOnFailureState { WorkflowId = workflowId };
+        var startCommand = new StartCompensateOnFailureProofCommand(workflowId, initialState);
+
+        var reachedTerminal = await this.host.RunToTerminalAsync<CompensateOnFailureProofSaga>(
+            workflowId,
+            startCommand);
+
+        // The saga reached its terminal phase: the saga document is deleted by
+        // MarkCompleted() on the terminal OnFailure completed handler.
+        await Assert.That(reachedTerminal).IsTrue();
+
+        // Both the compensation rollback AND the OnFailure handler step ran exactly
+        // once: this is the interop proof (previously mutually exclusive).
+        await Assert.That(this.host.Invocations.CountFor(nameof(CofRollbackStep))).IsEqualTo(1);
+        await Assert.That(this.host.Invocations.CountFor(nameof(CofNotifyFailure))).IsEqualTo(1);
+
+        // Fixed ordering: the rollback ran BEFORE the OnFailure handler step.
+        var invocations = this.host.Invocations.Invocations;
+        var rollbackIndex = invocations.ToList().IndexOf(nameof(CofRollbackStep));
+        var notifyIndex = invocations.ToList().IndexOf(nameof(CofNotifyFailure));
+        await Assert.That(rollbackIndex).IsGreaterThanOrEqualTo(0);
+        await Assert.That(notifyIndex).IsGreaterThan(rollbackIndex);
+
+        // The prepare step ran once; the terminal step never ran.
+        await Assert.That(this.host.Invocations.CountFor(nameof(CofPrepareStep))).IsEqualTo(1);
+        await Assert.That(this.host.Invocations.CountFor(nameof(CofNeverReachedStep))).IsEqualTo(0);
+    }
+}

--- a/src/Strategos.Generators.Behavioral.Tests/EventSourcedAuditEventTests.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/EventSourcedAuditEventTests.cs
@@ -1,0 +1,125 @@
+// -----------------------------------------------------------------------
+// <copyright file="EventSourcedAuditEventTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Generators.Behavioral.Tests.Workflows;
+
+namespace Strategos.Generators.Behavioral.Tests;
+
+/// <summary>
+/// End-to-end behavioral proof (#138 G-5) that an EventSourced-mode workflow emits
+/// the named audit <b>stream events</b> — <c>StepFailed</c> on terminal failure and
+/// <c>LowConfidenceRouted</c> on confidence-gated routing — to the Marten event
+/// stream. This resolves the step-resilience design's Open Question #1
+/// (audit-event taxonomy): until now terminal-failure / low-confidence audit was
+/// captured only as queryable saga document properties + structured logs, not as
+/// named stream events.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The events are inspected by reading the workflow's raw Marten stream
+/// (<c>FetchStreamAsync</c>), the same surface the <c>EventSourcedHostFixture</c>
+/// smoke test proves round-trips. The audit events carry no Marten <c>Apply</c>
+/// overload, so the inline snapshot projection tolerates them while they still land
+/// in the stream.
+/// </para>
+/// <para>
+/// Marked <see cref="NotInParallelAttribute"/> because they share the single
+/// process-wide container + host and observe the process-shared invocation log.
+/// </para>
+/// </remarks>
+[Property("Category", "Integration")]
+[NotInParallel]
+[ClassDataSource<EventSourcedHostFixture>(Shared = SharedType.PerTestSession)]
+public sealed class EventSourcedAuditEventTests
+{
+    private readonly EventSourcedHostFixture host;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventSourcedAuditEventTests"/>
+    /// class.
+    /// </summary>
+    /// <param name="host">
+    /// The shared EventSourced Wolverine+Marten host fixture, injected by TUnit and
+    /// shared across the entire test session.
+    /// </param>
+    public EventSourcedAuditEventTests(EventSourcedHostFixture host)
+    {
+        this.host = host;
+    }
+
+    /// <summary>
+    /// Runs the event-sourced failure-proof saga (a middle step that always throws,
+    /// NO step-level resilience, with a workflow-level <c>OnFailure</c> chain) and
+    /// asserts a <c>StepFailed</c> audit event — carrying the failed step name and
+    /// the exception type — lands in the workflow's Marten stream.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Behavioral_EventSourcedStepFailure_AppendsStepFailedEvent()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+
+        var initialState = new EventSourcedFailureState { WorkflowId = workflowId };
+        var startCommand = new StartEventSourcedFailureProofCommand(workflowId, initialState);
+
+        var reachedTerminal = await this.host.RunToTerminalAsync<EventSourcedFailureProofSaga>(
+            workflowId,
+            startCommand);
+
+        await Assert.That(reachedTerminal).IsTrue();
+
+        // The OnFailure handler ran (the chain routed), so the failure path executed.
+        await Assert.That(this.host.Invocations.CountFor(nameof(EventSourcedNotifyFailureStep)))
+            .IsEqualTo(1);
+
+        // Audit-event proof: a StepFailed event landed in the Marten stream.
+        var stepFailed = await this.host.WaitForStreamEventAsync<EventSourcedFailureProofStepFailed>(workflowId);
+        await Assert.That(stepFailed).IsNotNull();
+
+        // It carries the failed step name and the exception type (the worker captures
+        // the short type name via ex.GetType().Name, which the trigger forwards).
+        await Assert.That(stepFailed!.FailedStepName).IsEqualTo(nameof(EventSourcedFailingStep));
+        await Assert.That(stepFailed.ExceptionType).IsEqualTo(nameof(EventSourcedFailureException));
+    }
+
+    /// <summary>
+    /// Runs the event-sourced low-confidence saga (its classify step returns
+    /// confidence 0.5, below the 0.85 threshold) and asserts a
+    /// <c>LowConfidenceRouted</c> audit event — carrying the gated step name, the
+    /// observed score, and the threshold — lands in the workflow's Marten stream.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Behavioral_EventSourcedLowConfidence_AppendsLowConfidenceRoutedEvent()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+
+        var initialState = new EventSourcedLowConfidenceState { WorkflowId = workflowId };
+        var startCommand = new StartEventSourcedLowConfidenceCommand(workflowId, initialState);
+
+        var completed = await this.host.RunWorkflowAsync<EventSourcedLowConfidenceSaga>(
+            workflowId,
+            startCommand);
+
+        await Assert.That(completed).IsTrue();
+
+        // Routing proof: confidence 0.5 < 0.85 → the review handler ran.
+        await Assert.That(this.host.Invocations.CountFor(nameof(EventSourcedLcReviewStep)))
+            .IsEqualTo(1);
+
+        // Audit-event proof: a LowConfidenceRouted event landed in the Marten stream.
+        var routed = await this.host.WaitForStreamEventAsync<EventSourcedLowConfidenceLowConfidenceRouted>(workflowId);
+        await Assert.That(routed).IsNotNull();
+
+        // It carries the gated step name, the observed score, and the threshold.
+        await Assert.That(routed!.StepName).IsEqualTo(nameof(EventSourcedLcClassifyStep));
+        await Assert.That(routed.Confidence).IsEqualTo(0.5);
+        await Assert.That(routed.Threshold).IsEqualTo(0.85);
+    }
+}

--- a/src/Strategos.Generators.Behavioral.Tests/FailureHandlerChainTests.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/FailureHandlerChainTests.cs
@@ -1,0 +1,92 @@
+// -----------------------------------------------------------------------
+// <copyright file="FailureHandlerChainTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Generators.Behavioral.Tests.Workflows;
+
+namespace Strategos.Generators.Behavioral.Tests;
+
+/// <summary>
+/// End-to-end behavioral proof (#140 G-3/CL-3) that a workflow-level
+/// <c>OnFailure(flow =&gt; flow.Then&lt;NotifyFailure&gt;())</c> chain actually
+/// RUNS at runtime when a step fails: the generated saga publishes the trigger,
+/// dispatches the failure-handler worker command, the (previously missing) worker
+/// handler runs the OnFailure handler step, and the saga routes to its terminal
+/// Failed phase.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Before this fix the workflow-level OnFailure chain was doubly dead: nothing
+/// published the <c>Trigger{Pascal}FailureHandlerCommand</c> for a non-compensated
+/// failing step, and even when dispatched, the
+/// <c>ExecuteFailureHandler_..WorkerCommand</c> had no worker <c>Handle</c>, so the
+/// handler step never executed. This test asserts the chain runs exactly once and
+/// the saga reaches its terminal phase (its document is removed by
+/// <c>MarkCompleted()</c>).
+/// </para>
+/// <para>
+/// Marked <see cref="NotInParallelAttribute"/> because it shares the single
+/// process-wide container + host and observes the process-shared invocation log.
+/// </para>
+/// </remarks>
+[Property("Category", "Integration")]
+[NotInParallel]
+[ClassDataSource<FailureHandlerHostFixture>(Shared = SharedType.PerTestSession)]
+public sealed class FailureHandlerChainTests
+{
+    private readonly FailureHandlerHostFixture host;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FailureHandlerChainTests"/>
+    /// class.
+    /// </summary>
+    /// <param name="host">
+    /// The shared Wolverine+Marten host fixture, injected by TUnit and shared
+    /// across the entire test session.
+    /// </param>
+    public FailureHandlerChainTests(FailureHandlerHostFixture host)
+    {
+        this.host = host;
+    }
+
+    /// <summary>
+    /// Starts the generated failure-handler-proof workflow saga whose middle step
+    /// always throws (with NO step-level resilience). Asserts the workflow-level
+    /// <c>OnFailure</c> handler step <see cref="NotifyFailure"/> ran exactly once,
+    /// the prepare step ran once, the terminal step never ran, and the saga reached
+    /// its terminal (Failed) phase.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Behavioral_WorkflowOnFailureChain_RunsHandlerStep()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+
+        var initialState = new FailureHandlerState { WorkflowId = workflowId };
+        var startCommand = new StartFailureHandlerProofCommand(workflowId, initialState);
+
+        var reachedTerminal = await this.host.RunToTerminalAsync<FailureHandlerProofSaga>(
+            workflowId,
+            startCommand);
+
+        // The saga reached its terminal phase: the saga document is deleted by
+        // MarkCompleted() on the terminal failure-handler completed handler, so its
+        // absence is the terminal-Failed signal.
+        await Assert.That(reachedTerminal).IsTrue();
+
+        // The OnFailure handler step ran exactly once: this is the proof the
+        // previously-dead chain now executes.
+        await Assert.That(this.host.Invocations.CountFor(nameof(NotifyFailure))).IsEqualTo(1);
+
+        // The deterministic prepare step ran once; the failing step ran (at least
+        // once); the terminal step never ran because the failure routed the saga to
+        // the OnFailure chain before the happy path.
+        await Assert.That(this.host.Invocations.CountFor(nameof(FailureHandlerPrepareStep))).IsEqualTo(1);
+        await Assert.That(this.host.Invocations.CountFor(nameof(FailureHandlerFailingStep))).IsGreaterThanOrEqualTo(1);
+        await Assert.That(this.host.Invocations.CountFor(nameof(FailureHandlerNeverReachedStep))).IsEqualTo(0);
+    }
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/CompensateOnFailureHostFixture.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/CompensateOnFailureHostFixture.cs
@@ -1,0 +1,176 @@
+// -----------------------------------------------------------------------
+// <copyright file="CompensateOnFailureHostFixture.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Diagnostics;
+
+using JasperFx.Resources;
+
+using Marten;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Strategos.Generators.Behavioral.Tests.Workflows;
+
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+
+namespace Strategos.Generators.Behavioral.Tests.Infrastructure;
+
+/// <summary>
+/// Runtime host fixture for the Compensate↔OnFailure interop behavioral proof
+/// (#140 Task 3.2). Stands up a real PostgreSQL container and a Wolverine+Marten
+/// host wired with the generated <c>AddCompensateOnFailureProofWorkflow()</c>
+/// registration, then runs the generated saga end-to-end to observe the fixed
+/// ordering: step compensation runs FIRST, then the workflow OnFailure chain.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This mirrors <see cref="CompensationHostFixture"/>: the trigger is published
+/// from the failing step's Wolverine error chain and released through the durable
+/// inbox/outbox by Wolverine's durability agent. The fixture publishes the start
+/// command, awaits the synchronously-cascaded activity, then polls saga-document
+/// absence until the merged compensation-then-OnFailure chain settles into the
+/// terminal Failed phase.
+/// </para>
+/// <para>
+/// Lifecycle is driven by TUnit via <see cref="IAsyncInitializer"/> /
+/// <see cref="IAsyncDisposable"/>. Share one instance for the whole session with
+/// <c>[ClassDataSource&lt;CompensateOnFailureHostFixture&gt;(Shared = SharedType.PerTestSession)]</c>.
+/// </para>
+/// </remarks>
+public sealed class CompensateOnFailureHostFixture : IAsyncInitializer, IAsyncDisposable
+{
+    private readonly PostgresFixture postgres = new();
+
+    private IHost? host;
+
+    /// <summary>
+    /// Gets the shared step-invocation log. Instrumented workflow steps push their
+    /// name here so a test can assert which steps ran and how many times.
+    /// </summary>
+    public WorkflowInvocationLog Invocations { get; } = new();
+
+    /// <summary>
+    /// Starts the shared Postgres container, then builds and starts the Wolverine
+    /// host with Marten-backed saga storage and the generated interop workflow
+    /// registration.
+    /// </summary>
+    /// <returns>A task that completes when the host is running.</returns>
+    public async Task InitializeAsync()
+    {
+        await this.postgres.InitializeAsync();
+
+        this.host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services
+                    .AddMarten(storeOptions =>
+                    {
+                        storeOptions.Connection(this.postgres.ConnectionString);
+                        storeOptions.AutoCreateSchemaObjects = JasperFx.AutoCreate.All;
+                    })
+                    .IntegrateWithWolverine()
+                    .ApplyAllDatabaseChangesOnStartup();
+
+                // The generated interop workflow declares BOTH a step-level
+                // .Compensate<CofRollbackStep>() AND a workflow-level OnFailure chain.
+                // Its single merged Handle(Trigger...) dispatches the compensation
+                // rollback first; the rollback's completed handler then chains into
+                // the OnFailure chain (#140 Task 3.2).
+                opts.Services.AddCompensateOnFailureProofWorkflow();
+
+                opts.Services.AddSingleton(this.Invocations);
+                opts.Services.AddResourceSetupOnStartup();
+            })
+            .StartAsync();
+    }
+
+    /// <summary>
+    /// Publishes a generated start command, awaits all synchronously-tracked
+    /// cascaded activity, then polls until the saga reaches its terminal phase
+    /// (its document is removed by <c>MarkCompleted()</c>) or the budget elapses.
+    /// </summary>
+    /// <typeparam name="TSaga">
+    /// The generated saga document type whose persistence is polled for terminal
+    /// completion (its absence signals the saga finished).
+    /// </typeparam>
+    /// <param name="workflowId">The workflow/saga identity to wait on.</param>
+    /// <param name="startCommand">The generated start command.</param>
+    /// <param name="terminalBudget">
+    /// Total budget to wait for the terminal phase, covering the failing step, the
+    /// outbox-released trigger, the rollback worker, the OnFailure handler worker,
+    /// and completion. Defaults to 60 seconds.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when the saga reached its terminal phase within the
+    /// budget; otherwise <see langword="false"/>.
+    /// </returns>
+    public async Task<bool> RunToTerminalAsync<TSaga>(
+        Guid workflowId,
+        object startCommand,
+        TimeSpan? terminalBudget = null)
+        where TSaga : class
+    {
+        ArgumentNullException.ThrowIfNull(startCommand, nameof(startCommand));
+
+        var runtime = this.RequireHost();
+        var budget = terminalBudget ?? TimeSpan.FromSeconds(60);
+
+        try
+        {
+            await runtime
+                .TrackActivity()
+                .Timeout(budget)
+                .DoNotAssertOnExceptionsDetected()
+                .PublishMessageAndWaitAsync(startCommand);
+        }
+        catch (TimeoutException)
+        {
+            // The error/dead-letter machinery may keep the tracked session busy past
+            // the point the saga has already routed into the compensation-then-
+            // OnFailure chain; fall through to the saga-absence poll, which is the
+            // authoritative terminal signal.
+        }
+
+        var store = runtime.Services.GetRequiredService<IDocumentStore>();
+        var sw = Stopwatch.StartNew();
+
+        while (sw.Elapsed < budget)
+        {
+            await using var query = store.QuerySession();
+            var saga = await query.LoadAsync<TSaga>(workflowId);
+            if (saga is null)
+            {
+                return true;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100), CancellationToken.None);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Stops and disposes the host and the shared Postgres container.
+    /// </summary>
+    /// <returns>A value task that completes when teardown finishes.</returns>
+    public async ValueTask DisposeAsync()
+    {
+        if (this.host is not null)
+        {
+            await this.host.StopAsync();
+            this.host.Dispose();
+        }
+
+        await this.postgres.DisposeAsync();
+    }
+
+    private IHost RequireHost() =>
+        this.host ?? throw new InvalidOperationException(
+            "Host not initialized. Ensure InitializeAsync ran (TUnit IAsyncInitializer).");
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/EventSourcedHostFixture.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/EventSourcedHostFixture.cs
@@ -1,0 +1,280 @@
+// -----------------------------------------------------------------------
+// <copyright file="EventSourcedHostFixture.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Diagnostics;
+
+using JasperFx.Resources;
+
+using Marten;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Strategos.Agents.Abstractions;
+using Strategos.Generators.Behavioral.Tests.Workflows;
+
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+
+namespace Strategos.Generators.Behavioral.Tests.Infrastructure;
+
+/// <summary>
+/// Runtime host fixture for the EVENT-SOURCED audit-event behavioral proofs
+/// (#138 G-5). Stands up a real PostgreSQL container and a Wolverine+Marten host
+/// whose Marten store is integrated with Wolverine, then runs generated sagas
+/// that declare <c>Persistence = PersistenceMode.EventSourced</c>. In that mode
+/// the generated handlers <c>session.Events.Append(WorkflowId, evt)</c> instead
+/// of mutating a saga document, so workflow events round-trip through the Marten
+/// event stream — the surface these tests inspect.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the event-sourced counterpart to <see cref="WolverineHostFixture"/>
+/// (document mode). The existing fixtures are all document-mode; the audit-event
+/// vertical needs to observe the named <c>StepFailed</c> / <c>LowConfidenceRouted</c>
+/// stream events, which only exist when the saga appends to the Marten stream.
+/// </para>
+/// <para>
+/// It owns a single shared <see cref="PostgresFixture"/> container for the
+/// session and registers the event-sourced fixture workflows. Lifecycle is
+/// driven by TUnit via <see cref="IAsyncInitializer"/> / <see cref="IAsyncDisposable"/>.
+/// Share one instance for the whole session with
+/// <c>[ClassDataSource&lt;EventSourcedHostFixture&gt;(Shared = SharedType.PerTestSession)]</c>;
+/// mark consumers <c>[NotInParallel]</c> because the host + invocation log are
+/// process-shared.
+/// </para>
+/// </remarks>
+public sealed class EventSourcedHostFixture : IAsyncInitializer, IAsyncDisposable
+{
+    private readonly PostgresFixture postgres = new();
+
+    private IHost? host;
+
+    /// <summary>
+    /// Gets the shared step-invocation log. Instrumented workflow steps push
+    /// their name here so a test can assert which steps ran and how many times.
+    /// </summary>
+    public WorkflowInvocationLog Invocations { get; } = new();
+
+    /// <summary>
+    /// Starts the shared Postgres container, then builds and starts a Wolverine
+    /// host with a Marten event store integrated with Wolverine and the generated
+    /// event-sourced workflow registrations.
+    /// </summary>
+    /// <returns>A task that completes when the host is running.</returns>
+    public async Task InitializeAsync()
+    {
+        await this.postgres.InitializeAsync();
+
+        this.host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // Marten owns BOTH the event store (the appended workflow events)
+                // and Wolverine's durable inbox/outbox. The generated
+                // Add{Name}Workflow() registrations call ConfigureMarten(...) to
+                // register each event-sourced state's inline snapshot projection;
+                // IntegrateWithWolverine() wires the saga/message durability.
+                opts.Services
+                    .AddMarten(storeOptions =>
+                    {
+                        storeOptions.Connection(this.postgres.ConnectionString);
+                        storeOptions.AutoCreateSchemaObjects = JasperFx.AutoCreate.All;
+                    })
+                    .IntegrateWithWolverine()
+                    .ApplyAllDatabaseChangesOnStartup();
+
+                // The event-sourced happy-path proof (Task 5.1): its generated saga
+                // appends a Started + step-completed events to the Marten stream.
+                opts.Services.AddEventSourcedHappyWorkflow();
+
+                // The event-sourced failure proof (Task 5.2): its failing step routes
+                // to the OnFailure chain; the trigger handler appends StepFailed.
+                opts.Services.AddEventSourcedFailureProofWorkflow();
+
+                // The event-sourced low-confidence proof (Task 5.3): its gated step
+                // returns low confidence; the confidence gate appends LowConfidenceRouted.
+                opts.Services.AddEventSourcedLowConfidenceWorkflow();
+
+                opts.Services.AddSingleton(this.Invocations);
+                opts.Services.AddResourceSetupOnStartup();
+            })
+            .StartAsync();
+    }
+
+    /// <summary>
+    /// Runs a generated event-sourced workflow saga to completion against the real
+    /// host, using Wolverine's message-tracking API to deterministically await all
+    /// cascaded processing.
+    /// </summary>
+    /// <typeparam name="TSaga">
+    /// The generated saga document type whose persistence is polled to confirm
+    /// terminal completion (its absence signals the saga finished).
+    /// </typeparam>
+    /// <param name="workflowId">The workflow/saga identity to wait on.</param>
+    /// <param name="startCommand">The generated start command.</param>
+    /// <param name="timeout">
+    /// Optional wait budget for the cascading saga + worker activity to settle.
+    /// Defaults to 30 seconds.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when the saga reached its terminal phase.
+    /// </returns>
+    public async Task<bool> RunWorkflowAsync<TSaga>(
+        Guid workflowId,
+        object startCommand,
+        TimeSpan? timeout = null)
+        where TSaga : class
+    {
+        ArgumentNullException.ThrowIfNull(startCommand, nameof(startCommand));
+
+        var runtime = this.RequireHost();
+
+        await runtime
+            .TrackActivity()
+            .Timeout(timeout ?? TimeSpan.FromSeconds(30))
+            .PublishMessageAndWaitAsync(startCommand);
+
+        await using var query = runtime.Services.GetRequiredService<IDocumentStore>().QuerySession();
+        var saga = await query.LoadAsync<TSaga>(workflowId);
+
+        return saga is null;
+    }
+
+    /// <summary>
+    /// Publishes a generated start command, awaits all synchronously-tracked
+    /// cascaded activity, then polls until the saga reaches its terminal phase
+    /// (its document removed by <c>MarkCompleted()</c>) or the budget elapses.
+    /// Used for failure-routed sagas whose terminal route is released through the
+    /// durable inbox/outbox (which <c>TrackActivity()</c> does not await).
+    /// </summary>
+    /// <typeparam name="TSaga">
+    /// The generated saga document type polled for terminal completion.
+    /// </typeparam>
+    /// <param name="workflowId">The workflow/saga identity to wait on.</param>
+    /// <param name="startCommand">The generated start command.</param>
+    /// <param name="terminalBudget">
+    /// Total budget to wait for the terminal phase. Defaults to 60 seconds.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when the saga reached its terminal phase within the
+    /// budget; otherwise <see langword="false"/>.
+    /// </returns>
+    public async Task<bool> RunToTerminalAsync<TSaga>(
+        Guid workflowId,
+        object startCommand,
+        TimeSpan? terminalBudget = null)
+        where TSaga : class
+    {
+        ArgumentNullException.ThrowIfNull(startCommand, nameof(startCommand));
+
+        var runtime = this.RequireHost();
+        var budget = terminalBudget ?? TimeSpan.FromSeconds(60);
+
+        try
+        {
+            await runtime
+                .TrackActivity()
+                .Timeout(budget)
+                .DoNotAssertOnExceptionsDetected()
+                .PublishMessageAndWaitAsync(startCommand);
+        }
+        catch (TimeoutException)
+        {
+            // The error/dead-letter machinery may keep the tracked session busy
+            // past the point the saga already routed to its terminal phase; fall
+            // through to the saga-absence poll, the authoritative terminal signal.
+        }
+
+        var store = runtime.Services.GetRequiredService<IDocumentStore>();
+        var sw = Stopwatch.StartNew();
+
+        while (sw.Elapsed < budget)
+        {
+            await using var query = store.QuerySession();
+            var saga = await query.LoadAsync<TSaga>(workflowId);
+            if (saga is null)
+            {
+                return true;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100), CancellationToken.None);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Reads back the raw event payloads appended to a workflow's Marten stream,
+    /// in append order. The audit-event tests use this to assert that the named
+    /// <c>StepFailed</c> / <c>LowConfidenceRouted</c> events (and baseline workflow
+    /// events) actually landed in the stream.
+    /// </summary>
+    /// <param name="workflowId">The workflow/stream identity.</param>
+    /// <returns>The ordered list of event payload objects in the stream.</returns>
+    public async Task<IReadOnlyList<object>> ReadStreamEventsAsync(Guid workflowId)
+    {
+        var runtime = this.RequireHost();
+        await using var query = runtime.Services.GetRequiredService<IDocumentStore>().QuerySession();
+        var events = await query.Events.FetchStreamAsync(workflowId);
+        return events.Select(e => e.Data).ToArray();
+    }
+
+    /// <summary>
+    /// Polls the workflow's Marten stream until an event of type
+    /// <typeparamref name="TEvent"/> appears or the budget elapses. Audit events
+    /// can be appended through the durable outbox slightly after the tracked
+    /// publish settles, so a short poll avoids a flaky read-too-early.
+    /// </summary>
+    /// <typeparam name="TEvent">The audit event type to wait for.</typeparam>
+    /// <param name="workflowId">The workflow/stream identity.</param>
+    /// <param name="budget">The wait budget. Defaults to 30 seconds.</param>
+    /// <returns>
+    /// The first matching event payload, or <see langword="null"/> if none
+    /// appeared within the budget.
+    /// </returns>
+    public async Task<TEvent?> WaitForStreamEventAsync<TEvent>(
+        Guid workflowId,
+        TimeSpan? budget = null)
+        where TEvent : class
+    {
+        var deadline = budget ?? TimeSpan.FromSeconds(30);
+        var sw = Stopwatch.StartNew();
+
+        while (sw.Elapsed < deadline)
+        {
+            var events = await this.ReadStreamEventsAsync(workflowId);
+            var match = events.OfType<TEvent>().FirstOrDefault();
+            if (match is not null)
+            {
+                return match;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100), CancellationToken.None);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Stops and disposes the host and the shared Postgres container.
+    /// </summary>
+    /// <returns>A value task that completes when teardown finishes.</returns>
+    public async ValueTask DisposeAsync()
+    {
+        if (this.host is not null)
+        {
+            await this.host.StopAsync();
+            this.host.Dispose();
+        }
+
+        await this.postgres.DisposeAsync();
+    }
+
+    private IHost RequireHost() =>
+        this.host ?? throw new InvalidOperationException(
+            "Host not initialized. Ensure InitializeAsync ran (TUnit IAsyncInitializer).");
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/EventSourcedHostFixtureTests.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/EventSourcedHostFixtureTests.cs
@@ -1,0 +1,80 @@
+// -----------------------------------------------------------------------
+// <copyright file="EventSourcedHostFixtureTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Behavioral.Tests.Workflows;
+
+namespace Strategos.Generators.Behavioral.Tests.Infrastructure;
+
+/// <summary>
+/// Smoke test for the <see cref="EventSourcedHostFixture"/> (#138 G-5 Task 5.1):
+/// proves an EventSourced-mode generated saga stands up on a real Marten event
+/// store and that a baseline workflow event round-trips through the Marten stream.
+/// This is the infrastructure backbone the <c>StepFailed</c> / <c>LowConfidenceRouted</c>
+/// audit-event tests build on.
+/// </summary>
+/// <remarks>
+/// Marked <see cref="NotInParallelAttribute"/> because it shares the single
+/// process-wide container + host and observes the process-shared invocation log.
+/// </remarks>
+[Property("Category", "Integration")]
+[NotInParallel]
+[ClassDataSource<EventSourcedHostFixture>(Shared = SharedType.PerTestSession)]
+public sealed class EventSourcedHostFixtureTests
+{
+    private readonly EventSourcedHostFixture host;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventSourcedHostFixtureTests"/>
+    /// class.
+    /// </summary>
+    /// <param name="host">
+    /// The shared EventSourced Wolverine+Marten host fixture, injected by TUnit and
+    /// shared across the entire test session.
+    /// </param>
+    public EventSourcedHostFixtureTests(EventSourcedHostFixture host)
+    {
+        this.host = host;
+    }
+
+    /// <summary>
+    /// Runs the event-sourced happy-path saga end-to-end and asserts a baseline
+    /// workflow event round-trips through the Marten stream: the generated handlers
+    /// appended events (Started + step completions) to <c>WorkflowId</c>'s stream,
+    /// which is exactly the surface the audit-event tests read.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task EventSourcedFixture_Smoke_AppendsAndReadsStream()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+
+        var initialState = new EventSourcedAuditState { WorkflowId = workflowId };
+        var startCommand = new StartEventSourcedHappyCommand(workflowId, initialState);
+
+        var completed = await this.host.RunWorkflowAsync<EventSourcedHappySaga>(workflowId, startCommand);
+
+        // The saga reached its terminal phase: the Finally step's MarkCompleted()
+        // removed the persisted saga document.
+        await Assert.That(completed).IsTrue();
+
+        // Both deterministic steps ran exactly once.
+        await Assert.That(this.host.Invocations.CountFor(nameof(EventSourcedHappyStep))).IsEqualTo(1);
+        await Assert.That(this.host.Invocations.CountFor(nameof(EventSourcedHappyFinishStep))).IsEqualTo(1);
+
+        // Round-trip proof: the EventSourced-mode handlers appended events to the
+        // Marten stream keyed by WorkflowId, so reading the stream back returns a
+        // non-empty list of event payloads — the baseline the audit-event tests rely on.
+        var events = await this.host.ReadStreamEventsAsync(workflowId);
+        await Assert.That(events).IsNotEmpty();
+
+        // The two step-completed events both folded through the stream (the
+        // generated handlers append the step-completed event before ApplyEvent).
+        var completedEventCount =
+            events.Count(e => e.GetType().Name.EndsWith("Completed", StringComparison.Ordinal));
+        await Assert.That(completedEventCount).IsGreaterThanOrEqualTo(2);
+    }
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/FailureHandlerHostFixture.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/FailureHandlerHostFixture.cs
@@ -1,0 +1,185 @@
+// -----------------------------------------------------------------------
+// <copyright file="FailureHandlerHostFixture.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Diagnostics;
+
+using JasperFx.Resources;
+
+using Marten;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Strategos.Generators.Behavioral.Tests.Workflows;
+
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+
+namespace Strategos.Generators.Behavioral.Tests.Infrastructure;
+
+/// <summary>
+/// Runtime host fixture for the workflow-level <c>OnFailure</c> chain behavioral
+/// proof (#140 Task 3.1). Stands up a real PostgreSQL container and a
+/// Wolverine+Marten host wired with the generated
+/// <c>AddFailureHandlerProofWorkflow()</c> registration, then runs the generated
+/// saga end-to-end to observe the previously-dead <c>OnFailure(flow =&gt;
+/// flow.Then&lt;NotifyFailure&gt;())</c> chain firing after a step fails.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This mirrors <see cref="CompensationHostFixture"/>: the failure-handler trigger
+/// is published from the failing step's Wolverine error chain once the step throws
+/// terminally, and is released through the durable inbox/outbox by Wolverine's
+/// durability agent rather than being awaited synchronously by
+/// <c>TrackActivity()</c>. The fixture therefore publishes the start command,
+/// awaits the synchronously-cascaded activity, then polls saga-document absence
+/// until the OnFailure chain settles into the terminal Failed phase.
+/// </para>
+/// <para>
+/// Lifecycle is driven by TUnit via <see cref="IAsyncInitializer"/> /
+/// <see cref="IAsyncDisposable"/>. Share one instance for the whole session with
+/// <c>[ClassDataSource&lt;FailureHandlerHostFixture&gt;(Shared = SharedType.PerTestSession)]</c>.
+/// </para>
+/// </remarks>
+public sealed class FailureHandlerHostFixture : IAsyncInitializer, IAsyncDisposable
+{
+    private readonly PostgresFixture postgres = new();
+
+    private IHost? host;
+
+    /// <summary>
+    /// Gets the shared step-invocation log. Instrumented workflow steps push their
+    /// name here so a test can assert which steps ran and how many times.
+    /// </summary>
+    public WorkflowInvocationLog Invocations { get; } = new();
+
+    /// <summary>
+    /// Starts the shared Postgres container, then builds and starts the Wolverine
+    /// host with Marten-backed saga storage and the generated failure-handler
+    /// workflow registration.
+    /// </summary>
+    /// <returns>A task that completes when the host is running.</returns>
+    public async Task InitializeAsync()
+    {
+        await this.postgres.InitializeAsync();
+
+        this.host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services
+                    .AddMarten(storeOptions =>
+                    {
+                        storeOptions.Connection(this.postgres.ConnectionString);
+                        storeOptions.AutoCreateSchemaObjects = JasperFx.AutoCreate.All;
+                    })
+                    .IntegrateWithWolverine()
+                    .ApplyAllDatabaseChangesOnStartup();
+
+                // The generated failure-handler workflow: its FailureHandlerFailingStep
+                // handler carries the generated Configure(HandlerChain) that publishes
+                // the Trigger{Pascal}FailureHandlerCommand on terminal failure, and its
+                // NotifyFailure handler carries the generated worker handler for the
+                // ExecuteFailureHandler_..WorkerCommand (#140 Task 3.1).
+                opts.Services.AddFailureHandlerProofWorkflow();
+
+                opts.Services.AddSingleton(this.Invocations);
+                opts.Services.AddResourceSetupOnStartup();
+            })
+            .StartAsync();
+    }
+
+    /// <summary>
+    /// Publishes a generated start command, awaits all synchronously-tracked
+    /// cascaded activity, then polls until the saga reaches its terminal phase
+    /// (its document is removed by <c>MarkCompleted()</c>) or the budget elapses.
+    /// </summary>
+    /// <typeparam name="TSaga">
+    /// The generated saga document type whose persistence is polled for terminal
+    /// completion (its absence signals the saga finished).
+    /// </typeparam>
+    /// <param name="workflowId">The workflow/saga identity to wait on.</param>
+    /// <param name="startCommand">The generated start command.</param>
+    /// <param name="terminalBudget">
+    /// Total budget to wait for the terminal phase, covering the failing step, the
+    /// outbox-released failure-handler trigger, the OnFailure handler worker, and
+    /// completion. Defaults to 60 seconds.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when the saga reached its terminal phase within the
+    /// budget; otherwise <see langword="false"/>.
+    /// </returns>
+    public async Task<bool> RunToTerminalAsync<TSaga>(
+        Guid workflowId,
+        object startCommand,
+        TimeSpan? terminalBudget = null)
+        where TSaga : class
+    {
+        ArgumentNullException.ThrowIfNull(startCommand, nameof(startCommand));
+
+        var runtime = this.RequireHost();
+        var budget = terminalBudget ?? TimeSpan.FromSeconds(60);
+
+        // Publish the start command. The failing step throws; the error chain
+        // publishes the trigger via the outbox. That trigger + the OnFailure handler
+        // worker + completion are released by the durability agent and polled for
+        // below, so the tracked publish is allowed to settle without requiring the
+        // whole OnFailure cascade to be synchronous.
+        try
+        {
+            await runtime
+                .TrackActivity()
+                .Timeout(budget)
+                .DoNotAssertOnExceptionsDetected()
+                .PublishMessageAndWaitAsync(startCommand);
+        }
+        catch (TimeoutException)
+        {
+            // The error/dead-letter machinery may keep the tracked session busy past
+            // the point the saga has already routed to the OnFailure chain; fall
+            // through to the saga-absence poll, which is the authoritative terminal
+            // signal.
+        }
+
+        var store = runtime.Services.GetRequiredService<IDocumentStore>();
+        var sw = Stopwatch.StartNew();
+
+        while (sw.Elapsed < budget)
+        {
+            await using var query = store.QuerySession();
+            var saga = await query.LoadAsync<TSaga>(workflowId);
+            if (saga is null)
+            {
+                // MarkCompleted() removed the saga document: terminal Failed reached
+                // after the OnFailure handler step ran.
+                return true;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100), CancellationToken.None);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Stops and disposes the host and the shared Postgres container.
+    /// </summary>
+    /// <returns>A value task that completes when teardown finishes.</returns>
+    public async ValueTask DisposeAsync()
+    {
+        if (this.host is not null)
+        {
+            await this.host.StopAsync();
+            this.host.Dispose();
+        }
+
+        await this.postgres.DisposeAsync();
+    }
+
+    private IHost RequireHost() =>
+        this.host ?? throw new InvalidOperationException(
+            "Host not initialized. Ensure InitializeAsync ran (TUnit IAsyncInitializer).");
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/FailureHandlerHostFixture.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/FailureHandlerHostFixture.cs
@@ -67,29 +67,39 @@ public sealed class FailureHandlerHostFixture : IAsyncInitializer, IAsyncDisposa
     {
         await this.postgres.InitializeAsync();
 
-        this.host = await Host.CreateDefaultBuilder()
-            .UseWolverine(opts =>
-            {
-                opts.Services
-                    .AddMarten(storeOptions =>
-                    {
-                        storeOptions.Connection(this.postgres.ConnectionString);
-                        storeOptions.AutoCreateSchemaObjects = JasperFx.AutoCreate.All;
-                    })
-                    .IntegrateWithWolverine()
-                    .ApplyAllDatabaseChangesOnStartup();
+        try
+        {
+            this.host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.Services
+                        .AddMarten(storeOptions =>
+                        {
+                            storeOptions.Connection(this.postgres.ConnectionString);
+                            storeOptions.AutoCreateSchemaObjects = JasperFx.AutoCreate.All;
+                        })
+                        .IntegrateWithWolverine()
+                        .ApplyAllDatabaseChangesOnStartup();
 
-                // The generated failure-handler workflow: its FailureHandlerFailingStep
-                // handler carries the generated Configure(HandlerChain) that publishes
-                // the Trigger{Pascal}FailureHandlerCommand on terminal failure, and its
-                // NotifyFailure handler carries the generated worker handler for the
-                // ExecuteFailureHandler_..WorkerCommand (#140 Task 3.1).
-                opts.Services.AddFailureHandlerProofWorkflow();
+                    // The generated failure-handler workflow: its FailureHandlerFailingStep
+                    // handler carries the generated Configure(HandlerChain) that publishes
+                    // the Trigger{Pascal}FailureHandlerCommand on terminal failure, and its
+                    // NotifyFailure handler carries the generated worker handler for the
+                    // ExecuteFailureHandler_..WorkerCommand (#140 Task 3.1).
+                    opts.Services.AddFailureHandlerProofWorkflow();
 
-                opts.Services.AddSingleton(this.Invocations);
-                opts.Services.AddResourceSetupOnStartup();
-            })
-            .StartAsync();
+                    opts.Services.AddSingleton(this.Invocations);
+                    opts.Services.AddResourceSetupOnStartup();
+                })
+                .StartAsync();
+        }
+        catch
+        {
+            // If host startup throws after the container is up, dispose the Postgres
+            // fixture so a failed Initialize does not leak a container for the run.
+            await this.postgres.DisposeAsync();
+            throw;
+        }
     }
 
     /// <summary>

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/StubObjectSetProvider.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/StubObjectSetProvider.cs
@@ -61,4 +61,12 @@ public sealed class StubObjectSetProvider(ContextProbe probe) : IObjectSetProvid
     public IAsyncEnumerable<T> StreamAsync<T>(ObjectSetExpression expression, CancellationToken ct = default)
         where T : class =>
         throw new NotSupportedException("The context-assembly path does not call StreamAsync.");
+
+    /// <inheritdoc />
+    public Task EnsureSchemaAsync<T>(CancellationToken ct = default) where T : class =>
+        throw new NotSupportedException("The context-assembly path does not call EnsureSchemaAsync.");
+
+    /// <inheritdoc />
+    public Task EnsureAllSchemasAsync(CancellationToken ct = default) =>
+        throw new NotSupportedException("The context-assembly path does not call EnsureAllSchemasAsync.");
 }

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/ValidationHostFixture.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/ValidationHostFixture.cs
@@ -1,0 +1,162 @@
+// -----------------------------------------------------------------------
+// <copyright file="ValidationHostFixture.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using JasperFx.Resources;
+
+using Marten;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Strategos.Generators.Behavioral.Tests.Workflows;
+
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+
+namespace Strategos.Generators.Behavioral.Tests.Infrastructure;
+
+/// <summary>
+/// Runtime host fixture for the validation-guard behavioral proof (#143, G-6 6.1
+/// backfill). Stands up a real PostgreSQL container and a Wolverine+Marten host
+/// wired with the generated <c>AddValidationProofWorkflow()</c> registration, then
+/// runs the generated saga end-to-end to observe the lowered <c>.ValidateState(...)</c>
+/// Guard-Then-Dispatch path: when the guard predicate is false the saga transitions to
+/// the <c>ValidationFailed</c> phase WITHOUT dispatching the guarded step's worker, and
+/// without calling <c>MarkCompleted()</c> — so the saga document PERSISTS carrying the
+/// failed phase.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike the compensation/timeout fixtures, the validation-failed terminal does NOT
+/// delete the saga document (there is no <c>MarkCompleted()</c> on the guard-failed
+/// path). Terminal observation is therefore the persisted saga's <c>Phase</c>, exposed
+/// here as its <c>CurrentPhaseName</c> string, rather than saga-document absence.
+/// </para>
+/// <para>
+/// Lifecycle is driven by TUnit via <see cref="IAsyncInitializer"/> /
+/// <see cref="IAsyncDisposable"/>. Share one instance for the whole session with
+/// <c>[ClassDataSource&lt;ValidationHostFixture&gt;(Shared = SharedType.PerTestSession)]</c>.
+/// </para>
+/// </remarks>
+public sealed class ValidationHostFixture : IAsyncInitializer, IAsyncDisposable
+{
+    private readonly PostgresFixture postgres = new();
+
+    private IHost? host;
+
+    /// <summary>
+    /// Gets the shared step-invocation log. Instrumented workflow steps push their
+    /// name here so a test can assert which steps ran and how many times.
+    /// </summary>
+    public WorkflowInvocationLog Invocations { get; } = new();
+
+    /// <summary>
+    /// Starts the shared Postgres container, then builds and starts the Wolverine
+    /// host with Marten-backed saga storage and the generated validation-workflow
+    /// registration.
+    /// </summary>
+    /// <returns>A task that completes when the host is running.</returns>
+    public async Task InitializeAsync()
+    {
+        await this.postgres.InitializeAsync();
+
+        this.host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services
+                    .AddMarten(storeOptions =>
+                    {
+                        storeOptions.Connection(this.postgres.ConnectionString);
+                        storeOptions.AutoCreateSchemaObjects = JasperFx.AutoCreate.All;
+                    })
+                    .IntegrateWithWolverine()
+                    .ApplyAllDatabaseChangesOnStartup();
+
+                // The generated validation workflow: its ValidationGuardedStep start
+                // handler carries the yield-based Guard-Then-Dispatch guard lowered from
+                // .ValidateState(s => s.IsAuthorized, "..."). When the guard fails it sets
+                // Phase = ValidationFailed and yield-breaks before dispatching the worker.
+                opts.Services.AddValidationProofWorkflow();
+
+                opts.Services.AddSingleton(this.Invocations);
+                opts.Services.AddResourceSetupOnStartup();
+            })
+            .StartAsync();
+    }
+
+    /// <summary>
+    /// Publishes the generated start command and awaits all synchronously-tracked
+    /// cascaded activity, then loads the persisted saga and returns its current phase
+    /// name. The guard-failed path does not delete the saga, so the persisted phase is
+    /// the authoritative terminal signal.
+    /// </summary>
+    /// <typeparam name="TSaga">
+    /// The generated saga document type (e.g. <c>ValidationProofSaga</c>) whose phase is
+    /// inspected after the run.
+    /// </typeparam>
+    /// <param name="workflowId">The workflow/saga identity to wait on.</param>
+    /// <param name="startCommand">The generated start command.</param>
+    /// <param name="timeout">
+    /// Optional wait budget for the cascading saga activity to settle. Defaults to
+    /// 30 seconds.
+    /// </param>
+    /// <returns>
+    /// The persisted saga's <c>CurrentPhaseName</c>, or <see langword="null"/> if no
+    /// saga document was persisted (which would itself be a regression signal).
+    /// </returns>
+    public async Task<string?> RunAndGetPhaseAsync<TSaga>(
+        Guid workflowId,
+        object startCommand,
+        TimeSpan? timeout = null)
+        where TSaga : class
+    {
+        ArgumentNullException.ThrowIfNull(startCommand, nameof(startCommand));
+
+        var runtime = this.RequireHost();
+
+        await runtime
+            .TrackActivity()
+            .Timeout(timeout ?? TimeSpan.FromSeconds(30))
+            .PublishMessageAndWaitAsync(startCommand);
+
+        await using var query = runtime.Services.GetRequiredService<IDocumentStore>().QuerySession();
+        var saga = await query.LoadAsync<TSaga>(workflowId);
+
+        if (saga is null)
+        {
+            return null;
+        }
+
+        // The generated saga exposes `public string CurrentPhaseName => Phase.ToString();`
+        // (SagaPropertiesEmitter), so we can read the terminal phase name without
+        // referencing the generated phase enum type.
+        var phaseNameProperty = typeof(TSaga).GetProperty("CurrentPhaseName")
+            ?? throw new InvalidOperationException(
+                $"Generated saga '{typeof(TSaga).Name}' is missing the CurrentPhaseName property.");
+
+        return (string?)phaseNameProperty.GetValue(saga);
+    }
+
+    /// <summary>
+    /// Stops and disposes the host and the shared Postgres container.
+    /// </summary>
+    /// <returns>A value task that completes when teardown finishes.</returns>
+    public async ValueTask DisposeAsync()
+    {
+        if (this.host is not null)
+        {
+            await this.host.StopAsync();
+            this.host.Dispose();
+        }
+
+        await this.postgres.DisposeAsync();
+    }
+
+    private IHost RequireHost() =>
+        this.host ?? throw new InvalidOperationException(
+            "Host not initialized. Ensure InitializeAsync ran (TUnit IAsyncInitializer).");
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/WolverineHostFixture.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/WolverineHostFixture.cs
@@ -246,15 +246,21 @@ public sealed class WolverineHostFixture : IAsyncInitializer, IAsyncDisposable
         var runtime = this.RequireHost();
         var budget = terminalBudget ?? TimeSpan.FromSeconds(30);
 
+        // The budget is the TOTAL wall-clock allowance covering BOTH the tracked
+        // publish and the post-publish poll. Start the clock before the publish so
+        // the poll window is the remainder, never a fresh second budget (which would
+        // let the method wait up to ~2x the documented budget).
+        var store = runtime.Services.GetRequiredService<IDocumentStore>();
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+
         await runtime
             .TrackActivity()
             .Timeout(budget)
             .PublishMessageAndWaitAsync(startCommand);
 
-        var store = runtime.Services.GetRequiredService<IDocumentStore>();
-        var sw = System.Diagnostics.Stopwatch.StartNew();
-
-        while (sw.Elapsed < budget)
+        // Poll at least once after the publish settles (do/while), then bound every
+        // subsequent wait by the time left in the budget.
+        do
         {
             await using var query = store.QuerySession();
             var saga = await query.LoadAsync<TSaga>(workflowId);
@@ -265,8 +271,16 @@ public sealed class WolverineHostFixture : IAsyncInitializer, IAsyncDisposable
                 return true;
             }
 
-            await Task.Delay(TimeSpan.FromMilliseconds(50), CancellationToken.None);
+            var remaining = budget - sw.Elapsed;
+            if (remaining <= TimeSpan.Zero)
+            {
+                break;
+            }
+
+            var pollInterval = TimeSpan.FromMilliseconds(50);
+            await Task.Delay(remaining < pollInterval ? remaining : pollInterval, CancellationToken.None);
         }
+        while (true);
 
         return false;
     }

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/WolverineHostFixture.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/WolverineHostFixture.cs
@@ -110,6 +110,15 @@ public sealed class WolverineHostFixture : IAsyncInitializer, IAsyncDisposable
                 opts.Services.AddLowConfidenceWorkflow();
                 opts.Services.AddHighConfidenceWorkflow();
 
+                // The StartWith/Finally step-config workflows (#141). The
+                // start-with-retry-proof saga carries the per-handler retry policy
+                // lowered from .StartWith<StartFlakyStep>(s => s.WithRetry(2)) on the
+                // ENTRY step; the finally-timeout-proof saga carries the deadline race
+                // lowered from .Finally<FinallySlowTimedStep>(s => s.WithTimeout(...)) on
+                // the TERMINAL step. Both share the singleton invocation log below.
+                opts.Services.AddStartWithRetryProofWorkflow();
+                opts.Services.AddFinallyTimeoutProofWorkflow();
+
                 // The shared invocation log injected into instrumented steps.
                 opts.Services.AddSingleton(this.Invocations);
 
@@ -192,6 +201,66 @@ public sealed class WolverineHostFixture : IAsyncInitializer, IAsyncDisposable
         var saga = await query.LoadAsync<TSaga>(workflowId);
 
         return saga is null;
+    }
+
+    /// <summary>
+    /// Publishes a generated start command, awaits all synchronously-tracked cascaded
+    /// activity, then polls until the saga reaches its terminal phase (its document is
+    /// removed by <c>MarkCompleted()</c>) or the budget elapses. Unlike
+    /// <see cref="RunWorkflowAsync{TSaga}"/>, this additionally polls for terminal
+    /// completion AFTER the tracked publish settles, so a saga whose terminal route is
+    /// driven by a durable scheduled message (e.g. the timeout deadline race released by
+    /// Wolverine's background durability agent, which <c>TrackActivity()</c> does NOT
+    /// await) is observed deterministically.
+    /// </summary>
+    /// <typeparam name="TSaga">
+    /// The generated saga document type whose persistence is polled for terminal
+    /// completion (its absence signals the saga finished).
+    /// </typeparam>
+    /// <param name="workflowId">The workflow/saga identity to wait on.</param>
+    /// <param name="startCommand">The generated start command.</param>
+    /// <param name="terminalBudget">
+    /// Total budget to wait for the terminal phase, covering the scheduled timeout
+    /// message delivery and its handling. Defaults to 30 seconds.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when the saga reached its terminal phase within the
+    /// budget; otherwise <see langword="false"/>.
+    /// </returns>
+    public async Task<bool> RunToTerminalAsync<TSaga>(
+        Guid workflowId,
+        object startCommand,
+        TimeSpan? terminalBudget = null)
+        where TSaga : class
+    {
+        ArgumentNullException.ThrowIfNull(startCommand, nameof(startCommand));
+
+        var runtime = this.RequireHost();
+        var budget = terminalBudget ?? TimeSpan.FromSeconds(30);
+
+        await runtime
+            .TrackActivity()
+            .Timeout(budget)
+            .PublishMessageAndWaitAsync(startCommand);
+
+        var store = runtime.Services.GetRequiredService<IDocumentStore>();
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+
+        while (sw.Elapsed < budget)
+        {
+            await using var query = store.QuerySession();
+            var saga = await query.LoadAsync<TSaga>(workflowId);
+            if (saga is null)
+            {
+                // MarkCompleted() removed the saga document: terminal reached
+                // (Completed for the happy path, or Failed for the timed-out path).
+                return true;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(50), CancellationToken.None);
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/WolverineHostFixture.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/WolverineHostFixture.cs
@@ -118,6 +118,15 @@ public sealed class WolverineHostFixture : IAsyncInitializer, IAsyncDisposable
                 opts.Services.AddLowConfidenceRejoinWorkflow();
                 opts.Services.AddLowConfidenceTerminatingWorkflow();
 
+                // The StartWith/Finally step-config workflows (#141). The
+                // start-with-retry-proof saga carries the per-handler retry policy
+                // lowered from .StartWith<StartFlakyStep>(s => s.WithRetry(2)) on the
+                // ENTRY step; the finally-timeout-proof saga carries the deadline race
+                // lowered from .Finally<FinallySlowTimedStep>(s => s.WithTimeout(...)) on
+                // the TERMINAL step. Both share the singleton invocation log below.
+                opts.Services.AddStartWithRetryProofWorkflow();
+                opts.Services.AddFinallyTimeoutProofWorkflow();
+
                 // The shared invocation log injected into instrumented steps.
                 opts.Services.AddSingleton(this.Invocations);
 
@@ -200,6 +209,66 @@ public sealed class WolverineHostFixture : IAsyncInitializer, IAsyncDisposable
         var saga = await query.LoadAsync<TSaga>(workflowId);
 
         return saga is null;
+    }
+
+    /// <summary>
+    /// Publishes a generated start command, awaits all synchronously-tracked cascaded
+    /// activity, then polls until the saga reaches its terminal phase (its document is
+    /// removed by <c>MarkCompleted()</c>) or the budget elapses. Unlike
+    /// <see cref="RunWorkflowAsync{TSaga}"/>, this additionally polls for terminal
+    /// completion AFTER the tracked publish settles, so a saga whose terminal route is
+    /// driven by a durable scheduled message (e.g. the timeout deadline race released by
+    /// Wolverine's background durability agent, which <c>TrackActivity()</c> does NOT
+    /// await) is observed deterministically.
+    /// </summary>
+    /// <typeparam name="TSaga">
+    /// The generated saga document type whose persistence is polled for terminal
+    /// completion (its absence signals the saga finished).
+    /// </typeparam>
+    /// <param name="workflowId">The workflow/saga identity to wait on.</param>
+    /// <param name="startCommand">The generated start command.</param>
+    /// <param name="terminalBudget">
+    /// Total budget to wait for the terminal phase, covering the scheduled timeout
+    /// message delivery and its handling. Defaults to 30 seconds.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when the saga reached its terminal phase within the
+    /// budget; otherwise <see langword="false"/>.
+    /// </returns>
+    public async Task<bool> RunToTerminalAsync<TSaga>(
+        Guid workflowId,
+        object startCommand,
+        TimeSpan? terminalBudget = null)
+        where TSaga : class
+    {
+        ArgumentNullException.ThrowIfNull(startCommand, nameof(startCommand));
+
+        var runtime = this.RequireHost();
+        var budget = terminalBudget ?? TimeSpan.FromSeconds(30);
+
+        await runtime
+            .TrackActivity()
+            .Timeout(budget)
+            .PublishMessageAndWaitAsync(startCommand);
+
+        var store = runtime.Services.GetRequiredService<IDocumentStore>();
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+
+        while (sw.Elapsed < budget)
+        {
+            await using var query = store.QuerySession();
+            var saga = await query.LoadAsync<TSaga>(workflowId);
+            if (saga is null)
+            {
+                // MarkCompleted() removed the saga document: terminal reached
+                // (Completed for the happy path, or Failed for the timed-out path).
+                return true;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(50), CancellationToken.None);
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/Strategos.Generators.Behavioral.Tests/Infrastructure/WolverineHostFixture.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Infrastructure/WolverineHostFixture.cs
@@ -110,6 +110,14 @@ public sealed class WolverineHostFixture : IAsyncInitializer, IAsyncDisposable
                 opts.Services.AddLowConfidenceWorkflow();
                 opts.Services.AddHighConfidenceWorkflow();
 
+                // The multi-step / rejoining OnLowConfidence workflows (G-4 / #139):
+                // a two-step handler chain, a single-step REJOINING handler that
+                // resumes the main flow, and a single-step TERMINATING handler
+                // (back-compat default). All share the singleton invocation log.
+                opts.Services.AddLowConfidenceChainWorkflow();
+                opts.Services.AddLowConfidenceRejoinWorkflow();
+                opts.Services.AddLowConfidenceTerminatingWorkflow();
+
                 // The shared invocation log injected into instrumented steps.
                 opts.Services.AddSingleton(this.Invocations);
 

--- a/src/Strategos.Generators.Behavioral.Tests/LowConfidenceChainTests.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/LowConfidenceChainTests.cs
@@ -1,0 +1,168 @@
+// -----------------------------------------------------------------------
+// <copyright file="LowConfidenceChainTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Linq;
+
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Generators.Behavioral.Tests.Workflows;
+
+namespace Strategos.Generators.Behavioral.Tests;
+
+/// <summary>
+/// End-to-end behavioral proof (G-4 / #139) for MULTI-STEP and REJOINING
+/// <c>OnLowConfidence</c> handlers running on a real PostgreSQL-backed
+/// Wolverine+Marten host:
+/// <list type="bullet">
+///   <item><description>
+///     A two-step OnLowConfidence chain runs BOTH handler steps in order
+///     (before #139 only the first <c>Then&lt;T&gt;</c> was lowered).
+///   </description></item>
+///   <item><description>
+///     A handler declared <c>.RejoinMainFlow()</c> resumes the MAIN flow at the
+///     step after the gated step rather than terminating.
+///   </description></item>
+///   <item><description>
+///     A handler with no rejoin marker still terminates the workflow
+///     (back-compat default).
+///   </description></item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// Marked <see cref="NotInParallelAttribute"/> because it shares the single
+/// process-wide container + host and observes the process-shared invocation log.
+/// </remarks>
+[Property("Category", "Integration")]
+[NotInParallel]
+[ClassDataSource<WolverineHostFixture>(Shared = SharedType.PerTestSession)]
+public sealed class LowConfidenceChainTests
+{
+    private readonly WolverineHostFixture host;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LowConfidenceChainTests"/>
+    /// class.
+    /// </summary>
+    /// <param name="host">
+    /// The shared Wolverine+Marten host fixture, injected by TUnit and shared
+    /// across the entire test session.
+    /// </param>
+    public LowConfidenceChainTests(WolverineHostFixture host)
+    {
+        this.host = host;
+    }
+
+    /// <summary>
+    /// Task 4.1: a step gated at confidence 0.85 returns 0.5 and declares a
+    /// TWO-step OnLowConfidence chain
+    /// (<c>OnLowConfidence(alt =&gt; alt.Then&lt;A&gt;().Then&lt;B&gt;())</c>). Asserts both
+    /// handler steps ran, exactly once each, and in order (A before B) — proving
+    /// the whole chain is lowered, not just the first <c>Then&lt;T&gt;</c>.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Behavioral_OnLowConfidenceTwoStepChain_RunsBothInOrder()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+
+        var initialState = new ChainConfidenceState { WorkflowId = workflowId };
+        var startCommand = new StartLowConfidenceChainCommand(workflowId, initialState);
+
+        var completed = await this.host.RunWorkflowAsync<LowConfidenceChainSaga>(workflowId, startCommand);
+
+        // The chain's last step terminates the (default terminating) handler.
+        await Assert.That(completed).IsTrue();
+
+        // The gated step ran once and diverted to the handler chain.
+        await Assert.That(this.host.Invocations.CountFor(nameof(ChainClassifyStep))).IsEqualTo(1);
+
+        // Both handler steps ran exactly once...
+        await Assert.That(this.host.Invocations.CountFor(nameof(ChainHandlerAStep))).IsEqualTo(1);
+        await Assert.That(this.host.Invocations.CountFor(nameof(ChainHandlerBStep))).IsEqualTo(1);
+
+        // ...in order: A before B.
+        var invocations = this.host.Invocations.Invocations.ToList();
+        var indexA = invocations.IndexOf(nameof(ChainHandlerAStep));
+        var indexB = invocations.IndexOf(nameof(ChainHandlerBStep));
+        await Assert.That(indexA).IsGreaterThanOrEqualTo(0);
+        await Assert.That(indexB).IsGreaterThanOrEqualTo(0);
+        await Assert.That(indexA).IsLessThan(indexB);
+
+        // The primary finish step was skipped (the gate diverted before it).
+        await Assert.That(this.host.Invocations.CountFor(nameof(ChainFinishStep))).IsEqualTo(0);
+    }
+
+    /// <summary>
+    /// Task 4.2: a step gated at confidence 0.85 returns 0.5 and declares a
+    /// single-step REJOINING handler
+    /// (<c>OnLowConfidence(alt =&gt; alt.Then&lt;H&gt;().RejoinMainFlow())</c>). Asserts the
+    /// handler ran and the saga then RESUMED the main flow at the step after the
+    /// gated step (the finish step ran), in order — handler before finish.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Behavioral_OnLowConfidenceRejoin_ResumesMainFlowAfterGatedStep()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+
+        var initialState = new ChainConfidenceState { WorkflowId = workflowId };
+        var startCommand = new StartLowConfidenceRejoinCommand(workflowId, initialState);
+
+        var completed = await this.host.RunWorkflowAsync<LowConfidenceRejoinSaga>(workflowId, startCommand);
+
+        // The main-flow finish step's MarkCompleted() ends the saga.
+        await Assert.That(completed).IsTrue();
+
+        // The gated step ran once and diverted to the handler.
+        await Assert.That(this.host.Invocations.CountFor(nameof(RejoinClassifyStep))).IsEqualTo(1);
+
+        // The handler ran once...
+        await Assert.That(this.host.Invocations.CountFor(nameof(RejoinHandlerStep))).IsEqualTo(1);
+
+        // ...and the saga REJOINED the main flow: the finish step ran.
+        await Assert.That(this.host.Invocations.CountFor(nameof(RejoinFinishStep))).IsEqualTo(1);
+
+        // Order: the handler ran before the rejoined main-flow finish step.
+        var invocations = this.host.Invocations.Invocations.ToList();
+        var indexHandler = invocations.IndexOf(nameof(RejoinHandlerStep));
+        var indexFinish = invocations.IndexOf(nameof(RejoinFinishStep));
+        await Assert.That(indexHandler).IsGreaterThanOrEqualTo(0);
+        await Assert.That(indexFinish).IsGreaterThanOrEqualTo(0);
+        await Assert.That(indexHandler).IsLessThan(indexFinish);
+    }
+
+    /// <summary>
+    /// Task 4.2 (back-compat default): a step gated at confidence 0.85 returns 0.5
+    /// and declares a single-step handler with NO rejoin marker
+    /// (<c>OnLowConfidence(alt =&gt; alt.Then&lt;H&gt;())</c>). Asserts the handler ran and
+    /// TERMINATED the workflow — the main-flow finish step did NOT run.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Behavioral_OnLowConfidenceTerminating_CompletesWorkflow()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+
+        var initialState = new ChainConfidenceState { WorkflowId = workflowId };
+        var startCommand = new StartLowConfidenceTerminatingCommand(workflowId, initialState);
+
+        var completed = await this.host.RunWorkflowAsync<LowConfidenceTerminatingSaga>(workflowId, startCommand);
+
+        // The handler step's MarkCompleted() ends the saga.
+        await Assert.That(completed).IsTrue();
+
+        // The gated step ran once and diverted to the handler.
+        await Assert.That(this.host.Invocations.CountFor(nameof(TermClassifyStep))).IsEqualTo(1);
+
+        // The handler ran once...
+        await Assert.That(this.host.Invocations.CountFor(nameof(TermHandlerStep))).IsEqualTo(1);
+
+        // ...and the workflow TERMINATED: the main-flow finish step did NOT run.
+        await Assert.That(this.host.Invocations.CountFor(nameof(TermFinishStep))).IsEqualTo(0);
+    }
+}

--- a/src/Strategos.Generators.Behavioral.Tests/StartWithFinallyResilienceTests.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/StartWithFinallyResilienceTests.cs
@@ -1,0 +1,124 @@
+// -----------------------------------------------------------------------
+// <copyright file="StartWithFinallyResilienceTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Generators.Behavioral.Tests.Workflows;
+
+namespace Strategos.Generators.Behavioral.Tests;
+
+/// <summary>
+/// End-to-end behavioral proof (#141) that per-step resilience declared inline on the
+/// ENTRY step via <c>StartWith&lt;TStep&gt;(s =&gt; s.WithRetry(...))</c> and on the
+/// TERMINAL step via <c>Finally&lt;TStep&gt;(s =&gt; s.WithTimeout(...))</c> is honored at
+/// runtime, run against a real PostgreSQL-backed Wolverine+Marten host.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These two tests are the mutation proof for the #141 builder overloads. Before the
+/// overloads existed, the entry and terminal steps could carry no config, so the
+/// generator emitted no per-handler <c>Configure(HandlerChain)</c> retry policy for the
+/// entry step and no timeout deadline race for the terminal step. Reverting the builder
+/// change re-breaks the workflow definitions at compile time (the configure lambda no
+/// longer binds), so these proofs cannot pass without the lowered emission.
+/// </para>
+/// <para>
+/// Marked <see cref="NotInParallelAttribute"/> because they share the single
+/// process-wide container + host and observe the process-shared invocation log.
+/// </para>
+/// </remarks>
+[Property("Category", "Integration")]
+[NotInParallel]
+[ClassDataSource<WolverineHostFixture>(Shared = SharedType.PerTestSession)]
+public sealed class StartWithFinallyResilienceTests
+{
+    private readonly WolverineHostFixture host;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StartWithFinallyResilienceTests"/>
+    /// class.
+    /// </summary>
+    /// <param name="host">
+    /// The shared Wolverine+Marten host fixture, injected by TUnit and shared across the
+    /// entire test session.
+    /// </param>
+    public StartWithFinallyResilienceTests(WolverineHostFixture host)
+    {
+        this.host = host;
+    }
+
+    /// <summary>
+    /// Proves that <c>.WithRetry(2)</c> declared on the ENTRY step via the new
+    /// <c>StartWith</c> configure overload is honored at runtime: the flaky entry step
+    /// throws on its first two invocations and succeeds on the third, so Wolverine's
+    /// generated per-handler retry policy must carry it through. Asserts the entry step
+    /// was invoked exactly three times (initial + two retries) and the saga reached its
+    /// terminal phase — neither of which happens without the retry lowering, since
+    /// without it the entry step would dead-letter on the first failure and the saga
+    /// would never reach its terminal finish step.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Behavioral_StartWithStepWithRetry_RetriesIndependently()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+
+        var initialState = new StartFinallyState { WorkflowId = workflowId };
+        var startCommand = new StartStartWithRetryProofCommand(workflowId, initialState);
+
+        var completed = await this.host.RunWorkflowAsync<StartWithRetryProofSaga>(
+            workflowId,
+            startCommand);
+
+        // The saga reached its terminal phase: it only gets past the flaky ENTRY step
+        // (and on to the terminal finish step + MarkCompleted) if the retry policy
+        // lowered from StartWith(s => s.WithRetry(2)) carried it through two transient
+        // failures.
+        await Assert.That(completed).IsTrue();
+
+        // The flaky ENTRY step ran exactly three times: the initial attempt plus the two
+        // retries lowered from .StartWith<StartFlakyStep>(s => s.WithRetry(2)). This is
+        // the StartWith retry proof.
+        await Assert.That(this.host.Invocations.CountFor(nameof(StartFlakyStep))).IsEqualTo(3);
+
+        // The deterministic terminal finish step ran exactly once.
+        await Assert.That(this.host.Invocations.CountFor(nameof(StartFinishStep))).IsEqualTo(1);
+    }
+
+    /// <summary>
+    /// Proves that <c>.WithTimeout(50 ms)</c> declared on the TERMINAL step via the new
+    /// <c>Finally</c> configure overload is honored at runtime: the terminal step sleeps
+    /// ~500 ms, so the saga's deadline-race timeout message reaches it before the step's
+    /// completion event and routes the saga to its timeout/failure path while the step is
+    /// still in flight. Asserts the kickoff and the slow terminal step both ran (the slow
+    /// step runs to completion — a deadline race, not hard cancellation) and the saga
+    /// reached a terminal phase via the timeout route.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Behavioral_FinallyStepWithTimeout_RoutesToTimeoutPath()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+
+        var initialState = new StartFinallyState { WorkflowId = workflowId };
+        var startCommand = new StartFinallyTimeoutProofCommand(workflowId, initialState);
+
+        var reachedTerminal = await this.host.RunToTerminalAsync<FinallyTimeoutProofSaga>(
+            workflowId,
+            startCommand);
+
+        // The saga reached a terminal phase: its document was removed by MarkCompleted on
+        // the timeout/failure route driven by the deadline race lowered from
+        // .Finally<FinallySlowTimedStep>(s => s.WithTimeout(50 ms)).
+        await Assert.That(reachedTerminal).IsTrue();
+
+        // The kickoff and the slow TERMINAL step both ran (the slow step runs to
+        // completion — this is a deadline race, not hard cancellation).
+        await Assert.That(this.host.Invocations.CountFor(nameof(FinallyKickoffStep))).IsEqualTo(1);
+        await Assert.That(this.host.Invocations.CountFor(nameof(FinallySlowTimedStep))).IsEqualTo(1);
+    }
+}

--- a/src/Strategos.Generators.Behavioral.Tests/StartWithFinallyResilienceTests.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/StartWithFinallyResilienceTests.cs
@@ -91,11 +91,15 @@ public sealed class StartWithFinallyResilienceTests
     /// <summary>
     /// Proves that <c>.WithTimeout(50 ms)</c> declared on the TERMINAL step via the new
     /// <c>Finally</c> configure overload is honored at runtime: the terminal step sleeps
-    /// ~500 ms, so the saga's deadline-race timeout message reaches it before the step's
+    /// ~3 s, so the saga's deadline-race timeout message reaches it before the step's
     /// completion event and routes the saga to its timeout/failure path while the step is
     /// still in flight. Asserts the kickoff and the slow terminal step both ran (the slow
-    /// step runs to completion — a deadline race, not hard cancellation) and the saga
-    /// reached a terminal phase via the timeout route.
+    /// step runs to completion — a deadline race, not hard cancellation) AND, route-
+    /// specifically, that the timeout PREEMPTED the completion: the slow step found its
+    /// own saga document already removed when it finished
+    /// (<see cref="FinallySlowTimedStep.TimeoutPreemptedMarker"/>). That last assertion is
+    /// what prevents a false pass on a normal completion — both terminals delete the saga,
+    /// so "reached terminal" alone cannot distinguish the timeout route.
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]
@@ -120,5 +124,12 @@ public sealed class StartWithFinallyResilienceTests
         // completion — this is a deadline race, not hard cancellation).
         await Assert.That(this.host.Invocations.CountFor(nameof(FinallyKickoffStep))).IsEqualTo(1);
         await Assert.That(this.host.Invocations.CountFor(nameof(FinallySlowTimedStep))).IsEqualTo(1);
+
+        // ROUTE-SPECIFIC: the 50 ms timeout preempted the ~3 s step — the step found its
+        // saga already gone (Failed terminal) when it finished. A normal completion would
+        // leave the marker absent and fail here, so this cannot false-pass on the wrong
+        // terminal path.
+        await Assert.That(this.host.Invocations.CountFor(FinallySlowTimedStep.TimeoutPreemptedMarker))
+            .IsEqualTo(1);
     }
 }

--- a/src/Strategos.Generators.Behavioral.Tests/ValidationBehaviorTests.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/ValidationBehaviorTests.cs
@@ -1,0 +1,98 @@
+// -----------------------------------------------------------------------
+// <copyright file="ValidationBehaviorTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Generators.Behavioral.Tests.Workflows;
+
+namespace Strategos.Generators.Behavioral.Tests;
+
+/// <summary>
+/// End-to-end behavioral proof (#143, G-6 6.1 backfill) that a step's
+/// <c>.ValidateState(predicate, message)</c> declaration is actually honored at
+/// runtime: the generated saga's yield-based Guard-Then-Dispatch start handler
+/// evaluates the lowered predicate against the saga's folded <c>State</c> BEFORE
+/// dispatching the step worker, and when the predicate is false it sets
+/// <c>Phase = ValidationFailed</c> and yield-breaks — so the guarded step's worker
+/// is never dispatched and the rest of the flow is short-circuited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the missing behavioral proof the #143 parity guard
+/// (<c>StepConfigParityTests</c>) requires for <c>ValidateState</c>: before this
+/// test, the only proof that <c>ValidateState</c> lowered was shape/golden-level
+/// (<c>SagaEmitterValidationTests</c> asserting the emitted source CONTAINS the
+/// guard). Those tests never run the saga, so they cannot prove the guard actually
+/// short-circuits at runtime. Asserting on a real PostgreSQL-backed host that the
+/// guarded step's <c>ExecuteAsync</c> never ran AND the persisted saga reached the
+/// <c>ValidationFailed</c> phase is the runtime lowering proof.
+/// </para>
+/// <para>
+/// Mutation proof: reverting the lowering so the start handler emits a standard
+/// dispatch (no guard) makes this test RED — the guarded step's worker would be
+/// dispatched, its <c>ExecuteAsync</c> would run (invocation count 1, not 0), and
+/// the saga would proceed past the guard rather than persisting in the
+/// <c>ValidationFailed</c> phase.
+/// </para>
+/// <para>
+/// Marked <see cref="NotInParallelAttribute"/> because it shares the single
+/// process-wide container + host and observes the process-shared invocation log.
+/// </para>
+/// </remarks>
+[Property("Category", "Integration")]
+[NotInParallel]
+[ClassDataSource<ValidationHostFixture>(Shared = SharedType.PerTestSession)]
+public sealed class ValidationBehaviorTests
+{
+    private readonly ValidationHostFixture host;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ValidationBehaviorTests"/> class.
+    /// </summary>
+    /// <param name="host">
+    /// The shared Wolverine+Marten host fixture, injected by TUnit and shared across
+    /// the entire test session.
+    /// </param>
+    public ValidationBehaviorTests(ValidationHostFixture host)
+    {
+        this.host = host;
+    }
+
+    /// <summary>
+    /// Starts the generated validation-proof workflow saga whose middle step declares
+    /// <c>.ValidateState(s =&gt; s.IsAuthorized, "...")</c> with the predicate false at
+    /// runtime. Asserts the prepare step ran once, the guarded step's worker was never
+    /// dispatched (its <c>ExecuteAsync</c> ran zero times), the terminal step never ran,
+    /// and the persisted saga reached the <c>ValidationFailed</c> phase.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Saga_StepWithValidateState_GuardFails_RoutesToValidationFailedWithoutDispatchingStep()
+    {
+        var workflowId = Guid.NewGuid();
+        this.host.Invocations.Reset();
+
+        var initialState = new ValidationState { WorkflowId = workflowId };
+        var startCommand = new StartValidationProofCommand(workflowId, initialState);
+
+        var phaseName = await this.host.RunAndGetPhaseAsync<ValidationProofSaga>(workflowId, startCommand);
+
+        // The deterministic prepare step ran exactly once and folded state (leaving
+        // IsAuthorized false), so the saga actually started and reached the guard.
+        await Assert.That(this.host.Invocations.CountFor(nameof(ValidationPrepareStep))).IsEqualTo(1);
+
+        // Guard proof: the lowered Guard-Then-Dispatch short-circuited the dispatch, so
+        // the guarded step's ExecuteAsync NEVER ran. This is the runtime lowering proof
+        // a shape/golden test cannot give.
+        await Assert.That(this.host.Invocations.CountFor(nameof(ValidationGuardedStep))).IsEqualTo(0);
+
+        // The terminal step was never reached because the guard yield-broke the flow.
+        await Assert.That(this.host.Invocations.CountFor(nameof(ValidationNeverReachedStep))).IsEqualTo(0);
+
+        // Phase proof: the persisted saga reached ValidationFailed (it is NOT completed,
+        // so the document persists carrying the failed phase).
+        await Assert.That(phaseName).IsEqualTo("ValidationFailed");
+    }
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Workflows/CompensateOnFailureWorkflow.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Workflows/CompensateOnFailureWorkflow.cs
@@ -1,0 +1,193 @@
+// -----------------------------------------------------------------------
+// <copyright file="CompensateOnFailureWorkflow.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Abstractions;
+using Strategos.Attributes;
+using Strategos.Builders;
+using Strategos.Definitions;
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Steps;
+
+namespace Strategos.Generators.Behavioral.Tests.Workflows;
+
+/// <summary>
+/// Immutable state for the Compensate↔OnFailure interop behavioral fixture
+/// (#140 Task 3.2).
+/// </summary>
+/// <remarks>
+/// Marked <see cref="WorkflowStateAttribute"/> so the source generator emits a
+/// reducer the saga uses to fold both the compensation step's and the OnFailure
+/// handler step's returned state.
+/// </remarks>
+[WorkflowState]
+public sealed record CompensateOnFailureState : IWorkflowState
+{
+    /// <summary>
+    /// Gets the unique identifier for this workflow instance.
+    /// </summary>
+    public Guid WorkflowId { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the compensation (rollback) ran.
+    /// </summary>
+    public bool RolledBack { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the OnFailure handler step ran.
+    /// </summary>
+    public bool FailureNotified { get; init; }
+}
+
+/// <summary>
+/// Permanent failure raised by <see cref="CofFailingStep"/> on EVERY invocation,
+/// so the saga runs both the step compensation and the workflow OnFailure chain.
+/// </summary>
+public sealed class CofStepException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CofStepException"/> class with
+    /// the supplied message.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    public CofStepException(string message)
+        : base(message)
+    {
+    }
+}
+
+/// <summary>
+/// Entry step of the interop fixture workflow. Deterministic (never throws);
+/// records its invocation so the test can confirm the saga started.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class CofPrepareStep(WorkflowInvocationLog log) : IWorkflowStep<CompensateOnFailureState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompensateOnFailureState>> ExecuteAsync(
+        CompensateOnFailureState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(CofPrepareStep));
+
+        return Task.FromResult(StepResult<CompensateOnFailureState>.FromState(state));
+    }
+}
+
+/// <summary>
+/// The compensated middle step. Declares <c>.Compensate&lt;CofRollbackStep&gt;()</c>
+/// and throws on EVERY invocation, so the saga runs the rollback FIRST, then the
+/// workflow OnFailure chain (#140 Task 3.2 fixed ordering).
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class CofFailingStep(WorkflowInvocationLog log) : IWorkflowStep<CompensateOnFailureState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompensateOnFailureState>> ExecuteAsync(
+        CompensateOnFailureState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(CofFailingStep));
+
+        throw new CofStepException(
+            "CofFailingStep always fails to force compensation then OnFailure.");
+    }
+}
+
+/// <summary>
+/// The compensation (rollback) step. Runs FIRST when <see cref="CofFailingStep"/>
+/// fails. Per INV-7 returns NEW state (sets
+/// <see cref="CompensateOnFailureState.RolledBack"/>) rather than mutating input.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class CofRollbackStep(WorkflowInvocationLog log) : IWorkflowStep<CompensateOnFailureState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompensateOnFailureState>> ExecuteAsync(
+        CompensateOnFailureState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(CofRollbackStep));
+
+        var updated = state with { RolledBack = true };
+        return Task.FromResult(StepResult<CompensateOnFailureState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The workflow-level OnFailure handler step. Runs AFTER the compensation rollback
+/// (#140 Task 3.2 fixed ordering). Per INV-7 returns NEW state (sets
+/// <see cref="CompensateOnFailureState.FailureNotified"/>).
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class CofNotifyFailure(WorkflowInvocationLog log) : IWorkflowStep<CompensateOnFailureState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompensateOnFailureState>> ExecuteAsync(
+        CompensateOnFailureState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(CofNotifyFailure));
+
+        var updated = state with { FailureNotified = true };
+        return Task.FromResult(StepResult<CompensateOnFailureState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// A step that must NOT run when <see cref="CofFailingStep"/> fails. Its
+/// invocation count being zero proves the failure routed away from the happy path.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class CofNeverReachedStep(WorkflowInvocationLog log) : IWorkflowStep<CompensateOnFailureState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<CompensateOnFailureState>> ExecuteAsync(
+        CompensateOnFailureState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(CofNeverReachedStep));
+
+        return Task.FromResult(StepResult<CompensateOnFailureState>.FromState(state));
+    }
+}
+
+/// <summary>
+/// The Compensate↔OnFailure interop fixture workflow definition (#140 Task 3.2).
+/// Declares BOTH a step-level <c>.Compensate&lt;CofRollbackStep&gt;()</c> AND a
+/// workflow-level <c>OnFailure</c> chain, which were previously mutually exclusive.
+/// The fixed-order contract: step compensation runs FIRST, then the OnFailure chain.
+/// </summary>
+[Workflow("compensate-on-failure-proof")]
+public static partial class CompensateOnFailureProofWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent workflow definition: a prepare step, a middle step declaring
+    /// <c>.Compensate&lt;CofRollbackStep&gt;()</c> that always throws, a terminal
+    /// step that must never be reached, and a workflow-level <c>OnFailure</c> chain
+    /// that runs <see cref="CofNotifyFailure"/>.
+    /// </summary>
+    public static WorkflowDefinition<CompensateOnFailureState> Definition => Workflow<CompensateOnFailureState>
+        .Create("compensate-on-failure-proof")
+        .StartWith<CofPrepareStep>()
+        .Then<CofFailingStep>(step => step.Compensate<CofRollbackStep>())
+        .OnFailure(flow => flow.Then<CofNotifyFailure>().Complete())
+        .Finally<CofNeverReachedStep>();
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Workflows/EventSourcedAuditWorkflow.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Workflows/EventSourcedAuditWorkflow.cs
@@ -1,0 +1,164 @@
+// -----------------------------------------------------------------------
+// <copyright file="EventSourcedAuditWorkflow.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Abstractions;
+using Strategos.Agents.Abstractions;
+using Strategos.Attributes;
+using Strategos.Builders;
+using Strategos.Definitions;
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Steps;
+
+namespace Strategos.Generators.Behavioral.Tests.Workflows;
+
+/// <summary>
+/// Immutable, event-sourced state for the audit-event behavioral fixtures
+/// (#138 G-5). Implements <see cref="IEventSourcedState{TState}"/> so the
+/// generated saga, which runs in <see cref="PersistenceMode.EventSourced"/>
+/// mode, applies each appended event via <see cref="ApplyEvent"/> (a pure fold)
+/// instead of the reducer pattern.
+/// </summary>
+/// <remarks>
+/// <para>
+/// In EventSourced mode the generated saga handlers call
+/// <c>session.Events.Append(WorkflowId, evt)</c> and then
+/// <c>State = State.ApplyEvent(evt)</c>; the appended events round-trip through
+/// the Marten event stream, which is exactly the surface the audit-event tests
+/// inspect.
+/// </para>
+/// </remarks>
+public sealed record EventSourcedAuditState : IEventSourcedState<EventSourcedAuditState>
+{
+    /// <summary>
+    /// Gets the Marten aggregate identity (the event stream id, equal to
+    /// <see cref="WorkflowId"/>). The generated <c>Add...Workflow()</c> registers an
+    /// inline <c>Snapshot&lt;EventSourcedAuditState&gt;</c> projection, so this state
+    /// must satisfy Marten's single-stream aggregation conventions (an <c>Id</c>
+    /// identity plus <c>Create</c>/<c>Apply</c> methods) for the host to start.
+    /// </summary>
+    public Guid Id { get; init; }
+
+    /// <summary>
+    /// Gets the unique identifier for this workflow instance.
+    /// </summary>
+    public Guid WorkflowId { get; init; }
+
+    /// <summary>
+    /// Gets the number of step-completed events folded into state so far.
+    /// </summary>
+    public int StepCount { get; init; }
+
+    /// <summary>
+    /// Marten single-stream aggregation seed: builds the aggregate from the
+    /// workflow's <c>Started</c> event (the first event in every stream).
+    /// </summary>
+    /// <param name="started">The generated workflow-started event.</param>
+    /// <returns>The seed aggregate keyed on the workflow id.</returns>
+    public static EventSourcedAuditState Create(EventSourcedHappyStarted started)
+    {
+        ArgumentNullException.ThrowIfNull(started, nameof(started));
+        return new EventSourcedAuditState { Id = started.WorkflowId, WorkflowId = started.WorkflowId };
+    }
+
+    /// <summary>
+    /// Marten aggregation fold for the prepare step's completed event.
+    /// </summary>
+    /// <param name="evt">The prepare-step completed event.</param>
+    /// <returns>The aggregate with the step counted.</returns>
+    public EventSourcedAuditState Apply(EventSourcedHappyStepCompleted evt) =>
+        this with { StepCount = this.StepCount + 1 };
+
+    /// <summary>
+    /// Marten aggregation fold for the finish step's completed event.
+    /// </summary>
+    /// <param name="evt">The finish-step completed event.</param>
+    /// <returns>The aggregate with the step counted.</returns>
+    public EventSourcedAuditState Apply(EventSourcedHappyFinishStepCompleted evt) =>
+        this with { StepCount = this.StepCount + 1 };
+
+    /// <inheritdoc />
+    public EventSourcedAuditState ApplyEvent(IProgressEvent evt)
+    {
+        ArgumentNullException.ThrowIfNull(evt, nameof(evt));
+
+        // The saga's in-memory fold (INV-1): count every step-completed event.
+        // Unrecognized events (Started, audit events) pass through unchanged —
+        // they are observational, not state-bearing.
+        return evt switch
+        {
+            EventSourcedHappyStepCompleted => this with { StepCount = this.StepCount + 1 },
+            EventSourcedHappyFinishStepCompleted => this with { StepCount = this.StepCount + 1 },
+            _ => this,
+        };
+    }
+}
+
+/// <summary>
+/// Entry step of the event-sourced happy-path fixture (#138 G-5 Task 5.1).
+/// Deterministic; records its invocation and returns new state.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class EventSourcedHappyStep(WorkflowInvocationLog log) : IWorkflowStep<EventSourcedAuditState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<EventSourcedAuditState>> ExecuteAsync(
+        EventSourcedAuditState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(EventSourcedHappyStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<EventSourcedAuditState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// Terminal step of the event-sourced happy-path fixture. As the workflow's
+/// <c>Finally</c> step, its completion drives the saga to its terminal phase and
+/// <c>MarkCompleted()</c>.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class EventSourcedHappyFinishStep(WorkflowInvocationLog log) : IWorkflowStep<EventSourcedAuditState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<EventSourcedAuditState>> ExecuteAsync(
+        EventSourcedAuditState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(EventSourcedHappyFinishStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<EventSourcedAuditState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The event-sourced happy-path fixture workflow definition (#138 G-5 Task 5.1).
+/// Declares <c>Persistence = PersistenceMode.EventSourced</c>, so the generator
+/// emits a saga whose handlers append events to the Marten stream. Used by the
+/// <c>EventSourcedHostFixture</c> smoke test to prove a baseline workflow event
+/// round-trips through the stream. Drives the generator to emit
+/// <c>EventSourcedHappySaga</c>, <c>StartEventSourcedHappyCommand</c>, and
+/// <c>AddEventSourcedHappyWorkflow()</c>.
+/// </summary>
+[Workflow("event-sourced-happy", Persistence = PersistenceMode.EventSourced)]
+public static partial class EventSourcedHappyWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent definition: a prepare step and a terminal finish step,
+    /// both deterministic, run in event-sourced persistence mode.
+    /// </summary>
+    public static WorkflowDefinition<EventSourcedAuditState> Definition => Workflow<EventSourcedAuditState>
+        .Create("event-sourced-happy")
+        .StartWith<EventSourcedHappyStep>()
+        .Finally<EventSourcedHappyFinishStep>();
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Workflows/EventSourcedFailureWorkflow.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Workflows/EventSourcedFailureWorkflow.cs
@@ -1,0 +1,199 @@
+// -----------------------------------------------------------------------
+// <copyright file="EventSourcedFailureWorkflow.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Abstractions;
+using Strategos.Agents.Abstractions;
+using Strategos.Attributes;
+using Strategos.Builders;
+using Strategos.Definitions;
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Steps;
+
+namespace Strategos.Generators.Behavioral.Tests.Workflows;
+
+/// <summary>
+/// Immutable, event-sourced state for the <c>StepFailed</c> audit-event proof
+/// (#138 G-5 Task 5.2). Implements <see cref="IEventSourcedState{TState}"/> so the
+/// EventSourced-mode saga applies each appended event via <see cref="ApplyEvent"/>.
+/// </summary>
+public sealed record EventSourcedFailureState : IEventSourcedState<EventSourcedFailureState>
+{
+    /// <summary>
+    /// Gets the Marten aggregate identity (the event stream id, equal to
+    /// <see cref="WorkflowId"/>). Required because the generated <c>Add...Workflow()</c>
+    /// registers an inline <c>Snapshot&lt;EventSourcedFailureState&gt;</c> projection,
+    /// which only builds when the state satisfies Marten's single-stream aggregation
+    /// conventions (an <c>Id</c> identity plus at least one matching <c>Apply</c>).
+    /// </summary>
+    public Guid Id { get; init; }
+
+    /// <summary>
+    /// Gets the unique identifier for this workflow instance.
+    /// </summary>
+    public Guid WorkflowId { get; init; }
+
+    /// <summary>
+    /// Gets the number of step-completed events folded into state so far.
+    /// </summary>
+    public int StepCount { get; init; }
+
+    /// <summary>
+    /// Marten aggregation fold for the prepare step's completed event (the first
+    /// event the saga appends to the stream). The <c>StepFailed</c> audit event has
+    /// no <c>Apply</c> overload, so Marten's inline aggregation tolerates and skips
+    /// it while it still lands in the raw stream the test reads.
+    /// </summary>
+    /// <param name="evt">The prepare-step completed event.</param>
+    /// <returns>The aggregate seeded with the stream id and the step counted.</returns>
+    public EventSourcedFailureState Apply(EventSourcedFailurePrepareStepCompleted evt) =>
+        this with { Id = this.WorkflowId, StepCount = this.StepCount + 1 };
+
+    /// <inheritdoc />
+    public EventSourcedFailureState ApplyEvent(IProgressEvent evt)
+    {
+        ArgumentNullException.ThrowIfNull(evt, nameof(evt));
+
+        // The saga's in-memory fold. This fixture asserts on the StepFailed audit
+        // event landing in the stream, not on folded state, so every event passes
+        // through unchanged (audit events are observational, not state-bearing).
+        return this;
+    }
+}
+
+/// <summary>
+/// Permanent failure raised by <see cref="EventSourcedFailingStep"/> on EVERY
+/// invocation, so the saga routes to the workflow-level <c>OnFailure</c> chain
+/// and the trigger handler appends the <c>StepFailed</c> audit event.
+/// </summary>
+public sealed class EventSourcedFailureException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventSourcedFailureException"/>
+    /// class with the supplied message.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    public EventSourcedFailureException(string message)
+        : base(message)
+    {
+    }
+}
+
+/// <summary>
+/// Entry step of the event-sourced failure fixture. Deterministic; records its
+/// invocation and returns new state.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class EventSourcedFailurePrepareStep(WorkflowInvocationLog log) : IWorkflowStep<EventSourcedFailureState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<EventSourcedFailureState>> ExecuteAsync(
+        EventSourcedFailureState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(EventSourcedFailurePrepareStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<EventSourcedFailureState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The failing step. Declares NO step-level resilience and throws on EVERY
+/// invocation, forcing the saga to route to the workflow-level <c>OnFailure</c>
+/// chain whose trigger handler appends the <c>StepFailed</c> audit event.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class EventSourcedFailingStep(WorkflowInvocationLog log) : IWorkflowStep<EventSourcedFailureState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<EventSourcedFailureState>> ExecuteAsync(
+        EventSourcedFailureState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(EventSourcedFailingStep));
+
+        throw new EventSourcedFailureException(
+            "EventSourcedFailingStep always fails to force the OnFailure chain and the StepFailed audit event.");
+    }
+}
+
+/// <summary>
+/// The workflow-level <c>OnFailure</c> handler step run when
+/// <see cref="EventSourcedFailingStep"/> fails. Records its invocation and
+/// returns new state.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class EventSourcedNotifyFailureStep(WorkflowInvocationLog log) : IWorkflowStep<EventSourcedFailureState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<EventSourcedFailureState>> ExecuteAsync(
+        EventSourcedFailureState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(EventSourcedNotifyFailureStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<EventSourcedFailureState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// A step that must NOT run when the preceding <see cref="EventSourcedFailingStep"/>
+/// fails: once the saga routes to the OnFailure chain it reaches Failed before ever
+/// cascading this step. Present only to satisfy the generator's
+/// <c>Finally&lt;T&gt;()</c> terminator requirement (AGWF010).
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class EventSourcedFailureNeverReachedStep(WorkflowInvocationLog log) : IWorkflowStep<EventSourcedFailureState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<EventSourcedFailureState>> ExecuteAsync(
+        EventSourcedFailureState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(EventSourcedFailureNeverReachedStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<EventSourcedFailureState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The event-sourced failure fixture workflow definition (#138 G-5 Task 5.2).
+/// Declares <c>Persistence = PersistenceMode.EventSourced</c> and a failing middle
+/// step with a workflow-level <c>OnFailure</c> chain, so the generator emits a saga
+/// whose trigger handler appends the <c>StepFailed</c> audit event to the Marten
+/// stream. Drives the generator to emit <c>EventSourcedFailureProofSaga</c>,
+/// <c>StartEventSourcedFailureProofCommand</c>, and
+/// <c>AddEventSourcedFailureProofWorkflow()</c>.
+/// </summary>
+[Workflow("event-sourced-failure-proof", Persistence = PersistenceMode.EventSourced)]
+public static partial class EventSourcedFailureProofWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent definition: a prepare step, a middle step that always
+    /// throws with NO step-level resilience, and a workflow-level <c>OnFailure</c>
+    /// chain that runs <see cref="EventSourcedNotifyFailureStep"/>.
+    /// </summary>
+    public static WorkflowDefinition<EventSourcedFailureState> Definition => Workflow<EventSourcedFailureState>
+        .Create("event-sourced-failure-proof")
+        .StartWith<EventSourcedFailurePrepareStep>()
+        .Then<EventSourcedFailingStep>()
+        .OnFailure(flow => flow.Then<EventSourcedNotifyFailureStep>().Complete())
+        .Finally<EventSourcedFailureNeverReachedStep>();
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Workflows/EventSourcedFailureWorkflow.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Workflows/EventSourcedFailureWorkflow.cs
@@ -49,7 +49,7 @@ public sealed record EventSourcedFailureState : IEventSourcedState<EventSourcedF
     /// <param name="evt">The prepare-step completed event.</param>
     /// <returns>The aggregate seeded with the stream id and the step counted.</returns>
     public EventSourcedFailureState Apply(EventSourcedFailurePrepareStepCompleted evt) =>
-        this with { Id = this.WorkflowId, StepCount = this.StepCount + 1 };
+        this with { Id = evt.WorkflowId, WorkflowId = evt.WorkflowId, StepCount = this.StepCount + 1 };
 
     /// <inheritdoc />
     public EventSourcedFailureState ApplyEvent(IProgressEvent evt)

--- a/src/Strategos.Generators.Behavioral.Tests/Workflows/EventSourcedLowConfidenceWorkflow.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Workflows/EventSourcedLowConfidenceWorkflow.cs
@@ -50,7 +50,7 @@ public sealed record EventSourcedLowConfidenceState : IEventSourcedState<EventSo
     /// <param name="evt">The prepare-step completed event.</param>
     /// <returns>The aggregate seeded with the stream id and the step counted.</returns>
     public EventSourcedLowConfidenceState Apply(EventSourcedLcPrepareStepCompleted evt) =>
-        this with { Id = this.WorkflowId, StepCount = this.StepCount + 1 };
+        this with { Id = evt.WorkflowId, WorkflowId = evt.WorkflowId, StepCount = this.StepCount + 1 };
 
     /// <inheritdoc />
     public EventSourcedLowConfidenceState ApplyEvent(IProgressEvent evt)

--- a/src/Strategos.Generators.Behavioral.Tests/Workflows/EventSourcedLowConfidenceWorkflow.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Workflows/EventSourcedLowConfidenceWorkflow.cs
@@ -1,0 +1,185 @@
+// -----------------------------------------------------------------------
+// <copyright file="EventSourcedLowConfidenceWorkflow.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Abstractions;
+using Strategos.Agents.Abstractions;
+using Strategos.Attributes;
+using Strategos.Builders;
+using Strategos.Definitions;
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Steps;
+
+namespace Strategos.Generators.Behavioral.Tests.Workflows;
+
+/// <summary>
+/// Immutable, event-sourced state for the <c>LowConfidenceRouted</c> audit-event
+/// proof (#138 G-5 Task 5.3). Implements <see cref="IEventSourcedState{TState}"/>
+/// so the EventSourced-mode saga applies each appended event via
+/// <see cref="ApplyEvent"/>.
+/// </summary>
+public sealed record EventSourcedLowConfidenceState : IEventSourcedState<EventSourcedLowConfidenceState>
+{
+    /// <summary>
+    /// Gets the Marten aggregate identity (the event stream id, equal to
+    /// <see cref="WorkflowId"/>). Required because the generated <c>Add...Workflow()</c>
+    /// registers an inline <c>Snapshot&lt;EventSourcedLowConfidenceState&gt;</c>
+    /// projection, which only builds when the state satisfies Marten's single-stream
+    /// aggregation conventions (an <c>Id</c> identity plus at least one matching <c>Apply</c>).
+    /// </summary>
+    public Guid Id { get; init; }
+
+    /// <summary>
+    /// Gets the unique identifier for this workflow instance.
+    /// </summary>
+    public Guid WorkflowId { get; init; }
+
+    /// <summary>
+    /// Gets the number of step-completed events folded into state so far.
+    /// </summary>
+    public int StepCount { get; init; }
+
+    /// <summary>
+    /// Marten aggregation fold for the prepare step's completed event (the first
+    /// event the saga appends to the stream). The <c>LowConfidenceRouted</c> audit
+    /// event has no <c>Apply</c> overload, so Marten's inline aggregation tolerates
+    /// and skips it while it still lands in the raw stream the test reads.
+    /// </summary>
+    /// <param name="evt">The prepare-step completed event.</param>
+    /// <returns>The aggregate seeded with the stream id and the step counted.</returns>
+    public EventSourcedLowConfidenceState Apply(EventSourcedLcPrepareStepCompleted evt) =>
+        this with { Id = this.WorkflowId, StepCount = this.StepCount + 1 };
+
+    /// <inheritdoc />
+    public EventSourcedLowConfidenceState ApplyEvent(IProgressEvent evt)
+    {
+        ArgumentNullException.ThrowIfNull(evt, nameof(evt));
+
+        // The saga's in-memory fold. This fixture asserts on the LowConfidenceRouted
+        // audit event landing in the stream, not on folded state, so every event
+        // passes through unchanged (audit events are observational, not state-bearing).
+        return this;
+    }
+}
+
+/// <summary>
+/// Entry step of the event-sourced low-confidence fixture. Deterministic;
+/// records its invocation and returns new state.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class EventSourcedLcPrepareStep(WorkflowInvocationLog log) : IWorkflowStep<EventSourcedLowConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<EventSourcedLowConfidenceState>> ExecuteAsync(
+        EventSourcedLowConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(EventSourcedLcPrepareStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<EventSourcedLowConfidenceState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The confidence-gated step. Returns a step result whose <c>Confidence</c> is
+/// 0.5 — below the 0.85 threshold — so the generated EventSourced saga's
+/// confidence gate routes to <see cref="EventSourcedLcReviewStep"/> AND appends
+/// the <c>LowConfidenceRouted</c> audit event to the Marten stream.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class EventSourcedLcClassifyStep(WorkflowInvocationLog log) : IWorkflowStep<EventSourcedLowConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<EventSourcedLowConfidenceState>> ExecuteAsync(
+        EventSourcedLowConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(EventSourcedLcClassifyStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<EventSourcedLowConfidenceState>.WithConfidence(updated, 0.5));
+    }
+}
+
+/// <summary>
+/// The low-confidence handler step. Runs only when the confidence gate routes to
+/// it (confidence below threshold). As a single-step OnLowConfidence handler it
+/// terminates the workflow (the generated handler calls <c>MarkCompleted()</c>).
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class EventSourcedLcReviewStep(WorkflowInvocationLog log) : IWorkflowStep<EventSourcedLowConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<EventSourcedLowConfidenceState>> ExecuteAsync(
+        EventSourcedLowConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(EventSourcedLcReviewStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<EventSourcedLowConfidenceState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The primary finish step. It must NOT run when confidence is low, because the
+/// gate diverts to the handler branch first.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class EventSourcedLcFinishStep(WorkflowInvocationLog log) : IWorkflowStep<EventSourcedLowConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<EventSourcedLowConfidenceState>> ExecuteAsync(
+        EventSourcedLowConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(EventSourcedLcFinishStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<EventSourcedLowConfidenceState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The event-sourced low-confidence fixture workflow definition (#138 G-5 Task
+/// 5.3). Declares <c>Persistence = PersistenceMode.EventSourced</c> and a
+/// confidence-gated classify step (returns 0.5, below the 0.85 threshold) whose
+/// <c>OnLowConfidence</c> branch runs <see cref="EventSourcedLcReviewStep"/>, so the
+/// generated saga's confidence gate appends the <c>LowConfidenceRouted</c> audit
+/// event to the Marten stream. Drives the generator to emit
+/// <c>EventSourcedLowConfidenceSaga</c>, <c>StartEventSourcedLowConfidenceCommand</c>,
+/// and <c>AddEventSourcedLowConfidenceWorkflow()</c>.
+/// </summary>
+[Workflow("event-sourced-low-confidence", Persistence = PersistenceMode.EventSourced)]
+public static partial class EventSourcedLowConfidenceWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent definition: a prepare step, a confidence-gated classify
+    /// step (returns 0.5, below the 0.85 threshold) whose <c>OnLowConfidence</c>
+    /// branch runs <see cref="EventSourcedLcReviewStep"/>, and a primary finish step
+    /// that should be skipped when confidence is low.
+    /// </summary>
+    public static WorkflowDefinition<EventSourcedLowConfidenceState> Definition =>
+        Workflow<EventSourcedLowConfidenceState>
+            .Create("event-sourced-low-confidence")
+            .StartWith<EventSourcedLcPrepareStep>()
+            .Then<EventSourcedLcClassifyStep>(step => step
+                .RequireConfidence(0.85)
+                .OnLowConfidence(alt => alt.Then<EventSourcedLcReviewStep>()))
+            .Finally<EventSourcedLcFinishStep>();
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Workflows/FailureHandlerWorkflow.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Workflows/FailureHandlerWorkflow.cs
@@ -1,0 +1,178 @@
+// -----------------------------------------------------------------------
+// <copyright file="FailureHandlerWorkflow.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Abstractions;
+using Strategos.Attributes;
+using Strategos.Builders;
+using Strategos.Definitions;
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Steps;
+
+namespace Strategos.Generators.Behavioral.Tests.Workflows;
+
+/// <summary>
+/// Immutable state for the OnFailure-chain behavioral fixture (#140 Task 3.1).
+/// </summary>
+/// <remarks>
+/// Marked <see cref="WorkflowStateAttribute"/> so the source generator emits a
+/// reducer used by the saga to fold each step's returned state, including the
+/// state returned by the workflow-level <c>OnFailure</c> handler step.
+/// </remarks>
+[WorkflowState]
+public sealed record FailureHandlerState : IWorkflowState
+{
+    /// <summary>
+    /// Gets the unique identifier for this workflow instance.
+    /// </summary>
+    public Guid WorkflowId { get; init; }
+
+    /// <summary>
+    /// Gets the number of steps that have folded their result into state.
+    /// </summary>
+    public int StepCount { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the OnFailure handler step ran.
+    /// </summary>
+    public bool FailureNotified { get; init; }
+}
+
+/// <summary>
+/// Permanent failure raised by <see cref="FailureHandlerFailingStep"/> on EVERY
+/// invocation, so the saga routes to the workflow-level <c>OnFailure</c> chain.
+/// </summary>
+public sealed class FailureHandlerStepException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FailureHandlerStepException"/>
+    /// class with the supplied message.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    public FailureHandlerStepException(string message)
+        : base(message)
+    {
+    }
+}
+
+/// <summary>
+/// Entry step of the OnFailure-chain fixture workflow. Deterministic (never
+/// throws); records its invocation so the test can confirm the saga started.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class FailureHandlerPrepareStep(WorkflowInvocationLog log) : IWorkflowStep<FailureHandlerState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<FailureHandlerState>> ExecuteAsync(
+        FailureHandlerState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(FailureHandlerPrepareStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<FailureHandlerState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The failing middle step. It declares NO step-level resilience (no retry, no
+/// compensation) and throws on EVERY invocation, so the saga must route to the
+/// workflow-level <c>OnFailure</c> handler chain.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class FailureHandlerFailingStep(WorkflowInvocationLog log) : IWorkflowStep<FailureHandlerState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<FailureHandlerState>> ExecuteAsync(
+        FailureHandlerState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(FailureHandlerFailingStep));
+
+        throw new FailureHandlerStepException(
+            "FailureHandlerFailingStep always fails to force the workflow OnFailure chain.");
+    }
+}
+
+/// <summary>
+/// The workflow-level <c>OnFailure</c> handler step run when
+/// <see cref="FailureHandlerFailingStep"/> fails. Records its invocation exactly
+/// once so the test can assert the dead OnFailure chain now actually runs. Per
+/// INV-7 it returns NEW state (sets <see cref="FailureHandlerState.FailureNotified"/>)
+/// rather than mutating the input.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class NotifyFailure(WorkflowInvocationLog log) : IWorkflowStep<FailureHandlerState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<FailureHandlerState>> ExecuteAsync(
+        FailureHandlerState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(NotifyFailure));
+
+        var updated = state with { FailureNotified = true };
+        return Task.FromResult(StepResult<FailureHandlerState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// A step that must NOT run when the preceding <see cref="FailureHandlerFailingStep"/>
+/// fails: once the saga routes to the OnFailure chain it reaches Failed before
+/// ever cascading this step. Its invocation count being zero is the observable
+/// proof that the failure routed away from the happy path.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class FailureHandlerNeverReachedStep(WorkflowInvocationLog log) : IWorkflowStep<FailureHandlerState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<FailureHandlerState>> ExecuteAsync(
+        FailureHandlerState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(FailureHandlerNeverReachedStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<FailureHandlerState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The OnFailure-chain proof fixture workflow definition (#140 Task 3.1). The
+/// <see cref="WorkflowAttribute"/> drives the Strategos source generator to emit,
+/// at build time, the Wolverine saga, the worker handlers for every step
+/// (including the <c>OnFailure</c> handler step <see cref="NotifyFailure"/>), the
+/// failure-handler trigger/start/worker commands, the failure-handler completed
+/// event, and the <c>AddFailureHandlerProofWorkflow()</c> DI extension consumed
+/// by the host fixture.
+/// </summary>
+[Workflow("failure-handler-proof")]
+public static partial class FailureHandlerProofWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent workflow definition: a prepare step, a middle step that
+    /// always throws with NO step-level resilience, a terminal step that must
+    /// never be reached, and a workflow-level <c>OnFailure</c> chain that runs
+    /// <see cref="NotifyFailure"/>.
+    /// </summary>
+    public static WorkflowDefinition<FailureHandlerState> Definition => Workflow<FailureHandlerState>
+        .Create("failure-handler-proof")
+        .StartWith<FailureHandlerPrepareStep>()
+        .Then<FailureHandlerFailingStep>()
+        .OnFailure(flow => flow.Then<NotifyFailure>().Complete())
+        .Finally<FailureHandlerNeverReachedStep>();
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Workflows/LowConfidenceChainWorkflow.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Workflows/LowConfidenceChainWorkflow.cs
@@ -1,0 +1,413 @@
+// -----------------------------------------------------------------------
+// <copyright file="LowConfidenceChainWorkflow.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Abstractions;
+using Strategos.Attributes;
+using Strategos.Builders;
+using Strategos.Definitions;
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Steps;
+
+namespace Strategos.Generators.Behavioral.Tests.Workflows;
+
+/// <summary>
+/// Immutable state shared by the multi-step / rejoining low-confidence fixture
+/// workflows (G-4 / #139). Distinct from <c>ConfidenceState</c> only by name so
+/// the generator emits an independent reducer per fixture set.
+/// </summary>
+[WorkflowState]
+public sealed record ChainConfidenceState : IWorkflowState
+{
+    /// <summary>
+    /// Gets the unique identifier for this workflow instance.
+    /// </summary>
+    public Guid WorkflowId { get; init; }
+
+    /// <summary>
+    /// Gets the number of steps that have folded their result into state.
+    /// </summary>
+    public int StepCount { get; init; }
+}
+
+// =============================================================================
+// Two-step chain scenario (Task 4.1): the classify step returns Confidence = 0.5
+// (below the 0.85 threshold), so the saga must route to a TWO-step OnLowConfidence
+// handler chain — ChainHandlerAStep then ChainHandlerBStep, in that order — before
+// the workflow ends. Distinct CLR types per [Workflow] definition avoid the
+// generator's CS0101 same-name collision.
+// =============================================================================
+
+/// <summary>
+/// Entry step of the two-step-chain fixture. Records its invocation.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class ChainPrepareStep(WorkflowInvocationLog log) : IWorkflowStep<ChainConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ChainConfidenceState>> ExecuteAsync(
+        ChainConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(ChainPrepareStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ChainConfidenceState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The confidence-gated step of the two-step-chain fixture. Returns confidence
+/// 0.5 (below the 0.85 threshold) so the generated saga routes to the two-step
+/// OnLowConfidence handler chain.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class ChainClassifyStep(WorkflowInvocationLog log) : IWorkflowStep<ChainConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ChainConfidenceState>> ExecuteAsync(
+        ChainConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(ChainClassifyStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ChainConfidenceState>.WithConfidence(updated, 0.5));
+    }
+}
+
+/// <summary>
+/// First step of the two-step OnLowConfidence handler chain. Must run before
+/// <see cref="ChainHandlerBStep"/>.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class ChainHandlerAStep(WorkflowInvocationLog log) : IWorkflowStep<ChainConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ChainConfidenceState>> ExecuteAsync(
+        ChainConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(ChainHandlerAStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ChainConfidenceState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// Second step of the two-step OnLowConfidence handler chain. As the terminal
+/// step of a (default) terminating handler it ends the workflow.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class ChainHandlerBStep(WorkflowInvocationLog log) : IWorkflowStep<ChainConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ChainConfidenceState>> ExecuteAsync(
+        ChainConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(ChainHandlerBStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ChainConfidenceState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The primary finish step of the two-step-chain fixture. Must NOT run because
+/// the gate diverts to the (terminating) handler chain.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class ChainFinishStep(WorkflowInvocationLog log) : IWorkflowStep<ChainConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ChainConfidenceState>> ExecuteAsync(
+        ChainConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(ChainFinishStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ChainConfidenceState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The two-step-chain fixture workflow definition. The classify step declares a
+/// confidence gate whose <c>OnLowConfidence</c> branch chains
+/// <c>ChainHandlerAStep</c> then <c>ChainHandlerBStep</c>, and returns confidence
+/// 0.5 so the generated saga must run BOTH handler steps in order.
+/// </summary>
+[Workflow("low-confidence-chain")]
+public static partial class LowConfidenceChainWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent definition with a two-step OnLowConfidence handler chain.
+    /// </summary>
+    public static WorkflowDefinition<ChainConfidenceState> Definition => Workflow<ChainConfidenceState>
+        .Create("low-confidence-chain")
+        .StartWith<ChainPrepareStep>()
+        .Then<ChainClassifyStep>(step => step
+            .RequireConfidence(0.85)
+            .OnLowConfidence(alt => alt
+                .Then<ChainHandlerAStep>()
+                .Then<ChainHandlerBStep>()))
+        .Finally<ChainFinishStep>();
+}
+
+// =============================================================================
+// Rejoin scenario (Task 4.2): the classify step returns Confidence = 0.5 (below
+// threshold), routing to a single-step OnLowConfidence handler that is declared
+// REJOINING via .RejoinMainFlow(). After the handler runs, the saga must resume
+// the MAIN flow at the step AFTER the gated step (RejoinFinishStep), instead of
+// terminating. Distinct CLR types again.
+// =============================================================================
+
+/// <summary>
+/// Entry step of the rejoin fixture. Records its invocation.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class RejoinPrepareStep(WorkflowInvocationLog log) : IWorkflowStep<ChainConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ChainConfidenceState>> ExecuteAsync(
+        ChainConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(RejoinPrepareStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ChainConfidenceState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The confidence-gated step of the rejoin fixture. Returns confidence 0.5 (below
+/// the 0.85 threshold) so the saga routes to the rejoining handler.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class RejoinClassifyStep(WorkflowInvocationLog log) : IWorkflowStep<ChainConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ChainConfidenceState>> ExecuteAsync(
+        ChainConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(RejoinClassifyStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ChainConfidenceState>.WithConfidence(updated, 0.5));
+    }
+}
+
+/// <summary>
+/// The rejoining OnLowConfidence handler step. After it runs, the saga resumes
+/// the main flow at <see cref="RejoinFinishStep"/> (the step after the gated
+/// step) rather than terminating, because the handler declared
+/// <c>.RejoinMainFlow()</c>.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class RejoinHandlerStep(WorkflowInvocationLog log) : IWorkflowStep<ChainConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ChainConfidenceState>> ExecuteAsync(
+        ChainConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(RejoinHandlerStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ChainConfidenceState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The main-flow finish step that a REJOINING handler resumes into. It must run
+/// after <see cref="RejoinHandlerStep"/> when the gate diverts and the handler
+/// rejoins; as the workflow's <c>Finally</c> step its completion ends the saga.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class RejoinFinishStep(WorkflowInvocationLog log) : IWorkflowStep<ChainConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ChainConfidenceState>> ExecuteAsync(
+        ChainConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(RejoinFinishStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ChainConfidenceState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The rejoin fixture workflow definition. The classify step's
+/// <c>OnLowConfidence</c> handler declares <c>.RejoinMainFlow()</c>, so after the
+/// handler step runs the saga must resume the main flow at
+/// <see cref="RejoinFinishStep"/>.
+/// </summary>
+[Workflow("low-confidence-rejoin")]
+public static partial class LowConfidenceRejoinWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent definition with a single-step REJOINING OnLowConfidence
+    /// handler.
+    /// </summary>
+    public static WorkflowDefinition<ChainConfidenceState> Definition => Workflow<ChainConfidenceState>
+        .Create("low-confidence-rejoin")
+        .StartWith<RejoinPrepareStep>()
+        .Then<RejoinClassifyStep>(step => step
+            .RequireConfidence(0.85)
+            .OnLowConfidence(alt => alt
+                .Then<RejoinHandlerStep>()
+                .RejoinMainFlow()))
+        .Finally<RejoinFinishStep>();
+}
+
+// =============================================================================
+// Terminating scenario (Task 4.2, back-compat default): the classify step returns
+// Confidence = 0.5, routing to a single-step OnLowConfidence handler with NO
+// rejoin marker. The handler must TERMINATE the workflow (MarkCompleted), and the
+// main-flow finish step must NOT run. Distinct CLR types again.
+// =============================================================================
+
+/// <summary>
+/// Entry step of the terminating fixture. Records its invocation.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class TermPrepareStep(WorkflowInvocationLog log) : IWorkflowStep<ChainConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ChainConfidenceState>> ExecuteAsync(
+        ChainConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(TermPrepareStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ChainConfidenceState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The confidence-gated step of the terminating fixture. Returns confidence 0.5
+/// (below the 0.85 threshold) so the saga routes to the terminating handler.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class TermClassifyStep(WorkflowInvocationLog log) : IWorkflowStep<ChainConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ChainConfidenceState>> ExecuteAsync(
+        ChainConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(TermClassifyStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ChainConfidenceState>.WithConfidence(updated, 0.5));
+    }
+}
+
+/// <summary>
+/// The terminating OnLowConfidence handler step. With no rejoin marker it is the
+/// terminal step of the workflow (the generated handler calls
+/// <c>MarkCompleted()</c>).
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class TermHandlerStep(WorkflowInvocationLog log) : IWorkflowStep<ChainConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ChainConfidenceState>> ExecuteAsync(
+        ChainConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(TermHandlerStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ChainConfidenceState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The main-flow finish step of the terminating fixture. It must NOT run, because
+/// the (default) terminating handler ends the workflow.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class TermFinishStep(WorkflowInvocationLog log) : IWorkflowStep<ChainConfidenceState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ChainConfidenceState>> ExecuteAsync(
+        ChainConfidenceState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(TermFinishStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ChainConfidenceState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The terminating fixture workflow definition (back-compat default). The classify
+/// step's <c>OnLowConfidence</c> handler has no rejoin marker, so the handler step
+/// terminates the workflow and <see cref="TermFinishStep"/> must NOT run.
+/// </summary>
+[Workflow("low-confidence-terminating")]
+public static partial class LowConfidenceTerminatingWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent definition with a single-step TERMINATING OnLowConfidence
+    /// handler (no rejoin marker).
+    /// </summary>
+    public static WorkflowDefinition<ChainConfidenceState> Definition => Workflow<ChainConfidenceState>
+        .Create("low-confidence-terminating")
+        .StartWith<TermPrepareStep>()
+        .Then<TermClassifyStep>(step => step
+            .RequireConfidence(0.85)
+            .OnLowConfidence(alt => alt
+                .Then<TermHandlerStep>()))
+        .Finally<TermFinishStep>();
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Workflows/StartWithFinallyResilienceWorkflow.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Workflows/StartWithFinallyResilienceWorkflow.cs
@@ -4,6 +4,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using Marten;
+
 using Strategos.Abstractions;
 using Strategos.Attributes;
 using Strategos.Builders;
@@ -125,17 +127,33 @@ public sealed class FinallyKickoffStep(WorkflowInvocationLog log) : IWorkflowSte
 /// <summary>
 /// The TERMINAL step of the Finally-timeout behavioral workflow, declared via the new
 /// <c>Finally&lt;TStep&gt;(step =&gt; step.WithTimeout(...))</c> overload (#141). It sleeps
-/// ~500 ms while configured with a 50 ms timeout, so the saga's deadline-race timeout
-/// message arrives long before this step's <c>Completed</c> event; the saga must route
-/// to its timeout/failure path while this terminal step is still in flight. Its single
-/// invocation (the step runs to completion — this is a deadline race, not hard
-/// cancellation) together with the saga reaching a terminal phase via the timeout route
-/// is the proof that the timeout lowered from the <c>Finally</c> configure lambda.
+/// ~3 s while configured with a 50 ms timeout (a deliberately generous ~60x margin so the
+/// timeout reliably preempts even under scheduled-delivery jitter), so the saga's
+/// deadline-race timeout message arrives long before this step's <c>Completed</c> event;
+/// the saga must route to its timeout/failure path while this terminal step is still in
+/// flight. Because the timeout terminal (<c>Phase = Failed</c>) and the normal terminal
+/// (<c>Phase = Completed</c>) both call <c>MarkCompleted()</c> — which deletes the saga
+/// document and leaves no post-hoc phase to read — this step proves the route DURING the
+/// race: after its delay it loads its own saga by id and, if it is already gone, records
+/// <see cref="TimeoutPreemptedMarker"/>. On the timeout route the saga was deleted at
+/// ~50 ms so the marker is recorded; on a (broken) normal completion the saga still
+/// exists at check time, the marker is absent, and the route-specific assertion fails.
 /// </summary>
 /// <param name="log">The shared invocation log injected by the host.</param>
-public sealed class FinallySlowTimedStep(WorkflowInvocationLog log) : IWorkflowStep<StartFinallyState>
+/// <param name="store">The Marten document store used to probe the saga document.</param>
+public sealed class FinallySlowTimedStep(WorkflowInvocationLog log, IDocumentStore store) : IWorkflowStep<StartFinallyState>
 {
+    /// <summary>
+    /// Distinct marker recorded when, on completing its delay, the step finds its own
+    /// saga document already removed — proof that the 50 ms Finally-timeout fired and
+    /// drove the saga to its <c>Failed</c> terminal BEFORE this step finished. Asserting
+    /// this marker (rather than only "some terminal was reached") makes the behavioral
+    /// test route-specific: it cannot false-pass on a normal completion.
+    /// </summary>
+    public const string TimeoutPreemptedMarker = "FinallySlowTimedStep:timeout-preempted";
+
     private readonly WorkflowInvocationLog log = log;
+    private readonly IDocumentStore store = store;
 
     /// <inheritdoc />
     public async Task<StepResult<StartFinallyState>> ExecuteAsync(
@@ -145,11 +163,23 @@ public sealed class FinallySlowTimedStep(WorkflowInvocationLog log) : IWorkflowS
     {
         this.log.Record(nameof(FinallySlowTimedStep));
 
-        // Exceed the configured 50 ms deadline. Honest deadline race: the step runs to
-        // completion; what matters is the timeout message reaches the saga first. Do
-        // NOT honour the cancellation token — the saga-level deadline race does not
-        // cancel the in-flight handler.
-        await Task.Delay(TimeSpan.FromMilliseconds(500), CancellationToken.None);
+        // Exceed the configured 50 ms deadline by a wide margin. Honest deadline race:
+        // the step runs to completion; what matters is the timeout message reaches the
+        // saga first. Do NOT honour the cancellation token — the saga-level deadline
+        // race does not cancel the in-flight handler.
+        await Task.Delay(TimeSpan.FromMilliseconds(3000), CancellationToken.None);
+
+        // Route-specific proof: by now the 50 ms timeout must have driven the saga to
+        // Failed + MarkCompleted (which removes the document). If the saga document is
+        // already gone, the timeout preempted this completion — record the marker the
+        // test asserts. If it still exists, the timeout did NOT win and the marker stays
+        // absent, failing the route-specific assertion instead of passing silently.
+        await using var query = this.store.QuerySession();
+        var saga = await query.LoadAsync<FinallyTimeoutProofSaga>(context.WorkflowId);
+        if (saga is null)
+        {
+            this.log.Record(TimeoutPreemptedMarker);
+        }
 
         var updated = state with { StepCount = state.StepCount + 1 };
         return StepResult<StartFinallyState>.FromState(updated);

--- a/src/Strategos.Generators.Behavioral.Tests/Workflows/StartWithFinallyResilienceWorkflow.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Workflows/StartWithFinallyResilienceWorkflow.cs
@@ -1,0 +1,205 @@
+// -----------------------------------------------------------------------
+// <copyright file="StartWithFinallyResilienceWorkflow.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Abstractions;
+using Strategos.Attributes;
+using Strategos.Builders;
+using Strategos.Definitions;
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Steps;
+
+namespace Strategos.Generators.Behavioral.Tests.Workflows;
+
+/// <summary>
+/// Immutable state for the StartWith/Finally step-config behavioral fixtures (#141).
+/// </summary>
+/// <remarks>
+/// Marked <see cref="WorkflowStateAttribute"/> so the source generator emits a
+/// reducer used by the saga to fold each step's returned state.
+/// </remarks>
+[WorkflowState]
+public sealed record StartFinallyState : IWorkflowState
+{
+    /// <summary>
+    /// Gets the unique identifier for this workflow instance.
+    /// </summary>
+    public Guid WorkflowId { get; init; }
+
+    /// <summary>
+    /// Gets the number of steps that have folded their result into state.
+    /// </summary>
+    public int StepCount { get; init; }
+}
+
+// NOTE: The two workflows below deliberately share NO step types. The source
+// generator emits worker handlers / commands / events per step TYPE within the
+// same compilation, so a step type reused across two [Workflow] definitions would
+// produce duplicate generated types (CS0101). Each workflow therefore gets its own
+// step classes.
+
+/// <summary>
+/// The ENTRY step of the StartWith-retry behavioral workflow, declared via the new
+/// <c>StartWith&lt;TStep&gt;(step =&gt; step.WithRetry(2))</c> overload (#141). It is
+/// deliberately flaky: it records every invocation in the shared
+/// <see cref="WorkflowInvocationLog"/> and throws a transient exception on attempts 1
+/// and 2, succeeding only on attempt 3. The recorded invocation count therefore equals
+/// the number of attempts Wolverine made, which the behavioral test asserts to prove
+/// the retry policy lowered from the <c>StartWith</c> configure lambda actually retried
+/// the FIRST step.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class StartFlakyStep(WorkflowInvocationLog log) : IWorkflowStep<StartFinallyState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<StartFinallyState>> ExecuteAsync(
+        StartFinallyState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        // Record FIRST, then decide based on this invocation's attempt number.
+        this.log.Record(nameof(StartFlakyStep));
+        var attempt = this.log.CountFor(nameof(StartFlakyStep));
+
+        if (attempt < 3)
+        {
+            throw new TransientStepException(
+                $"StartFlakyStep transient failure on attempt {attempt}.");
+        }
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<StartFinallyState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The terminal step of the StartWith-retry behavioral workflow. Deterministic (never
+/// throws); records its invocation. As the workflow's <c>Finally</c> step, its
+/// completion drives the saga to its terminal phase and <c>MarkCompleted()</c>, so the
+/// test only observes it once the flaky entry step has finally succeeded.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class StartFinishStep(WorkflowInvocationLog log) : IWorkflowStep<StartFinallyState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<StartFinallyState>> ExecuteAsync(
+        StartFinallyState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(StartFinishStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<StartFinallyState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The ENTRY step of the Finally-timeout behavioral workflow. Deterministic and fast;
+/// records its invocation so the test can confirm the saga started.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class FinallyKickoffStep(WorkflowInvocationLog log) : IWorkflowStep<StartFinallyState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<StartFinallyState>> ExecuteAsync(
+        StartFinallyState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(FinallyKickoffStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<StartFinallyState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The TERMINAL step of the Finally-timeout behavioral workflow, declared via the new
+/// <c>Finally&lt;TStep&gt;(step =&gt; step.WithTimeout(...))</c> overload (#141). It sleeps
+/// ~500 ms while configured with a 50 ms timeout, so the saga's deadline-race timeout
+/// message arrives long before this step's <c>Completed</c> event; the saga must route
+/// to its timeout/failure path while this terminal step is still in flight. Its single
+/// invocation (the step runs to completion — this is a deadline race, not hard
+/// cancellation) together with the saga reaching a terminal phase via the timeout route
+/// is the proof that the timeout lowered from the <c>Finally</c> configure lambda.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class FinallySlowTimedStep(WorkflowInvocationLog log) : IWorkflowStep<StartFinallyState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public async Task<StepResult<StartFinallyState>> ExecuteAsync(
+        StartFinallyState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(FinallySlowTimedStep));
+
+        // Exceed the configured 50 ms deadline. Honest deadline race: the step runs to
+        // completion; what matters is the timeout message reaches the saga first. Do
+        // NOT honour the cancellation token — the saga-level deadline race does not
+        // cancel the in-flight handler.
+        await Task.Delay(TimeSpan.FromMilliseconds(500), CancellationToken.None);
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return StepResult<StartFinallyState>.FromState(updated);
+    }
+}
+
+/// <summary>
+/// The StartWith-retry behavioral workflow definition (#141). The entry step declares
+/// <c>.WithRetry(2)</c> inline via the new <c>StartWith</c> configure overload. The
+/// <see cref="WorkflowAttribute"/> drives the source generator to emit the saga, the
+/// worker handler for <see cref="StartFlakyStep"/> carrying the generated
+/// <c>Configure(HandlerChain)</c> retry policy, the start command
+/// (<c>StartStartWithRetryProofCommand</c>), and the
+/// <c>AddStartWithRetryProofWorkflow()</c> DI extension.
+/// </summary>
+[Workflow("start-with-retry-proof")]
+public static partial class StartWithRetryProofWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent definition: a flaky ENTRY step declaring <c>.WithRetry(2)</c>
+    /// (two retries after the initial attempt, up to three total invocations) via the
+    /// new <c>StartWith</c> configure overload, then a terminal finish step whose
+    /// completion the test waits on.
+    /// </summary>
+    public static WorkflowDefinition<StartFinallyState> Definition => Workflow<StartFinallyState>
+        .Create("start-with-retry-proof")
+        .StartWith<StartFlakyStep>(step => step.WithRetry(2))
+        .Finally<StartFinishStep>();
+}
+
+/// <summary>
+/// The Finally-timeout behavioral workflow definition (#141). The TERMINAL step declares
+/// <c>.WithTimeout(50 ms)</c> inline via the new <c>Finally</c> configure overload and
+/// then exceeds its deadline, so the saga must route to its timeout/failure path. The
+/// <see cref="WorkflowAttribute"/> drives the source generator to emit the saga, the
+/// worker handler for <see cref="FinallySlowTimedStep"/> carrying the generated timeout
+/// deadline-race, the start command (<c>StartFinallyTimeoutProofCommand</c>), and the
+/// <c>AddFinallyTimeoutProofWorkflow()</c> DI extension.
+/// </summary>
+[Workflow("finally-timeout-proof")]
+public static partial class FinallyTimeoutProofWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent definition: a fast kickoff step, then a slow TERMINAL step
+    /// declaring <c>.WithTimeout(50 ms)</c> via the new <c>Finally</c> configure overload
+    /// while sleeping ~500 ms, so the timeout fires before its completion event.
+    /// </summary>
+    public static WorkflowDefinition<StartFinallyState> Definition => Workflow<StartFinallyState>
+        .Create("finally-timeout-proof")
+        .StartWith<FinallyKickoffStep>()
+        .Finally<FinallySlowTimedStep>(step => step
+            .WithTimeout(TimeSpan.FromMilliseconds(50)));
+}

--- a/src/Strategos.Generators.Behavioral.Tests/Workflows/ValidationWorkflow.cs
+++ b/src/Strategos.Generators.Behavioral.Tests/Workflows/ValidationWorkflow.cs
@@ -1,0 +1,146 @@
+// -----------------------------------------------------------------------
+// <copyright file="ValidationWorkflow.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Abstractions;
+using Strategos.Attributes;
+using Strategos.Builders;
+using Strategos.Definitions;
+using Strategos.Generators.Behavioral.Tests.Infrastructure;
+using Strategos.Steps;
+
+namespace Strategos.Generators.Behavioral.Tests.Workflows;
+
+/// <summary>
+/// Immutable state for the validation-guard behavioral fixture (#143, G-6 6.1
+/// backfill). The guarded step's <c>.ValidateState(...)</c> predicate reads
+/// <see cref="IsAuthorized"/>, which is left at its default <see langword="false"/>
+/// so the guard fails at runtime and the saga routes to <c>ValidationFailed</c>.
+/// </summary>
+/// <remarks>
+/// Marked <see cref="WorkflowStateAttribute"/> so the source generator emits a
+/// reducer used by the saga to fold each step's returned state.
+/// </remarks>
+[WorkflowState]
+public sealed record ValidationState : IWorkflowState
+{
+    /// <summary>
+    /// Gets the unique identifier for this workflow instance.
+    /// </summary>
+    public Guid WorkflowId { get; init; }
+
+    /// <summary>
+    /// Gets the number of steps that have folded their result into state.
+    /// </summary>
+    public int StepCount { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the workflow is authorized to run the guarded
+    /// step. Left at its default <see langword="false"/> by the prepare step, so the
+    /// guarded step's <c>.ValidateState(s =&gt; s.IsAuthorized, ...)</c> predicate
+    /// fails and the lowered Guard-Then-Dispatch short-circuits the worker dispatch.
+    /// </summary>
+    public bool IsAuthorized { get; init; }
+}
+
+/// <summary>
+/// Entry step of the validation fixture workflow. Deterministic (never throws);
+/// records its invocation and folds state WITHOUT setting
+/// <see cref="ValidationState.IsAuthorized"/>, so the downstream guard fails.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class ValidationPrepareStep(WorkflowInvocationLog log) : IWorkflowStep<ValidationState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ValidationState>> ExecuteAsync(
+        ValidationState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(ValidationPrepareStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ValidationState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The validation-guarded middle step. It declares
+/// <c>.ValidateState(s =&gt; s.IsAuthorized, "...")</c>. Because the prepare step
+/// leaves <see cref="ValidationState.IsAuthorized"/> at <see langword="false"/>,
+/// the generated saga's Guard-Then-Dispatch guard fails BEFORE this worker is
+/// dispatched, so this step's <see cref="ExecuteAsync"/> MUST NOT run. Recording
+/// any invocation here is the failure signal: it would mean the guard did not
+/// short-circuit (the lowering regressed to a standard dispatch).
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class ValidationGuardedStep(WorkflowInvocationLog log) : IWorkflowStep<ValidationState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ValidationState>> ExecuteAsync(
+        ValidationState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(ValidationGuardedStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ValidationState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// Terminal step that must NOT run: once the guard fails the saga transitions to
+/// <c>ValidationFailed</c> and <c>yield break</c>s without cascading further start
+/// commands, so this step is never reached. Its invocation count being zero is the
+/// observable proof that the failed guard short-circuited the rest of the flow.
+/// </summary>
+/// <param name="log">The shared invocation log injected by the host.</param>
+public sealed class ValidationNeverReachedStep(WorkflowInvocationLog log) : IWorkflowStep<ValidationState>
+{
+    private readonly WorkflowInvocationLog log = log;
+
+    /// <inheritdoc />
+    public Task<StepResult<ValidationState>> ExecuteAsync(
+        ValidationState state,
+        StepContext context,
+        CancellationToken cancellationToken)
+    {
+        this.log.Record(nameof(ValidationNeverReachedStep));
+
+        var updated = state with { StepCount = state.StepCount + 1 };
+        return Task.FromResult(StepResult<ValidationState>.FromState(updated));
+    }
+}
+
+/// <summary>
+/// The validation-proof fixture workflow definition. The
+/// <see cref="WorkflowAttribute"/> drives the Strategos source generator to emit,
+/// at build time, the Wolverine saga (<c>ValidationProofSaga</c>), the yield-based
+/// Guard-Then-Dispatch start handler for <see cref="ValidationGuardedStep"/> lowered
+/// from <c>.ValidateState(...)</c>, the <c>ValidationProofValidationFailed</c> event,
+/// the <c>ValidationFailed</c> phase, the start command
+/// (<c>StartValidationProofCommand</c>), and the
+/// <c>AddValidationProofWorkflow()</c> DI extension consumed by the host fixture.
+/// </summary>
+[Workflow("validation-proof")]
+public static partial class ValidationProofWorkflowDefinition
+{
+    /// <summary>
+    /// Gets the fluent workflow definition: a prepare step, a guarded middle step
+    /// declaring <c>.ValidateState(s =&gt; s.IsAuthorized, "...")</c> whose predicate
+    /// is FALSE at runtime, and a terminal step that must never be reached.
+    /// </summary>
+    public static WorkflowDefinition<ValidationState> Definition => Workflow<ValidationState>
+        .Create("validation-proof")
+        .StartWith<ValidationPrepareStep>()
+        .Then<ValidationGuardedStep>(step => step
+            .ValidateState(s => s.IsAuthorized, "Workflow is not authorized to run the guarded step."))
+        .Finally<ValidationNeverReachedStep>();
+}

--- a/src/Strategos.Generators.Tests/Diagnostics/DeclaredButInertTests.cs
+++ b/src/Strategos.Generators.Tests/Diagnostics/DeclaredButInertTests.cs
@@ -1,0 +1,238 @@
+// -----------------------------------------------------------------------
+// <copyright file="DeclaredButInertTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Tests.Fixtures;
+
+namespace Strategos.Generators.Tests.Diagnostics;
+
+/// <summary>
+/// #143, G-6 6.2 — AGWF022 "declared-but-inert" diagnostic. A step configuration
+/// member that is parsed into the <c>StepModel</c> IR but that no emitter consumes for
+/// the step's kind is silently dropped today. AGWF022 surfaces that drop at compile time
+/// so a deferred/unlowered configuration cannot masquerade as working.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The concrete inert case this guards (verified against the generated saga): confidence
+/// gating (<c>RequireConfidence</c>/<c>OnLowConfidence</c>) declared on a step that lives
+/// on a <c>Fork</c> path. The fork-path parse threads the configure lambda into the IR —
+/// so an out-of-range threshold still surfaces AGWF018 — but the saga emitter does not
+/// lower confidence-gated routing for fork-path steps. That variant is deferred to
+/// v2.10.0 / DR-17 (#134), so the configuration is inert: no <c>confidenceScore</c> gate
+/// and no <c>OnLowConfidence</c> routing reach the generated saga.
+/// </para>
+/// <para>
+/// AGWF022 is the next monotonic id past the live ceiling AGWF021 (INV-5: never reuse,
+/// never renumber).
+/// </para>
+/// </remarks>
+[Property("Category", "Integration")]
+public sealed class DeclaredButInertTests
+{
+    private const string DeclaredButInertId = "AGWF022";
+
+    /// <summary>
+    /// Verifies that confidence gating declared on a fork-path step — a configuration the
+    /// generator does not lower for fork-path steps — fires AGWF022 at the workflow
+    /// attribute call site.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Generator_StepConfigFieldInertForStepKind_ReportsAgwf022()
+    {
+        var source = ForkWorkflowWithPathConfig(
+            forkPathStepConfig: "step => step"
+                + ".RequireConfidence(0.85)"
+                + ".OnLowConfidence(alt => alt.Then<HumanReview>())");
+
+        var result = GeneratorTestHelper.RunGenerator(source);
+
+        var diagnostic = result.Diagnostics.FirstOrDefault(d => d.Id == DeclaredButInertId);
+        await Assert.That(diagnostic).IsNotNull()
+            .Because("confidence gating on a fork-path step is inert and must surface as AGWF022");
+        await Assert.That(diagnostic!.Severity).IsEqualTo(DiagnosticSeverity.Warning);
+        await Assert.That(diagnostic.GetMessage()).Contains("ForkedAssess");
+    }
+
+    /// <summary>
+    /// Conformant-negative: confidence gating declared on a TOP-LEVEL step (where it IS
+    /// lowered into the saga) must NOT fire AGWF022.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Generator_StepConfigFieldLoweredForStepKind_DoesNotReportAgwf022()
+    {
+        var source = TopLevelWorkflowWithStepConfig(
+            stepConfig: "step => step"
+                + ".RequireConfidence(0.85)"
+                + ".OnLowConfidence(alt => alt.Then<HumanReview>())");
+
+        var result = GeneratorTestHelper.RunGenerator(source);
+
+        await Assert.That(result.Diagnostics.Any(d => d.Id == DeclaredButInertId)).IsFalse()
+            .Because("confidence gating on a top-level step IS lowered, so AGWF022 must not fire");
+    }
+
+    /// <summary>
+    /// Conformant-negative: a fork-path step that declares only LOWERED config (retry) and
+    /// no confidence gating must NOT fire AGWF022 (the diagnostic is scoped to the inert
+    /// config, not to all fork-path steps).
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Generator_ForkPathStepWithoutInertConfig_DoesNotReportAgwf022()
+    {
+        var source = ForkWorkflowWithPathConfig(
+            forkPathStepConfig: "step => step.WithRetry(2)");
+
+        var result = GeneratorTestHelper.RunGenerator(source);
+
+        await Assert.That(result.Diagnostics.Any(d => d.Id == DeclaredButInertId)).IsFalse()
+            .Because("a fork-path step with only lowered (retry) config must not fire AGWF022");
+    }
+
+    // =========================================================================
+    // Source builder helpers
+    // =========================================================================
+
+    /// <summary>
+    /// Builds a workflow whose <c>ForkedAssess</c> step lives on the first <c>Fork</c> path
+    /// and carries the supplied configure lambda. The second path carries a deterministic
+    /// step so the fork is well-formed, and the fork is closed with a <c>Join</c>.
+    /// </summary>
+    private static string ForkWorkflowWithPathConfig(string forkPathStepConfig) => $$"""
+        using System;
+        using System.Threading;
+        using System.Threading.Tasks;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record ClaimState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class IntakeClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class ForkedAssess : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class ForkedReview : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class HumanReview : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class AggregateClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class SettleClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        [Workflow("inert-fork-claim")]
+        public static partial class InertForkClaimWorkflow
+        {
+            public static WorkflowDefinition<ClaimState> Definition => Workflow<ClaimState>
+                .Create("inert-fork-claim")
+                .StartWith<IntakeClaim>()
+                .Fork(
+                    path => path.Then<ForkedAssess>({{forkPathStepConfig}}),
+                    path => path.Then<ForkedReview>())
+                .Join<AggregateClaim>()
+                .Finally<SettleClaim>();
+        }
+        """;
+
+    /// <summary>
+    /// Builds a top-level (non-fork) workflow whose <c>AssessClaim</c> step carries the
+    /// supplied configure lambda — the conformant-lowered baseline.
+    /// </summary>
+    private static string TopLevelWorkflowWithStepConfig(string stepConfig) => $$"""
+        using System;
+        using System.Threading;
+        using System.Threading.Tasks;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record ClaimState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class IntakeClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class AssessClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class HumanReview : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class SettleClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        [Workflow("lowered-claim")]
+        public static partial class LoweredClaimWorkflow
+        {
+            public static WorkflowDefinition<ClaimState> Definition => Workflow<ClaimState>
+                .Create("lowered-claim")
+                .StartWith<IntakeClaim>()
+                .Then<AssessClaim>({{stepConfig}})
+                .Finally<SettleClaim>();
+        }
+        """;
+}

--- a/src/Strategos.Generators.Tests/Emitters/CompensationLoweringTests.cs
+++ b/src/Strategos.Generators.Tests/Emitters/CompensationLoweringTests.cs
@@ -297,6 +297,76 @@ public class CompensationLoweringTests
         """;
 
     /// <summary>
+    /// A workflow declaring BOTH a step-level <c>.Compensate&lt;RollbackPayment&gt;()</c>
+    /// AND a workflow-level <c>OnFailure</c> chain (#140 Task 3.2). Previously these
+    /// were mutually exclusive (the compensation emitter no-op'd when OnFailure was
+    /// present); they now compose via a SINGLE merged <c>Handle(Trigger…)</c> site:
+    /// compensation runs FIRST, then the OnFailure chain.
+    /// </summary>
+    private const string WorkflowWithCompensateAndOnFailure = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record OrderState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class ValidateOrder : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class ProcessPayment : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class RollbackPayment : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class NotifyFailure : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class SendConfirmation : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        [Workflow("process-order")]
+        public static partial class ProcessOrderWorkflow
+        {
+            public static WorkflowDefinition<OrderState> Definition => Workflow<OrderState>
+                .Create("process-order")
+                .StartWith<ValidateOrder>()
+                .Then<ProcessPayment>(step => step
+                    .Compensate<RollbackPayment>())
+                .OnFailure(flow => flow.Then<NotifyFailure>().Complete())
+                .Finally<SendConfirmation>();
+        }
+        """;
+
+    /// <summary>
     /// A step with <c>.Compensate&lt;T&gt;()</c> lowers, onto the compensated
     /// step's worker <c>Configure(HandlerChain)</c>, an error chain that PUBLISHES
     /// the trigger failure-handler command via
@@ -451,6 +521,85 @@ public class CompensationLoweringTests
         // Assert — no CS0111 (duplicate member) anywhere in the generated saga.
         // Other diagnostics (missing Wolverine/Marten runtime types) are expected
         // in the bare test compilation and are not asserted on.
+        var cs0111 = diagnostics
+            .Where(d => string.Equals(d.Id, "CS0111", StringComparison.Ordinal))
+            .Select(d => d.GetMessage())
+            .ToList();
+
+        await Assert.That(cs0111).IsEmpty();
+    }
+
+    /// <summary>
+    /// #140 Task 3.2 — when a workflow declares BOTH a step-level
+    /// <c>.Compensate&lt;T&gt;()</c> AND a workflow-level <c>OnFailure</c> chain, the
+    /// generated saga has EXACTLY ONE <c>Handle(Trigger…FailureHandlerCommand)</c>
+    /// site (the merged compensation+OnFailure trigger), not two — pinning the
+    /// resolution of the duplicate-method (CS0111) collision the old mutual-exclusion
+    /// no-op avoided by skipping compensation entirely.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Emit_CompensateAndOnFailure_HasExactlyOneTriggerHandleSite()
+    {
+        // Arrange & Act
+        var result = GeneratorTestHelper.RunGenerator(WorkflowWithCompensateAndOnFailure);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+
+        // Assert — exactly one Handle(Trigger…) site (its command parameter line).
+        var triggerHandleSites = CountOccurrences(
+            sagaSource,
+            "TriggerProcessOrderFailureHandlerCommand cmd,");
+        await Assert.That(triggerHandleSites).IsEqualTo(1);
+    }
+
+    /// <summary>
+    /// #140 Task 3.2 — the merged single trigger handler dispatches the compensation
+    /// rollback FIRST (sets <c>Compensating</c>, yields the rollback worker), and the
+    /// rollback's completed handler chains into the OnFailure chain (returns the
+    /// OnFailure first-step start command) rather than marking the saga Failed — the
+    /// fixed compensation-then-OnFailure ordering.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Emit_CompensateAndOnFailure_CompensationRunsFirstThenChainsToOnFailure()
+    {
+        // Arrange & Act
+        var result = GeneratorTestHelper.RunGenerator(WorkflowWithCompensateAndOnFailure);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+
+        // The single trigger handler dispatches the compensation rollback first.
+        var triggerHandler = ExtractTriggerHandlerRegion(sagaSource);
+        await Assert.That(triggerHandler).Contains("Phase = ProcessOrderPhase.Compensating");
+        await Assert.That(triggerHandler).Contains("new ExecuteRollbackPaymentWorkerCommand(WorkflowId");
+
+        // The rollback's completed handler chains into the OnFailure chain (returns
+        // its first step's start command) instead of MarkCompleted().
+        await Assert.That(sagaSource).Contains("RollbackPaymentCompleted evt");
+        await Assert.That(sagaSource)
+            .Contains("return new StartFailureHandler_ProcessOrder_FailureHandler0_NotifyFailureCommand(WorkflowId)");
+
+        // The terminal OnFailure completed handler — not the compensation one — ends
+        // the saga in the Failed phase.
+        await Assert.That(sagaSource).Contains("FailureHandler_ProcessOrder_FailureHandler0_NotifyFailureCompleted");
+        await Assert.That(sagaSource).Contains("Phase = ProcessOrderPhase.Failed");
+    }
+
+    /// <summary>
+    /// #140 Task 3.2 — the compile fixture (source PLUS generator output) has NO
+    /// CS0111 duplicate-method error when a workflow declares BOTH compensation and
+    /// OnFailure. This is the concrete failure mode the old mutual-exclusion no-op
+    /// avoided; the merged single trigger site resolves it without skipping
+    /// compensation.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Emit_CompensateAndOnFailure_GeneratedSagaHasNoCs0111()
+    {
+        // Arrange & Act
+        var diagnostics = GeneratorTestHelper.GetCompilationDiagnostics(
+            WorkflowWithCompensateAndOnFailure);
+
+        // Assert — no CS0111 (duplicate member) anywhere in the generated output.
         var cs0111 = diagnostics
             .Where(d => string.Equals(d.Id, "CS0111", StringComparison.Ordinal))
             .Select(d => d.GetMessage())

--- a/src/Strategos.Generators.Tests/Emitters/ConfidenceLoweringTests.cs
+++ b/src/Strategos.Generators.Tests/Emitters/ConfidenceLoweringTests.cs
@@ -347,4 +347,214 @@ public class ConfidenceLoweringTests
         await Assert.That(sagaSource).DoesNotContain("evt.Confidence <");
         await Assert.That(sagaSource).DoesNotContain("StartHumanReviewCommand");
     }
+
+    /// <summary>
+    /// A linear workflow whose middle step declares a TWO-step OnLowConfidence
+    /// chain (<c>OnLowConfidence(alt =&gt; alt.Then&lt;HumanReview&gt;().Then&lt;EscalateReview&gt;())</c>),
+    /// with no rejoin marker (so the chain terminates). Drives the multi-step
+    /// chain lowering (G-4 / #139).
+    /// </summary>
+    private const string WorkflowWithTwoStepChain = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record OrderState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class ValidateOrder : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class ClassifyIntent : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class HumanReview : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class EscalateReview : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class SendConfirmation : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        [Workflow("process-order")]
+        public static partial class ProcessOrderWorkflow
+        {
+            public static WorkflowDefinition<OrderState> Definition => Workflow<OrderState>
+                .Create("process-order")
+                .StartWith<ValidateOrder>()
+                .Then<ClassifyIntent>(step => step
+                    .RequireConfidence(0.85)
+                    .OnLowConfidence(alt => alt
+                        .Then<HumanReview>()
+                        .Then<EscalateReview>()))
+                .Finally<SendConfirmation>();
+        }
+        """;
+
+    /// <summary>
+    /// A linear workflow whose middle step declares a single-step REJOINING
+    /// OnLowConfidence handler
+    /// (<c>OnLowConfidence(alt =&gt; alt.Then&lt;HumanReview&gt;().RejoinMainFlow())</c>).
+    /// Drives the rejoin lowering (G-4 / #139): the handler resumes the main flow
+    /// at the step after the gated step (SendConfirmation).
+    /// </summary>
+    private const string WorkflowWithRejoiningHandler = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record OrderState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class ValidateOrder : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class ClassifyIntent : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class HumanReview : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        public class SendConfirmation : IWorkflowStep<OrderState>
+        {
+            public Task<StepResult<OrderState>> ExecuteAsync(
+                OrderState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<OrderState>.FromState(state));
+        }
+
+        [Workflow("process-order")]
+        public static partial class ProcessOrderWorkflow
+        {
+            public static WorkflowDefinition<OrderState> Definition => Workflow<OrderState>
+                .Create("process-order")
+                .StartWith<ValidateOrder>()
+                .Then<ClassifyIntent>(step => step
+                    .RequireConfidence(0.85)
+                    .OnLowConfidence(alt => alt
+                        .Then<HumanReview>()
+                        .RejoinMainFlow()))
+                .Finally<SendConfirmation>();
+        }
+        """;
+
+    /// <summary>
+    /// Task 4.1 golden shape: a TWO-step OnLowConfidence chain lowers BOTH handler
+    /// steps, with the confidence gate routing to the FIRST (HumanReview), the
+    /// first handler chaining to the SECOND (EscalateReview), and the second
+    /// (terminating, no rejoin marker) marking the saga completed. Before #139
+    /// only one handler step was lowered.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Emit_TwoStepChain_LowersBothHandlerStepsInOrder()
+    {
+        // Arrange & Act
+        var result = GeneratorTestHelper.RunGenerator(WorkflowWithTwoStepChain);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+        var commandsSource = GeneratorTestHelper.GetGeneratedSource(result, "Commands.g.cs");
+
+        // The confidence gate routes to the FIRST handler step.
+        await Assert.That(sagaSource).Contains("StartHumanReviewCommand");
+
+        // BOTH handler steps are fully lowered (each has its own start command).
+        await Assert.That(commandsSource).Contains("StartHumanReviewCommand");
+        await Assert.That(commandsSource).Contains("StartEscalateReviewCommand");
+
+        // The first handler step (HumanReview) chains to the second (EscalateReview)
+        // rather than terminating: its completed handler returns the second's start
+        // command.
+        var firstHandler = ExtractConfidenceHandlerRegion(sagaSource, "HumanReviewCompleted evt,");
+        await Assert.That(firstHandler).Contains("StartEscalateReviewCommand");
+
+        // The second (last) handler step terminates the (default terminating) chain.
+        var secondHandler = ExtractConfidenceHandlerRegion(sagaSource, "EscalateReviewCompleted evt,");
+        await Assert.That(secondHandler).Contains("MarkCompleted()");
+    }
+
+    /// <summary>
+    /// Task 4.2 golden shape (terminating, back-compat default): a single-step
+    /// OnLowConfidence handler with no rejoin marker marks the saga completed —
+    /// it does NOT chain back to the main flow's next step (SendConfirmation).
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Emit_TerminatingHandler_MarksSagaCompleted()
+    {
+        // Arrange & Act
+        var result = GeneratorTestHelper.RunGenerator(WorkflowWithStepConfidence);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+
+        // The handler step's own completed handler marks the saga completed and does
+        // NOT route back to the main-flow step after the gate (SendConfirmation).
+        var handler = ExtractConfidenceHandlerRegion(sagaSource, "HumanReviewCompleted evt,");
+        await Assert.That(handler).Contains("MarkCompleted()");
+        await Assert.That(handler).DoesNotContain("StartSendConfirmationCommand");
+    }
+
+    /// <summary>
+    /// Task 4.2 golden shape (rejoining): a single-step OnLowConfidence handler
+    /// declared <c>.RejoinMainFlow()</c> resumes the MAIN flow at the step after the
+    /// gated step (SendConfirmation) instead of marking the saga completed.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Emit_RejoiningHandler_ResumesMainFlowAfterGatedStep()
+    {
+        // Arrange & Act
+        var result = GeneratorTestHelper.RunGenerator(WorkflowWithRejoiningHandler);
+        var sagaSource = GeneratorTestHelper.GetGeneratedSource(result, "ProcessOrderSaga.g.cs");
+
+        // The handler step's own completed handler routes to the main-flow step
+        // after the gate (SendConfirmation) and does NOT mark the saga completed.
+        var handler = ExtractConfidenceHandlerRegion(sagaSource, "HumanReviewCompleted evt,");
+        await Assert.That(handler).Contains("StartSendConfirmationCommand");
+        await Assert.That(handler).DoesNotContain("MarkCompleted()");
+    }
 }

--- a/src/Strategos.Generators.Tests/Emitters/Saga/StepCompletedHandlerEmitterTests.cs
+++ b/src/Strategos.Generators.Tests/Emitters/Saga/StepCompletedHandlerEmitterTests.cs
@@ -763,7 +763,13 @@ public class StepCompletedHandlerEmitterTests
             StepNames: ["ValidateStep", "ProcessStep", "CompleteStep", "FailedStep"],
             StateTypeName: "TestState",
             Loops: null,
-            FailureHandlers: [failureHandler]);
+            FailureHandlers: [failureHandler])
+        {
+            // This model represents a state type that carries a Phase property, so
+            // the saga syncs Phase = State.Phase (the route-1 OnFailure path). The
+            // emitter only emits that sync when StateHasPhaseProperty is true (#140).
+            StateHasPhaseProperty = true,
+        };
     }
 
     private static WorkflowModel CreateModelWithFailureHandlersAndWorkflowState()

--- a/src/Strategos.Generators.Tests/Emitters/Saga/StepStartHandlerEmitterTests.cs
+++ b/src/Strategos.Generators.Tests/Emitters/Saga/StepStartHandlerEmitterTests.cs
@@ -332,6 +332,47 @@ public class StepStartHandlerEmitterTests
     }
 
     // =============================================================================
+    // E.0 Validation Error Message Literal Escaping Tests
+    // =============================================================================
+
+    /// <summary>
+    /// Verifies that a validation error message containing a double-quote and a
+    /// backslash is emitted as a properly escaped C# string literal, so the
+    /// generated start-handler source compiles instead of producing a broken
+    /// literal. Regression for CL-1 (#142): the raw <c>Token.ValueText</c> was
+    /// interpolated directly into the literal, so a <c>"</c> or <c>\</c> in the
+    /// message terminated/corrupted the emitted string.
+    /// </summary>
+    [Test]
+    public async Task StepStartHandlerEmitter_ValidationMessageWithQuoteAndBackslash_EmitsCompilableLiteral()
+    {
+        // Arrange
+        const string message = "He said \"go\" \\ stop";
+        var emitter = new StepStartHandlerEmitter();
+        var sb = new StringBuilder();
+        var model = CreateMinimalModel();
+        var stepModel = StepModel.Create(
+            stepName: "ValidateStep",
+            stepTypeName: "Test.ValidateStep",
+            validationPredicate: "state.IsValid",
+            validationErrorMessage: message);
+        var context = CreateContext(stepIndex: 0, stepModel: stepModel);
+
+        // Act
+        emitter.EmitHandler(sb, model, "ValidateStep", context);
+        var result = sb.ToString();
+
+        // Assert - the message must appear as a fully escaped, quote-wrapped literal.
+        // SymbolDisplay.FormatLiteral(message, quote: true) is the canonical, compilable form.
+        var expectedLiteral = SymbolDisplay.FormatLiteral(message, quote: true);
+        await Assert.That(result).Contains(expectedLiteral);
+
+        // And the broken raw form (verbatim message wrapped in plain quotes) must NOT appear -
+        // that is the unescaped interpolation that fails to compile.
+        await Assert.That(result).DoesNotContain("\"" + message + "\"");
+    }
+
+    // =============================================================================
     // E. State Parameter Replacement Tests
     // =============================================================================
 

--- a/src/Strategos.Generators.Tests/Emitters/WorkerHandlerEmitterUnitTests.cs
+++ b/src/Strategos.Generators.Tests/Emitters/WorkerHandlerEmitterUnitTests.cs
@@ -427,8 +427,115 @@ public class WorkerHandlerEmitterUnitTests
     }
 
     // =============================================================================
+    // M. OnFailure Worker Handler Tests (#140 Task 3.1)
+    // =============================================================================
+
+    /// <summary>
+    /// Verifies that a workflow with an OnFailure chain emits a dedicated worker
+    /// handler that handles the saga-dispatched
+    /// <c>ExecuteFailureHandler_{id}_{step}WorkerCommand</c> and returns the
+    /// <c>FailureHandler_{id}_{step}Completed</c> event. This is the previously-dead
+    /// receiver that left the OnFailure chain unrunnable.
+    /// </summary>
+    [Test]
+    public async Task Emit_WorkflowWithOnFailure_EmitsFailureHandlerWorkerHandle()
+    {
+        // Arrange
+        var model = CreateOnFailureModel();
+
+        // Act
+        var source = WorkerHandlerEmitter.Emit(model);
+
+        // Assert - a dedicated FailureHandler_{id}_{step}Handler class exists
+        await Assert.That(source).Contains("class FailureHandler_recovery_NotifyFailureHandler");
+
+        // It HANDLES the saga-dispatched failure-handler worker command...
+        await Assert.That(source).Contains("ExecuteFailureHandler_recovery_NotifyFailureWorkerCommand command,");
+
+        // ...and RETURNS the failure-handler completed event the saga folds and routes on.
+        await Assert.That(source).Contains("Task<FailureHandler_recovery_NotifyFailureCompleted> Handle");
+        await Assert.That(source).Contains("return new FailureHandler_recovery_NotifyFailureCompleted(");
+
+        // It executes the OnFailure step.
+        await Assert.That(source).Contains("await _step.ExecuteAsync(command.State, stepContext, ct)");
+    }
+
+    /// <summary>
+    /// Verifies that a main-flow step in a workflow with an OnFailure chain lowers a
+    /// trigger-publishing <c>Configure(HandlerChain)</c> so a thrown step routes into
+    /// the OnFailure chain at runtime (the previously-missing publish for a
+    /// non-compensated failing step).
+    /// </summary>
+    [Test]
+    public async Task Emit_WorkflowWithOnFailure_MainFlowStep_PublishesTrigger()
+    {
+        // Arrange
+        var model = CreateOnFailureModel();
+
+        // Act
+        var source = WorkerHandlerEmitter.Emit(model);
+
+        // Assert - the main-flow step's error chain publishes the trigger command.
+        await Assert.That(source).Contains("public static void Configure(HandlerChain chain)");
+        await Assert.That(source).Contains("bus.PublishAsync(new TriggerOnFailureProofFailureHandlerCommand(");
+        await Assert.That(source).Contains("// routes to OnFailure chain");
+    }
+
+    /// <summary>
+    /// Verifies that the OnFailure handler step itself does NOT publish the trigger
+    /// (it is the recovery path and must not re-trigger the OnFailure chain).
+    /// </summary>
+    [Test]
+    public async Task Emit_WorkflowWithOnFailure_HandlerStep_DoesNotPublishTrigger()
+    {
+        // Arrange
+        var model = CreateOnFailureModel();
+
+        // Act
+        var source = WorkerHandlerEmitter.Emit(model);
+
+        // Assert - the NotifyFailure step's plain main-flow handler has no Configure
+        // that publishes the trigger; only the dedicated failure-handler worker class
+        // references NotifyFailure as a recovery step. Confirm exactly the main-flow
+        // steps (ValidateOrder) carry the trigger publish but the OnFailure step's
+        // dedicated worker class never publishes a trigger.
+        var notifyWorkerStart = source.IndexOf(
+            "class FailureHandler_recovery_NotifyFailureHandler",
+            StringComparison.Ordinal);
+        await Assert.That(notifyWorkerStart).IsGreaterThan(-1);
+
+        var notifyWorkerBody = source.Substring(notifyWorkerStart);
+        await Assert.That(notifyWorkerBody).DoesNotContain("PublishAsync(new TriggerOnFailureProofFailureHandlerCommand");
+    }
+
+    // =============================================================================
     // Helper Methods
     // =============================================================================
+
+    private static WorkflowModel CreateOnFailureModel()
+    {
+        var handler = FailureHandlerModel.Create(
+            handlerId: "recovery",
+            scope: FailureHandlerScope.Workflow,
+            stepNames: ["NotifyFailure"],
+            isTerminal: true,
+            steps: [StepModel.Create("NotifyFailure", "TestNamespace.NotifyFailure")]);
+
+        var steps = new List<StepModel>
+        {
+            StepModel.Create("ValidateOrder", "TestNamespace.ValidateOrder"),
+            StepModel.Create("NotifyFailure", "TestNamespace.NotifyFailure"),
+        };
+
+        return new WorkflowModel(
+            WorkflowName: "on-failure-proof",
+            PascalName: "OnFailureProof",
+            Namespace: "TestNamespace",
+            StepNames: ["ValidateOrder", "NotifyFailure"],
+            StateTypeName: "OrderState",
+            Steps: steps,
+            FailureHandlers: [handler]);
+    }
 
     private static WorkflowModel CreateTestModel()
     {

--- a/src/Strategos.Generators.Tests/Emitters/WorkerHandlerEmitterUnitTests.cs
+++ b/src/Strategos.Generators.Tests/Emitters/WorkerHandlerEmitterUnitTests.cs
@@ -499,12 +499,20 @@ public class WorkerHandlerEmitterUnitTests
         // references NotifyFailure as a recovery step. Confirm exactly the main-flow
         // steps (ValidateOrder) carry the trigger publish but the OnFailure step's
         // dedicated worker class never publishes a trigger.
-        var notifyWorkerStart = source.IndexOf(
-            "class FailureHandler_recovery_NotifyFailureHandler",
-            StringComparison.Ordinal);
+        const string notifyWorkerDecl = "class FailureHandler_recovery_NotifyFailureHandler";
+        var notifyWorkerStart = source.IndexOf(notifyWorkerDecl, StringComparison.Ordinal);
         await Assert.That(notifyWorkerStart).IsGreaterThan(-1);
 
-        var notifyWorkerBody = source.Substring(notifyWorkerStart);
+        // Scope the negative assertion to THIS class body only: slice to the next
+        // class declaration (or EOF) so a trigger publish in any LATER generated
+        // class cannot false-fail the assertion on the NotifyFailure handler.
+        var nextClassStart = source.IndexOf(
+            "class ",
+            notifyWorkerStart + notifyWorkerDecl.Length,
+            StringComparison.Ordinal);
+        var notifyWorkerBody = nextClassStart > -1
+            ? source.Substring(notifyWorkerStart, nextClassStart - notifyWorkerStart)
+            : source.Substring(notifyWorkerStart);
         await Assert.That(notifyWorkerBody).DoesNotContain("PublishAsync(new TriggerOnFailureProofFailureHandlerCommand");
     }
 

--- a/src/Strategos.Generators.Tests/Helpers/NestedLambdaLeakageTests.cs
+++ b/src/Strategos.Generators.Tests/Helpers/NestedLambdaLeakageTests.cs
@@ -14,12 +14,13 @@ namespace Strategos.Generators.Tests.Helpers;
 
 /// <summary>
 /// CodeRabbit F1 (PR #137, epic #135) — regression tests for nested-lambda leakage
-/// across the three step-resilience / step-discovery extraction sites that walk a
+/// across the step-resilience / step-discovery / step-validation extraction sites that walk a
 /// configure/handler lambda with <c>DescendantNodes()</c>:
 /// <list type="bullet">
 ///   <item>parent-step resilience (<c>StepExtractor.ExtractConfiguredResilience</c>),</item>
 ///   <item>branch-path step discovery (<c>StepExtractor.ParseBranchPathStepModels</c>),</item>
-///   <item>failure-handler step discovery (<c>FailureHandlerExtractor.ParseFailureHandlerBody</c>).</item>
+///   <item>failure-handler step discovery (<c>FailureHandlerExtractor.ParseFailureHandlerBody</c>),</item>
+///   <item>parent-step validation (<c>StepExtractor.ExtractConfiguredValidation</c>) — G-6 review (#143).</item>
 /// </list>
 /// Each site must consider ONLY invocations in its own lambda body, never those captured
 /// from a nested lambda (e.g. an inner <c>OnLowConfidence(alt =&gt; alt.Then&lt;Y&gt;(c =&gt; c.WithTimeout(t)))</c>).
@@ -133,6 +134,60 @@ public sealed class NestedLambdaLeakageTests
 
         // Assert - the nested Then<NestedRecovery> is NOT a failure-handler step
         await Assert.That(stepNames.Contains("NestedRecovery")).IsFalse();
+    }
+
+    // =========================================================================
+    // F1d — parent-step validation must NOT absorb a nested lambda's ValidateState.
+    // (G-6 review, #143) The top-level fallback added in TryGetStepModel made the
+    // latent unscoped DescendantNodes() walk in ExtractConfiguredValidation reachable:
+    // a top-level step with NO direct ValidateState but a nested
+    // OnLowConfidence(alt => alt.Then<HumanReview>(c => c.ValidateState(...))) would
+    // wrongly absorb the inner handler's guard.
+    // =========================================================================
+
+    /// <summary>
+    /// The top-level <c>AssessClaim</c> step declares NO direct <c>ValidateState</c>, only an
+    /// <c>OnLowConfidence</c> whose handler step declares <c>ValidateState</c> via its own configure
+    /// lambda. The top-level step must NOT carry the inner handler's validation guard.
+    /// </summary>
+    [Test]
+    public async Task ExtractValidation_NestedOnLowConfidenceValidateState_DoesNotLeakToOuterStep()
+    {
+        // Arrange
+        var stepModels = ParserTestHelper.ExtractStepModels(NestedConfidenceValidationWorkflow);
+
+        // Act
+        var outerStep = stepModels.Single(s => s.StepName == "AssessClaim");
+
+        // Assert - the inner handler's ValidateState must NOT leak onto the outer step
+        await Assert.That(outerStep.HasValidation).IsFalse();
+        await Assert.That(outerStep.ValidationPredicate).IsNull();
+    }
+
+    /// <summary>
+    /// The legitimately-nested <c>OnLowConfidence(alt =&gt; alt.Then&lt;HumanReview&gt;(...))</c>
+    /// handler step must still be identified on the outer step's confidence model — the
+    /// nested-lambda boundary fix must not drop config that belongs to the inner handler.
+    /// (The handler step's own validation extraction is a separate concern — DR-5 lowers the
+    /// handler by name/type, mirroring the F1a resilience assertion.)
+    /// </summary>
+    [Test]
+    public async Task ExtractValidation_NestedOnLowConfidenceValidateState_HandlerStepStillIdentified()
+    {
+        // Arrange
+        var stepModels = ParserTestHelper.ExtractStepModels(NestedConfidenceValidationWorkflow);
+        var outerStep = stepModels.Single(s => s.StepName == "AssessClaim");
+
+        // Act
+        var confidence = outerStep.Confidence;
+        var handlerStep = confidence?.OnLowConfidenceHandlerStep;
+
+        // Assert - the threshold and low-confidence handler survive the boundary fix
+        await Assert.That(confidence).IsNotNull();
+        await Assert.That(confidence!.Threshold).IsEqualTo(0.85);
+        await Assert.That(confidence.OnLowConfidenceHandlerId).IsEqualTo("HumanReview");
+        await Assert.That(handlerStep).IsNotNull();
+        await Assert.That(handlerStep!.StepName).IsEqualTo("HumanReview");
     }
 
     // =========================================================================
@@ -368,6 +423,60 @@ public sealed class NestedLambdaLeakageTests
                     .RequireConfidence(0.6)
                     .OnLowConfidence(alt => alt.Then<NestedRecovery>())).Complete())
                 .Finally<CompleteOrder>();
+        }
+        """;
+
+    /// <summary>
+    /// A top-level <c>StartWith&lt;AssessClaim&gt;</c> step carrying NO direct <c>ValidateState</c>,
+    /// only an <c>OnLowConfidence</c> whose handler step (<c>HumanReview</c>) declares its own
+    /// <c>ValidateState</c> via a nested configure lambda. Probes parent-step validation leakage (F1d).
+    /// </summary>
+    private const string NestedConfidenceValidationWorkflow = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record ClaimState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+            public bool Ok { get; init; }
+        }
+
+        public class AssessClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class HumanReview : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class Finish : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        [Workflow("nested-confidence-validation")]
+        public static partial class NestedConfidenceValidationWorkflow
+        {
+            public static WorkflowDefinition<ClaimState> Definition => Workflow<ClaimState>
+                .Create("nested-confidence-validation")
+                .StartWith<AssessClaim>(step => step
+                    .RequireConfidence(0.85)
+                    .OnLowConfidence(alt => alt.Then<HumanReview>(c => c.ValidateState(s => s.Ok, "inner-only"))))
+                .Finally<Finish>();
         }
         """;
 }

--- a/src/Strategos.Generators.Tests/Helpers/StepExtractorConfigTests.cs
+++ b/src/Strategos.Generators.Tests/Helpers/StepExtractorConfigTests.cs
@@ -1,0 +1,200 @@
+// -----------------------------------------------------------------------
+// <copyright file="StepExtractorConfigTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Strategos.Generators.Models;
+using Strategos.Generators.Tests.Fixtures;
+
+namespace Strategos.Generators.Tests.Helpers;
+
+/// <summary>
+/// Tests that the per-step resilience configuration declared via the new
+/// <c>StartWith&lt;TStep&gt;(step =&gt; ...)</c> and <c>Finally&lt;TStep&gt;(step =&gt; ...)</c>
+/// configure-lambda overloads (GitHub #141) reaches the generator's
+/// <see cref="StepModel"/> IR for the FIRST (entry) and TERMINAL steps.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Before #141 only <c>Then&lt;TStep&gt;(configure)</c> accepted a configure lambda, so
+/// the entry step (<c>StartWith</c>) and the terminal step (<c>Finally</c>) could not
+/// declare per-step retry/timeout/compensation/confidence — they had to be preceded /
+/// followed by a non-configured <c>Then</c>. These tests pin that the entry and
+/// terminal <see cref="StepModel"/> now carry the resilience config declared inline on
+/// the <c>StartWith</c>/<c>Finally</c> calls.
+/// </para>
+/// <para>
+/// The generator side already threads config uniformly: the shared
+/// <c>StepExtractor.TryGetStepModel</c> path runs <c>ExtractConfiguredResilience</c> for
+/// every DSL call (<c>StartWith</c>/<c>Then</c>/<c>Finally</c>), so once the C# overloads
+/// exist the entry/terminal steps populate without any extractor change. These tests
+/// drive a workflow snippet through <see cref="ParserTestHelper.ExtractStepModels"/>,
+/// which routes through <c>FluentDslParser.ExtractStepModels</c> →
+/// <see cref="StepExtractor.ExtractStepModels"/>.
+/// </para>
+/// </remarks>
+[Property("Category", "Unit")]
+public sealed class StepExtractorConfigTests
+{
+    /// <summary>
+    /// Verifies that <c>.WithRetry(2)</c> declared inline on the entry step via the new
+    /// <c>StartWith&lt;First&gt;(step =&gt; step.WithRetry(2))</c> overload populates the
+    /// FIRST step's <see cref="StepModel.Retry"/>.
+    /// </summary>
+    [Test]
+    public async Task StepExtractor_StartWithConfigure_PopulatesFirstStepResilience()
+    {
+        // Arrange
+        var stepModels = ParserTestHelper.ExtractStepModels(StartWithFinallyConfigWorkflow);
+
+        // Act - the entry step declared via StartWith<First>(s => s.WithRetry(2))
+        var firstStep = stepModels.Single(s => s.StepName == "First");
+
+        // Assert - the configure lambda on StartWith reaches the entry step's IR
+        await Assert.That(firstStep.Retry).IsNotNull();
+        await Assert.That(firstStep.Retry!.MaxAttempts).IsEqualTo(2);
+    }
+
+    /// <summary>
+    /// Verifies that <c>.WithTimeout(TimeSpan.FromSeconds(5))</c> declared inline on the
+    /// terminal step via the new <c>Finally&lt;Last&gt;(step =&gt; step.WithTimeout(...))</c>
+    /// overload populates the TERMINAL step's <see cref="StepModel.Timeout"/>.
+    /// </summary>
+    [Test]
+    public async Task StepExtractor_FinallyConfigure_PopulatesTerminalStepResilience()
+    {
+        // Arrange
+        var stepModels = ParserTestHelper.ExtractStepModels(StartWithFinallyConfigWorkflow);
+
+        // Act - the terminal step declared via Finally<Last>(s => s.WithTimeout(...))
+        var lastStep = stepModels.Single(s => s.StepName == "Last");
+
+        // Assert - the configure lambda on Finally reaches the terminal step's IR
+        await Assert.That(lastStep.Timeout).IsNotNull();
+        await Assert.That(lastStep.Timeout!.Timeout).IsEqualTo(TimeSpan.FromSeconds(5));
+    }
+
+    /// <summary>
+    /// Verifies that the named-instance + configure overload
+    /// (<c>StartWith&lt;First&gt;("Entry", step =&gt; step.WithRetry(4))</c>) carries BOTH the
+    /// instance name AND the resilience config onto the entry step's
+    /// <see cref="StepModel"/> (the string literal is read as the instance name; the
+    /// lambda is read as the config).
+    /// </summary>
+    [Test]
+    public async Task StepExtractor_StartWithNamedConfigure_CarriesInstanceNameAndResilience()
+    {
+        // Arrange
+        var stepModels = ParserTestHelper.ExtractStepModels(StartWithNamedConfigWorkflow);
+
+        // Act - the entry step declared via StartWith<First>("Entry", s => s.WithRetry(4))
+        var firstStep = stepModels.Single(s => s.StepName == "First");
+
+        // Assert - both the instance name and the resilience config reach the IR
+        await Assert.That(firstStep.InstanceName).IsEqualTo("Entry");
+        await Assert.That(firstStep.Retry).IsNotNull();
+        await Assert.That(firstStep.Retry!.MaxAttempts).IsEqualTo(4);
+    }
+
+    // =========================================================================
+    // Test source workflows
+    // =========================================================================
+
+    /// <summary>
+    /// A linear workflow whose ENTRY step declares <c>.WithRetry(2)</c> via the new
+    /// <c>StartWith</c> configure overload and whose TERMINAL step declares
+    /// <c>.WithTimeout(TimeSpan.FromSeconds(5))</c> via the new <c>Finally</c> configure
+    /// overload.
+    /// </summary>
+    private const string StartWithFinallyConfigWorkflow = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record FlowState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class First : IWorkflowStep<FlowState>
+        {
+            public Task<StepResult<FlowState>> ExecuteAsync(
+                FlowState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<FlowState>.FromState(state));
+        }
+
+        public class Middle : IWorkflowStep<FlowState>
+        {
+            public Task<StepResult<FlowState>> ExecuteAsync(
+                FlowState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<FlowState>.FromState(state));
+        }
+
+        public class Last : IWorkflowStep<FlowState>
+        {
+            public Task<StepResult<FlowState>> ExecuteAsync(
+                FlowState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<FlowState>.FromState(state));
+        }
+
+        [Workflow("startwith-finally-config")]
+        public static partial class StartWithFinallyConfigWorkflow
+        {
+            public static WorkflowDefinition<FlowState> Definition => Workflow<FlowState>
+                .Create("startwith-finally-config")
+                .StartWith<First>(step => step.WithRetry(2))
+                .Then<Middle>()
+                .Finally<Last>(step => step.WithTimeout(TimeSpan.FromSeconds(5)));
+        }
+        """;
+
+    /// <summary>
+    /// A linear workflow whose ENTRY step declares both an instance name and a retry
+    /// policy via the named-instance + configure <c>StartWith</c> overload
+    /// (<c>StartWith&lt;First&gt;("Entry", step =&gt; step.WithRetry(4))</c>).
+    /// </summary>
+    private const string StartWithNamedConfigWorkflow = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record FlowState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class First : IWorkflowStep<FlowState>
+        {
+            public Task<StepResult<FlowState>> ExecuteAsync(
+                FlowState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<FlowState>.FromState(state));
+        }
+
+        public class Last : IWorkflowStep<FlowState>
+        {
+            public Task<StepResult<FlowState>> ExecuteAsync(
+                FlowState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<FlowState>.FromState(state));
+        }
+
+        [Workflow("startwith-named-config")]
+        public static partial class StartWithNamedConfigWorkflow
+        {
+            public static WorkflowDefinition<FlowState> Definition => Workflow<FlowState>
+                .Create("startwith-named-config")
+                .StartWith<First>("Entry", step => step.WithRetry(4))
+                .Finally<Last>();
+        }
+        """;
+}

--- a/src/Strategos.Generators.Tests/Helpers/StepExtractorResilienceTests.cs
+++ b/src/Strategos.Generators.Tests/Helpers/StepExtractorResilienceTests.cs
@@ -153,6 +153,64 @@ public sealed class StepExtractorResilienceTests
         await Assert.That(assessStep.Confidence).IsNotNull();
         await Assert.That(assessStep.Confidence!.Threshold).IsEqualTo(0.85);
         await Assert.That(assessStep.Confidence!.OnLowConfidenceHandlerId).IsEqualTo("HumanReview");
+
+        // The single-step handler chain carries exactly that step and terminates
+        // (no rejoin marker) by default (G-4 / #139).
+        await Assert.That(assessStep.Confidence!.OnLowConfidenceHandlerChain).IsNotNull();
+        await Assert.That(assessStep.Confidence!.OnLowConfidenceHandlerChain!.Steps.Count).IsEqualTo(1);
+        await Assert.That(assessStep.Confidence!.OnLowConfidenceHandlerChain!.Steps[0].StepName).IsEqualTo("HumanReview");
+        await Assert.That(assessStep.Confidence!.OnLowConfidenceHandlerChain!.RejoinsMainFlow).IsFalse();
+    }
+
+    /// <summary>
+    /// G-4 / #139: a TWO-step <c>OnLowConfidence</c> chain
+    /// (<c>OnLowConfidence(alt =&gt; alt.Then&lt;A&gt;().Then&lt;B&gt;())</c>) extracts BOTH handler
+    /// steps as an ORDERED chain (A before B), with the first step retained as the
+    /// confidence gate's routing target. Before #139 only one step was captured.
+    /// </summary>
+    [Test]
+    public async Task WalkInvocationChain_TwoStepOnLowConfidenceChain_ExtractsOrderedSteps()
+    {
+        // Arrange
+        var stepModels = ParserTestHelper.ExtractStepModels(ConfidenceChainWorkflow);
+
+        // Act
+        var assessStep = stepModels.Single(s => s.StepName == "AssessClaim");
+
+        // Assert — the ordered handler chain carries both steps in declaration order.
+        await Assert.That(assessStep.Confidence).IsNotNull();
+        await Assert.That(assessStep.Confidence!.OnLowConfidenceHandlerChain).IsNotNull();
+        var chain = assessStep.Confidence!.OnLowConfidenceHandlerChain!;
+        await Assert.That(chain.Steps.Count).IsEqualTo(2);
+        await Assert.That(chain.Steps[0].StepName).IsEqualTo("HumanReview");
+        await Assert.That(chain.Steps[1].StepName).IsEqualTo("EscalateReview");
+
+        // The gate's routing target (first handler) is retained for back-compat.
+        await Assert.That(assessStep.Confidence!.OnLowConfidenceHandlerId).IsEqualTo("HumanReview");
+
+        // No rejoin marker → terminating (the back-compat default).
+        await Assert.That(chain.RejoinsMainFlow).IsFalse();
+    }
+
+    /// <summary>
+    /// G-4 / #139: a <c>.RejoinMainFlow()</c> call inside the <c>OnLowConfidence</c>
+    /// lambda is inferred as the chain's REJOIN marker
+    /// (<c>RejoinsMainFlow == true</c>); its absence terminates (asserted above).
+    /// </summary>
+    [Test]
+    public async Task WalkInvocationChain_RejoinMainFlowMarker_SetsRejoinsMainFlow()
+    {
+        // Arrange
+        var stepModels = ParserTestHelper.ExtractStepModels(ConfidenceRejoinWorkflow);
+
+        // Act
+        var assessStep = stepModels.Single(s => s.StepName == "AssessClaim");
+
+        // Assert
+        await Assert.That(assessStep.Confidence!.OnLowConfidenceHandlerChain).IsNotNull();
+        await Assert.That(assessStep.Confidence!.OnLowConfidenceHandlerChain!.RejoinsMainFlow).IsTrue();
+        await Assert.That(assessStep.Confidence!.OnLowConfidenceHandlerChain!.Steps.Count).IsEqualTo(1);
+        await Assert.That(assessStep.Confidence!.OnLowConfidenceHandlerChain!.Steps[0].StepName).IsEqualTo("HumanReview");
     }
 
     // =========================================================================
@@ -434,6 +492,139 @@ public sealed class StepExtractorResilienceTests
                     .RequireConfidence(0.85)
                     .OnLowConfidence(alt => alt.Then<HumanReview>())
                     .Compensate<RollbackAssessment>())
+                .Finally<SettleClaim>();
+        }
+        """;
+
+    /// <summary>
+    /// A workflow whose gated step declares a TWO-step <c>OnLowConfidence</c> chain
+    /// (<c>alt.Then&lt;HumanReview&gt;().Then&lt;EscalateReview&gt;()</c>) with no rejoin
+    /// marker (G-4 / #139).
+    /// </summary>
+    private const string ConfidenceChainWorkflow = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record ClaimState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class IntakeClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class AssessClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class HumanReview : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class EscalateReview : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class SettleClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        [Workflow("confidence-chain")]
+        public static partial class ConfidenceChainWorkflow
+        {
+            public static WorkflowDefinition<ClaimState> Definition => Workflow<ClaimState>
+                .Create("confidence-chain")
+                .StartWith<IntakeClaim>()
+                .Then<AssessClaim>(step => step
+                    .RequireConfidence(0.85)
+                    .OnLowConfidence(alt => alt
+                        .Then<HumanReview>()
+                        .Then<EscalateReview>()))
+                .Finally<SettleClaim>();
+        }
+        """;
+
+    /// <summary>
+    /// A workflow whose gated step declares a single-step REJOINING
+    /// <c>OnLowConfidence</c> handler
+    /// (<c>alt.Then&lt;HumanReview&gt;().RejoinMainFlow()</c>) (G-4 / #139).
+    /// </summary>
+    private const string ConfidenceRejoinWorkflow = """
+        using System;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record ClaimState : IWorkflowState
+        {
+            public Guid WorkflowId { get; init; }
+        }
+
+        public class IntakeClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class AssessClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class HumanReview : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        public class SettleClaim : IWorkflowStep<ClaimState>
+        {
+            public Task<StepResult<ClaimState>> ExecuteAsync(
+                ClaimState state, StepContext context, CancellationToken ct)
+                => Task.FromResult(StepResult<ClaimState>.FromState(state));
+        }
+
+        [Workflow("confidence-rejoin")]
+        public static partial class ConfidenceRejoinWorkflow
+        {
+            public static WorkflowDefinition<ClaimState> Definition => Workflow<ClaimState>
+                .Create("confidence-rejoin")
+                .StartWith<IntakeClaim>()
+                .Then<AssessClaim>(step => step
+                    .RequireConfidence(0.85)
+                    .OnLowConfidence(alt => alt
+                        .Then<HumanReview>()
+                        .RejoinMainFlow()))
                 .Finally<SettleClaim>();
         }
         """;

--- a/src/Strategos.Generators.Tests/Helpers/ValidationParserTests.cs
+++ b/src/Strategos.Generators.Tests/Helpers/ValidationParserTests.cs
@@ -108,20 +108,43 @@ public class ValidationParserTests
     }
 
     /// <summary>
-    /// Verifies that Extract extracts complex predicate expression.
+    /// Verifies that Extract extracts a complex predicate expression and normalizes the
+    /// lambda parameter to the canonical name <c>state</c> so the downstream emitter's
+    /// <c>state.</c> -&gt; <c>State.</c> rewrite applies regardless of the author's chosen
+    /// parameter name. The non-receiver tokens (member names, literals, operators) are
+    /// preserved.
     /// </summary>
     [Test]
-    public async Task Extract_ComplexPredicate_ExtractsFullExpression()
+    public async Task Extract_ComplexPredicate_ExtractsFullExpressionAndNormalizesParameter()
     {
-        // Arrange
+        // Arrange — author used parameter name "s".
         var invocation = ParseInvocation("builder.ValidateState(s => s.Amount > 0 && s.Status == \"Active\", \"Must have positive amount and active status\")");
 
         // Act
         var (predicate, errorMessage) = ValidationParser.Extract(invocation);
 
-        // Assert
-        await Assert.That(predicate).IsEqualTo("s.Amount > 0 && s.Status == \"Active\"");
+        // Assert — "s" receivers normalized to "state"; everything else preserved.
+        await Assert.That(predicate).IsEqualTo("state.Amount > 0 && state.Status == \"Active\"");
         await Assert.That(errorMessage).IsEqualTo("Must have positive amount and active status");
+    }
+
+    /// <summary>
+    /// Verifies that Extract normalizes ANY single-parameter lambda name (here a
+    /// parenthesized lambda with parameter <c>ctx</c>) to the canonical <c>state</c>, and
+    /// that a member named the same as the parameter is NOT rewritten (only the receiver
+    /// identifier is).
+    /// </summary>
+    [Test]
+    public async Task Extract_NonStateParameterName_NormalizesReceiverOnly()
+    {
+        // Arrange — parenthesized lambda, parameter "ctx", with a member also named "ctx".
+        var invocation = ParseInvocation("builder.ValidateState((ctx) => ctx.ctx == true, \"msg\")");
+
+        // Act
+        var (predicate, _) = ValidationParser.Extract(invocation);
+
+        // Assert — only the receiver "ctx" became "state"; the member ".ctx" is untouched.
+        await Assert.That(predicate).IsEqualTo("state.ctx == true");
     }
 
     // =============================================================================

--- a/src/Strategos.Generators.Tests/InvariantGuardTests.cs
+++ b/src/Strategos.Generators.Tests/InvariantGuardTests.cs
@@ -47,6 +47,9 @@ public class InvariantGuardTests
             "Strategos.Generators.Models.CompensationModel",
             "Strategos.Generators.Models.ConfidenceModel",
 
+            // Multi-step / rejoining OnLowConfidence handler chain IR (G-4 / #139) — sealed record.
+            "Strategos.Generators.Models.LowConfidenceHandlerChainModel",
+
             // New saga resilience-component emitters — sealed classes.
             "Strategos.Generators.Emitters.Saga.SagaTimeoutComponentEmitter",
             "Strategos.Generators.Emitters.Saga.SagaCompensationComponentEmitter",
@@ -93,6 +96,7 @@ public class InvariantGuardTests
             "Strategos.Generators.Models.TimeoutModel",
             "Strategos.Generators.Models.CompensationModel",
             "Strategos.Generators.Models.ConfidenceModel",
+            "Strategos.Generators.Models.LowConfidenceHandlerChainModel",
         };
 
         var offenders = new List<string>();

--- a/src/Strategos.Generators.Tests/InvariantGuardTests.cs
+++ b/src/Strategos.Generators.Tests/InvariantGuardTests.cs
@@ -6,6 +6,8 @@
 
 using System.Reflection;
 
+using Strategos.Generators.Tests.Fixtures;
+
 namespace Strategos.Generators.Tests;
 
 /// <summary>
@@ -132,5 +134,200 @@ public class InvariantGuardTests
         }
 
         await Assert.That(offenders).IsEmpty();
+    }
+
+    /// <summary>
+    /// An EventSourced workflow that declares a failing step with a workflow-level
+    /// <c>OnFailure</c> chain (drives the <c>StepFailed</c> audit event) and a
+    /// confidence-gated step with an <c>OnLowConfidence</c> handler (drives the
+    /// <c>LowConfidenceRouted</c> audit event).
+    /// </summary>
+    private const string EventSourcedAuditWorkflow = """
+        using System.Threading;
+        using System.Threading.Tasks;
+        using Strategos.Abstractions;
+        using Strategos.Agents.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        public record AuditState : IEventSourcedState<AuditState>
+        {
+            public System.Guid WorkflowId { get; init; }
+            public AuditState ApplyEvent(IProgressEvent evt) => this;
+        }
+
+        public class PrepareStep : IWorkflowStep<AuditState>
+        {
+            public Task<StepResult<AuditState>> ExecuteAsync(AuditState s, StepContext c, CancellationToken ct)
+                => Task.FromResult(StepResult<AuditState>.FromState(s));
+        }
+
+        public class GatedStep : IWorkflowStep<AuditState>
+        {
+            public Task<StepResult<AuditState>> ExecuteAsync(AuditState s, StepContext c, CancellationToken ct)
+                => Task.FromResult(StepResult<AuditState>.WithConfidence(s, 0.5));
+        }
+
+        public class ReviewStep : IWorkflowStep<AuditState>
+        {
+            public Task<StepResult<AuditState>> ExecuteAsync(AuditState s, StepContext c, CancellationToken ct)
+                => Task.FromResult(StepResult<AuditState>.FromState(s));
+        }
+
+        public class FailingStep : IWorkflowStep<AuditState>
+        {
+            public Task<StepResult<AuditState>> ExecuteAsync(AuditState s, StepContext c, CancellationToken ct)
+                => throw new System.InvalidOperationException("always fails");
+        }
+
+        public class NotifyStep : IWorkflowStep<AuditState>
+        {
+            public Task<StepResult<AuditState>> ExecuteAsync(AuditState s, StepContext c, CancellationToken ct)
+                => Task.FromResult(StepResult<AuditState>.FromState(s));
+        }
+
+        public class FinishStep : IWorkflowStep<AuditState>
+        {
+            public Task<StepResult<AuditState>> ExecuteAsync(AuditState s, StepContext c, CancellationToken ct)
+                => Task.FromResult(StepResult<AuditState>.FromState(s));
+        }
+
+        [Workflow("audit-events", Persistence = PersistenceMode.EventSourced)]
+        public static partial class AuditEventsWorkflow
+        {
+            public static WorkflowDefinition<AuditState> Definition => Workflow<AuditState>
+                .Create("audit-events")
+                .StartWith<PrepareStep>()
+                .Then<GatedStep>(step => step
+                    .RequireConfidence(0.85)
+                    .OnLowConfidence(alt => alt.Then<ReviewStep>()))
+                .Then<FailingStep>()
+                .OnFailure(flow => flow.Then<NotifyStep>().Complete())
+                .Finally<FinishStep>();
+        }
+        """;
+
+    /// <summary>
+    /// The SagaDocument (default-mode) counterpart of <see cref="EventSourcedAuditWorkflow"/>.
+    /// The audit stream events apply only in EventSourced mode, so document mode must
+    /// NOT emit them (byte-unchanged document-mode output).
+    /// </summary>
+    private const string DocumentModeAuditWorkflow = """
+        using System.Threading;
+        using System.Threading.Tasks;
+        using Strategos.Abstractions;
+        using Strategos.Attributes;
+        using Strategos.Builders;
+        using Strategos.Definitions;
+        using Strategos.Steps;
+
+        namespace TestNamespace;
+
+        [WorkflowState]
+        public record AuditState : IWorkflowState
+        {
+            public System.Guid WorkflowId { get; init; }
+        }
+
+        public class PrepareStep : IWorkflowStep<AuditState>
+        {
+            public Task<StepResult<AuditState>> ExecuteAsync(AuditState s, StepContext c, CancellationToken ct)
+                => Task.FromResult(StepResult<AuditState>.FromState(s));
+        }
+
+        public class GatedStep : IWorkflowStep<AuditState>
+        {
+            public Task<StepResult<AuditState>> ExecuteAsync(AuditState s, StepContext c, CancellationToken ct)
+                => Task.FromResult(StepResult<AuditState>.WithConfidence(s, 0.5));
+        }
+
+        public class ReviewStep : IWorkflowStep<AuditState>
+        {
+            public Task<StepResult<AuditState>> ExecuteAsync(AuditState s, StepContext c, CancellationToken ct)
+                => Task.FromResult(StepResult<AuditState>.FromState(s));
+        }
+
+        public class FailingStep : IWorkflowStep<AuditState>
+        {
+            public Task<StepResult<AuditState>> ExecuteAsync(AuditState s, StepContext c, CancellationToken ct)
+                => throw new System.InvalidOperationException("always fails");
+        }
+
+        public class NotifyStep : IWorkflowStep<AuditState>
+        {
+            public Task<StepResult<AuditState>> ExecuteAsync(AuditState s, StepContext c, CancellationToken ct)
+                => Task.FromResult(StepResult<AuditState>.FromState(s));
+        }
+
+        public class FinishStep : IWorkflowStep<AuditState>
+        {
+            public Task<StepResult<AuditState>> ExecuteAsync(AuditState s, StepContext c, CancellationToken ct)
+                => Task.FromResult(StepResult<AuditState>.FromState(s));
+        }
+
+        [Workflow("audit-events")]
+        public static partial class AuditEventsWorkflow
+        {
+            public static WorkflowDefinition<AuditState> Definition => Workflow<AuditState>
+                .Create("audit-events")
+                .StartWith<PrepareStep>()
+                .Then<GatedStep>(step => step
+                    .RequireConfidence(0.85)
+                    .OnLowConfidence(alt => alt.Then<ReviewStep>()))
+                .Then<FailingStep>()
+                .OnFailure(flow => flow.Then<NotifyStep>().Complete())
+                .Finally<FinishStep>();
+        }
+        """;
+
+    /// <summary>
+    /// INV-6 (sealed-by-default) + init-only, #138 audit-event taxonomy (OQ#1): the
+    /// generated <c>StepFailed</c> and <c>LowConfidenceRouted</c> audit STREAM events
+    /// are emitted as <c>sealed partial record</c>s with positional (init-only)
+    /// members. Positional record parameters lower to init-only setters, so asserting
+    /// the <c>sealed partial record</c> declaration with the expected positional
+    /// parameter list pins both the sealing and the init-only contract mechanically.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task InvariantGuard_AuditStreamEvents_AreSealedInitOnlyRecords()
+    {
+        var result = GeneratorTestHelper.RunGenerator(EventSourcedAuditWorkflow);
+        var eventsSource = GeneratorTestHelper.GetGeneratedSource(result, "AuditEventsEvents.g.cs");
+
+        // StepFailed: sealed init-only record carrying the failed step + exception type/message.
+        await Assert.That(eventsSource).Contains("public sealed partial record AuditEventsStepFailed(");
+        await Assert.That(eventsSource).Contains("string FailedStepName,");
+        await Assert.That(eventsSource).Contains("string? ExceptionType,");
+
+        // LowConfidenceRouted: sealed init-only record carrying the step + score + threshold.
+        await Assert.That(eventsSource).Contains("public sealed partial record AuditEventsLowConfidenceRouted(");
+        await Assert.That(eventsSource).Contains("string StepName,");
+        await Assert.That(eventsSource).Contains("double Confidence,");
+        await Assert.That(eventsSource).Contains("double Threshold,");
+
+        // Both implement the workflow's event marker interface (so the saga's
+        // ApplyEvent(IProgressEvent) and the Marten stream recognize them).
+        await Assert.That(eventsSource).Contains(") : IAuditEventsEvent;");
+    }
+
+    /// <summary>
+    /// #138 byte-unchanged guard: the audit stream events apply only in EventSourced
+    /// mode, so a SagaDocument-mode workflow must NOT emit them. This pins that the
+    /// document-mode generated output is unchanged by the audit-event taxonomy.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task InvariantGuard_DocumentMode_DoesNotEmitAuditStreamEvents()
+    {
+        var result = GeneratorTestHelper.RunGenerator(DocumentModeAuditWorkflow);
+        var eventsSource = GeneratorTestHelper.GetGeneratedSource(result, "AuditEventsEvents.g.cs");
+
+        await Assert.That(eventsSource).DoesNotContain("StepFailed");
+        await Assert.That(eventsSource).DoesNotContain("LowConfidenceRouted");
     }
 }

--- a/src/Strategos.Generators.Tests/Parity/StepConfigParityTests.cs
+++ b/src/Strategos.Generators.Tests/Parity/StepConfigParityTests.cs
@@ -110,15 +110,28 @@ public sealed class StepConfigParityTests
     private static readonly IReadOnlyDictionary<string, DeferredEntry> Deferred =
         new Dictionary<string, DeferredEntry>(StringComparer.Ordinal)
         {
+            // Fork-path confidence config IS threaded into the IR (so AGWF018 still fires on a
+            // bad threshold) but is not lowered into saga routing — it is structurally
+            // diagnosable and is guarded by AGWF022 (DeclaredButInert / DeclaredButInertTests).
             ["RequireConfidence(fork-path)"] = new(
                 134,
-                "Confidence gating on a fork path is deferred to v2.10.0 / DR-17."),
+                "Confidence gating on a fork path is deferred to v2.10.0 / DR-17; the config "
+                + "reaches the IR and is AGWF022-guarded (DeclaredButInertTests), so it is "
+                + "structurally diagnosable."),
             ["OnLowConfidence(fork-path)"] = new(
                 134,
-                "OnLowConfidence routing on a fork path is deferred to v2.10.0 / DR-17."),
+                "OnLowConfidence routing on a fork path is deferred to v2.10.0 / DR-17; the "
+                + "config reaches the IR and is AGWF022-guarded (DeclaredButInertTests), so it "
+                + "is structurally diagnosable."),
+            // Distinct from the fork-path case above: loop-body / nested-RepeatUntil confidence
+            // config is DROPPED from the IR entirely by step extraction, so an IR-based
+            // diagnostic structurally CANNOT see it — it is NOT AGWF022-guarded. Silently inert,
+            // tracked under #134 for v2.10.0.
             ["OnLowConfidence(nested-RepeatUntil)"] = new(
                 134,
-                "OnLowConfidence inside a nested RepeatUntil loop is deferred to v2.10.0 / DR-17."),
+                "OnLowConfidence inside a nested RepeatUntil loop is dropped from the IR by step "
+                + "extraction (structurally undiagnosable — no AGWF022), deferred to "
+                + "v2.10.0 / DR-17."),
         };
 
     /// <summary>
@@ -148,7 +161,12 @@ public sealed class StepConfigParityTests
                 "a member must be in EXACTLY one set; double-classified: " +
                 string.Join(", ", doubleClassified));
 
-        // Every Lowered entry must name a behavioral proof (not a shape/golden test).
+        // Every Lowered entry must name a behavioral proof (not a shape/golden test) that
+        // actually EXISTS: the referenced file must be on disk AND the named test method must
+        // appear in it. A non-empty string alone is not a forcing function — a stale/typo'd
+        // reference would silently pass. (Grep-level check; we deliberately do NOT add a
+        // project reference to the behavioral suite, which would pull Testcontainers/Marten.)
+        var solutionRoot = FindSolutionRoot();
         foreach (var (member, proof) in Lowered)
         {
             await Assert.That(proof.BehavioralTest)
@@ -157,6 +175,18 @@ public sealed class StepConfigParityTests
             await Assert.That(proof.BehavioralTestFile)
                 .Contains("Behavioral.Tests")
                 .Because($"Lowered member '{member}' proof must live in the behavioral suite, not a shape test");
+
+            var proofPath = Path.Combine(solutionRoot, proof.BehavioralTestFile);
+            await Assert.That(File.Exists(proofPath))
+                .IsTrue()
+                .Because($"Lowered member '{member}' references behavioral proof file '{proof.BehavioralTestFile}', which must exist on disk at '{proofPath}'");
+
+            // The reference is "ClassName.MethodName"; the method name is the last segment.
+            var methodName = proof.BehavioralTest.Split('.').Last();
+            var fileText = File.ReadAllText(proofPath);
+            await Assert.That(fileText.Contains(methodName, StringComparison.Ordinal))
+                .IsTrue()
+                .Because($"Lowered member '{member}' references behavioral test method '{methodName}', which must appear in '{proof.BehavioralTestFile}'");
         }
 
         // Every Deferred entry must carry a tracking issue.
@@ -247,6 +277,32 @@ public sealed class StepConfigParityTests
         }
 
         return (unclassified, doubleClassified);
+    }
+
+    /// <summary>
+    /// Walks up from the running test assembly's directory to the solution root — the directory
+    /// containing <c>strategos.sln</c> (the <c>src</c> dir) — so the relative
+    /// <see cref="LoweredProof.BehavioralTestFile"/> paths can be resolved at test runtime
+    /// regardless of the build output layout.
+    /// </summary>
+    /// <returns>The absolute path to the solution root directory.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no ancestor contains <c>strategos.sln</c>.</exception>
+    private static string FindSolutionRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "strategos.sln")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            "Could not locate the solution root (no ancestor of "
+            + $"'{AppContext.BaseDirectory}' contains strategos.sln).");
     }
 
     /// <summary>

--- a/src/Strategos.Generators.Tests/Parity/StepConfigParityTests.cs
+++ b/src/Strategos.Generators.Tests/Parity/StepConfigParityTests.cs
@@ -1,0 +1,287 @@
+// -----------------------------------------------------------------------
+// <copyright file="StepConfigParityTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Reflection;
+
+using Strategos.Builders;
+using Strategos.Definitions;
+
+namespace Strategos.Generators.Tests.Parity;
+
+/// <summary>
+/// Forcing-function parity guard (#143, G-6 6.1) over the declared step-configuration
+/// surface. Reflects the public surface of <see cref="IStepConfiguration{TState}"/> and
+/// the public fields of <see cref="StepConfigurationDefinition"/> and asserts that EVERY
+/// configurable member is explicitly classified in exactly one of two author-maintained
+/// sets:
+/// <list type="bullet">
+///   <item><description>
+///     <see cref="Lowered"/> — the member lowers into the generated Wolverine+Marten saga,
+///     proven by a NAMED <em>behavioral</em> (compile-run-saga on a real host) test, not a
+///     shape/golden test.
+///   </description></item>
+///   <item><description>
+///     <see cref="Deferred"/> — the member is intentionally not yet lowered, carrying a
+///     tracking issue number.
+///   </description></item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is a forcing function: when a new configuration member is added to either surface
+/// and is NOT classified here, the guard fails. The author must then either point it at a
+/// behavioral lowering proof (move it to <see cref="Lowered"/>) or file a deferral
+/// (move it to <see cref="Deferred"/> with an issue). A config member is "done" only with
+/// a behavioral proof or a tracked deferral — never with a shape/golden test alone.
+/// </para>
+/// <para>
+/// The keys in both sets are the reflected member <em>names</em>. Overloads (e.g. the two
+/// <c>WithRetry</c> overloads) collapse to a single name, which is the unit of
+/// classification.
+/// </para>
+/// </remarks>
+[Property("Category", "Unit")]
+public sealed class StepConfigParityTests
+{
+    /// <summary>
+    /// The set of declared step-configuration members that LOWER into the generated saga,
+    /// each mapped to the behavioral (compile-run-saga, real-host) test that proves the
+    /// lowering. Shape/golden tests do NOT qualify — the proof must run the generated saga.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, LoweredProof> Lowered =
+        new Dictionary<string, LoweredProof>(StringComparer.Ordinal)
+        {
+            // --- IStepConfiguration<TState> builder methods ---
+            ["RequireConfidence"] = new(
+                "ConfidenceBehaviorTests.Saga_HighConfidence_ProceedsOnPrimaryPath",
+                "Strategos.Generators.Behavioral.Tests/ConfidenceBehaviorTests.cs"),
+            ["OnLowConfidence"] = new(
+                "ConfidenceBehaviorTests.Saga_LowConfidence_RoutesToOnLowConfidenceBranch",
+                "Strategos.Generators.Behavioral.Tests/ConfidenceBehaviorTests.cs"),
+            ["Compensate"] = new(
+                "CompensationBehaviorTests.Saga_RetryExhaustedWithCompensate_RunsCompensationOnceAndTransitionsToFailed",
+                "Strategos.Generators.Behavioral.Tests/CompensationBehaviorTests.cs"),
+            ["WithRetry"] = new(
+                "RetryBehaviorTests.Saga_StepWithWithRetry2_InvokesStepExactlyTwiceThenSucceeds",
+                "Strategos.Generators.Behavioral.Tests/RetryBehaviorTests.cs"),
+            ["WithTimeout"] = new(
+                "TimeoutBehaviorTests.Saga_StepExceedsTimeout_RoutesToTimeoutPath",
+                "Strategos.Generators.Behavioral.Tests/TimeoutBehaviorTests.cs"),
+            ["ValidateState"] = new(
+                "ValidationBehaviorTests.Saga_StepWithValidateState_GuardFails_RoutesToValidationFailedWithoutDispatchingStep",
+                "Strategos.Generators.Behavioral.Tests/ValidationBehaviorTests.cs"),
+            ["WithContext"] = new(
+                "ContextBehaviorTests.Saga_StepWithContext_AssemblesContextAndInvokesExecuteSimilarity",
+                "Strategos.Generators.Behavioral.Tests/ContextBehaviorTests.cs"),
+
+            // --- StepConfigurationDefinition IR fields (same lowering proof as the
+            //     builder method that populates each) ---
+            ["ConfidenceThreshold"] = new(
+                "ConfidenceBehaviorTests.Saga_HighConfidence_ProceedsOnPrimaryPath",
+                "Strategos.Generators.Behavioral.Tests/ConfidenceBehaviorTests.cs"),
+            ["Compensation"] = new(
+                "CompensationBehaviorTests.Saga_RetryExhaustedWithCompensate_RunsCompensationOnceAndTransitionsToFailed",
+                "Strategos.Generators.Behavioral.Tests/CompensationBehaviorTests.cs"),
+            ["Retry"] = new(
+                "RetryBehaviorTests.Saga_StepWithWithRetry2_InvokesStepExactlyTwiceThenSucceeds",
+                "Strategos.Generators.Behavioral.Tests/RetryBehaviorTests.cs"),
+            ["Timeout"] = new(
+                "TimeoutBehaviorTests.Saga_StepExceedsTimeout_RoutesToTimeoutPath",
+                "Strategos.Generators.Behavioral.Tests/TimeoutBehaviorTests.cs"),
+            ["Validation"] = new(
+                "ValidationBehaviorTests.Saga_StepWithValidateState_GuardFails_RoutesToValidationFailedWithoutDispatchingStep",
+                "Strategos.Generators.Behavioral.Tests/ValidationBehaviorTests.cs"),
+            ["Context"] = new(
+                "ContextBehaviorTests.Saga_StepWithContext_AssemblesContextAndInvokesExecuteSimilarity",
+                "Strategos.Generators.Behavioral.Tests/ContextBehaviorTests.cs"),
+        };
+
+    /// <summary>
+    /// The set of declared step-configuration member sub-paths intentionally NOT yet
+    /// lowered, each carrying its tracking issue. These keys are sub-paths of members that
+    /// ARE lowered for the linear/top-level case but whose fork-path / nested-loop variants
+    /// are deferred — they intentionally do NOT collide with the surface member names, so
+    /// the surface-coverage assertion is unaffected; they document the known deferrals and
+    /// are themselves validated to carry a tracking issue.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, DeferredEntry> Deferred =
+        new Dictionary<string, DeferredEntry>(StringComparer.Ordinal)
+        {
+            ["RequireConfidence(fork-path)"] = new(
+                134,
+                "Confidence gating on a fork path is deferred to v2.10.0 / DR-17."),
+            ["OnLowConfidence(fork-path)"] = new(
+                134,
+                "OnLowConfidence routing on a fork path is deferred to v2.10.0 / DR-17."),
+            ["OnLowConfidence(nested-RepeatUntil)"] = new(
+                134,
+                "OnLowConfidence inside a nested RepeatUntil loop is deferred to v2.10.0 / DR-17."),
+        };
+
+    /// <summary>
+    /// Asserts every member of the declared step-configuration surface (builder methods and
+    /// IR fields) is classified in exactly one of <see cref="Lowered"/> or
+    /// <see cref="Deferred"/>, that each lowered entry names a behavioral proof, and that
+    /// each deferred entry carries a tracking issue.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task StepConfigParity_EveryMember_IsLoweredOrDeferred()
+    {
+        var members = EnumerateConfigSurface().ToList();
+
+        var (unclassified, doubleClassified) = Classify(members);
+
+        await Assert.That(unclassified)
+            .IsEmpty()
+            .Because(
+                "every declared step-config member must be classified as Lowered (with a " +
+                "behavioral proof) or Deferred (with a tracking issue); unclassified: " +
+                string.Join(", ", unclassified));
+
+        await Assert.That(doubleClassified)
+            .IsEmpty()
+            .Because(
+                "a member must be in EXACTLY one set; double-classified: " +
+                string.Join(", ", doubleClassified));
+
+        // Every Lowered entry must name a behavioral proof (not a shape/golden test).
+        foreach (var (member, proof) in Lowered)
+        {
+            await Assert.That(proof.BehavioralTest)
+                .IsNotEmpty()
+                .Because($"Lowered member '{member}' must reference a behavioral lowering proof");
+            await Assert.That(proof.BehavioralTestFile)
+                .Contains("Behavioral.Tests")
+                .Because($"Lowered member '{member}' proof must live in the behavioral suite, not a shape test");
+        }
+
+        // Every Deferred entry must carry a tracking issue.
+        foreach (var (member, entry) in Deferred)
+        {
+            await Assert.That(entry.TrackingIssue)
+                .IsGreaterThan(0)
+                .Because($"Deferred member '{member}' must carry a tracking issue number");
+        }
+    }
+
+    /// <summary>
+    /// Negative guard for the forcing function: a synthetic config surface that includes an
+    /// UNCLASSIFIED member must be flagged by the same classification logic, and a member
+    /// placed in BOTH sets must be flagged as double-classified. This proves the guard fails
+    /// when a new (or mis-classified) member appears, without having to actually add a real
+    /// member to the production surface.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task StepConfigParity_UnclassifiedOrDoubleClassifiedMember_IsFlagged()
+    {
+        // A synthetic surface: two real classified members plus one fabricated member that
+        // appears in NEITHER set, and one that appears in BOTH.
+        var syntheticSurface = new[]
+        {
+            "WithRetry",                 // classified (Lowered)
+            "RequireConfidence",         // classified (Lowered)
+            "WithBrandNewUnloweredKnob", // unclassified -> must be flagged
+        };
+
+        var (unclassified, _) = Classify(syntheticSurface);
+
+        await Assert.That(unclassified)
+            .Contains("WithBrandNewUnloweredKnob")
+            .Because("a member in neither Lowered nor Deferred must be reported as unclassified");
+
+        await Assert.That(unclassified)
+            .DoesNotContain("WithRetry")
+            .Because("a classified member must NOT be reported as unclassified");
+
+        // A member present in both sets must be reported as double-classified.
+        var doubleSurface = new[] { "WithRetry" };
+        var doubleSets = new HashSet<string>(StringComparer.Ordinal) { "WithRetry" };
+        var (_, doubleClassified) = Classify(
+            doubleSurface,
+            loweredKeys: doubleSets,
+            deferredKeys: doubleSets);
+
+        await Assert.That(doubleClassified)
+            .Contains("WithRetry")
+            .Because("a member present in BOTH sets must be reported as double-classified");
+    }
+
+    /// <summary>
+    /// Splits the supplied member names into the unclassified (in neither set) and
+    /// double-classified (in both sets) buckets, using the supplied Lowered/Deferred key
+    /// sets (defaulting to the production allowlists).
+    /// </summary>
+    /// <param name="members">The member names to classify.</param>
+    /// <param name="loweredKeys">Override for the Lowered key set (defaults to <see cref="Lowered"/>).</param>
+    /// <param name="deferredKeys">Override for the Deferred key set (defaults to <see cref="Deferred"/>).</param>
+    /// <returns>The unclassified and double-classified member names.</returns>
+    private static (List<string> Unclassified, List<string> DoubleClassified) Classify(
+        IEnumerable<string> members,
+        ISet<string>? loweredKeys = null,
+        ISet<string>? deferredKeys = null)
+    {
+        var lowered = loweredKeys ?? new HashSet<string>(Lowered.Keys, StringComparer.Ordinal);
+        var deferred = deferredKeys ?? new HashSet<string>(Deferred.Keys, StringComparer.Ordinal);
+
+        var unclassified = new List<string>();
+        var doubleClassified = new List<string>();
+
+        foreach (var member in members)
+        {
+            var inLowered = lowered.Contains(member);
+            var inDeferred = deferred.Contains(member);
+
+            if (inLowered && inDeferred)
+            {
+                doubleClassified.Add(member);
+            }
+            else if (!inLowered && !inDeferred)
+            {
+                unclassified.Add(member);
+            }
+        }
+
+        return (unclassified, doubleClassified);
+    }
+
+    /// <summary>
+    /// Enumerates the declared step-configuration surface: the public instance methods of
+    /// <see cref="IStepConfiguration{TState}"/> and the public instance properties of
+    /// <see cref="StepConfigurationDefinition"/> that represent configurable state. Static
+    /// members and the inherited <see cref="object"/> members are excluded. Names are
+    /// returned distinct so overloads collapse to a single classifiable unit.
+    /// </summary>
+    /// <returns>The distinct set of classifiable member names.</returns>
+    private static IEnumerable<string> EnumerateConfigSurface()
+    {
+        var builderMethods = typeof(IStepConfiguration<>)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => !m.IsSpecialName)
+            .Select(m => m.Name);
+
+        var definitionFields = typeof(StepConfigurationDefinition)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Select(p => p.Name);
+
+        return builderMethods.Concat(definitionFields).Distinct(StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// A lowered-member proof: the behavioral test name and the file it lives in.
+    /// </summary>
+    /// <param name="BehavioralTest">The behavioral test method that proves the lowering.</param>
+    /// <param name="BehavioralTestFile">The behavioral test file (must be in the behavioral suite).</param>
+    private sealed record LoweredProof(string BehavioralTest, string BehavioralTestFile);
+
+    /// <summary>
+    /// A deferred-member entry: the tracking issue and a short reason.
+    /// </summary>
+    /// <param name="TrackingIssue">The GitHub issue number tracking the deferral.</param>
+    /// <param name="Reason">A short human-readable reason for the deferral.</param>
+    private sealed record DeferredEntry(int TrackingIssue, string Reason);
+}

--- a/src/Strategos.Generators/Diagnostics/WorkflowDiagnostics.cs
+++ b/src/Strategos.Generators/Diagnostics/WorkflowDiagnostics.cs
@@ -267,11 +267,20 @@ internal static class WorkflowDiagnostics
     /// </summary>
     /// <remarks>
     /// Reported when a step declares a configuration concern that the generator does not
-    /// lower for that step's kind, so the configuration silently has no effect. The first
-    /// guarded case is confidence gating (<c>RequireConfidence</c>/<c>OnLowConfidence</c>)
-    /// on a loop-body step — that variant is deferred (v2.10.0 / DR-17, #134), so the
-    /// configuration reaches the IR but no confidence-gated routing is emitted. A warning
-    /// (not an error) so an author can suppress it by id while the deferral stands.
+    /// lower for that step's kind, so the configuration silently has no effect. The guarded
+    /// case is confidence gating (<c>RequireConfidence</c>/<c>OnLowConfidence</c>) on a
+    /// <b>fork-path</b> step: the fork-path parse threads the configure lambda into the
+    /// StepModel IR (so an out-of-range threshold still surfaces
+    /// <see cref="ConfidenceThresholdOutOfRange"/>), but the saga emitter does not lower
+    /// confidence-gated routing for fork-path steps — that lowering is deferred
+    /// (v2.10.0 / DR-17, #134), so the gate is inert. A warning (not an error) so an author
+    /// can suppress it by id while the deferral stands.
+    /// <para>
+    /// Note: loop-body / nested-<c>RepeatUntil</c> confidence configuration is a distinct
+    /// case that this diagnostic does NOT cover — it is dropped from the IR entirely by step
+    /// extraction, so an IR-based diagnostic structurally cannot see it (also tracked under
+    /// #134 for v2.10.0).
+    /// </para>
     /// </remarks>
     public static readonly DiagnosticDescriptor DeclaredButInert = new(
         id: AgwfCodes.DeclaredButInert,

--- a/src/Strategos.Generators/Diagnostics/WorkflowDiagnostics.cs
+++ b/src/Strategos.Generators/Diagnostics/WorkflowDiagnostics.cs
@@ -261,4 +261,24 @@ internal static class WorkflowDiagnostics
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description: "A step timeout must be a positive duration. A zero or negative timeout cannot bound the step's execution meaningfully.");
+
+    /// <summary>
+    /// Declared-but-inert step configuration (#143, G-6).
+    /// </summary>
+    /// <remarks>
+    /// Reported when a step declares a configuration concern that the generator does not
+    /// lower for that step's kind, so the configuration silently has no effect. The first
+    /// guarded case is confidence gating (<c>RequireConfidence</c>/<c>OnLowConfidence</c>)
+    /// on a loop-body step — that variant is deferred (v2.10.0 / DR-17, #134), so the
+    /// configuration reaches the IR but no confidence-gated routing is emitted. A warning
+    /// (not an error) so an author can suppress it by id while the deferral stands.
+    /// </remarks>
+    public static readonly DiagnosticDescriptor DeclaredButInert = new(
+        id: AgwfCodes.DeclaredButInert,
+        title: "Declared-but-inert step configuration",
+        messageFormat: "Step '{0}' in workflow '{1}' declares {2}, which the generator does not lower for this step kind, so the configuration is inert. Remove it or move the step to a position where the configuration is lowered.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A step configuration concern the generator does not lower for the step's kind is silently inert. Surfacing it prevents a deferred or unsupported configuration from masquerading as working.");
 }

--- a/src/Strategos.Generators/Emitters/EventsEmitter.cs
+++ b/src/Strategos.Generators/Emitters/EventsEmitter.cs
@@ -183,6 +183,30 @@ internal static class EventsEmitter
             EmitWorkflowFailedEvent(sb, model);
         }
 
+        // StepFailed audit STREAM event (#138 G-5 / OQ#1). Named, queryable Marten
+        // stream event for terminal step failure — distinct from the saga document
+        // properties + structured logs that already capture the same audit data.
+        // Emitted ONLY in EventSourced mode (stream events apply only there) and
+        // only when the workflow declares a failure/compensation path that can
+        // produce a terminal failure; in SagaDocument mode this record is not
+        // emitted, keeping document-mode output byte-unchanged.
+        if (model.IsEventSourced && (model.HasFailureHandlers || model.HasCompensation))
+        {
+            sb.AppendLine();
+            EmitStepFailedEvent(sb, model);
+        }
+
+        // LowConfidenceRouted audit STREAM event (#138 G-5 / OQ#1). Named, queryable
+        // Marten stream event appended when a confidence-gated step routes to its
+        // OnLowConfidence handler. Emitted ONLY in EventSourced mode and only when the
+        // workflow lowers an OnLowConfidence handler (the gate that can route); in
+        // SagaDocument mode this record is not emitted (document-mode byte-unchanged).
+        if (model.IsEventSourced && model.HasConfidenceHandlers)
+        {
+            sb.AppendLine();
+            EmitLowConfidenceRoutedEvent(sb, model);
+        }
+
         return sb.ToString();
     }
 
@@ -264,6 +288,41 @@ internal static class EventsEmitter
         sb.AppendLine("    string? ExceptionType,");
         sb.AppendLine("    string? ExceptionMessage,");
         sb.AppendLine("    string? StackTrace,");
+        sb.AppendLine($"    DateTimeOffset Timestamp) : I{model.PascalName}Event;");
+    }
+
+    private static void EmitStepFailedEvent(StringBuilder sb, WorkflowModel model)
+    {
+        sb.AppendLine("/// <summary>");
+        sb.AppendLine($"/// Audit stream event appended when a step of the {model.WorkflowName} workflow");
+        sb.AppendLine("/// fails terminally (#138 OQ#1). Captures the failed step name and the exception");
+        sb.AppendLine("/// type/message so the failure is queryable from the Marten event stream, not only");
+        sb.AppendLine("/// from the saga document properties + structured logs.");
+        sb.AppendLine("/// </summary>");
+        sb.AppendLine("[GeneratedCode(\"Strategos.Generators\", \"1.0.0\")]");
+        sb.AppendLine($"public sealed partial record {model.PascalName}StepFailed(");
+        sb.AppendLine("    [property: SagaIdentity] Guid WorkflowId,");
+        sb.AppendLine("    string FailedStepName,");
+        sb.AppendLine("    string? ExceptionType,");
+        sb.AppendLine("    string? ExceptionMessage,");
+        sb.AppendLine($"    DateTimeOffset Timestamp) : I{model.PascalName}Event;");
+    }
+
+    private static void EmitLowConfidenceRoutedEvent(StringBuilder sb, WorkflowModel model)
+    {
+        sb.AppendLine("/// <summary>");
+        sb.AppendLine($"/// Audit stream event appended when a confidence-gated step of the {model.WorkflowName}");
+        sb.AppendLine("/// workflow routes to its OnLowConfidence handler because the step's result confidence");
+        sb.AppendLine("/// was below the configured threshold (#138 OQ#1). Captures the gated step name, the");
+        sb.AppendLine("/// observed confidence score, and the threshold so the routing decision is queryable");
+        sb.AppendLine("/// from the Marten event stream, not only from the structured logs.");
+        sb.AppendLine("/// </summary>");
+        sb.AppendLine("[GeneratedCode(\"Strategos.Generators\", \"1.0.0\")]");
+        sb.AppendLine($"public sealed partial record {model.PascalName}LowConfidenceRouted(");
+        sb.AppendLine("    [property: SagaIdentity] Guid WorkflowId,");
+        sb.AppendLine("    string StepName,");
+        sb.AppendLine("    double Confidence,");
+        sb.AppendLine("    double Threshold,");
         sb.AppendLine($"    DateTimeOffset Timestamp) : I{model.PascalName}Event;");
     }
 

--- a/src/Strategos.Generators/Emitters/ExtensionsEmitter.cs
+++ b/src/Strategos.Generators/Emitters/ExtensionsEmitter.cs
@@ -42,12 +42,17 @@ internal static class ExtensionsEmitter
             "Microsoft.Extensions.DependencyInjection",
         };
 
-        // Event-sourced mode needs Marten for SnapshottedAggregation configuration
+        // Event-sourced mode needs Marten for SnapshottedAggregation configuration.
+        // Marten 9.x relocated SnapshotLifecycle into JasperFx.Events.Projections
+        // (the shared JasperFx.Events event-store core), so that namespace is
+        // required for the generated opts.Projections.Snapshot<T>(SnapshotLifecycle.Inline)
+        // to resolve when the extensions are compiled against a real Marten reference.
         if (model.IsEventSourced)
         {
             usings.Add("Marten");
             usings.Add("Marten.Events.Aggregation");
             usings.Add("Marten.Events.Projections");
+            usings.Add("JasperFx.Events.Projections");
         }
 
         // Add step type namespaces from the model

--- a/src/Strategos.Generators/Emitters/ExtensionsEmitter.cs
+++ b/src/Strategos.Generators/Emitters/ExtensionsEmitter.cs
@@ -186,6 +186,22 @@ internal static class ExtensionsEmitter
             }
         }
 
+        // Register workflow-level OnFailure handler step worker handlers (#140 Task
+        // 3.1). These are DISTINCT FailureHandler_{id}_{step}Handler classes (not the
+        // folded main-flow {step}Handler), one per OnFailure step, so the saga's
+        // ExecuteFailureHandler_{id}_{step}WorkerCommand has a resolvable receiver.
+        if (model.FailureHandlers is not null)
+        {
+            foreach (var failureHandler in model.FailureHandlers)
+            {
+                var sanitizedId = failureHandler.HandlerId.Replace("-", "_");
+                foreach (var stepName in failureHandler.StepNames)
+                {
+                    sb.AppendLine($"        services.AddTransient<FailureHandler_{sanitizedId}_{stepName}Handler>();");
+                }
+            }
+        }
+
         // Register context assemblers (DR-6). One per step that declared
         // .WithContext(...); the step's worker handler takes it as a constructor
         // dependency. A retrieval-bearing assembler additionally depends on

--- a/src/Strategos.Generators/Emitters/Saga/SagaCompensationComponentEmitter.cs
+++ b/src/Strategos.Generators/Emitters/Saga/SagaCompensationComponentEmitter.cs
@@ -149,13 +149,21 @@ internal sealed class SagaCompensationComponentEmitter : ISagaComponentEmitter
         sb.AppendLine("    /// compensation step actually runs.");
         sb.AppendLine("    /// </summary>");
         sb.AppendLine("    /// <param name=\"cmd\">The trigger command carrying the failure context.</param>");
+        StateApplicationHelper.EmitSessionParameterDoc(sb, model);
         sb.AppendLine("    /// <param name=\"logger\">The injected logger.</param>");
         sb.AppendLine("    /// <returns>The compensation worker command(s) to dispatch.</returns>");
         sb.AppendLine("    public IEnumerable<object> Handle(");
         sb.AppendLine($"        {triggerCommandName} cmd,");
+
+        // #138 G-5: append the StepFailed audit STREAM event when event-sourced. The
+        // compensation trigger is the single ordered terminal-failure site for the
+        // Compensate path (and the merged Compensate↔OnFailure path), so it is where
+        // the named StepFailed event belongs. It needs an IDocumentSession to append.
+        StateApplicationHelper.EmitSessionParameter(sb, model);
         sb.AppendLine($"        ILogger<{sagaClassName}> logger)");
         sb.AppendLine("    {");
         sb.AppendLine("        ArgumentNullException.ThrowIfNull(cmd, nameof(cmd));");
+        StateApplicationHelper.EmitSessionGuard(sb, model);
         sb.AppendLine("        ArgumentNullException.ThrowIfNull(logger, nameof(logger));");
         sb.AppendLine();
         sb.AppendLine("        FailedStepName = cmd.FailedStepName;");
@@ -164,6 +172,20 @@ internal sealed class SagaCompensationComponentEmitter : ISagaComponentEmitter
         sb.AppendLine("        FailureStackTrace = cmd.StackTrace;");
         sb.AppendLine("        FailureTimestamp = DateTimeOffset.UtcNow;");
         sb.AppendLine($"        Phase = {model.PhaseEnumName}.Compensating;");
+
+        if (model.IsEventSourced)
+        {
+            sb.AppendLine();
+            sb.AppendLine($"        session.Events.Append(");
+            sb.AppendLine("            WorkflowId,");
+            sb.AppendLine($"            new {model.PascalName}StepFailed(");
+            sb.AppendLine("                WorkflowId,");
+            sb.AppendLine("                cmd.FailedStepName,");
+            sb.AppendLine("                cmd.ExceptionType,");
+            sb.AppendLine("                cmd.ExceptionMessage,");
+            sb.AppendLine("                FailureTimestamp.Value));");
+        }
+
         sb.AppendLine();
         sb.AppendLine("        logger.LogWarning(");
         sb.AppendLine("            \"Step {FailedStepName} failed for workflow {WorkflowId}; running compensation\",");

--- a/src/Strategos.Generators/Emitters/Saga/SagaCompensationComponentEmitter.cs
+++ b/src/Strategos.Generators/Emitters/Saga/SagaCompensationComponentEmitter.cs
@@ -82,13 +82,16 @@ internal sealed class SagaCompensationComponentEmitter : ISagaComponentEmitter
             return;
         }
 
-        // The OnFailure path (SagaFailureHandlerComponentEmitter) owns the trigger
-        // handler when present; emitting ours too would collide (CS0111).
-        if (model.HasFailureHandlers)
-        {
-            return;
-        }
-
+        // #140 Task 3.2 — Compensate↔OnFailure interop. Previously this emitter was a
+        // NO-OP whenever the workflow ALSO declared OnFailure (to avoid a duplicate
+        // Handle(Trigger…) CS0111 collision), making step compensation and a
+        // workflow-level OnFailure mutually exclusive. They now COMPOSE in a fixed
+        // order from a SINGLE merged trigger site: this emitter owns the one
+        // Handle(Trigger…), dispatches the compensation rollback FIRST, and its
+        // compensation-completed handler chains into the OnFailure chain (instead of
+        // marking the saga Failed). The OnFailure emitter suppresses its own trigger
+        // handler when HasCompensation is true, so there is exactly one
+        // Handle(Trigger…).
         var compensatedSteps = model.CompensationSteps;
 
         sb.AppendLine();
@@ -212,8 +215,10 @@ internal sealed class SagaCompensationComponentEmitter : ISagaComponentEmitter
 
     /// <summary>
     /// Emits the saga handler for a compensation step's completed event: folds the
-    /// rollback's returned state, transitions to the terminal <c>Failed</c> phase,
-    /// and marks the saga completed.
+    /// rollback's returned state and then EITHER transitions the saga to its terminal
+    /// <c>Failed</c> phase (compensation-only) OR — when the workflow also declares an
+    /// <c>OnFailure</c> chain (#140 Task 3.2) — chains into that chain's first step,
+    /// enforcing the fixed compensation-then-OnFailure ordering.
     /// </summary>
     private static void EmitCompensationCompletedHandler(
         StringBuilder sb,
@@ -222,6 +227,15 @@ internal sealed class SagaCompensationComponentEmitter : ISagaComponentEmitter
     {
         var completedEventName = NamingHelper.GetCompletedEventName(compStepName);
         var sagaClassName = NamingHelper.GetSagaClassName(model.PascalName, model.Version);
+
+        // When the workflow ALSO declares OnFailure, the rollback's completion chains
+        // into the OnFailure chain rather than ending the saga (fixed ordering:
+        // compensation FIRST, then OnFailure). Otherwise it is the terminal handler.
+        if (model.HasFailureHandlers)
+        {
+            EmitCompensationThenOnFailureCompletedHandler(sb, model, compStepName, completedEventName, sagaClassName);
+            return;
+        }
 
         sb.AppendLine("    /// <summary>");
         sb.AppendLine($"    /// Handles the {completedEventName} event (DR-3) - folds the rollback's");
@@ -251,6 +265,57 @@ internal sealed class SagaCompensationComponentEmitter : ISagaComponentEmitter
         sb.AppendLine("            WorkflowId);");
         sb.AppendLine();
         sb.AppendLine("        MarkCompleted();");
+        sb.AppendLine("    }");
+    }
+
+    /// <summary>
+    /// Emits the compensation-completed handler for the Compensate↔OnFailure interop
+    /// case (#140 Task 3.2): folds the rollback's returned state, then chains into the
+    /// workflow's OnFailure chain by returning its first step's start command. The
+    /// OnFailure chain's own (terminal) completed handler later marks the saga Failed,
+    /// so this handler must NOT mark completed.
+    /// </summary>
+    private static void EmitCompensationThenOnFailureCompletedHandler(
+        StringBuilder sb,
+        WorkflowModel model,
+        string compStepName,
+        string completedEventName,
+        string sagaClassName)
+    {
+        var firstHandler = model.FailureHandlers!.First();
+        var sanitizedId = firstHandler.HandlerId.Replace("-", "_");
+        var firstStepName = firstHandler.FirstStepName;
+        var startCommandName = $"StartFailureHandler_{sanitizedId}_{firstStepName}Command";
+
+        sb.AppendLine("    /// <summary>");
+        sb.AppendLine($"    /// Handles the {completedEventName} event (#140 Task 3.2) - folds the");
+        sb.AppendLine("    /// rollback's returned state, then chains into the workflow OnFailure chain");
+        sb.AppendLine("    /// (compensation runs FIRST, then OnFailure). Does NOT mark completed: the");
+        sb.AppendLine("    /// terminal OnFailure completed handler ends the saga in the Failed phase.");
+        sb.AppendLine("    /// </summary>");
+        sb.AppendLine($"    /// <param name=\"evt\">The {compStepName} compensation completed event.</param>");
+        StateApplicationHelper.EmitSessionParameterDoc(sb, model);
+        sb.AppendLine("    /// <param name=\"logger\">The injected logger.</param>");
+        sb.AppendLine("    /// <returns>The command to start the first OnFailure handler step.</returns>");
+        sb.AppendLine($"    public {startCommandName} Handle(");
+        sb.AppendLine($"        {completedEventName} evt,");
+        StateApplicationHelper.EmitSessionParameter(sb, model);
+        sb.AppendLine($"        ILogger<{sagaClassName}> logger)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        ArgumentNullException.ThrowIfNull(evt, nameof(evt));");
+        StateApplicationHelper.EmitSessionGuard(sb, model);
+        sb.AppendLine("        ArgumentNullException.ThrowIfNull(logger, nameof(logger));");
+        sb.AppendLine();
+
+        // INV-7: the compensation step returns NEW state; the saga only folds it.
+        StateApplicationHelper.EmitStateApplication(sb, model);
+
+        sb.AppendLine();
+        sb.AppendLine("        logger.LogInformation(");
+        sb.AppendLine("            \"Compensation completed for workflow {WorkflowId}; running OnFailure chain\",");
+        sb.AppendLine("            WorkflowId);");
+        sb.AppendLine();
+        sb.AppendLine($"        return new {startCommandName}(WorkflowId);");
         sb.AppendLine("    }");
     }
 }

--- a/src/Strategos.Generators/Emitters/Saga/SagaFailureHandlerComponentEmitter.cs
+++ b/src/Strategos.Generators/Emitters/Saga/SagaFailureHandlerComponentEmitter.cs
@@ -45,9 +45,18 @@ internal sealed class SagaFailureHandlerComponentEmitter : ISagaComponentEmitter
         var firstHandler = model.FailureHandlers!.First();
         var firstStepName = firstHandler.FirstStepName;
 
-        // Emit the trigger handler
-        sb.AppendLine();
-        EmitTriggerHandler(sb, model, firstHandler);
+        // Emit the trigger handler — UNLESS the workflow also declares compensation
+        // (#140 Task 3.2). When both are present, a single merged Handle(Trigger…)
+        // lives in SagaCompensationComponentEmitter (it dispatches the rollback
+        // FIRST, then chains into this OnFailure chain). Emitting our own trigger
+        // handler too would be a duplicate-method (CS0111) collision — exactly the
+        // collision the old mutual-exclusion no-op avoided, now resolved by a single
+        // ordered trigger site instead of skipping compensation.
+        if (!model.HasCompensation)
+        {
+            sb.AppendLine();
+            EmitTriggerHandler(sb, model, firstHandler);
+        }
 
         // Emit handlers for each failure handler step
         foreach (var handler in model.FailureHandlers!)

--- a/src/Strategos.Generators/Emitters/Saga/SagaFailureHandlerComponentEmitter.cs
+++ b/src/Strategos.Generators/Emitters/Saga/SagaFailureHandlerComponentEmitter.cs
@@ -95,16 +95,48 @@ internal sealed class SagaFailureHandlerComponentEmitter : ISagaComponentEmitter
         sb.AppendLine($"    /// Handles the failure handler trigger command - stores exception context and starts first step.");
         sb.AppendLine("    /// </summary>");
         sb.AppendLine($"    /// <param name=\"cmd\">The trigger command containing failure information.</param>");
+        StateApplicationHelper.EmitSessionParameterDoc(sb, model);
         sb.AppendLine($"    /// <returns>The command to start the first failure handler step.</returns>");
-        sb.AppendLine($"    public {startCommandName} Handle({triggerCommandName} cmd)");
+
+        // #138 G-5: append the StepFailed audit STREAM event when event-sourced.
+        // The trigger handler is the single ordered site where terminal failure is
+        // recorded for the OnFailure (no-compensation) path, so it is where the
+        // named StepFailed event belongs. It needs an IDocumentSession to append,
+        // mirroring the completed handlers' EventSourced session parameter.
+        if (model.IsEventSourced)
+        {
+            sb.AppendLine($"    public {startCommandName} Handle(");
+            sb.AppendLine($"        {triggerCommandName} cmd,");
+            sb.AppendLine("        IDocumentSession session)");
+        }
+        else
+        {
+            sb.AppendLine($"    public {startCommandName} Handle({triggerCommandName} cmd)");
+        }
+
         sb.AppendLine("    {");
         sb.AppendLine("        ArgumentNullException.ThrowIfNull(cmd, nameof(cmd));");
+        StateApplicationHelper.EmitSessionGuard(sb, model);
         sb.AppendLine();
         sb.AppendLine("        FailedStepName = cmd.FailedStepName;");
         sb.AppendLine("        FailureExceptionMessage = cmd.ExceptionMessage;");
         sb.AppendLine("        FailureExceptionType = cmd.ExceptionType;");
         sb.AppendLine("        FailureStackTrace = cmd.StackTrace;");
         sb.AppendLine("        FailureTimestamp = DateTimeOffset.UtcNow;");
+
+        if (model.IsEventSourced)
+        {
+            sb.AppendLine();
+            sb.AppendLine($"        session.Events.Append(");
+            sb.AppendLine("            WorkflowId,");
+            sb.AppendLine($"            new {model.PascalName}StepFailed(");
+            sb.AppendLine("                WorkflowId,");
+            sb.AppendLine("                cmd.FailedStepName,");
+            sb.AppendLine("                cmd.ExceptionType,");
+            sb.AppendLine("                cmd.ExceptionMessage,");
+            sb.AppendLine("                FailureTimestamp.Value));");
+        }
+
         sb.AppendLine();
         sb.AppendLine($"        return new {startCommandName}(WorkflowId);");
         sb.AppendLine("    }");

--- a/src/Strategos.Generators/Emitters/Saga/SagaStepHandlersEmitter.cs
+++ b/src/Strategos.Generators/Emitters/Saga/SagaStepHandlersEmitter.cs
@@ -166,10 +166,9 @@ internal sealed class SagaStepHandlersEmitter : ISagaComponentEmitter
         int index)
     {
         // Confidence handler steps (DR-5) are appended to StepNames for full lowering but are NOT
-        // part of the main linear flow. They must not be a "next step" for the main flow, and they
-        // themselves terminate the workflow. Compute main-flow adjacency by skipping over them so the
-        // preceding main-flow step (e.g. a Finally) keeps its terminal status instead of wrongly
-        // chaining into a handler step.
+        // part of the main linear flow. They must not be a "next step" for the main flow. Compute
+        // main-flow adjacency by skipping over them so the preceding main-flow step (e.g. a Finally)
+        // keeps its terminal status instead of wrongly chaining into a handler step.
         var model = ctx.Model;
         var isConfidenceHandlerStep = model.IsConfidenceHandlerStep(stepName);
 
@@ -186,9 +185,39 @@ internal sealed class SagaStepHandlersEmitter : ISagaComponentEmitter
             }
         }
 
-        // The step is "last in the main flow" when no later main-flow step exists. A confidence
-        // handler step is always treated as terminal (single-step handler ends the workflow).
+        // The step is "last in the main flow" when no later main-flow step exists.
         var isLastStep = isConfidenceHandlerStep || nextStepName is null;
+
+        // Confidence handler CHAIN routing (G-4 / #139). A handler step is NOT unconditionally
+        // terminal: it chains to the next step in its OnLowConfidence chain when one exists, and the
+        // chain's LAST step either rejoins the main flow (.RejoinMainFlow()) at the step after the
+        // gated step, or terminates the workflow (back-compat default). Only the terminating last
+        // step is treated as "last" so the completed-handler emitter marks the saga completed; a
+        // chaining or rejoining step gets a concrete next-step command.
+        if (isConfidenceHandlerStep)
+        {
+            var (nextHandlerStepName, isLastInChain, rejoinStepName) =
+                model.GetConfidenceHandlerChainRouting(stepName);
+
+            if (!isLastInChain)
+            {
+                // Mid-chain: chain to the next handler step.
+                nextStepName = nextHandlerStepName;
+                isLastStep = false;
+            }
+            else if (rejoinStepName is not null)
+            {
+                // Terminal step of a REJOINING chain: resume the main flow.
+                nextStepName = rejoinStepName;
+                isLastStep = false;
+            }
+            else
+            {
+                // Terminal step of a TERMINATING chain (default): end the workflow.
+                nextStepName = null;
+                isLastStep = true;
+            }
+        }
 
         ctx.LoopsByLastStep.TryGetValue(stepName, out var loopsAtStep);
         ctx.BranchesByPreviousStep.TryGetValue(stepName, out var branchAtStep);

--- a/src/Strategos.Generators/Emitters/Saga/StepCompletedHandlerEmitter.cs
+++ b/src/Strategos.Generators/Emitters/Saga/StepCompletedHandlerEmitter.cs
@@ -123,6 +123,14 @@ internal sealed class StepCompletedHandlerEmitter
         var thresholdLiteral = confidence.Threshold.ToString("R", System.Globalization.CultureInfo.InvariantCulture);
         var proceedsToCompletion = context.IsTerminalStep || context.IsLastStep;
 
+        // #138 G-5: the gated step's own name (the step whose low-confidence result
+        // drove the route) for the LowConfidenceRouted audit event. Derive it from
+        // the completed event name (strip the trailing "Completed") so it is robust
+        // even when StepModel is unavailable.
+        var gatedStepName = eventName.EndsWith("Completed", System.StringComparison.Ordinal)
+            ? eventName.Substring(0, eventName.Length - "Completed".Length)
+            : eventName;
+
         sb.AppendLine($"    /// <returns>The low-confidence handler start command when below the");
         sb.AppendLine($"    /// confidence threshold; otherwise the normal next-step command.</returns>");
         sb.AppendLine("    public IEnumerable<object> Handle(");
@@ -186,6 +194,24 @@ internal sealed class StepCompletedHandlerEmitter
         sb.AppendLine($"                {thresholdLiteral},");
         sb.AppendLine("                WorkflowId,");
         sb.AppendLine($"                nameof({lowConfidenceCommand}));");
+
+        // #138 G-5: append the LowConfidenceRouted audit STREAM event when
+        // event-sourced. This is the single site where a confidence-gated step
+        // actually routes below-threshold, so it is where the named event belongs.
+        // The handler already receives IDocumentSession session in EventSourced mode.
+        if (model.IsEventSourced)
+        {
+            sb.AppendLine();
+            sb.AppendLine($"            session.Events.Append(");
+            sb.AppendLine("                WorkflowId,");
+            sb.AppendLine($"                new {model.PascalName}LowConfidenceRouted(");
+            sb.AppendLine("                    WorkflowId,");
+            sb.AppendLine($"                    \"{gatedStepName}\",");
+            sb.AppendLine("                    confidenceScore,");
+            sb.AppendLine($"                    {thresholdLiteral},");
+            sb.AppendLine("                    DateTimeOffset.UtcNow));");
+        }
+
         sb.AppendLine();
         sb.AppendLine($"            yield return new {lowConfidenceCommand}(WorkflowId);");
         sb.AppendLine("            yield break;");

--- a/src/Strategos.Generators/Emitters/Saga/StepCompletedHandlerEmitter.cs
+++ b/src/Strategos.Generators/Emitters/Saga/StepCompletedHandlerEmitter.cs
@@ -147,6 +147,7 @@ internal sealed class StepCompletedHandlerEmitter
         // "WorkflowState" track phase at the saga level only, so they are excluded
         // from the sync, exactly as EmitPhaseAwareNonFinalStepHandler does.
         if (model.HasFailureHandlers
+            && model.StateHasPhaseProperty
             && !string.IsNullOrEmpty(model.StateTypeName)
             && !model.StateTypeName.EndsWith("WorkflowState", StringComparison.Ordinal))
         {
@@ -336,10 +337,14 @@ internal sealed class StepCompletedHandlerEmitter
         {
             StateApplicationHelper.EmitStateApplication(sb, model);
 
-            // Sync saga Phase from state for state types that have Phase property
-            // State types ending in "WorkflowState" typically don't have Phase property
-            // (e.g., OrchestratorWorkflowState uses saga-level phase tracking only)
-            if (!model.StateTypeName.EndsWith("WorkflowState", StringComparison.Ordinal))
+            // Sync saga Phase from state ONLY for state types that actually expose a
+            // Phase property (mechanically detected via StateHasPhaseProperty). State
+            // types tracking phase at the saga level only (e.g. OrchestratorWorkflowState,
+            // or any realistic exception-triggered OnFailure state) have no Phase member,
+            // so emitting State.Phase would not compile. The "WorkflowState" suffix check
+            // is retained as a defensive secondary guard.
+            if (model.StateHasPhaseProperty
+                && !model.StateTypeName.EndsWith("WorkflowState", StringComparison.Ordinal))
             {
                 sb.AppendLine($"        Phase = State.Phase;");
             }

--- a/src/Strategos.Generators/Emitters/Saga/StepStartHandlerEmitter.cs
+++ b/src/Strategos.Generators/Emitters/Saga/StepStartHandlerEmitter.cs
@@ -121,16 +121,20 @@ internal sealed class StepStartHandlerEmitter
         sb.AppendLine("        {");
         sb.AppendLine($"            Phase = {model.PhaseEnumName}.ValidationFailed;");
         sb.AppendLine();
+        // The validation error message is user-supplied text (raw Token.ValueText), so it may
+        // contain double-quotes or backslashes. Emit it via SymbolDisplay.FormatLiteral, which
+        // returns the fully escaped, quote-wrapped literal, so the generated source compiles.
+        var validationMessageLiteral = SymbolDisplay.FormatLiteral(stepModel.ValidationErrorMessage!, quote: true);
         sb.AppendLine($"            logger.LogWarning(");
         sb.AppendLine($"                \"Validation failed for step {{StepName}} in workflow {{WorkflowId}}: {{ValidationMessage}}\",");
         sb.AppendLine($"                \"{stepName}\",");
         sb.AppendLine("                WorkflowId,");
-        sb.AppendLine($"                \"{stepModel.ValidationErrorMessage}\");");
+        sb.AppendLine($"                {validationMessageLiteral});");
         sb.AppendLine();
         sb.AppendLine($"            yield return new {model.PascalName}ValidationFailed(");
         sb.AppendLine("                WorkflowId,");
         sb.AppendLine($"                \"{stepName}\",");
-        sb.AppendLine($"                \"{stepModel.ValidationErrorMessage}\",");
+        sb.AppendLine($"                {validationMessageLiteral},");
         sb.AppendLine("                DateTimeOffset.UtcNow);");
         sb.AppendLine("            yield break;");
         sb.AppendLine("        }");

--- a/src/Strategos.Generators/Emitters/WorkerHandlerEmitter.cs
+++ b/src/Strategos.Generators/Emitters/WorkerHandlerEmitter.cs
@@ -57,7 +57,11 @@ internal static class WorkerHandlerEmitter
         // Wolverine.Runtime.Handlers; the fluent OnAnyException()/RetryTimes()/
         // RetryWithCooldown()/WithExponentialJitter()/CompensatingAction() extensions
         // live in Wolverine.ErrorHandling.
-        if (model.Steps is not null && model.Steps.Any(s => s.Retry is not null || s.Compensation is not null))
+        // Also pulled in when the workflow declares an OnFailure chain: every
+        // main-flow step then lowers a trigger-publishing Configure(HandlerChain) so
+        // a thrown step routes into the OnFailure recovery chain (#140 Task 3.1).
+        if ((model.Steps is not null && model.Steps.Any(s => s.Retry is not null || s.Compensation is not null))
+            || model.HasFailureHandlers)
         {
             usings.Add("Wolverine.ErrorHandling");
             usings.Add("Wolverine.Runtime.Handlers");
@@ -140,7 +144,110 @@ internal static class WorkerHandlerEmitter
             }
         }
 
+        // Generate worker handlers for workflow-level OnFailure handler steps (#140
+        // Task 3.1). The saga dispatches a dedicated
+        // ExecuteFailureHandler_{id}_{step}WorkerCommand for each OnFailure step and
+        // expects a FailureHandler_{id}_{step}Completed event back; without this
+        // handler the dispatched command had no receiver and the OnFailure chain was
+        // dead. The handler is a DISTINCT class
+        // (FailureHandler_{id}_{step}Handler) so it never collides with the folded
+        // main-flow {step}Handler when the failure step type is also a main-flow step.
+        if (model.FailureHandlers is not null)
+        {
+            foreach (var handler in model.FailureHandlers)
+            {
+                var sanitizedId = handler.HandlerId.Replace("-", "_");
+                foreach (var stepName in handler.StepNames)
+                {
+                    EmitFailureHandlerWorkerClass(sb, model, stepName, sanitizedId);
+                    sb.AppendLine();
+                }
+            }
+        }
+
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Emits the worker handler class for a single workflow-level OnFailure handler
+    /// step (#140 Task 3.1). The handler receives the saga-dispatched
+    /// <c>ExecuteFailureHandler_{id}_{step}WorkerCommand</c>, executes the OnFailure
+    /// step (the "Muscle"), and returns the
+    /// <c>FailureHandler_{id}_{step}Completed</c> event the saga folds and routes on.
+    /// </summary>
+    private static void EmitFailureHandlerWorkerClass(
+        StringBuilder sb,
+        WorkflowModel model,
+        string stepName,
+        string sanitizedId)
+    {
+        var workerCommandName = $"ExecuteFailureHandler_{sanitizedId}_{stepName}WorkerCommand";
+        var completedEventName = $"FailureHandler_{sanitizedId}_{stepName}Completed";
+        var handlerClassName = $"FailureHandler_{sanitizedId}_{stepName}Handler";
+
+        sb.AppendLine("/// <summary>");
+        sb.AppendLine($"/// Worker handler for the {stepName} workflow-level OnFailure handler step.");
+        sb.AppendLine("/// </summary>");
+        sb.AppendLine("/// <remarks>");
+        sb.AppendLine("/// <para>");
+        sb.AppendLine("/// This handler implements the \"Muscle\" part of the Brain &amp; Muscle pattern for");
+        sb.AppendLine("/// the workflow's OnFailure recovery chain. It executes the failure-handler step");
+        sb.AppendLine("/// after a workflow step failed, then returns the completed event the saga folds");
+        sb.AppendLine("/// into state and routes on (chaining to the next OnFailure step or marking the");
+        sb.AppendLine("/// workflow Failed).");
+        sb.AppendLine("/// </para>");
+        sb.AppendLine("/// </remarks>");
+        sb.AppendLine("[GeneratedCode(\"Strategos.Generators\", \"1.0.0\")]");
+        sb.AppendLine($"public sealed partial class {handlerClassName}(");
+        sb.AppendLine($"    {stepName} step,");
+        sb.AppendLine($"    ILogger<{handlerClassName}> logger)");
+        sb.AppendLine("{");
+        sb.AppendLine($"    private readonly {stepName} _step = step;");
+        sb.AppendLine($"    private readonly ILogger<{handlerClassName}> _logger = logger;");
+        sb.AppendLine();
+
+        sb.AppendLine("    /// <summary>");
+        sb.AppendLine($"    /// Handles the {workerCommandName} by executing the failure-handler step.");
+        sb.AppendLine("    /// </summary>");
+        sb.AppendLine("    /// <param name=\"command\">The worker command with workflow state and failure context.</param>");
+        sb.AppendLine("    /// <param name=\"ct\">The cancellation token.</param>");
+        sb.AppendLine("    /// <returns>The completion event for saga routing via cascading.</returns>");
+        sb.AppendLine("    /// <exception cref=\"ArgumentNullException\">Thrown when <paramref name=\"command\"/> is null.</exception>");
+        sb.AppendLine($"    public async Task<{completedEventName}> Handle(");
+        sb.AppendLine($"        {workerCommandName} command,");
+        sb.AppendLine("        CancellationToken ct)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        ArgumentNullException.ThrowIfNull(command, nameof(command));");
+        sb.AppendLine();
+        sb.AppendLine("        _logger.LogDebug(");
+        sb.AppendLine("            \"Executing failure handler step {StepName} for workflow {WorkflowId}\",");
+        sb.AppendLine($"            \"{stepName}\",");
+        sb.AppendLine("            command.WorkflowId);");
+        sb.AppendLine();
+        sb.AppendLine($"        using var activity = WorkflowTelemetry.StartStepSpan(\"{stepName}\", command.WorkflowId);");
+        sb.AppendLine("        var sw = Stopwatch.StartNew();");
+        sb.AppendLine();
+        sb.AppendLine($"        var stepContext = StepContext.Create(command.WorkflowId, \"{stepName}\", \"{stepName}\");");
+        sb.AppendLine("        var result = await _step.ExecuteAsync(command.State, stepContext, ct);");
+        sb.AppendLine();
+        sb.AppendLine("        sw.Stop();");
+        sb.AppendLine("        activity?.SetStatus(ActivityStatusCode.Ok);");
+        sb.AppendLine("        activity?.SetTag(\"step.duration_ms\", sw.ElapsedMilliseconds);");
+        sb.AppendLine();
+        sb.AppendLine("        _logger.LogDebug(");
+        sb.AppendLine("            \"Failure handler step {StepName} completed for workflow {WorkflowId} in {ElapsedMs}ms\",");
+        sb.AppendLine($"            \"{stepName}\",");
+        sb.AppendLine("            command.WorkflowId,");
+        sb.AppendLine("            sw.ElapsedMilliseconds);");
+        sb.AppendLine();
+        sb.AppendLine("        // Return cascading: Wolverine routes via [SagaIdentity] on the event");
+        sb.AppendLine($"        return new {completedEventName}(");
+        sb.AppendLine("            command.WorkflowId,");
+        sb.AppendLine("            command.StepExecutionId,");
+        sb.AppendLine("            result.UpdatedState,");
+        sb.AppendLine("            DateTimeOffset.UtcNow);");
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
     }
 
     /// <summary>
@@ -160,6 +267,31 @@ internal static class WorkerHandlerEmitter
     private static void EmitHandlerClassFromName(StringBuilder sb, WorkflowModel model, string stepName)
     {
         EmitHandlerClassCore(sb, model, stepName, step: null);
+    }
+
+    /// <summary>
+    /// Builds the set of step names that belong to a workflow-level OnFailure
+    /// recovery chain. These steps must NOT publish the failure-handler trigger
+    /// themselves (they ARE the recovery path); only main-flow steps route into the
+    /// OnFailure chain on failure.
+    /// </summary>
+    private static HashSet<string> BuildFailureHandlerStepNames(WorkflowModel model)
+    {
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        if (model.FailureHandlers is null)
+        {
+            return set;
+        }
+
+        foreach (var handler in model.FailureHandlers)
+        {
+            foreach (var stepName in handler.StepNames)
+            {
+                set.Add(stepName);
+            }
+        }
+
+        return set;
     }
 
     private static void EmitHandlerClassCore(StringBuilder sb, WorkflowModel model, string stepName, StepModel? step)
@@ -218,15 +350,29 @@ internal static class WorkerHandlerEmitter
         // Handle method
         EmitHandleMethod(sb, model, stepName, workerCommandName, completedEventName, stateType, hasContext);
 
-        // Per-handler Wolverine error policy (DR-2 retry, DR-3 compensation).
-        // Emitted ONLY when the step declared resilience that lowers onto the
-        // handler's chain (retry and/or compensation). The re-throw in the Handle
-        // catch block is what feeds this policy. Guarded so a step with no
-        // resilience keeps the no-policy baseline handler shape.
-        if (step is not null && (step.Retry is not null || step.Compensation is not null))
+        // A main-flow step routes into the workflow-level OnFailure chain when it
+        // fails (#140 Task 3.1): its error chain must publish the
+        // Trigger{Pascal}FailureHandlerCommand so the saga starts the OnFailure
+        // chain. This is the previously-missing publish for a NON-compensated failing
+        // step (compensation already publishes the same trigger via its own path).
+        // The failure-handler steps themselves are excluded — they ARE the recovery
+        // path and must not re-trigger it.
+        var publishOnFailureTrigger =
+            model.HasFailureHandlers
+            && !BuildFailureHandlerStepNames(model).Contains(stepName)
+            && (step is null || step.Compensation is null);
+
+        // Per-handler Wolverine error policy (DR-2 retry, DR-3 compensation, plus the
+        // OnFailure trigger publish above). Emitted when the step declared resilience
+        // that lowers onto the handler's chain (retry and/or compensation) OR when a
+        // main-flow step must publish the OnFailure trigger on failure. The re-throw
+        // in the Handle catch block is what feeds this policy. Guarded so a step with
+        // no resilience and no OnFailure routing keeps the no-policy baseline shape.
+        if ((step is not null && (step.Retry is not null || step.Compensation is not null))
+            || publishOnFailureTrigger)
         {
             sb.AppendLine();
-            EmitConfigureMethod(sb, model, step, workerCommandName);
+            EmitConfigureMethod(sb, model, step, stepName, workerCommandName, publishOnFailureTrigger);
         }
 
         sb.AppendLine("}");
@@ -243,32 +389,41 @@ internal static class WorkerHandlerEmitter
     /// <para>
     /// The chain composes additively: a retry prefix
     /// (<c>RetryTimes</c>/<c>RetryWithCooldown</c>) is followed, when the step also
-    /// declares <c>.Compensate&lt;T&gt;()</c>, by
+    /// declares <c>.Compensate&lt;T&gt;()</c> OR the workflow declares an
+    /// <c>OnFailure</c> chain, by
     /// <c>.Then.CompensatingAction&lt;{WorkerCommand}&gt;(...)</c> that PUBLISHES the
     /// trigger failure-handler command on terminal failure (after retries are
     /// exhausted), with <c>InvokeResult.Stop</c> so the message is not retried again.
     /// This is what makes the previously-never-published trigger command reach the
-    /// saga at runtime (DR-3), so the compensation step actually runs.
+    /// saga at runtime, so the compensation step (DR-3) and/or the workflow-level
+    /// OnFailure chain (#140 Task 3.1) actually runs.
     /// </para>
     /// <para>
-    /// When only compensation is declared (no retry), the compensating action
-    /// applies directly to <c>chain.OnAnyException()</c> with no retry prefix.
+    /// When only compensation (or only OnFailure routing) is declared with no retry,
+    /// the compensating action applies directly to <c>chain.OnAnyException()</c> with
+    /// no retry prefix.
     /// </para>
     /// </remarks>
     private static void EmitConfigureMethod(
         StringBuilder sb,
         WorkflowModel model,
-        StepModel step,
-        string workerCommandName)
+        StepModel? step,
+        string stepName,
+        string workerCommandName,
+        bool publishOnFailureTrigger)
     {
-        var retry = step.Retry;
-        var compensation = step.Compensation;
+        var retry = step?.Retry;
+        var compensation = step?.Compensation;
+
+        // The trigger is published on terminal failure when the step compensates OR
+        // when this main-flow step must route into the workflow-level OnFailure chain.
+        var publishesTrigger = compensation is not null || publishOnFailureTrigger;
 
         sb.AppendLine("    /// <summary>");
         sb.AppendLine("    /// Configures this handler's Wolverine error policy. Lowered from the");
-        sb.AppendLine("    /// step's <c>.WithRetry(...)</c> and/or <c>.Compensate&lt;T&gt;()</c>");
-        sb.AppendLine("    /// declaration; Wolverine discovers this static method by convention and");
-        sb.AppendLine("    /// scopes the policy to this handler.");
+        sb.AppendLine("    /// step's <c>.WithRetry(...)</c> / <c>.Compensate&lt;T&gt;()</c> declaration");
+        sb.AppendLine("    /// and/or the workflow's <c>OnFailure</c> chain; Wolverine discovers this");
+        sb.AppendLine("    /// static method by convention and scopes the policy to this handler.");
         sb.AppendLine("    /// </summary>");
         sb.AppendLine("    /// <param name=\"chain\">The handler chain to apply the error policy to.</param>");
         sb.AppendLine("    public static void Configure(HandlerChain chain)");
@@ -301,10 +456,11 @@ internal static class WorkerHandlerEmitter
             }
         }
 
-        if (compensation is not null)
+        if (publishesTrigger)
         {
             // On terminal failure (after any retries), publish the trigger
-            // failure-handler command so the saga runs the compensation step.
+            // failure-handler command so the saga runs the compensation step (DR-3)
+            // and/or the workflow OnFailure chain (#140 Task 3.1).
             // ".Then" is only needed to bridge from a retry continuation back to a
             // failure-action surface; with no retry, OnAnyException() already is one.
             if (retry is not null)
@@ -314,21 +470,28 @@ internal static class WorkerHandlerEmitter
             }
 
             var triggerCommandName = $"Trigger{model.PascalName}FailureHandlerCommand";
-            var compStepName = NamingHelper.GetSimpleTypeName(compensation.CompensationStepTypeName);
 
             sb.AppendLine();
             sb.AppendLine($"            .CompensatingAction<{workerCommandName}>(");
             sb.AppendLine($"                (cmd, ex, bus) => bus.PublishAsync(new {triggerCommandName}(");
             sb.AppendLine("                    cmd.WorkflowId,");
-            sb.AppendLine($"                    \"{step.StepName}\",");
+            sb.AppendLine($"                    \"{stepName}\",");
             sb.AppendLine("                    ex.Message,");
             sb.AppendLine("                    ex.GetType().Name,");
             sb.AppendLine("                    ex.StackTrace)),");
             sb.Append("                InvokeResult.Stop)");
 
-            // Reference the compensation step name in a comment so the lowering is
-            // traceable in the generated source.
-            sb.AppendLine($"; // runs {compStepName}");
+            if (compensation is not null)
+            {
+                // Reference the compensation step name in a comment so the lowering is
+                // traceable in the generated source.
+                var compStepName = NamingHelper.GetSimpleTypeName(compensation.CompensationStepTypeName);
+                sb.AppendLine($"; // runs {compStepName}");
+            }
+            else
+            {
+                sb.AppendLine("; // routes to OnFailure chain");
+            }
         }
         else
         {

--- a/src/Strategos.Generators/FluentDslParser.cs
+++ b/src/Strategos.Generators/FluentDslParser.cs
@@ -57,6 +57,31 @@ internal static class FluentDslParser
     }
 
     /// <summary>
+    /// Determines whether the workflow's state type exposes a public instance
+    /// <c>Phase</c> property, used to gate the failure-handler <c>Phase = State.Phase</c>
+    /// sync so a realistic state type never produces an uncompilable reference.
+    /// </summary>
+    /// <param name="typeDeclaration">The type declaration containing the workflow definition.</param>
+    /// <param name="semanticModel">The semantic model for type resolution.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// <see langword="true"/> when the state type carries a public, non-static
+    /// <c>Phase</c> property; otherwise <see langword="false"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when a required argument is null.</exception>
+    public static bool StateTypeHasPhaseProperty(
+        SyntaxNode typeDeclaration,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        ThrowHelper.ThrowIfNull(typeDeclaration, nameof(typeDeclaration));
+        ThrowHelper.ThrowIfNull(semanticModel, nameof(semanticModel));
+
+        var context = FluentDslParseContext.Create(typeDeclaration, semanticModel, null, cancellationToken);
+        return StateTypeExtractor.StateHasPhaseProperty(context);
+    }
+
+    /// <summary>
     /// Extracts step information including loop context from the workflow DSL.
     /// </summary>
     /// <param name="typeDeclaration">The type declaration containing the workflow definition.</param>

--- a/src/Strategos.Generators/Helpers/StateTypeExtractor.cs
+++ b/src/Strategos.Generators/Helpers/StateTypeExtractor.cs
@@ -60,4 +60,65 @@ internal static class StateTypeExtractor
 
         return null;
     }
+
+    /// <summary>
+    /// Determines whether the workflow's state type exposes a public instance
+    /// <c>Phase</c> property. Used by the failure-handler routing lowering: the
+    /// saga only syncs <c>Phase = State.Phase</c> when the state type actually
+    /// carries a phase, so a realistic state type (one that tracks its phase at
+    /// the saga level only) never produces an uncompilable <c>State.Phase</c>
+    /// reference.
+    /// </summary>
+    /// <param name="context">The parse context containing pre-computed lookups.</param>
+    /// <returns>
+    /// <see langword="true"/> when the resolved state type symbol declares (or
+    /// inherits) a public, non-static <c>Phase</c> property; otherwise
+    /// <see langword="false"/> (including when the symbol cannot be resolved).
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is null.</exception>
+    public static bool StateHasPhaseProperty(FluentDslParseContext context)
+    {
+        ThrowHelper.ThrowIfNull(context, nameof(context));
+
+        context.CancellationToken.ThrowIfCancellationRequested();
+
+        var createInvocation = context.AllInvocations
+            .FirstOrDefault(inv => SyntaxHelper.IsMethodCall(inv, "Create"));
+
+        if (createInvocation?.Expression is not MemberAccessExpressionSyntax memberAccess)
+        {
+            return false;
+        }
+
+        if (memberAccess.Expression is not GenericNameSyntax genericName)
+        {
+            return false;
+        }
+
+        var typeArgument = genericName.TypeArgumentList.Arguments.FirstOrDefault();
+        if (typeArgument is null)
+        {
+            return false;
+        }
+
+        var symbolInfo = context.SemanticModel.GetSymbolInfo(typeArgument);
+        if (symbolInfo.Symbol is not INamedTypeSymbol namedType)
+        {
+            return false;
+        }
+
+        // Walk the type and its base types for a public, non-static Phase property.
+        for (var current = namedType; current is not null; current = current.BaseType)
+        {
+            foreach (var member in current.GetMembers("Phase"))
+            {
+                if (member is IPropertySymbol { IsStatic: false, DeclaredAccessibility: Accessibility.Public })
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Strategos.Generators/Helpers/StepExtractor.cs
+++ b/src/Strategos.Generators/Helpers/StepExtractor.cs
@@ -1231,6 +1231,20 @@ internal static class StepExtractor
 
         var instanceName = ExtractInstanceName(invocation);
         var resilience = ExtractConfiguredResilience(invocation, semanticModel);
+
+        // Thread validation declared via the configure-lambda overload
+        // (Then<TStep>(step => step.ValidateState(...))) uniformly, exactly as
+        // ExtractConfiguredResilience already threads WithRetry/WithTimeout/Compensate/
+        // confidence from the same lambda. A pending predicate supplied by the caller
+        // (the legacy separately-chained .ValidateState(...) form, or a fork/branch
+        // pre-extraction) takes precedence; otherwise fall back to this step's own
+        // configure lambda so top-level/loop steps lower their guard like fork-path and
+        // branch-path steps do.
+        if (validationPredicate is null)
+        {
+            (validationPredicate, validationErrorMessage) = ExtractConfiguredValidation(invocation);
+        }
+
         stepModel = StepModel.Create(
             stepName,
             stepTypeName,

--- a/src/Strategos.Generators/Helpers/StepExtractor.cs
+++ b/src/Strategos.Generators/Helpers/StepExtractor.cs
@@ -1147,14 +1147,19 @@ internal static class StepExtractor
         foreach (var arg in arguments.Value)
         {
             // The configure lambda is the Action<IStepConfiguration<TState>> argument.
-            if (arg.Expression is not LambdaExpressionSyntax)
+            if (arg.Expression is not LambdaExpressionSyntax configureLambda)
             {
                 continue;
             }
 
-            var validateCall = arg.Expression
-                .DescendantNodes()
-                .OfType<InvocationExpressionSyntax>()
+            // F1 (G-6 review, #143): scope the validation walk to THIS configure lambda's own
+            // body, mirroring ExtractConfiguredResilience. A raw DescendantNodes() walk would
+            // capture a ValidateState call from a NESTED lambda — e.g.
+            // OnLowConfidence(alt => alt.Then<Y>(c => c.ValidateState(...))) — and wrongly attach
+            // Y's guard to the parent step. CollectInvocationsInLambda filters out invocations
+            // nested inside inner lambdas.
+            var validateCall = InvocationChainWalker
+                .CollectInvocationsInLambda(configureLambda)
                 .FirstOrDefault(call => SyntaxHelper.IsMethodCall(call, "ValidateState"));
 
             if (validateCall is not null)

--- a/src/Strategos.Generators/Helpers/StepExtractor.cs
+++ b/src/Strategos.Generators/Helpers/StepExtractor.cs
@@ -1397,6 +1397,7 @@ internal static class StepExtractor
         var threshold = existing?.Threshold ?? 0.0;
         var handlerId = existing?.OnLowConfidenceHandlerId;
         var handlerStep = existing?.OnLowConfidenceHandlerStep;
+        var handlerChain = existing?.OnLowConfidenceHandlerChain;
 
         if (SyntaxHelper.IsMethodCall(confidenceCall, "RequireConfidence"))
         {
@@ -1408,25 +1409,32 @@ internal static class StepExtractor
         }
         else if (SyntaxHelper.IsMethodCall(confidenceCall, "OnLowConfidence"))
         {
-            var extracted = ExtractLowConfidenceHandlerStep(confidenceCall, semanticModel);
+            var extracted = ExtractLowConfidenceHandlerChain(confidenceCall, semanticModel);
             if (extracted is not null)
             {
-                handlerStep = extracted;
-                handlerId = extracted.StepName;
+                handlerChain = extracted;
+
+                // The confidence gate routes to the FIRST handler step; retain it (and its simple
+                // name) for back-compat with the saga routing surface.
+                handlerStep = extracted.Steps[0];
+                handlerId = extracted.Steps[0].StepName;
             }
         }
 
-        return new ConfidenceModel(threshold, handlerId, handlerStep);
+        return new ConfidenceModel(threshold, handlerId, handlerStep, handlerChain);
     }
 
     /// <summary>
-    /// Extracts the low-confidence handler step — the first <c>Then&lt;THandler&gt;()</c> step
-    /// declared inside an <c>OnLowConfidence(alt =&gt; ...)</c> handler lambda — as a fully-resolved
-    /// <see cref="StepModel"/> carrying both its simple name and fully qualified type name. The fully
-    /// qualified name is required so the handler step lowers into a worker handler with correct DI
-    /// usings (DR-5).
+    /// Extracts the ordered <c>OnLowConfidence</c> handler chain (G-4 / #139) — every
+    /// <c>Then&lt;THandler&gt;()</c> step declared inside an <c>OnLowConfidence(alt =&gt; ...)</c>
+    /// handler lambda, in source order — as a <see cref="LowConfidenceHandlerChainModel"/> of
+    /// fully-resolved <see cref="StepModel"/>s. Each step carries both its simple name and fully
+    /// qualified type name (the latter is required so the handler step lowers into a worker handler
+    /// with correct DI usings, DR-5). The chain's exit semantics are inferred from the lambda shape:
+    /// a <c>.RejoinMainFlow()</c> call marks the chain rejoining; its absence terminates (the
+    /// back-compat default).
     /// </summary>
-    private static StepModel? ExtractLowConfidenceHandlerStep(
+    private static LowConfidenceHandlerChainModel? ExtractLowConfidenceHandlerChain(
         InvocationExpressionSyntax onLowConfidenceCall,
         SemanticModel semanticModel)
     {
@@ -1436,22 +1444,51 @@ internal static class StepExtractor
             return null;
         }
 
-        var firstThen = handlerLambda
+        // Collect every Then<THandler>() call inside the handler lambda, in source order. A
+        // fluent chain "alt.Then<A>().Then<B>()" nests A's invocation INSIDE B's (B is the outer
+        // invocation whose receiver is the A invocation), and BOTH spans START at the leftmost
+        // token ("alt"), so ordering by SpanStart is ambiguous. The inner (earlier-declared)
+        // invocation has the smaller Span.End, so ordering by Span.End yields declaration order
+        // (A before B). Nested configure/OnLowConfidence lambdas on a handler step would surface
+        // phantom Then calls, but the confidence handler DSL does not nest those today; we still
+        // scope to the lambda body only.
+        var thenCalls = handlerLambda
             .DescendantNodes()
             .OfType<InvocationExpressionSyntax>()
-            .FirstOrDefault(inv => SyntaxHelper.IsMethodCall(inv, "Then"));
+            .Where(inv => SyntaxHelper.IsMethodCall(inv, "Then"))
+            .OrderBy(inv => inv.Span.End)
+            .ToList();
 
-        if (firstThen is null || !TryGetGenericTypeArgument(firstThen, "Then", out var typeArgument))
+        var steps = new List<StepModel>(thenCalls.Count);
+        foreach (var thenCall in thenCalls)
+        {
+            if (!TryGetGenericTypeArgument(thenCall, "Then", out var typeArgument))
+            {
+                continue;
+            }
+
+            if (!ResolveTypeNameAndFullName(typeArgument, semanticModel, out var stepName, out var stepTypeName))
+            {
+                continue;
+            }
+
+            steps.Add(StepModel.Create(stepName, stepTypeName));
+        }
+
+        if (steps.Count == 0)
         {
             return null;
         }
 
-        if (!ResolveTypeNameAndFullName(typeArgument, semanticModel, out var stepName, out var stepTypeName))
-        {
-            return null;
-        }
+        // Exit semantics (Task 4.2): the handler REJOINS the main flow only when it explicitly
+        // declares .RejoinMainFlow(); otherwise it TERMINATES (back-compat default, preserving the
+        // single-step terminating handler shipped in DR-5).
+        var rejoinsMainFlow = handlerLambda
+            .DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Any(inv => SyntaxHelper.IsMethodCall(inv, "RejoinMainFlow"));
 
-        return StepModel.Create(stepName, stepTypeName);
+        return new LowConfidenceHandlerChainModel(steps, rejoinsMainFlow);
     }
 
     private static bool TryGetDoubleLiteral(ExpressionSyntax expression, out double value)

--- a/src/Strategos.Generators/Helpers/ValidationParser.cs
+++ b/src/Strategos.Generators/Helpers/ValidationParser.cs
@@ -49,7 +49,12 @@ internal static class ValidationParser
         var predicateArg = arguments[0];
         if (predicateArg.Expression is LambdaExpressionSyntax lambdaExpression)
         {
-            predicate = lambdaExpression.Body.ToString();
+            // Normalize the lambda parameter to the canonical name "state" so the
+            // downstream emitter's "state." -> "State." rewrite works regardless of
+            // the parameter name the author chose (e.g. s, st, x). Without this, a
+            // predicate like `s => s.IsAuthorized` would be emitted verbatim and fail
+            // to compile ("s" is not in scope in the generated saga handler).
+            predicate = NormalizePredicateParameter(lambdaExpression);
         }
 
         // Second argument: error message
@@ -62,4 +67,62 @@ internal static class ValidationParser
 
         return (predicate, errorMessage);
     }
+
+    /// <summary>
+    /// Returns the lambda body text with the lambda's parameter identifier rewritten to
+    /// the canonical name <c>state</c>, so the emitter's <c>state.</c> -&gt; <c>State.</c>
+    /// rewrite applies regardless of the author's chosen parameter name.
+    /// </summary>
+    /// <param name="lambda">The predicate lambda.</param>
+    /// <returns>The normalized predicate body text.</returns>
+    /// <remarks>
+    /// Rewrites only identifier tokens whose text equals the parameter name, so a member
+    /// access that happens to share the name (e.g. <c>x.x</c>) only rewrites the receiver,
+    /// not the member. If the parameter is already named <c>state</c> the body is returned
+    /// unchanged.
+    /// </remarks>
+    private static string NormalizePredicateParameter(LambdaExpressionSyntax lambda)
+    {
+        var parameterName = lambda switch
+        {
+            SimpleLambdaExpressionSyntax simple => simple.Parameter.Identifier.ValueText,
+            ParenthesizedLambdaExpressionSyntax parens =>
+                parens.ParameterList.Parameters.Count == 1
+                    ? parens.ParameterList.Parameters[0].Identifier.ValueText
+                    : null,
+            _ => null,
+        };
+
+        var body = lambda.Body;
+
+        if (string.IsNullOrEmpty(parameterName) || parameterName == "state")
+        {
+            return body.ToString();
+        }
+
+        // Rewrite only standalone references to the parameter (IdentifierName nodes whose
+        // text equals the parameter name), NOT the member-name side of a member access —
+        // so `ctx.ctx` rewrites the receiver only, yielding `state.ctx`.
+        var parameterReferences = body.DescendantNodes()
+            .OfType<IdentifierNameSyntax>()
+            .Where(id => id.Identifier.ValueText == parameterName && !IsMemberName(id));
+
+        var rewritten = body.ReplaceNodes(
+            parameterReferences,
+            (original, _) => SyntaxFactory.IdentifierName(
+                SyntaxFactory.Identifier("state").WithTriviaFrom(original.Identifier)));
+
+        return rewritten.ToString();
+    }
+
+    /// <summary>
+    /// Returns true if the identifier is the member-name (right-hand) side of a member
+    /// access — e.g. the second <c>ctx</c> in <c>ctx.ctx</c> — so it is NOT a reference to
+    /// the lambda parameter and must not be rewritten.
+    /// </summary>
+    /// <param name="identifier">The identifier node to test.</param>
+    /// <returns>True if the identifier is a member name; otherwise false.</returns>
+    private static bool IsMemberName(IdentifierNameSyntax identifier) =>
+        identifier.Parent is MemberAccessExpressionSyntax memberAccess
+            && memberAccess.Name == identifier;
 }

--- a/src/Strategos.Generators/Models/ResilienceModels.cs
+++ b/src/Strategos.Generators/Models/ResilienceModels.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 
 namespace Strategos.Generators.Models;
 
@@ -62,6 +63,37 @@ internal sealed record CompensationModel(
     bool IsRegisteredStep = true);
 
 /// <summary>
+/// Generator IR for an ordered chain of <c>OnLowConfidence</c> handler steps and
+/// the chain's exit semantics (G-4 / #139).
+/// </summary>
+/// <param name="Steps">
+/// The ordered handler steps lowered from every <c>Then&lt;THandler&gt;()</c> call
+/// inside an <c>OnLowConfidence(alt =&gt; ...)</c> lambda. The confidence gate routes
+/// to the first step; each non-last step chains to the next; the last step's exit
+/// is governed by <paramref name="RejoinsMainFlow"/>. Carries each step's fully
+/// qualified type name (needed for DI / worker-handler lowering) in addition to its
+/// simple name. Per INV-8 every step's identity is a descriptor string, never a CLR
+/// <see cref="System.Type"/>.
+/// </param>
+/// <param name="RejoinsMainFlow">
+/// A value indicating whether the chain REJOINS the main flow at the step after the
+/// gated step once its last step completes (<see langword="true"/>), or TERMINATES
+/// the workflow via <c>MarkCompleted()</c> (<see langword="false"/>). Defaults to
+/// <see langword="false"/> — terminating is the back-compat default (DR-5's
+/// single-step handler terminated). Inferred from the handler lambda shape: a
+/// <c>.RejoinMainFlow()</c> call opts into rejoining; its absence terminates.
+/// </param>
+/// <remarks>
+/// Sealed, init-only IR (INV-6): positional-record params lower to init-only setters,
+/// so a downstream pipeline stage cannot rewrite the chain after parse. The record's
+/// structural equality is value-based on its members, which the incremental generator
+/// pipeline relies on for cache-keying.
+/// </remarks>
+internal sealed record LowConfidenceHandlerChainModel(
+    IReadOnlyList<StepModel> Steps,
+    bool RejoinsMainFlow = false);
+
+/// <summary>
 /// Generator IR for a step's confidence-gating policy.
 /// </summary>
 /// <param name="Threshold">
@@ -74,14 +106,23 @@ internal sealed record CompensationModel(
 /// the <c>OnLowConfidence(alt =&gt; ...)</c> lambda.
 /// </param>
 /// <param name="OnLowConfidenceHandlerStep">
-/// The fully-resolved <see cref="StepModel"/> for the low-confidence handler step,
-/// or null if no handler is configured. Carries the handler step's fully qualified
-/// type name (needed for DI / worker-handler lowering) in addition to its simple
-/// name. The handler step is lowered into the saga (its own phase, worker handler,
-/// start/completed commands and events) so DR-5 can route to it via a Wolverine
-/// cascade (INV-1).
+/// The fully-resolved <see cref="StepModel"/> for the FIRST low-confidence handler
+/// step, or null if no handler is configured. Carries the handler step's fully
+/// qualified type name (needed for DI / worker-handler lowering) in addition to its
+/// simple name. The confidence-gated completed handler routes to this step via a
+/// Wolverine cascade (INV-1) when confidence is below the threshold. Retained
+/// alongside <paramref name="OnLowConfidenceHandlerChain"/> for back-compat — it is
+/// the chain's first step.
+/// </param>
+/// <param name="OnLowConfidenceHandlerChain">
+/// The ordered handler chain (G-4 / #139), or null if no handler is configured. When
+/// present, every step in <see cref="LowConfidenceHandlerChainModel.Steps"/> is
+/// lowered into the saga (its own phase, worker handler, start/completed commands and
+/// events); non-last steps chain to the next, and the last step either rejoins the
+/// main flow or terminates per <see cref="LowConfidenceHandlerChainModel.RejoinsMainFlow"/>.
 /// </param>
 internal sealed record ConfidenceModel(
     double Threshold,
     string? OnLowConfidenceHandlerId = null,
-    StepModel? OnLowConfidenceHandlerStep = null);
+    StepModel? OnLowConfidenceHandlerStep = null,
+    LowConfidenceHandlerChainModel? OnLowConfidenceHandlerChain = null);

--- a/src/Strategos.Generators/Models/WorkflowModel.cs
+++ b/src/Strategos.Generators/Models/WorkflowModel.cs
@@ -175,6 +175,100 @@ internal sealed record WorkflowModel(
         && ConfidenceHandlerStepNames.Contains(stepName);
 
     /// <summary>
+    /// Resolves the routing of a lowered <c>OnLowConfidence</c> handler step within its chain
+    /// (G-4 / #139): the next handler step to chain to, whether it is the chain's terminal step,
+    /// and (for a rejoining chain) the main-flow step to resume at.
+    /// </summary>
+    /// <param name="stepName">The handler step phase name to resolve.</param>
+    /// <returns>
+    /// A tuple describing the step's chain position: <c>NextHandlerStepName</c> is the next handler
+    /// step in the chain (null when this is the chain's last step), <c>IsLastInChain</c> is true when
+    /// no later handler step exists, and <c>RejoinStepName</c> is the main-flow step the chain resumes
+    /// at when it rejoins (null when the chain terminates or this is not the last step). Returns all
+    /// nulls / false when the step is not a confidence handler step or its chain cannot be resolved.
+    /// </returns>
+    public (string? NextHandlerStepName, bool IsLastInChain, string? RejoinStepName) GetConfidenceHandlerChainRouting(string stepName)
+    {
+        if (Steps is null || !IsConfidenceHandlerStep(stepName))
+        {
+            return (null, false, null);
+        }
+
+        // Find the gated step whose OnLowConfidence chain contains this handler step.
+        for (var gatedIndex = 0; gatedIndex < Steps.Count; gatedIndex++)
+        {
+            var chain = Steps[gatedIndex].Confidence?.OnLowConfidenceHandlerChain;
+            if (chain is null)
+            {
+                continue;
+            }
+
+            var position = -1;
+            for (var i = 0; i < chain.Steps.Count; i++)
+            {
+                if (string.Equals(chain.Steps[i].StepName, stepName, StringComparison.Ordinal))
+                {
+                    position = i;
+                    break;
+                }
+            }
+
+            if (position < 0)
+            {
+                continue;
+            }
+
+            var isLastInChain = position == chain.Steps.Count - 1;
+            var nextHandlerStepName = isLastInChain ? null : chain.Steps[position + 1].StepName;
+
+            string? rejoinStepName = null;
+            if (isLastInChain && chain.RejoinsMainFlow)
+            {
+                rejoinStepName = NextMainFlowStepName(Steps[gatedIndex].PhaseName);
+            }
+
+            return (nextHandlerStepName, isLastInChain, rejoinStepName);
+        }
+
+        return (null, false, null);
+    }
+
+    /// <summary>
+    /// Gets the next MAIN-flow step phase name after the given step phase name, skipping over any
+    /// lowered <c>OnLowConfidence</c> handler steps (which are appended to <see cref="StepNames"/>
+    /// but are not part of the linear flow). Returns null when no later main-flow step exists.
+    /// </summary>
+    /// <param name="phaseName">The phase name to search after.</param>
+    /// <returns>The next main-flow step phase name, or null if the given step is last in the main flow.</returns>
+    private string? NextMainFlowStepName(string phaseName)
+    {
+        var index = -1;
+        for (var i = 0; i < StepNames.Count; i++)
+        {
+            if (string.Equals(StepNames[i], phaseName, StringComparison.Ordinal))
+            {
+                index = i;
+                break;
+            }
+        }
+
+        if (index < 0)
+        {
+            return null;
+        }
+
+        for (var j = index + 1; j < StepNames.Count; j++)
+        {
+            if (!IsConfidenceHandlerStep(StepNames[j]))
+            {
+                return StepNames[j];
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Gets a value indicating whether any step in this workflow has validation guards.
     /// </summary>
     /// <remarks>

--- a/src/Strategos.Generators/Models/WorkflowModel.cs
+++ b/src/Strategos.Generators/Models/WorkflowModel.cs
@@ -54,6 +54,21 @@ internal sealed record WorkflowModel(
     IReadOnlyList<string>? ConfidenceHandlerStepNames = null)
 {
     /// <summary>
+    /// Gets a value indicating whether the workflow's state type exposes a public
+    /// instance <c>Phase</c> property.
+    /// </summary>
+    /// <remarks>
+    /// The failure-handler routing lowering syncs the saga's <c>Phase</c> from the
+    /// reduced state (<c>Phase = State.Phase</c>) only when this is
+    /// <see langword="true"/>. A realistic state type that tracks its phase at the
+    /// saga level only (no <c>Phase</c> member) must NOT emit that sync, otherwise
+    /// the generated saga references a property the state does not have and fails to
+    /// compile. Defaults to <see langword="false"/> so the safe (no-sync) shape is
+    /// the default for the many positional/factory model constructions in tests.
+    /// </remarks>
+    public bool StateHasPhaseProperty { get; init; }
+
+    /// <summary>
     /// Gets the derived phase enum name.
     /// </summary>
     public string PhaseEnumName => $"{PascalName}Phase";

--- a/src/Strategos.Generators/Models/WorkflowModel.cs
+++ b/src/Strategos.Generators/Models/WorkflowModel.cs
@@ -190,6 +190,99 @@ internal sealed record WorkflowModel(
         && ConfidenceHandlerStepNames.Contains(stepName);
 
     /// <summary>
+    /// Resolves the routing of a lowered <c>OnLowConfidence</c> handler step within its chain
+    /// (G-4 / #139): the next handler step to chain to, whether it is the chain's terminal step,
+    /// and (for a rejoining chain) the main-flow step to resume at.
+    /// </summary>
+    /// <param name="stepName">The handler step phase name to resolve.</param>
+    /// <returns>
+    /// A tuple describing the step's chain position: <c>NextHandlerStepName</c> is the next handler
+    /// step in the chain (null when this is the chain's last step), <c>IsLastInChain</c> is true when
+    /// no later handler step exists, and <c>RejoinStepName</c> is the main-flow step the chain resumes
+    /// at when it rejoins (null when the chain terminates or this is not the last step). Returns all
+    /// nulls / false when the step is not a confidence handler step or its chain cannot be resolved.
+    /// </returns>
+    public (string? NextHandlerStepName, bool IsLastInChain, string? RejoinStepName) GetConfidenceHandlerChainRouting(string stepName)
+    {
+        if (Steps is null || !IsConfidenceHandlerStep(stepName))
+        {
+            return (null, false, null);
+        }
+
+        // Find the gated step whose OnLowConfidence chain contains this handler step.
+        for (var gatedIndex = 0; gatedIndex < Steps.Count; gatedIndex++)
+        {
+            var chain = Steps[gatedIndex].Confidence?.OnLowConfidenceHandlerChain;
+            if (chain is null)
+            {
+                continue;
+            }
+
+            var position = -1;
+            for (var i = 0; i < chain.Steps.Count; i++)
+            {
+                if (string.Equals(chain.Steps[i].StepName, stepName, StringComparison.Ordinal))
+                {
+                    position = i;
+                    break;
+                }
+            }
+
+            if (position < 0)
+            {
+                continue;
+            }
+
+            var isLastInChain = position == chain.Steps.Count - 1;
+            var nextHandlerStepName = isLastInChain ? null : chain.Steps[position + 1].StepName;
+
+            string? rejoinStepName = null;
+            if (isLastInChain && chain.RejoinsMainFlow)
+            {
+                rejoinStepName = NextMainFlowStepName(Steps[gatedIndex].PhaseName);
+            }
+
+            return (nextHandlerStepName, isLastInChain, rejoinStepName);
+        }
+
+        return (null, false, null);
+    }
+
+    /// <summary>
+    /// Gets the next MAIN-flow step phase name after the given step phase name, skipping over any
+    /// lowered <c>OnLowConfidence</c> handler steps (which are appended to <see cref="StepNames"/>
+    /// but are not part of the linear flow). Returns null when no later main-flow step exists.
+    /// </summary>
+    /// <param name="phaseName">The phase name to search after.</param>
+    /// <returns>The next main-flow step phase name, or null if the given step is last in the main flow.</returns>
+    private string? NextMainFlowStepName(string phaseName)
+    {
+        var index = -1;
+        for (var i = 0; i < StepNames.Count; i++)
+        {
+            if (string.Equals(StepNames[i], phaseName, StringComparison.Ordinal))
+            {
+                index = i;
+                break;
+            }
+        }
+
+        if (index < 0)
+        {
+            return null;
+        }
+
+        for (var j = index + 1; j < StepNames.Count; j++)
+        {
+            if (!IsConfidenceHandlerStep(StepNames[j]))
+            {
+                return StepNames[j];
+            }
+        }
+
+        return null;
+    }
+    /// <summary>
     /// Gets a value indicating whether any step in this workflow has validation guards.
     /// </summary>
     /// <remarks>

--- a/src/Strategos.Generators/Models/WorkflowModel.cs
+++ b/src/Strategos.Generators/Models/WorkflowModel.cs
@@ -282,6 +282,7 @@ internal sealed record WorkflowModel(
 
         return null;
     }
+
     /// <summary>
     /// Gets a value indicating whether any step in this workflow has validation guards.
     /// </summary>

--- a/src/Strategos.Generators/WorkflowIncrementalGenerator.cs
+++ b/src/Strategos.Generators/WorkflowIncrementalGenerator.cs
@@ -482,9 +482,13 @@ public sealed class WorkflowIncrementalGenerator : IIncrementalGenerator
         // handler, start/completed commands and events, and a terminal saga completed handler.
         // The saga's confidence-gated completed handler then routes to Start{H}Command via a
         // Wolverine cascade when the result confidence is below the threshold (INV-1).
+        // Lower EVERY step in each OnLowConfidence handler chain (G-4 / #139), in order. Before
+        // #139 only the first Then<T> was lowered; a multi-step chain now contributes all of its
+        // steps so the chain runs end to end. The chain's ordered Steps are the source of truth;
+        // OnLowConfidenceHandlerStep (the first step) is retained only for the saga routing surface.
         var confidenceHandlerSteps = stepModels
-            .Where(s => s.Confidence?.OnLowConfidenceHandlerStep is not null)
-            .Select(s => s.Confidence!.OnLowConfidenceHandlerStep!)
+            .Where(s => s.Confidence?.OnLowConfidenceHandlerChain is not null)
+            .SelectMany(s => s.Confidence!.OnLowConfidenceHandlerChain!.Steps)
             .ToList();
 
         // Track the lowered handler step names so the saga emitter can keep them off the

--- a/src/Strategos.Generators/WorkflowIncrementalGenerator.cs
+++ b/src/Strategos.Generators/WorkflowIncrementalGenerator.cs
@@ -490,9 +490,13 @@ public sealed class WorkflowIncrementalGenerator : IIncrementalGenerator
         // handler, start/completed commands and events, and a terminal saga completed handler.
         // The saga's confidence-gated completed handler then routes to Start{H}Command via a
         // Wolverine cascade when the result confidence is below the threshold (INV-1).
+        // Lower EVERY step in each OnLowConfidence handler chain (G-4 / #139), in order. Before
+        // #139 only the first Then<T> was lowered; a multi-step chain now contributes all of its
+        // steps so the chain runs end to end. The chain's ordered Steps are the source of truth;
+        // OnLowConfidenceHandlerStep (the first step) is retained only for the saga routing surface.
         var confidenceHandlerSteps = stepModels
-            .Where(s => s.Confidence?.OnLowConfidenceHandlerStep is not null)
-            .Select(s => s.Confidence!.OnLowConfidenceHandlerStep!)
+            .Where(s => s.Confidence?.OnLowConfidenceHandlerChain is not null)
+            .SelectMany(s => s.Confidence!.OnLowConfidenceHandlerChain!.Steps)
             .ToList();
 
         // Track the lowered handler step names so the saga emitter can keep them off the

--- a/src/Strategos.Generators/WorkflowIncrementalGenerator.cs
+++ b/src/Strategos.Generators/WorkflowIncrementalGenerator.cs
@@ -186,6 +186,14 @@ public sealed class WorkflowIncrementalGenerator : IIncrementalGenerator
             context.SemanticModel,
             ct);
 
+        // Whether the state type exposes a public Phase property. Gates the
+        // failure-handler Phase = State.Phase sync so a realistic state type
+        // (no Phase member) never produces an uncompilable State.Phase reference.
+        var stateHasPhaseProperty = FluentDslParser.StateTypeHasPhaseProperty(
+            context.TargetNode,
+            context.SemanticModel,
+            ct);
+
         // Validate event-sourced mode requires a state type
         if (persistenceMode == Models.PersistenceMode.EventSourced
             && string.IsNullOrEmpty(stateTypeName))
@@ -723,7 +731,10 @@ public sealed class WorkflowIncrementalGenerator : IIncrementalGenerator
             FailureHandlers: failureHandlerModels,
             Forks: forkModels,
             ApprovalPoints: approvalModels,
-            ConfidenceHandlerStepNames: confidenceHandlerStepNames);
+            ConfidenceHandlerStepNames: confidenceHandlerStepNames)
+        {
+            StateHasPhaseProperty = stateHasPhaseProperty,
+        };
 
         return new WorkflowGeneratorResult(model, diagnostics);
     }

--- a/src/Strategos.Generators/WorkflowIncrementalGenerator.cs
+++ b/src/Strategos.Generators/WorkflowIncrementalGenerator.cs
@@ -640,7 +640,7 @@ public sealed class WorkflowIncrementalGenerator : IIncrementalGenerator
         // suppress it by id; others (non-positive timeout, RequireConfidence without
         // OnLowConfidence, Compensate<T> non-step) are net-new. They do not gate code
         // generation — the builder runtime / C# generic constraint already enforce them.
-        ReportResilienceDiagnostics(stepModels, validName, GetAttributeLocation(context), diagnostics);
+        ReportResilienceDiagnostics(stepModels, forkModels, validName, GetAttributeLocation(context), diagnostics);
 
         // Return null model (no code generation) when there are errors
         var hasErrors = duplicateSteps.Count > 0
@@ -748,11 +748,13 @@ public sealed class WorkflowIncrementalGenerator : IIncrementalGenerator
     /// models. Each reported diagnostic carries a stable, suppressible AGWF id.
     /// </summary>
     /// <param name="stepModels">The parsed step models whose resilience IR is validated.</param>
+    /// <param name="forkModels">The parsed fork models, used to detect declared-but-inert config on fork-path steps.</param>
     /// <param name="workflowName">The validated workflow name, threaded into messages.</param>
     /// <param name="location">The diagnostic location (the workflow attribute).</param>
     /// <param name="diagnostics">The diagnostics accumulator to append to.</param>
     private static void ReportResilienceDiagnostics(
         IReadOnlyList<StepModel> stepModels,
+        IReadOnlyList<ForkModel> forkModels,
         string workflowName,
         Location location,
         List<Diagnostic> diagnostics)
@@ -813,6 +815,32 @@ public sealed class WorkflowIncrementalGenerator : IIncrementalGenerator
                     location,
                     step.EffectiveName,
                     workflowName));
+            }
+        }
+
+        // DeclaredButInert (#143, G-6) — confidence gating on a fork-path step. The
+        // fork-path parse threads the configure lambda into the StepModel IR (so an
+        // out-of-range threshold still surfaces the ConfidenceThresholdOutOfRange code),
+        // but the saga emitter does NOT lower confidence-gated routing for fork-path steps
+        // — that variant is deferred to v2.10.0 / DR-17 (#134). The configuration is
+        // therefore inert: no confidence gate and no OnLowConfidence routing reach the
+        // generated saga. Surface it so a deferred configuration cannot masquerade as working.
+        foreach (var fork in forkModels)
+        {
+            foreach (var path in fork.Paths)
+            {
+                foreach (var forkStep in path.Steps)
+                {
+                    if (forkStep.Confidence is not null)
+                    {
+                        diagnostics.Add(Diagnostic.Create(
+                            WorkflowDiagnostics.DeclaredButInert,
+                            location,
+                            forkStep.EffectiveName,
+                            workflowName,
+                            "confidence gating (RequireConfidence/OnLowConfidence) on a fork path"));
+                    }
+                }
             }
         }
     }

--- a/src/Strategos.Ontology.Npgsql.Tests/Schema/EnsureSchemaBootstrapTests.cs
+++ b/src/Strategos.Ontology.Npgsql.Tests/Schema/EnsureSchemaBootstrapTests.cs
@@ -1,0 +1,278 @@
+using global::Npgsql;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Strategos.Ontology;
+using Strategos.Ontology.Builder;
+using Strategos.Ontology.Npgsql.Internal;
+using Strategos.Ontology.Npgsql.Tests.Integration;
+using Strategos.Ontology.ObjectSets;
+
+namespace Strategos.Ontology.Npgsql.Tests.Schema;
+
+/// <summary>
+/// G-7 / CL-7 (#132): the BATCH/SAFE schema-bootstrap API that removes the
+/// multi-registration startup footgun. Before this, a host wanting to stand up a
+/// multi-registered carrier type's tables had to hand-roll a loop over
+/// <see cref="Query.IOntologyQuery.GetObjectTypeNames{T}"/> and call the
+/// single-descriptor <c>EnsureSchema</c> once per name, because
+/// <see cref="PgVectorObjectSetProvider.EnsureSchemaAsync{T}(string?, CancellationToken)"/>
+/// with a null name THROWS for a multi-registered type. The two new entry points
+/// — <see cref="IObjectSetProvider.EnsureSchemaAsync{T}(CancellationToken)"/> (ensure
+/// ALL descriptors for T) and
+/// <see cref="IObjectSetProvider.EnsureAllSchemasAsync(CancellationToken)"/> (ensure
+/// every object descriptor in the graph) — bootstrap the layout in one call.
+/// </summary>
+/// <remarks>
+/// These are DB-GATED via <see cref="SkipIfNoPostgresAttribute"/>: there is no
+/// Postgres in the default dev/CI lane, so they SKIP (not fail) unless
+/// STRATEGOS_PG_TEST_CONN names a reachable database. INV-2: raw Npgsql/pgvector
+/// only (no Marten/Wolverine). INV-8: descriptors are resolved by name, never
+/// <c>typeof</c>.
+/// </remarks>
+public class EnsureSchemaBootstrapTests
+{
+    // ----- Task 7.1 -------------------------------------------------------
+    // SAFE EnsureSchemaAsync<T>(ct): a multi-registered type ensures BOTH
+    // descriptor tables, instead of throwing on the ambiguous default overload.
+    // ----------------------------------------------------------------------
+
+    [Test]
+    [SkipIfNoPostgres]
+    public async Task EnsureSchemaAsync_MultiRegisteredType_EnsuresAllDescriptorTables()
+    {
+        var conn = RequireConn();
+
+        // Doc is registered under TWO descriptors: "a" and "b". The pre-#132
+        // EnsureSchemaAsync<Doc>(null) throws "has multiple registrations"; the
+        // new safe overload ensures both.
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<DocMultiRegistrationOntology>()
+            .Build();
+
+        await using var harness = await BootstrapHarness.CreateAsync(conn, graph);
+
+        await harness.Provider.EnsureSchemaAsync<Doc>(CancellationToken.None);
+
+        await Assert.That(await harness.TableExistsAsync("a")).IsTrue();
+        await Assert.That(await harness.TableExistsAsync("b")).IsTrue();
+    }
+
+    // ----- Task 7.2 -------------------------------------------------------
+    // Graph-wide EnsureAllSchemasAsync(ct): every object descriptor in the graph
+    // gets a vertex table after ONE call.
+    // ----------------------------------------------------------------------
+
+    [Test]
+    [SkipIfNoPostgres]
+    public async Task EnsureAllSchemasAsync_Graph_CreatesTableForEveryObjectDescriptor()
+    {
+        var conn = RequireConn();
+
+        // A graph with three distinct object descriptors across two CLR types.
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<DocMultiRegistrationOntology>()
+            .AddDomain<NoteOntology>()
+            .Build();
+
+        await using var harness = await BootstrapHarness.CreateAsync(conn, graph);
+
+        await harness.Provider.EnsureAllSchemasAsync(CancellationToken.None);
+
+        await Assert.That(await harness.TableExistsAsync("a")).IsTrue();
+        await Assert.That(await harness.TableExistsAsync("b")).IsTrue();
+        await Assert.That(await harness.TableExistsAsync("note")).IsTrue();
+    }
+
+    // ----- Task 7.3 -------------------------------------------------------
+    // Validation corpus: the reported basileus scenario — a shared content carrier
+    // registered under two collection partitions — bootstraps cleanly under BOTH
+    // new entry points.
+    // ----------------------------------------------------------------------
+
+    [Test]
+    [SkipIfNoPostgres]
+    public async Task EnsureAllSchemasAsync_BasileusMultiRegistrationScenario_BootstrapsCleanly()
+    {
+        var conn = RequireConn();
+
+        // SemanticDocument is the shared content carrier; it is registered under
+        // two collection partitions (trading_documents / knowledge_documents),
+        // exactly the shape that tripped the multi-registration footgun.
+        var graph = new OntologyGraphBuilder()
+            .AddDomain<BasileusDocumentOntology>()
+            .Build();
+
+        // (1) Graph-wide entry point bootstraps every partition in one call.
+        await using (var harness = await BootstrapHarness.CreateAsync(conn, graph))
+        {
+            await harness.Provider.EnsureAllSchemasAsync(CancellationToken.None);
+
+            await Assert.That(await harness.TableExistsAsync("trading_documents")).IsTrue();
+            await Assert.That(await harness.TableExistsAsync("knowledge_documents")).IsTrue();
+        }
+
+        // (2) Safe per-type entry point ensures BOTH partitions for the carrier,
+        //     no throw on the multi-registration.
+        await using (var harness = await BootstrapHarness.CreateAsync(conn, graph))
+        {
+            await harness.Provider.EnsureSchemaAsync<SemanticDocument>(
+                CancellationToken.None);
+
+            await Assert.That(await harness.TableExistsAsync("trading_documents")).IsTrue();
+            await Assert.That(await harness.TableExistsAsync("knowledge_documents")).IsTrue();
+        }
+    }
+
+    private static string RequireConn()
+    {
+        var conn = Environment.GetEnvironmentVariable(SkipIfNoPostgresAttribute.ConnectionEnvVar);
+        if (string.IsNullOrWhiteSpace(conn))
+        {
+            throw new InvalidOperationException(
+                $"{SkipIfNoPostgresAttribute.ConnectionEnvVar} is not set; the gated test should "
+                + "have been skipped.");
+        }
+
+        return conn;
+    }
+
+    /// <summary>
+    /// A minimal live-DB harness for the schema-bootstrap tests. Mirrors
+    /// <c>EdgeFailureModeNpgsqlHarness</c>'s posture: a UNIQUE per-instance schema
+    /// (the bootstrap tests run in parallel against a SHARED Postgres, so a shared
+    /// schema would race the catalog on concurrent CREATE TABLE), the PRODUCTION
+    /// <see cref="PgVectorObjectSetProvider"/> as the unit under test, and a CASCADE
+    /// drop of the per-instance schema on dispose so a long-lived shared Postgres
+    /// does not accumulate orphaned schemas.
+    /// </summary>
+    private sealed class BootstrapHarness : IAsyncDisposable
+    {
+        private readonly NpgsqlDataSource _dataSource;
+        private readonly string _schema = $"bootstrap_{Guid.NewGuid():N}";
+
+        private BootstrapHarness(NpgsqlDataSource dataSource, OntologyGraph graph)
+        {
+            _dataSource = dataSource;
+            var embedding = Substitute.For<IEmbeddingProvider>();
+            embedding.Dimensions.Returns(3);
+            Provider = new PgVectorObjectSetProvider(
+                dataSource,
+                embedding,
+                Options.Create(new PgVectorOptions { Schema = _schema }),
+                NullLogger<PgVectorObjectSetProvider>.Instance,
+                graph);
+        }
+
+        public PgVectorObjectSetProvider Provider { get; }
+
+        public static async Task<BootstrapHarness> CreateAsync(string connectionString, OntologyGraph graph)
+        {
+            var dataSource = NpgsqlDataSource.Create(connectionString);
+            var harness = new BootstrapHarness(dataSource, graph);
+            try
+            {
+                await harness.ExecuteAsync($"CREATE SCHEMA IF NOT EXISTS \"{harness._schema}\";")
+                    .ConfigureAwait(false);
+            }
+            catch
+            {
+                await dataSource.DisposeAsync().ConfigureAwait(false);
+                throw;
+            }
+
+            return harness;
+        }
+
+        /// <summary>
+        /// True when a relation named <paramref name="table"/> exists in this
+        /// harness's per-instance schema. Uses <c>to_regclass</c>, which returns
+        /// NULL for an absent relation rather than raising.
+        /// </summary>
+        public async Task<bool> TableExistsAsync(string table)
+        {
+            await using var cmd = _dataSource.CreateCommand("SELECT to_regclass(@qualified) IS NOT NULL;");
+            cmd.Parameters.AddWithValue("qualified", $"\"{_schema}\".\"{table}\"");
+            var scalar = await cmd.ExecuteScalarAsync().ConfigureAwait(false);
+            return scalar is true;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await ExecuteAsync($"DROP SCHEMA IF EXISTS \"{_schema}\" CASCADE;").ConfigureAwait(false);
+            }
+            catch (NpgsqlException)
+            {
+                // Best-effort cleanup; a failed drop must not mask a test result.
+            }
+
+            await _dataSource.DisposeAsync().ConfigureAwait(false);
+        }
+
+        private async Task ExecuteAsync(string sql)
+        {
+            await using var cmd = _dataSource.CreateCommand(sql);
+            await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test fixtures — top-level + public so OntologyGraphBuilder.AddDomain<T>() can
+// instantiate them (requires a public parameterless constructor).
+// ---------------------------------------------------------------------------
+
+public sealed class Doc
+{
+    public string Id { get; set; } = string.Empty;
+}
+
+public sealed class Note
+{
+    public string Id { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Standalone SemanticDocument-like content carrier for the basileus
+/// multi-registration corpus (Task 7.3). A single CLR type registered under
+/// multiple COLLECTION partitions — the exact shape that triggered #132.
+/// </summary>
+public sealed class SemanticDocument
+{
+    public string Id { get; set; } = string.Empty;
+
+    public string Content { get; set; } = string.Empty;
+}
+
+public class DocMultiRegistrationOntology : DomainOntology
+{
+    public override string DomainName => "doc-multi";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<Doc>("a", obj => obj.Key(f => f.Id));
+        builder.Object<Doc>("b", obj => obj.Key(f => f.Id));
+    }
+}
+
+public class NoteOntology : DomainOntology
+{
+    public override string DomainName => "note";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<Note>("note", obj => obj.Key(f => f.Id));
+    }
+}
+
+public class BasileusDocumentOntology : DomainOntology
+{
+    public override string DomainName => "basileus-docs";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<SemanticDocument>("trading_documents", obj => obj.Key(f => f.Id));
+        builder.Object<SemanticDocument>("knowledge_documents", obj => obj.Key(f => f.Id));
+    }
+}

--- a/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
+++ b/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
@@ -1175,15 +1175,18 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
     /// </summary>
     /// <typeparam name="T">The CLR type whose backing table should be created.</typeparam>
     /// <param name="descriptorName">
-    /// Optional explicit descriptor name identifying the target table. When
-    /// <c>null</c>, the target is resolved via
+    /// Explicit descriptor name identifying the target table, or <c>null</c> to
+    /// resolve the target via
     /// <see cref="ResolveTableNameForDefaultOverload{T}(OntologyGraph?)"/>
     /// using the provider's optional <see cref="OntologyGraph"/>; for
     /// multi-registered types the resolution throws and callers must
-    /// specify the name explicitly (one call per descriptor).
+    /// specify the name explicitly (one call per descriptor). The parameter is
+    /// required (no default) so a zero-argument <c>EnsureSchemaAsync&lt;T&gt;()</c>
+    /// resolves unambiguously to the safe
+    /// <see cref="EnsureSchemaAsync{T}(CancellationToken)"/> overload (CS0121 guard).
     /// </param>
     /// <param name="ct">The cancellation token.</param>
-    public async Task EnsureSchemaAsync<T>(string? descriptorName = null, CancellationToken ct = default) where T : class
+    public async Task EnsureSchemaAsync<T>(string? descriptorName, CancellationToken ct = default) where T : class
     {
         var tableName = ResolveEnsureSchemaTableName<T>(descriptorName, _graph);
         var keyPropertyName = ResolveEnsureSchemaKeyProperty<T>(descriptorName, _graph);

--- a/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
+++ b/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
@@ -147,7 +147,9 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
                 $"({string.Join(", ", names.Select(n => $"'{n}'"))}). " +
                 $"Use StoreAsync<T>(string descriptorName, T item, ct) or " +
                 $"StoreBatchAsync<T>(string descriptorName, IReadOnlyList<T> items, ct) " +
-                $"to specify the target descriptor.");
+                $"to specify the target descriptor. To create the schema for every " +
+                $"registered descriptor at once, use the safe EnsureSchemaAsync<T>(ct) " +
+                $"overload (or EnsureAllSchemasAsync(ct) for the whole graph) — #132.");
         }
 
         // Graph absent — fall back to typeof(T).Name → snake_case for
@@ -1185,6 +1187,83 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
     {
         var tableName = ResolveEnsureSchemaTableName<T>(descriptorName, _graph);
         var keyPropertyName = ResolveEnsureSchemaKeyProperty<T>(descriptorName, _graph);
+        await EnsureSchemaForTableAsync(tableName, keyPropertyName, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// G-7 / CL-7 (#132): the SAFE per-type bootstrap. The single-descriptor
+    /// <see cref="EnsureSchemaAsync{T}(string?, CancellationToken)"/> with a null
+    /// name THROWS for a multi-registered type (it cannot pick one partition); this
+    /// overload instead resolves the FULL registration set from the ontology graph's
+    /// reverse index (<see cref="OntologyGraph.ObjectTypeNamesByType"/>) and ensures
+    /// EACH descriptor's schema, removing the consumer-side
+    /// <c>foreach (GetObjectTypeNames&lt;T&gt;()) EnsureSchema(name)</c> loop the
+    /// footgun forced. Each per-descriptor ensure resolves its table and key property
+    /// by descriptor NAME (INV-8), reusing the same single-descriptor lowering. When
+    /// no graph is in scope (direct/test instantiation) the registration set is
+    /// unavailable, so it falls back to the single default-overload ensure
+    /// (<c>typeof(T).Name</c> → snake_case), byte-identical to the pre-#132 behavior.
+    /// INV-2: raw Npgsql DDL only.
+    /// </remarks>
+    public async Task EnsureSchemaAsync<T>(CancellationToken ct = default) where T : class
+    {
+        if (_graph is null
+            || !_graph.ObjectTypeNamesByType.TryGetValue(typeof(T), out var descriptorNames)
+            || descriptorNames.Count == 0)
+        {
+            // No graph (or unregistered): defer to the single-descriptor default
+            // resolution, which falls back to typeof(T).Name when the graph is absent
+            // and throws the canonical typed error when the graph is present but the
+            // type is unregistered (symmetric with the write path).
+            await EnsureSchemaAsync<T>(descriptorName: null, ct).ConfigureAwait(false);
+            return;
+        }
+
+        // Multi- (or single-) registered: ensure EVERY descriptor partition. Keyed on
+        // the resolved descriptor name (INV-8), never typeof.
+        foreach (var descriptorName in descriptorNames)
+        {
+            await EnsureSchemaAsync<T>(descriptorName, ct).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// G-7 / CL-7 (#132): the GRAPH-WIDE bootstrap. Iterates
+    /// <see cref="OntologyGraph.ObjectTypes"/> and ensures a vertex table for EVERY
+    /// registered object descriptor in one call, so a host can stand up the entire
+    /// physical layout at startup without hand-rolling a per-type registration walk.
+    /// Each descriptor's table name and unique-index key property are read straight
+    /// from the descriptor (by NAME, INV-8), so a multi-registered carrier's distinct
+    /// partitions each get their own table. A graph-less provider has nothing to
+    /// enumerate, so this is a no-op. INV-2: raw Npgsql DDL only.
+    /// </remarks>
+    public async Task EnsureAllSchemasAsync(CancellationToken ct = default)
+    {
+        if (_graph is null)
+        {
+            return;
+        }
+
+        foreach (var descriptor in _graph.ObjectTypes)
+        {
+            ct.ThrowIfCancellationRequested();
+            var tableName = TypeMapper.ToSnakeCase(descriptor.Name);
+            await EnsureSchemaForTableAsync(tableName, descriptor.KeyProperty?.Name, ct).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Non-generic schema-creation core shared by every <c>EnsureSchema</c> entry
+    /// point: builds and executes the vertex DDL for a single resolved
+    /// <paramref name="tableName"/>, emitting the DR-13/R2 key-property unique index
+    /// when <paramref name="keyPropertyName"/> is supplied. Keeps the per-descriptor
+    /// DDL shape in lockstep across the single-descriptor, per-type (all-descriptor),
+    /// and graph-wide bootstrap paths. INV-2: raw Npgsql DDL only.
+    /// </summary>
+    private async Task EnsureSchemaForTableAsync(string tableName, string? keyPropertyName, CancellationToken ct)
+    {
         var ddl = SqlGenerator.BuildSchemaCreationDdl(
             _options.Schema,
             tableName,

--- a/src/Strategos.Ontology.Tests/Configuration/AddOntologyTests.cs
+++ b/src/Strategos.Ontology.Tests/Configuration/AddOntologyTests.cs
@@ -37,6 +37,10 @@ public class StubObjectSetProvider : IObjectSetProvider
     public Task<ScoredObjectSetResult<T>> ExecuteSimilarityAsync<T>(
         SimilarityExpression expression, CancellationToken ct = default) where T : class =>
         Task.FromResult(new ScoredObjectSetResult<T>([], 0, ObjectSetInclusion.Properties, []));
+
+    public Task EnsureSchemaAsync<T>(CancellationToken ct = default) where T : class => Task.CompletedTask;
+
+    public Task EnsureAllSchemasAsync(CancellationToken ct = default) => Task.CompletedTask;
 }
 
 public class StubEventStreamProvider : IEventStreamProvider

--- a/src/Strategos.Ontology.Tests/Configuration/EmbeddingProviderRegistrationTests.cs
+++ b/src/Strategos.Ontology.Tests/Configuration/EmbeddingProviderRegistrationTests.cs
@@ -67,6 +67,11 @@ public class DualProvider : IObjectSetProvider, IObjectSetWriter
         SimilarityExpression expression, CancellationToken ct = default) where T : class =>
         Task.FromResult(new ScoredObjectSetResult<T>([], 0, ObjectSetInclusion.Properties, []));
 
+    // Schema-bootstrap methods added for #132; this DI test double does not need schema behavior.
+    public Task EnsureSchemaAsync<T>(CancellationToken ct = default) where T : class => Task.CompletedTask;
+
+    public Task EnsureAllSchemasAsync(CancellationToken ct = default) => Task.CompletedTask;
+
     public Task StoreAsync<T>(T item, CancellationToken ct = default) where T : class =>
         Task.CompletedTask;
 

--- a/src/Strategos.Ontology.Tests/Integration/OntologyIntegrationTests.cs
+++ b/src/Strategos.Ontology.Tests/Integration/OntologyIntegrationTests.cs
@@ -144,6 +144,10 @@ public class IntegrationStubObjectSetProvider : IObjectSetProvider
     public Task<ScoredObjectSetResult<T>> ExecuteSimilarityAsync<T>(
         SimilarityExpression expression, CancellationToken ct = default) where T : class =>
         Task.FromResult(new ScoredObjectSetResult<T>([], 0, ObjectSetInclusion.Properties, []));
+
+    public Task EnsureSchemaAsync<T>(CancellationToken ct = default) where T : class => Task.CompletedTask;
+
+    public Task EnsureAllSchemasAsync(CancellationToken ct = default) => Task.CompletedTask;
 }
 
 public class IntegrationStubEventStreamProvider : IEventStreamProvider

--- a/src/Strategos.Ontology/ObjectSets/IObjectSetProvider.cs
+++ b/src/Strategos.Ontology/ObjectSets/IObjectSetProvider.cs
@@ -20,4 +20,32 @@ public interface IObjectSetProvider
     /// </summary>
     Task<ScoredObjectSetResult<T>> ExecuteSimilarityAsync<T>(
         SimilarityExpression expression, CancellationToken ct = default) where T : class;
+
+    /// <summary>
+    /// SAFE schema-bootstrap for a (possibly multi-registered) CLR type: ensures
+    /// the backing schema for EVERY descriptor <typeparamref name="T"/> is
+    /// registered under, in one call. Unlike a single-descriptor
+    /// <c>EnsureSchema</c>, this never throws on a multi-registered type — it
+    /// resolves the full registration set from the ontology graph (keyed on the
+    /// resolved descriptor name, INV-8) and ensures each descriptor's schema,
+    /// removing the consumer-side loop over
+    /// <see cref="Query.IOntologyQuery.GetObjectTypeNames{T}"/> that the
+    /// multi-registration footgun otherwise forced (#132).
+    /// </summary>
+    /// <typeparam name="T">The CLR type whose every registered descriptor's schema should be ensured.</typeparam>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A task that completes when every descriptor's schema has been ensured.</returns>
+    Task EnsureSchemaAsync<T>(CancellationToken ct = default) where T : class;
+
+    /// <summary>
+    /// Graph-wide schema bootstrap: ensures the backing schema for EVERY object
+    /// descriptor registered in the ontology, in one call. The batch counterpart to
+    /// the per-type entry points — a host can stand up the entire physical layout in
+    /// a single statement-loop at startup rather than hand-rolling a registration
+    /// walk per type (#132). A provider with no schema concept (e.g. the in-memory
+    /// provider) treats this as a no-op.
+    /// </summary>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A task that completes when every object descriptor's schema has been ensured.</returns>
+    Task EnsureAllSchemasAsync(CancellationToken ct = default);
 }

--- a/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryObjectSetProvider.cs
@@ -869,6 +869,35 @@ public sealed class InMemoryObjectSetProvider : IObjectSetProvider, IObjectSetWr
         return (double)matchCount / queryTerms.Length;
     }
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// G-7 / CL-7 (#132): the in-memory provider carries NO physical schema —
+    /// partitions are materialized lazily on first <see cref="Seed{T}"/> / store, by
+    /// descriptor name — so there is nothing to create ahead of time and the safe
+    /// per-type bootstrap is a no-op. Implemented for cross-provider PARITY so a host
+    /// can call the SAME entry point against either backend at startup. INV-8: had
+    /// there been a schema to create, descriptors would be keyed by resolved name,
+    /// never <c>typeof</c>.
+    /// </remarks>
+    public Task EnsureSchemaAsync<T>(CancellationToken ct = default) where T : class
+    {
+        ct.ThrowIfCancellationRequested();
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// G-7 / CL-7 (#132): no physical schema to provision (see
+    /// <see cref="EnsureSchemaAsync{T}(CancellationToken)"/>), so the graph-wide
+    /// bootstrap is a no-op here. Present for parity with the Npgsql provider so the
+    /// SAME startup call works against either backend.
+    /// </remarks>
+    public Task EnsureAllSchemasAsync(CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        return Task.CompletedTask;
+    }
+
     private static double CosineSimilarity(float[] a, float[] b)
     {
         if (a.Length == 0 || b.Length == 0 || a.Length != b.Length)

--- a/src/Strategos.Tests/Builders/BranchBuilderTests.cs
+++ b/src/Strategos.Tests/Builders/BranchBuilderTests.cs
@@ -337,4 +337,56 @@ public class BranchBuilderTests
         var branchPath = workflow.BranchPoints[0].Paths[0];
         await Assert.That(branchPath.ConditionDescription).IsEqualTo("Otherwise");
     }
+
+    // =============================================================================
+    // F. Complete / RejoinMainFlow exclusivity (mechanically enforced contract)
+    // =============================================================================
+
+    /// <summary>
+    /// Verifies that calling <c>RejoinMainFlow()</c> after <c>Complete()</c> on the
+    /// same path throws: the IBranchBuilder remarks declare the two exit semantics
+    /// mutually exclusive, and the builder enforces that contract at build time.
+    /// </summary>
+    [Test]
+    public async Task RejoinMainFlow_AfterComplete_ThrowsInvalidOperationException()
+    {
+        await Assert.That(() => Workflow<TestWorkflowState>
+                .Create("test-workflow")
+                .StartWith<ValidateStep>()
+                .Branch(
+                    state => state.ProcessingMode,
+                    BranchCase<TestWorkflowState, ProcessingMode>.When(
+                        ProcessingMode.Auto,
+                        path =>
+                        {
+                            path.Then<AutoProcessStep>();
+                            path.Complete();
+                            path.RejoinMainFlow();
+                        })))
+            .Throws<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// Verifies that calling <c>Complete()</c> after <c>RejoinMainFlow()</c> on the
+    /// same path throws, enforcing the same mutual-exclusivity contract from the
+    /// opposite ordering.
+    /// </summary>
+    [Test]
+    public async Task Complete_AfterRejoinMainFlow_ThrowsInvalidOperationException()
+    {
+        await Assert.That(() => Workflow<TestWorkflowState>
+                .Create("test-workflow")
+                .StartWith<ValidateStep>()
+                .Branch(
+                    state => state.ProcessingMode,
+                    BranchCase<TestWorkflowState, ProcessingMode>.When(
+                        ProcessingMode.Auto,
+                        path =>
+                        {
+                            path.Then<AutoProcessStep>();
+                            path.RejoinMainFlow();
+                            path.Complete();
+                        })))
+            .Throws<InvalidOperationException>();
+    }
 }

--- a/src/Strategos.Tests/Builders/WorkflowBuilderStepConfigTests.cs
+++ b/src/Strategos.Tests/Builders/WorkflowBuilderStepConfigTests.cs
@@ -1,0 +1,184 @@
+// =============================================================================
+// <copyright file="WorkflowBuilderStepConfigTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// =============================================================================
+
+namespace Strategos.Tests.Builders;
+
+/// <summary>
+/// Tests for the <c>StartWith</c>/<c>Finally</c> step-config overloads (#141):
+/// <c>StartWith&lt;TStep&gt;(configure)</c>, <c>StartWith&lt;TStep&gt;(instanceName, configure)</c>,
+/// and <c>Finally&lt;TStep&gt;(configure)</c>. They mirror the existing
+/// <c>Then&lt;TStep&gt;(configure)</c> overload, routing the captured configuration through
+/// the same <c>WithConfiguration</c> path so the ENTRY (StartWith) and TERMINAL (Finally)
+/// steps can declare per-step resilience inline.
+/// </summary>
+[Property("Category", "Unit")]
+public class WorkflowBuilderStepConfigTests
+{
+    // =============================================================================
+    // A. StartWith(configure)
+    // =============================================================================
+
+    /// <summary>
+    /// Verifies that <c>StartWith&lt;TStep&gt;(step =&gt; step.WithRetry(2))</c> carries the
+    /// retry configuration onto the entry step in the built definition.
+    /// </summary>
+    [Test]
+    public async Task StartWith_WithConfigure_StoresRetryOnEntryStep()
+    {
+        // Arrange & Act
+        var definition = Workflow<TestWorkflowState>.Create("test-workflow")
+            .StartWith<ValidateStep>(step => step.WithRetry(2))
+            .Finally<CompleteStep>();
+
+        // Assert
+        var entryStep = definition.Steps.First(s => s.StepType == typeof(ValidateStep));
+        await Assert.That(entryStep.Configuration).IsNotNull();
+        await Assert.That(entryStep.Configuration!.Retry).IsNotNull();
+        await Assert.That(entryStep.Configuration!.Retry!.MaxAttempts).IsEqualTo(2);
+    }
+
+    /// <summary>
+    /// Verifies that the entry step keeps its entry identity (the built definition's
+    /// EntryStep is the configured step), so configuration does not displace it.
+    /// </summary>
+    [Test]
+    public async Task StartWith_WithConfigure_EntryStepIsConfiguredStep()
+    {
+        // Arrange & Act
+        var definition = Workflow<TestWorkflowState>.Create("test-workflow")
+            .StartWith<ValidateStep>(step => step.WithRetry(2))
+            .Finally<CompleteStep>();
+
+        // Assert
+        await Assert.That(definition.EntryStep).IsNotNull();
+        await Assert.That(definition.EntryStep!.StepType).IsEqualTo(typeof(ValidateStep));
+        await Assert.That(definition.EntryStep!.Configuration).IsNotNull();
+    }
+
+    /// <summary>
+    /// Verifies that <c>StartWith&lt;TStep&gt;((Action&lt;IStepConfiguration&lt;TState&gt;&gt;)null)</c>
+    /// throws <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [Test]
+    public async Task StartWith_WithNullConfigure_Throws()
+    {
+        // Arrange
+        var builder = Workflow<TestWorkflowState>.Create("test-workflow");
+
+        // Act & Assert
+        await Assert.That(() => builder.StartWith<ValidateStep>(
+            (Action<IStepConfiguration<TestWorkflowState>>)null!))
+            .Throws<ArgumentNullException>();
+    }
+
+    // =============================================================================
+    // B. StartWith(instanceName, configure)
+    // =============================================================================
+
+    /// <summary>
+    /// Verifies that <c>StartWith&lt;TStep&gt;("Entry", step =&gt; step.WithRetry(4))</c>
+    /// carries BOTH the instance name AND the retry configuration onto the entry step.
+    /// </summary>
+    [Test]
+    public async Task StartWith_WithInstanceNameAndConfigure_StoresBoth()
+    {
+        // Arrange & Act
+        var definition = Workflow<TestWorkflowState>.Create("test-workflow")
+            .StartWith<ValidateStep>("InitialValidation", step => step.WithRetry(4))
+            .Finally<CompleteStep>();
+
+        // Assert
+        var entryStep = definition.Steps.First(s => s.StepType == typeof(ValidateStep));
+        await Assert.That(entryStep.InstanceName).IsEqualTo("InitialValidation");
+        await Assert.That(entryStep.Configuration).IsNotNull();
+        await Assert.That(entryStep.Configuration!.Retry!.MaxAttempts).IsEqualTo(4);
+    }
+
+    /// <summary>
+    /// Verifies the named-instance + configure overload guards a null configure.
+    /// </summary>
+    [Test]
+    public async Task StartWith_WithInstanceNameAndNullConfigure_Throws()
+    {
+        // Arrange
+        var builder = Workflow<TestWorkflowState>.Create("test-workflow");
+
+        // Act & Assert
+        await Assert.That(() => builder.StartWith<ValidateStep>("Entry", null!))
+            .Throws<ArgumentNullException>();
+    }
+
+    // =============================================================================
+    // C. Finally(configure)
+    // =============================================================================
+
+    /// <summary>
+    /// Verifies that <c>Finally&lt;TStep&gt;(step =&gt; step.WithTimeout(...))</c> carries the
+    /// timeout configuration onto the terminal step in the built definition and keeps it
+    /// marked terminal.
+    /// </summary>
+    [Test]
+    public async Task Finally_WithConfigure_StoresTimeoutOnTerminalStep()
+    {
+        // Arrange & Act
+        var definition = Workflow<TestWorkflowState>.Create("test-workflow")
+            .StartWith<ValidateStep>()
+            .Finally<CompleteStep>(step => step.WithTimeout(TimeSpan.FromSeconds(5)));
+
+        // Assert
+        var terminalStep = definition.Steps.First(s => s.StepType == typeof(CompleteStep));
+        await Assert.That(terminalStep.IsTerminal).IsTrue();
+        await Assert.That(terminalStep.Configuration).IsNotNull();
+        await Assert.That(terminalStep.Configuration!.Timeout).IsEqualTo(TimeSpan.FromSeconds(5));
+    }
+
+    /// <summary>
+    /// Verifies that the built definition's TerminalStep is the configured terminal step.
+    /// </summary>
+    [Test]
+    public async Task Finally_WithConfigure_TerminalStepIsConfiguredStep()
+    {
+        // Arrange & Act
+        var definition = Workflow<TestWorkflowState>.Create("test-workflow")
+            .StartWith<ValidateStep>()
+            .Finally<CompleteStep>(step => step.WithTimeout(TimeSpan.FromSeconds(5)));
+
+        // Assert
+        await Assert.That(definition.TerminalStep).IsNotNull();
+        await Assert.That(definition.TerminalStep!.StepType).IsEqualTo(typeof(CompleteStep));
+        await Assert.That(definition.TerminalStep!.Configuration).IsNotNull();
+    }
+
+    /// <summary>
+    /// Verifies that <c>Finally&lt;TStep&gt;(null)</c> throws <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [Test]
+    public async Task Finally_WithNullConfigure_Throws()
+    {
+        // Arrange
+        var builder = Workflow<TestWorkflowState>.Create("test-workflow")
+            .StartWith<ValidateStep>();
+
+        // Act & Assert
+        await Assert.That(() => builder.Finally<CompleteStep>(null!))
+            .Throws<ArgumentNullException>();
+    }
+
+    /// <summary>
+    /// Verifies that <c>Finally&lt;TStep&gt;(configure)</c> before <c>StartWith</c> throws
+    /// <see cref="InvalidOperationException"/>, mirroring the parameterless overload's guard.
+    /// </summary>
+    [Test]
+    public async Task Finally_WithConfigureBeforeStartWith_Throws()
+    {
+        // Arrange
+        var builder = Workflow<TestWorkflowState>.Create("test-workflow");
+
+        // Act & Assert
+        await Assert.That(() => builder.Finally<CompleteStep>(step => step.WithRetry(2)))
+            .Throws<InvalidOperationException>();
+    }
+}

--- a/src/Strategos.Tests/Builders/WorkflowBuilderStepConfigTests.cs
+++ b/src/Strategos.Tests/Builders/WorkflowBuilderStepConfigTests.cs
@@ -15,7 +15,7 @@ namespace Strategos.Tests.Builders;
 /// steps can declare per-step resilience inline.
 /// </summary>
 [Property("Category", "Unit")]
-public class WorkflowBuilderStepConfigTests
+public sealed class WorkflowBuilderStepConfigTests
 {
     // =============================================================================
     // A. StartWith(configure)

--- a/src/Strategos/Abstractions/IBranchBuilder.cs
+++ b/src/Strategos/Abstractions/IBranchBuilder.cs
@@ -103,6 +103,35 @@ public interface IBranchBuilder<TState>
     void Complete();
 
     /// <summary>
+    /// Marks this path as rejoining the main flow rather than terminating.
+    /// </summary>
+    /// <returns>The builder for fluent chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// Intended for an <c>OnLowConfidence(alt =&gt; ...)</c> handler (G-4 / #139): by
+    /// default a low-confidence handler chain TERMINATES the workflow once its last
+    /// step completes (back-compat with the single-step terminating handler shipped
+    /// in DR-5). Calling <see cref="RejoinMainFlow"/> opts the handler into resuming
+    /// the MAIN flow at the step immediately after the confidence-gated step instead
+    /// of marking the workflow completed:
+    /// <code>
+    /// .Then&lt;Classify&gt;(step => step
+    ///     .RequireConfidence(0.85)
+    ///     .OnLowConfidence(alt => alt
+    ///         .Then&lt;HumanReview&gt;()
+    ///         .RejoinMainFlow()))
+    /// .Finally&lt;Finish&gt;()   // a rejoining handler resumes here
+    /// </code>
+    /// </para>
+    /// <para>
+    /// Terminating remains the default; <see cref="Complete"/> is the explicit
+    /// terminal marker. <see cref="RejoinMainFlow"/> and <see cref="Complete"/> are
+    /// mutually exclusive declarations of the handler's exit semantics.
+    /// </para>
+    /// </remarks>
+    IBranchBuilder<TState> RejoinMainFlow();
+
+    /// <summary>
     /// Adds an approval gate to this branch path.
     /// </summary>
     /// <typeparam name="TApprover">The approver type (marker class for routing).</typeparam>

--- a/src/Strategos/Abstractions/IWorkflowBuilder.cs
+++ b/src/Strategos/Abstractions/IWorkflowBuilder.cs
@@ -75,6 +75,54 @@ public interface IWorkflowBuilder<TState>
         where TStep : class, IWorkflowStep<TState>;
 
     /// <summary>
+    /// Sets the entry step of the workflow with configuration.
+    /// </summary>
+    /// <typeparam name="TStep">The step implementation type.</typeparam>
+    /// <param name="configure">Action to configure the step.</param>
+    /// <returns>The builder for fluent chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configure"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if StartWith has already been called.</exception>
+    /// <remarks>
+    /// <para>
+    /// Step configuration allows the entry step to declare per-step resilience, e.g.:
+    /// <code>
+    /// .StartWith&lt;ValidateOrder&gt;(step => step
+    ///     .RequireConfidence(0.85)
+    ///     .Compensate&lt;RollbackValidation&gt;()
+    ///     .WithRetry(3))
+    /// </code>
+    /// </para>
+    /// </remarks>
+    IWorkflowBuilder<TState> StartWith<TStep>(Action<IStepConfiguration<TState>> configure)
+        where TStep : class, IWorkflowStep<TState>;
+
+    /// <summary>
+    /// Sets the entry step of the workflow with an instance name and configuration.
+    /// </summary>
+    /// <typeparam name="TStep">The step implementation type.</typeparam>
+    /// <param name="instanceName">
+    /// The instance name for this step. Enables reusing the same step type
+    /// in different contexts with distinct identities.
+    /// </param>
+    /// <param name="configure">Action to configure the step.</param>
+    /// <returns>The builder for fluent chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="instanceName"/> or <paramref name="configure"/> is null.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">Thrown if StartWith has already been called.</exception>
+    /// <remarks>
+    /// <para>
+    /// Combines the named-instance and configure overloads so the entry step can carry
+    /// both a distinct identity and per-step resilience, e.g.:
+    /// <code>
+    /// .StartWith&lt;ValidateOrder&gt;("InitialValidation", step => step.WithRetry(3))
+    /// </code>
+    /// </para>
+    /// </remarks>
+    IWorkflowBuilder<TState> StartWith<TStep>(string instanceName, Action<IStepConfiguration<TState>> configure)
+        where TStep : class, IWorkflowStep<TState>;
+
+    /// <summary>
     /// Adds a sequential step to the workflow.
     /// </summary>
     /// <typeparam name="TStep">The step implementation type.</typeparam>
@@ -167,6 +215,27 @@ public interface IWorkflowBuilder<TState>
     /// <returns>The completed workflow definition.</returns>
     /// <exception cref="InvalidOperationException">Thrown if StartWith has not been called.</exception>
     WorkflowDefinition<TState> Finally<TStep>()
+        where TStep : class, IWorkflowStep<TState>;
+
+    /// <summary>
+    /// Sets the terminal step with configuration and builds the workflow definition.
+    /// </summary>
+    /// <typeparam name="TStep">The terminal step implementation type.</typeparam>
+    /// <param name="configure">Action to configure the terminal step.</param>
+    /// <returns>The completed workflow definition.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configure"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if StartWith has not been called.</exception>
+    /// <remarks>
+    /// <para>
+    /// Step configuration allows the terminal step to declare per-step resilience, e.g.:
+    /// <code>
+    /// .Finally&lt;SendConfirmation&gt;(step => step
+    ///     .WithTimeout(TimeSpan.FromSeconds(5))
+    ///     .WithRetry(3))
+    /// </code>
+    /// </para>
+    /// </remarks>
+    WorkflowDefinition<TState> Finally<TStep>(Action<IStepConfiguration<TState>> configure)
         where TStep : class, IWorkflowStep<TState>;
 
     /// <summary>

--- a/src/Strategos/Builders/BranchBuilder.cs
+++ b/src/Strategos/Builders/BranchBuilder.cs
@@ -78,12 +78,31 @@ internal sealed class BranchBuilder<TState> : IBranchBuilder<TState>
     /// <inheritdoc/>
     public void Complete()
     {
+        // Complete() and RejoinMainFlow() are mutually exclusive exit semantics
+        // (see IBranchBuilder remarks): a path either terminates or rejoins, never
+        // both. Enforce the documented contract mechanically so a conflicting
+        // declaration fails fast at build time rather than producing ambiguous
+        // lowering/runtime behavior.
+        if (RejoinsMainFlow)
+        {
+            throw new InvalidOperationException(
+                "Complete() cannot be called on a path that already declared RejoinMainFlow(); "
+                + "a branch path either terminates or rejoins the main flow, not both.");
+        }
+
         IsTerminal = true;
     }
 
     /// <inheritdoc/>
     public IBranchBuilder<TState> RejoinMainFlow()
     {
+        if (IsTerminal)
+        {
+            throw new InvalidOperationException(
+                "RejoinMainFlow() cannot be called on a path that already declared Complete(); "
+                + "a branch path either terminates or rejoins the main flow, not both.");
+        }
+
         RejoinsMainFlow = true;
         return this;
     }

--- a/src/Strategos/Builders/BranchBuilder.cs
+++ b/src/Strategos/Builders/BranchBuilder.cs
@@ -27,6 +27,12 @@ internal sealed class BranchBuilder<TState> : IBranchBuilder<TState>
     internal bool IsTerminal { get; private set; }
 
     /// <summary>
+    /// Gets a value indicating whether this path rejoins the main flow rather than
+    /// terminating (G-4 / #139). Set by <see cref="RejoinMainFlow"/>.
+    /// </summary>
+    internal bool RejoinsMainFlow { get; private set; }
+
+    /// <summary>
     /// Gets the approval definition for this branch path, if any.
     /// </summary>
     internal ApprovalDefinition? Approval => _approval;
@@ -73,6 +79,13 @@ internal sealed class BranchBuilder<TState> : IBranchBuilder<TState>
     public void Complete()
     {
         IsTerminal = true;
+    }
+
+    /// <inheritdoc/>
+    public IBranchBuilder<TState> RejoinMainFlow()
+    {
+        RejoinsMainFlow = true;
+        return this;
     }
 
     /// <inheritdoc/>

--- a/src/Strategos/Builders/WorkflowBuilder.cs
+++ b/src/Strategos/Builders/WorkflowBuilder.cs
@@ -39,7 +39,7 @@ internal sealed class WorkflowBuilder<TState> : IWorkflowBuilder<TState>
     public IWorkflowBuilder<TState> StartWith<TStep>()
         where TStep : class, IWorkflowStep<TState>
     {
-        return StartWithInternal<TStep>(instanceName: null);
+        return StartWithInternal<TStep>(instanceName: null, configure: null);
     }
 
     /// <inheritdoc/>
@@ -48,10 +48,31 @@ internal sealed class WorkflowBuilder<TState> : IWorkflowBuilder<TState>
     {
         ArgumentNullException.ThrowIfNull(instanceName, nameof(instanceName));
 
-        return StartWithInternal<TStep>(instanceName);
+        return StartWithInternal<TStep>(instanceName, configure: null);
     }
 
-    private IWorkflowBuilder<TState> StartWithInternal<TStep>(string? instanceName)
+    /// <inheritdoc/>
+    public IWorkflowBuilder<TState> StartWith<TStep>(Action<IStepConfiguration<TState>> configure)
+        where TStep : class, IWorkflowStep<TState>
+    {
+        ArgumentNullException.ThrowIfNull(configure, nameof(configure));
+
+        return StartWithInternal<TStep>(instanceName: null, configure);
+    }
+
+    /// <inheritdoc/>
+    public IWorkflowBuilder<TState> StartWith<TStep>(string instanceName, Action<IStepConfiguration<TState>> configure)
+        where TStep : class, IWorkflowStep<TState>
+    {
+        ArgumentNullException.ThrowIfNull(instanceName, nameof(instanceName));
+        ArgumentNullException.ThrowIfNull(configure, nameof(configure));
+
+        return StartWithInternal<TStep>(instanceName, configure);
+    }
+
+    private IWorkflowBuilder<TState> StartWithInternal<TStep>(
+        string? instanceName,
+        Action<IStepConfiguration<TState>>? configure)
         where TStep : class, IWorkflowStep<TState>
     {
         if (_entryStep is not null)
@@ -60,6 +81,16 @@ internal sealed class WorkflowBuilder<TState> : IWorkflowBuilder<TState>
         }
 
         var step = StepDefinition.Create(typeof(TStep), customName: null, instanceName: instanceName);
+
+        // Route any configure lambda through the SAME WithConfiguration path Then(configure)
+        // uses, so the entry step carries its per-step resilience into the IR.
+        if (configure is not null)
+        {
+            var configBuilder = new StepConfigurationBuilder<TState>();
+            configure(configBuilder);
+            step = step.WithConfiguration(configBuilder.Configuration);
+        }
+
         _entryStep = step;
         _lastStep = step;
         _steps.Add(step);
@@ -240,6 +271,21 @@ internal sealed class WorkflowBuilder<TState> : IWorkflowBuilder<TState>
     public WorkflowDefinition<TState> Finally<TStep>()
         where TStep : class, IWorkflowStep<TState>
     {
+        return FinallyInternal<TStep>(configure: null);
+    }
+
+    /// <inheritdoc/>
+    public WorkflowDefinition<TState> Finally<TStep>(Action<IStepConfiguration<TState>> configure)
+        where TStep : class, IWorkflowStep<TState>
+    {
+        ArgumentNullException.ThrowIfNull(configure, nameof(configure));
+
+        return FinallyInternal<TStep>(configure);
+    }
+
+    private WorkflowDefinition<TState> FinallyInternal<TStep>(Action<IStepConfiguration<TState>>? configure)
+        where TStep : class, IWorkflowStep<TState>
+    {
         if (_entryStep is null)
         {
             throw new InvalidOperationException("StartWith must be called before Finally.");
@@ -247,6 +293,16 @@ internal sealed class WorkflowBuilder<TState> : IWorkflowBuilder<TState>
 
         // Create and add terminal step
         var terminalStep = StepDefinition.Create(typeof(TStep)).AsTerminal();
+
+        // Route any configure lambda through the SAME WithConfiguration path Then(configure)
+        // uses, so the terminal step carries its per-step resilience into the IR.
+        if (configure is not null)
+        {
+            var configBuilder = new StepConfigurationBuilder<TState>();
+            configure(configBuilder);
+            terminalStep = terminalStep.WithConfiguration(configBuilder.Configuration);
+        }
+
         _steps.Add(terminalStep);
 
         // Handle pending branch rejoins

--- a/src/Strategos/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Strategos/PublicAPI/PublicAPI.Shipped.txt
@@ -12,6 +12,7 @@ Strategos.Builders.IApprovalBuilder<TState, TApprover>.WithTimeout(System.TimeSp
 Strategos.Builders.IBranchBuilder<TState>
 Strategos.Builders.IBranchBuilder<TState>.AwaitApproval<TApprover>(System.Action<Strategos.Builders.IApprovalBuilder<TState!, TApprover!>!>! configure) -> Strategos.Builders.IBranchBuilder<TState!>!
 Strategos.Builders.IBranchBuilder<TState>.Complete() -> void
+Strategos.Builders.IBranchBuilder<TState>.RejoinMainFlow() -> Strategos.Builders.IBranchBuilder<TState!>!
 Strategos.Builders.IBranchBuilder<TState>.Then<TStep>() -> Strategos.Builders.IBranchBuilder<TState!>!
 Strategos.Builders.IBranchBuilder<TState>.Then<TStep>(string! instanceName) -> Strategos.Builders.IBranchBuilder<TState!>!
 Strategos.Builders.IBranchBuilder<TState>.Then<TStep>(System.Action<Strategos.Builders.IStepConfiguration<TState!>!>! configure) -> Strategos.Builders.IBranchBuilder<TState!>!

--- a/src/Strategos/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Strategos/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+Strategos.Builders.IWorkflowBuilder<TState>.Finally<TStep>(System.Action<Strategos.Builders.IStepConfiguration<TState!>!>! configure) -> Strategos.Definitions.WorkflowDefinition<TState!>!
+Strategos.Builders.IWorkflowBuilder<TState>.StartWith<TStep>(System.Action<Strategos.Builders.IStepConfiguration<TState!>!>! configure) -> Strategos.Builders.IWorkflowBuilder<TState!>!
+Strategos.Builders.IWorkflowBuilder<TState>.StartWith<TStep>(string! instanceName, System.Action<Strategos.Builders.IStepConfiguration<TState!>!>! configure) -> Strategos.Builders.IWorkflowBuilder<TState!>!


### PR DESCRIPTION
## v2.9.0 Close-Out Bundle

Completes the step-resilience surface, adds a declared↔lowered parity guard, and lands safe schema bootstrap. Single PR because the groups share generator/emitter files (split PRs would conflict on `StepExtractor`, the saga emitters, and the AGWF catalog).

### What's included

| Issue | Group | Change |
|---|---|---|
| #142 | G-1 | Escape validation-error-message literal in the generated start handler (`SymbolDisplay.FormatLiteral`) — previously emitted uncompilable source for messages with quotes/backslashes. |
| #141 | G-2 | `StartWith`/`Finally` accept step config (`Action<IStepConfiguration<TState>>`), threading retry/timeout/etc. through the same path as `Then(configure)`. |
| #140 | G-3 | OnFailure worker handler chain now actually executes (was dispatched to a non-existent handler); Compensate↔OnFailure interop via a single ordered trigger (compensation then failure chain, no CS0111). |
| #139 | G-4 | Multi-step `OnLowConfidence` handler chains + rejoin-to-main-flow (default stays terminal). |
| #138 | G-5 | EventSourced `StepFailed` / `LowConfidenceRouted` Marten stream events (gated on `IsEventSourced`); new EventSourced behavioral fixture. |
| #143 | G-6 | Declared↔lowered **parity guard** (`StepConfigParityTests`) — every `IStepConfiguration` member must be classified Lowered (behavioral-test-backed) or Deferred (tracked issue); `AGWF022` declared-but-inert diagnostic for fork-path confidence config. |
| #132 | G-7 | Safe `EnsureSchemaAsync<T>(ct)` (all descriptors for a multi-registered type) + graph-wide `EnsureAllSchemasAsync(ct)`. |

### The parity guard earned its keep

Writing the required `ValidateState` behavioral backfill (G-6) exposed **two real top-level lowering bugs** that shape/golden tests had missed — both fixed here:
- Configure-lambda validation (`.Then<T>(s => s.ValidateState(...))`) was only extracted on fork paths; top-level/loop steps silently dropped it.
- The emitter assumed the predicate parameter was literally `state`, so `s => s.X` emitted uncompilable code.

Code review then caught a **HIGH regression** introduced by the first fix: the new top-level extraction walked nested lambdas, so a parent step absorbed a nested `OnLowConfidence` step's `ValidateState` guard. Fixed by scoping the walk to the configure lambda's own body (`InvocationChainWalker.CollectInvocationsInLambda`, mirroring the already-hardened resilience extraction) + a nested-lambda regression test.

### Testing
- Build: **33 projects, 0 warnings, 0 errors**.
- `Strategos.Generators.Tests`: **1268/1268**.
- `Strategos.Generators.Behavioral.Tests`: **28/28** (real Wolverine + Marten + Testcontainers Postgres) — lowering correctness is mutation-proven.
- `Strategos.Contracts.Tests`: **57/57** (incl. AGWF catalog single-source + grep-gate).

### Deferred / follow-ons
- Fork-path `RequireConfidence`/`OnLowConfidence` lowering + nested `RepeatUntil` config → #134 (v2.10.0). Loop-body confidence config is dropped from the IR entirely (structurally undiagnosable by an IR-based diagnostic) — documented in `docs/deferred-features.md`.
- Pre-existing, non-exploitable SQL key-name interpolation in `SqlGenerator.cs:286` (CLR identifier, can't contain `'`) — noted, not addressed here.

Closes #142, #141, #140, #139, #138, #143, #132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
