### PR TITLE
feat(contracts): add GateClass.Rules for deterministic rule-set gates

### DIFF
--- a/src/Strategos.Contracts.Tests/Gates/GateClassSchemaTests.cs
+++ b/src/Strategos.Contracts.Tests/Gates/GateClassSchemaTests.cs
@@ -35,6 +35,7 @@ public sealed class GateClassSchemaTests
         ("MutationAdequacy", "mutation_adequacy"),
         ("MergeGate", "merge_gate"),
         ("LlmJudge", "llm_judge"),
+        ("Rules", "rules"),
     ];
 
     /// <summary>

--- a/src/Strategos.Contracts/Gates/GateClass.tsp
+++ b/src/Strategos.Contracts/Gates/GateClass.tsp
@@ -37,4 +37,11 @@ enum GateClass {
 
   /** LLM-as-judge evaluation. */
   LlmJudge: "llm_judge",
+
+  /**
+   * A deterministic rule set, evaluated with no LLM or network cost. The class
+   * names the MECHANISM, not the input: a gate that merely *filters*
+   * LLM-produced findings is `rules`, not `llm_judge`.
+   */
+  Rules: "rules",
 }

--- a/src/Strategos.Contracts/Generated/GateClass.g.cs
+++ b/src/Strategos.Contracts/Generated/GateClass.g.cs
@@ -44,4 +44,7 @@ public enum GateClass
 
     [JsonStringEnumMemberName("llm_judge")]
     LlmJudge,
+
+    [JsonStringEnumMemberName("rules")]
+    Rules,
 }

--- a/src/Strategos.Contracts/schemas/json-schema/GateClass.json
+++ b/src/Strategos.Contracts/schemas/json-schema/GateClass.json
@@ -9,7 +9,8 @@
         "full_suite",
         "mutation_adequacy",
         "merge_gate",
-        "llm_judge"
+        "llm_judge",
+        "rules"
     ],
     "description": "Closed enum of the gate CLASSES a workflow's quality/merge gates evaluate\n(#150, DR-1). This is the single typed gate identity shared across the\ncontract boundary so both runtimes consume ONE gate vocabulary.\n\nMember names are PascalCase; the wire VALUES are the exact snake_case tokens\ncross-repo consumers match on. Exarchos's TypeScript enum and Basileus's C#\nenum round-trip against these **by value** (INV-8 polyglot identity) — never by\nordinal. Adding a class is an additive minor; renaming or removing one is a\nbreaking major."
 }

--- a/src/Strategos.Contracts/schemas/workflow-definition-v1.schema.json
+++ b/src/Strategos.Contracts/schemas/workflow-definition-v1.schema.json
@@ -535,7 +535,8 @@
                 "full_suite",
                 "mutation_adequacy",
                 "merge_gate",
-                "llm_judge"
+                "llm_judge",
+                "rules"
             ],
             "description": "Closed enum of the gate CLASSES a workflow's quality/merge gates evaluate\n(#150, DR-1). This is the single typed gate identity shared across the\ncontract boundary so both runtimes consume ONE gate vocabulary.\n\nMember names are PascalCase; the wire VALUES are the exact snake_case tokens\ncross-repo consumers match on. Exarchos's TypeScript enum and Basileus's C#\nenum round-trip against these **by value** (INV-8 polyglot identity) — never by\nordinal. Adding a class is an additive minor; renaming or removing one is a\nbreaking major."
         },


### PR DESCRIPTION
## Why

The closed `GateClass` vocabulary has no member for a gate that is a **deterministic rule set evaluated with no LLM or network cost**. Such a gate can only be mis-mapped onto `llm_judge` or left unmapped.

This surfaced from [lvlup-sw/basileus#392](https://github.com/lvlup-sw/basileus/issues/392) DR-1, which classifies `IFindingGroundingGate` as `rules`. That gate *filters* LLM-produced findings but does not *use* an LLM to judge them. An earlier revision of that spec did map it to `llm_judge`, on the "it filters LLM output" reading — which describes its **input**, not its **mechanism**, and would have made any future `llm_judge` aggregate derive entirely from a gate containing no LLM.

The new member's doc comment records that distinction explicitly, so the same misreading isn't repeated by the next consumer.

## What

- `GateClass.tsp` — append `Rules: "rules"`
- Regenerate via `scripts/contracts-codegen.sh` → `GateClass.json`, `GateClass.g.cs`, `workflow-definition-v1.schema.json`
- Extend the frozen-member map in `GateClassSchemaTests`

The whole diff is 15 insertions / 2 deletions; every regenerated hunk is exactly the one added member.

## Compatibility

**Additive minor**, per this enum's own contract note — *"Adding a class is an additive minor; renaming or removing one is a breaking major."* Round-trip is by value, never ordinal (INV-8), so appending at the end is safe.

`<ContractsVersion>` is already pinned at `0.4.0` on `main` but **no `contracts-v0.4.0` tag exists and nuget.org carries only 0.2.0 / 0.3.0**. This therefore folds into 0.4.0 rather than requiring a 0.5.0 — no consumer has ever observed the seven-member form. That window closes the moment the tag is cut, which is why this lands first.

## Verification

- `Strategos.Contracts.Tests` — **94/94 pass**, including `GateClassSchema_IsClosedStringEnum_WithFrozenSnakeCaseValues` and `GateClassEnum_CarriesSnakeCaseWireNames_AndRoundTripsByValue`
- `src/strategos.sln` — builds with **0 warnings / 0 errors**
- No exhaustive `switch` over `GateClass` exists in the tree (only non-generated reference is a comment in `WireDtos.cs`), so the addition breaks no consumer

## Follow-on

Once merged, `contracts-v0.4.0` gets tagged to publish `LevelUp.Strategos.Contracts` 0.4.0, which unblocks basileus #392 Task 01 (and transitively its remaining 15 tasks).

Note for downstream: exarchos carries a TypeScript mirror of this enum; picking up `rules` there is additive and not required by this PR.

Refs: #150, lvlup-sw/basileus#392

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018evWqrEK5ShWvy2BCXCzqx
