### PR TITLE
docs(generators): repoint deferred fork-path/loop confidence lowering to #145

### DIFF
--- a/docs/deferred-features.md
+++ b/docs/deferred-features.md
@@ -60,7 +60,7 @@ This document catalogs all features from the Strategos design specification that
 >   on a `Fork` path** — the fork-path parse threads the configure lambda into the IR (so an
 >   out-of-range threshold still surfaces the threshold-range code), but the saga emitter does
 >   not lower fork-path confidence routing. That variant is **deferred to v2.10.0 / DR-17
->   (#134)**; until then the diagnostic prevents the inert configuration from masquerading as
+>   (#145)**; until then the diagnostic prevents the inert configuration from masquerading as
 >   working. (Surfacing 6.1's backfill also fixed two real top-level `ValidateState` lowering
 >   gaps — configure-lambda validation was dropped for top-level/loop steps, and the predicate
 >   parameter had to be named literally `state` to compile.)
@@ -71,7 +71,7 @@ This document catalogs all features from the Strategos design specification that
 >   see it — there is nothing in the IR for AGWF022 to inspect. It is therefore **silently inert**
 >   (no compile-time warning), distinct from the fork-path case above which *is* threaded into the
 >   IR and *is* diagnosed. Loop-body confidence routing is likewise **deferred to v2.10.0 / DR-17
->   (#134)**; emitting a diagnostic for it requires the lowering work that brings loop-body config
+>   (#145)**; emitting a diagnostic for it requires the lowering work that brings loop-body config
 >   into the IR in the first place.
 
 **Total Deferred Features:** 8

--- a/src/Strategos.Generators.Tests/Parity/StepConfigParityTests.cs
+++ b/src/Strategos.Generators.Tests/Parity/StepConfigParityTests.cs
@@ -114,21 +114,21 @@ public sealed class StepConfigParityTests
             // bad threshold) but is not lowered into saga routing — it is structurally
             // diagnosable and is guarded by AGWF022 (DeclaredButInert / DeclaredButInertTests).
             ["RequireConfidence(fork-path)"] = new(
-                134,
+                145,
                 "Confidence gating on a fork path is deferred to v2.10.0 / DR-17; the config "
                 + "reaches the IR and is AGWF022-guarded (DeclaredButInertTests), so it is "
                 + "structurally diagnosable."),
             ["OnLowConfidence(fork-path)"] = new(
-                134,
+                145,
                 "OnLowConfidence routing on a fork path is deferred to v2.10.0 / DR-17; the "
                 + "config reaches the IR and is AGWF022-guarded (DeclaredButInertTests), so it "
                 + "is structurally diagnosable."),
             // Distinct from the fork-path case above: loop-body / nested-RepeatUntil confidence
             // config is DROPPED from the IR entirely by step extraction, so an IR-based
             // diagnostic structurally CANNOT see it — it is NOT AGWF022-guarded. Silently inert,
-            // tracked under #134 for v2.10.0.
+            // tracked under #145 for v2.10.0.
             ["OnLowConfidence(nested-RepeatUntil)"] = new(
-                134,
+                145,
                 "OnLowConfidence inside a nested RepeatUntil loop is dropped from the IR by step "
                 + "extraction (structurally undiagnosable — no AGWF022), deferred to "
                 + "v2.10.0 / DR-17."),


### PR DESCRIPTION
## What

Repoint the deferred fork-path / nested-`RepeatUntil` confidence **lowering** references from the now-closed **#134** to the new tracking issue **#145**.

## Why

#134's scope was the fork-path `Then<TStep>(configure)` **builder overload** — that shipped in #136 and #134 was closed as completed. But the declared↔lowered parity guard (`StepConfigParityTests`) and `docs/deferred-features.md` had repurposed #134 as the tracker for the still-deferred **lowering** of fork-path / loop-body confidence routing (v2.10.0 / DR-17). So the deferred work pointed at a closed issue. #145 is its proper open home.

## Changes

- `StepConfigParityTests.cs` — three `Deferred` entries (`RequireConfidence(fork-path)`, `OnLowConfidence(fork-path)`, `OnLowConfidence(nested-RepeatUntil)`) + the inline comment → `#145`.
- `docs/deferred-features.md` — the two `deferred to v2.10.0 / DR-17 (#134)` notes → `#145`.
- **Unchanged:** the `Then<TStep>(configure) … (fork landed earlier via #134)` history line — that's accurate attribution of #134's delivered scope.

No behavior change; pure tracking-reference correction. `StepConfigParityTests` green (2/2).

Refs #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
