### PR TITLE
docs(changelog): complete the 2.10.0 notes with GateClass.Rules (#158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.10.0] - 2026-07-07
+## [2.10.0] - 2026-08-07
 
 The **strategy-compiler contract layer** (roadmap #153): the shared `Strategos.Contracts`
 IR spine gains gate, fork, and abstention shapes, and the workflow generator gains a
@@ -17,13 +17,15 @@ breaking changes).
 
 ### Added
 
-**Gate taxonomy + measured reliability (#150).** A closed `GateClass` enum
-(`typecheck | lint | scoped_test | full_suite | mutation_adequacy | merge_gate | llm_judge`,
-snake_case wire values) and a `GateDeclaration { class, id, reliability? }` record whose
+**Gate taxonomy + measured reliability (#150, #158).** A closed `GateClass` enum
+(`typecheck | lint | scoped_test | full_suite | mutation_adequacy | merge_gate | llm_judge |
+rules`, snake_case wire values) and a `GateDeclaration { class, id, reliability? }` record whose
 optional `reliability` block is provenance-required (`source` mandatory — reliability is
 telemetry-measured, never hand-authored). `WorkflowDefinitionV1` gains additive optional
 `gates[]` and a `gateId` back-reference on the gate step; gates are consumer-plane data, so
-the generated saga is unaffected.
+the generated saga is unaffected. The `rules` class (#158) names a deterministic rule set
+evaluated with no LLM or network cost — the class names the **mechanism, not the input**, so
+a gate that merely *filters* LLM-produced findings is `rules`, not `llm_judge`.
 
 **Fork/compensation DSL edge (#151).** An `AllowDiagnosticFork(...)` builder surface
 (staged so a fork without an anchor or a permitted trigger cannot compile) declaring where a


### PR DESCRIPTION
## Why

`v2.10.0` is **merged but never tagged** — the strategy-compiler bundle (PR #154) landed 2026-07-09 and all four consumers (basileus, exarchos, valkyrie, dynatoi) are still on 2.9.1. This is the last cleanup before cutting the tag.

## What

The `[2.10.0]` CHANGELOG section was drafted 2026-07-07, **before #158 landed**, so it enumerates seven `GateClass` members while the shipped enum has eight.

- Adds `rules` to the enumerated `GateClass` members and credits #158 alongside #150.
- Documents its semantic from the TypeSpec doc comment: the class names the **mechanism, not the input**, so a gate that merely *filters* LLM-produced findings is `rules`, not `llm_judge`.
- Corrects the release date to the actual tag date — the section had carried its drafting date while the tag went un-pushed for a month.

No code change. This makes the human-facing release record match the shipped surface before the tag.

## Release context

- `contracts-v0.4.0` already points at `99b1070` (current `main` HEAD), so the product tag and the contracts tag will align on the same commit.
- CI and Contracts codegen guard are both green on `99b1070`.
- After merge: push `v2.10.0`, which triggers `publish.yml` (MinVer version + git-cliff notes). The NuGet push waits on manual approval via the `nuget-publish` environment.

Refs #158, #150, #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQ8YVoCUbyZ5a3tdPxzMSC